### PR TITLE
[php-nextgen] Use php type declarations

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -17,6 +17,7 @@
 
 package org.openapitools.codegen.languages;
 
+import io.swagger.v3.oas.models.media.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
@@ -167,7 +168,6 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         objs = super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
         for (CodegenOperation operation : operations.getOperation()) {
-            LOGGER.error("PHPHPHP operation: {}", operation.operationId);
             if (operation.returnType == null) {
                 operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
             }
@@ -186,5 +186,17 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         }
 
         return objs;
+    }
+
+    @Override
+    public String toDefaultValue(CodegenProperty codegenProperty, Schema schema) {
+        if (codegenProperty.isArray) {
+            if (schema.getDefault() != null) {
+                return "[" + schema.getDefault().toString() + "]";
+            } else {
+                return null;
+            }
+        }
+        return super.toDefaultValue(codegenProperty, schema);
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -18,11 +18,7 @@
 package org.openapitools.codegen.languages;
 
 import org.apache.commons.lang3.StringUtils;
-import org.openapitools.codegen.CliOption;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenType;
-import org.openapitools.codegen.SupportingFile;
+import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.GeneratorMetadata;
 import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
@@ -141,6 +137,15 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
     private ModelsMap postProcessModelsMap(ModelsMap objs) {
         for (ModelMap m : objs.getModels()) {
             CodegenModel model = m.getModel();
+
+            for (CodegenProperty prop : model.vars) {
+                if (prop.isArray || prop.isMap) {
+                    prop.vendorExtensions.putIfAbsent("x-php-prop-type", "array");
+                }
+                else {
+                    prop.vendorExtensions.putIfAbsent("x-php-prop-type", prop.dataType);
+                }
+            }
 
             if (model.isEnum) {
                 for (Map<String, Object> enumVars : (List<Map<String, Object>>) model.getAllowableValues().get("enumVars")) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -24,6 +24,8 @@ import org.openapitools.codegen.meta.Stability;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
+import org.openapitools.codegen.model.OperationMap;
+import org.openapitools.codegen.model.OperationsMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,6 +159,32 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
                 }
             }
         }
+        return objs;
+    }
+
+    @Override
+    public OperationsMap postProcessOperationsWithModels(OperationsMap objs, List<ModelMap> allModels) {
+        objs = super.postProcessOperationsWithModels(objs, allModels);
+        OperationMap operations = objs.getOperations();
+        for (CodegenOperation operation : operations.getOperation()) {
+            LOGGER.error("PHPHPHP operation: {}", operation.operationId);
+            if (operation.returnType == null) {
+                operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
+            }
+            else {
+                operation.vendorExtensions.putIfAbsent("x-php-return-type", operation.returnType);
+            }
+
+            for (CodegenParameter param : operation.allParams) {
+                if (param.isArray || param.isMap) {
+                    param.vendorExtensions.putIfAbsent("x-php-param-type", "array");
+                }
+                else {
+                    param.vendorExtensions.putIfAbsent("x-php-param-type", param.dataType);
+                }
+            }
+        }
+
         return objs;
     }
 }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
@@ -35,21 +35,21 @@ class ApiException extends Exception
      *
      * @var \stdClass|string|null
      */
-    protected $responseBody;
+    protected \stdClass|string|null $responseBody;
 
     /**
      * The HTTP header of the server response.
      *
      * @var string[]|null
      */
-    protected $responseHeaders;
+    protected ?array $responseHeaders;
 
     /**
      * The deserialized response object
      *
-     * @var \stdClass|string|null
+     * @var mixed
      */
-    protected $responseObject;
+    protected mixed $responseObject;
 
     /**
      * Constructor
@@ -57,9 +57,9 @@ class ApiException extends Exception
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
      * @param string[]|null         $responseHeaders HTTP response header
-     * @param \stdClass|string|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
+     * @param mixed $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -71,7 +71,7 @@ class ApiException extends Exception
      *
      * @return string[]|null HTTP response header
      */
-    public function getResponseHeaders()
+    public function getResponseHeaders(): ?array
     {
         return $this->responseHeaders;
     }
@@ -81,7 +81,7 @@ class ApiException extends Exception
      *
      * @return \stdClass|string|null HTTP body of the server response either as \stdClass or string
      */
-    public function getResponseBody()
+    public function getResponseBody(): \stdClass|string|null
     {
         return $this->responseBody;
     }
@@ -93,7 +93,7 @@ class ApiException extends Exception
      *
      * @return void
      */
-    public function setResponseObject($obj)
+    public function setResponseObject(mixed $obj): void
     {
         $this->responseObject = $obj;
     }
@@ -103,7 +103,7 @@ class ApiException extends Exception
      *
      * @return mixed the deserialized response object
      */
-    public function getResponseObject()
+    public function getResponseObject(): mixed
     {
         return $this->responseObject;
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ApiException.mustache
@@ -18,7 +18,8 @@
 
 namespace {{invokerPackage}};
 
-use \Exception;
+use Exception;
+use stdClass;
 
 /**
  * ApiException Class Doc Comment
@@ -33,9 +34,9 @@ class ApiException extends Exception
     /**
      * The HTTP body of the server response either as Json or string.
      *
-     * @var \stdClass|string|null
+     * @var stdClass|string|null
      */
-    protected \stdClass|string|null $responseBody;
+    protected stdClass|string|null $responseBody;
 
     /**
      * The HTTP header of the server response.
@@ -57,7 +58,7 @@ class ApiException extends Exception
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
      * @param string[]|null         $responseHeaders HTTP response header
-     * @param mixed $responseBody    HTTP decoded body of the server response either as \stdClass or string
+     * @param mixed $responseBody    HTTP decoded body of the server response either as stdClass or string
      */
     public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
     {
@@ -79,9 +80,9 @@ class ApiException extends Exception
     /**
      * Gets the HTTP body of the server response either as Json or string
      *
-     * @return \stdClass|string|null HTTP body of the server response either as \stdClass or string
+     * @return stdClass|string|null HTTP body of the server response either as \stdClass or string
      */
-    public function getResponseBody(): \stdClass|string|null
+    public function getResponseBody(): stdClass|string|null
     {
         return $this->responseBody;
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -34,84 +34,84 @@ class Configuration
     /**
      * @var Configuration
      */
-    private static $defaultConfiguration;
+    private static ?Configuration $defaultConfiguration = null;
 
     /**
      * Associate array to store API key(s)
      *
      * @var string[]
      */
-    protected $apiKeys = [];
+    protected array $apiKeys = [];
 
     /**
      * Associate array to store API prefix (e.g. Bearer)
      *
      * @var string[]
      */
-    protected $apiKeyPrefixes = [];
+    protected array $apiKeyPrefixes = [];
 
     /**
      * Access token for OAuth/Bearer authentication
      *
      * @var string
      */
-    protected $accessToken = '';
+    protected string $accessToken = '';
 
     /**
      * Boolean format for query string
      *
      * @var string
      */
-    protected $booleanFormatForQueryString = self::BOOLEAN_FORMAT_INT;
+    protected string $booleanFormatForQueryString = self::BOOLEAN_FORMAT_INT;
 
     /**
      * Username for HTTP basic authentication
      *
      * @var string
      */
-    protected $username = '';
+    protected string $username = '';
 
     /**
      * Password for HTTP basic authentication
      *
      * @var string
      */
-    protected $password = '';
+    protected string $password = '';
 
     /**
      * The host
      *
      * @var string
      */
-    protected $host = '{{basePath}}';
+    protected string $host = '{{basePath}}';
 
     /**
      * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
      *
      * @var string
      */
-    protected $userAgent = '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}{{^artifactVersion}}1.0.0{{/artifactVersion}}/PHP{{/httpUserAgent}}';
+    protected string $userAgent = '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{artifactVersion}}}{{^artifactVersion}}1.0.0{{/artifactVersion}}/PHP{{/httpUserAgent}}';
 
     /**
      * Debug switch (default set to false)
      *
      * @var bool
      */
-    protected $debug = false;
+    protected bool $debug = false;
 
     /**
      * Debug file location (log to STDOUT by default)
      *
      * @var string
      */
-    protected $debugFile = 'php://output';
+    protected string $debugFile = 'php://output';
 
     /**
      * Debug file location (log to STDOUT by default)
      *
      * @var string
      */
-    protected $tempFolderPath;
+    protected string $tempFolderPath;
 
     /**
      * Constructor
@@ -129,7 +129,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKey($apiKeyIdentifier, $key)
+    public function setApiKey(string $apiKeyIdentifier, string $key): static
     {
         $this->apiKeys[$apiKeyIdentifier] = $key;
         return $this;
@@ -142,9 +142,9 @@ class Configuration
      *
      * @return null|string API key or token
      */
-    public function getApiKey($apiKeyIdentifier)
+    public function getApiKey(string $apiKeyIdentifier): ?string
     {
-        return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
+        return $this->apiKeys[$apiKeyIdentifier] ?? null;
     }
 
     /**
@@ -155,7 +155,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
+    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix)
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
         return $this;
@@ -168,9 +168,9 @@ class Configuration
      *
      * @return null|string
      */
-    public function getApiKeyPrefix($apiKeyIdentifier)
+    public function getApiKeyPrefix(string $apiKeyIdentifier): ?string
     {
-        return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
+        return $this->apiKeyPrefixes[$apiKeyIdentifier] ?? null;
     }
 
     /**
@@ -180,7 +180,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setAccessToken($accessToken)
+    public function setAccessToken(string $accessToken): static
     {
         $this->accessToken = $accessToken;
         return $this;
@@ -191,7 +191,7 @@ class Configuration
      *
      * @return string Access token for OAuth
      */
-    public function getAccessToken()
+    public function getAccessToken(): string
     {
         return $this->accessToken;
     }
@@ -203,7 +203,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setBooleanFormatForQueryString(string $booleanFormat)
+    public function setBooleanFormatForQueryString(string $booleanFormat): static
     {
         $this->booleanFormatForQueryString = $booleanFormat;
 
@@ -227,7 +227,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setUsername($username)
+    public function setUsername(string $username): static
     {
         $this->username = $username;
         return $this;
@@ -238,7 +238,7 @@ class Configuration
      *
      * @return string Username for HTTP basic authentication
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -250,7 +250,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setPassword($password)
+    public function setPassword(string $password): static
     {
         $this->password = $password;
         return $this;
@@ -261,7 +261,7 @@ class Configuration
      *
      * @return string Password for HTTP basic authentication
      */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->password;
     }
@@ -273,7 +273,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setHost($host)
+    public function setHost(string $host): static
     {
         $this->host = $host;
         return $this;
@@ -284,7 +284,7 @@ class Configuration
      *
      * @return string Host
      */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
@@ -297,7 +297,7 @@ class Configuration
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent(string $userAgent): static
     {
         if (!is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
@@ -312,7 +312,7 @@ class Configuration
      *
      * @return string user agent
      */
-    public function getUserAgent()
+    public function getUserAgent(): string
     {
         return $this->userAgent;
     }
@@ -324,7 +324,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebug($debug)
+    public function setDebug(bool $debug): static
     {
         $this->debug = $debug;
         return $this;
@@ -335,7 +335,7 @@ class Configuration
      *
      * @return bool
      */
-    public function getDebug()
+    public function getDebug(): bool
     {
         return $this->debug;
     }
@@ -347,7 +347,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebugFile($debugFile)
+    public function setDebugFile(string $debugFile): static
     {
         $this->debugFile = $debugFile;
         return $this;
@@ -358,7 +358,7 @@ class Configuration
      *
      * @return string
      */
-    public function getDebugFile()
+    public function getDebugFile(): string
     {
         return $this->debugFile;
     }
@@ -370,7 +370,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setTempFolderPath($tempFolderPath)
+    public function setTempFolderPath(string $tempFolderPath): static
     {
         $this->tempFolderPath = $tempFolderPath;
         return $this;
@@ -381,7 +381,7 @@ class Configuration
      *
      * @return string Temp folder path
      */
-    public function getTempFolderPath()
+    public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
     }
@@ -391,7 +391,7 @@ class Configuration
      *
      * @return Configuration
      */
-    public static function getDefaultConfiguration()
+    public static function getDefaultConfiguration(): Configuration
     {
         if (self::$defaultConfiguration === null) {
             self::$defaultConfiguration = new Configuration();
@@ -417,7 +417,7 @@ class Configuration
      *
      * @return string The report for debugging
      */
-    public static function toDebugReport()
+    public static function toDebugReport(): string
     {
         $report  = 'PHP SDK ({{invokerPackage}}) Debug Report:' . PHP_EOL;
         $report .= '    OS: ' . php_uname() . PHP_EOL;
@@ -438,7 +438,7 @@ class Configuration
      *
      * @return null|string API key with the prefix
      */
-    public function getApiKeyWithPrefix($apiKeyIdentifier)
+    public function getApiKeyWithPrefix(string $apiKeyIdentifier): ?string
     {
         $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->getApiKey($apiKeyIdentifier);
@@ -461,7 +461,7 @@ class Configuration
      *
      * @return array an array of host settings
      */
-    public function getHostSettings()
+    public function getHostSettings(): array
     {
         return [
         {{#servers}}
@@ -502,7 +502,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostsSettings, int $hostIndex, array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];
@@ -540,7 +540,7 @@ class Configuration
      * @param array|null $variables hash of variable and the corresponding value (optional)
      * @return string URL based on host settings
      */
-    public function getHostFromSettings($index, $variables = null)
+    public function getHostFromSettings(int $index, ?array $variables = null): string
     {
         return self::getHostString($this->getHostSettings(), $index, $variables);
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -18,6 +18,8 @@
 
 namespace {{invokerPackage}};
 
+use InvalidArgumentException;
+
 /**
  * Configuration Class Doc Comment
  *
@@ -32,7 +34,7 @@ class Configuration
     public const BOOLEAN_FORMAT_STRING = 'string';
 
     /**
-     * @var Configuration
+     * @var Configuration|null
      */
     private static ?Configuration $defaultConfiguration = null;
 
@@ -155,7 +157,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix)
+    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix): static
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
         return $this;
@@ -199,7 +201,7 @@ class Configuration
     /**
      * Sets boolean format for query string.
      *
-     * @param string $booleanFormatForQueryString Boolean format for query string
+     * @param string $booleanFormat Boolean format for query string
      *
      * @return $this
      */
@@ -294,15 +296,11 @@ class Configuration
      *
      * @param string $userAgent the user agent of the api client
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return $this
      */
     public function setUserAgent(string $userAgent): static
     {
-        if (!is_string($userAgent)) {
-            throw new \InvalidArgumentException('User-agent must be a string.');
-        }
-
         $this->userAgent = $userAgent;
         return $this;
     }
@@ -407,7 +405,7 @@ class Configuration
      *
      * @return void
      */
-    public static function setDefaultConfiguration(Configuration $config)
+    public static function setDefaultConfiguration(Configuration $config): void
     {
         self::$defaultConfiguration = $config;
     }
@@ -497,7 +495,7 @@ class Configuration
     /**
     * Returns URL based on host settings, index and variables
     *
-    * @param array      $hostSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
+    * @param array      $hostsSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
     * @param int        $hostIndex    index of the host settings
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
@@ -510,7 +508,7 @@ class Configuration
 
         // check array index out of bound
         if ($hostIndex < 0 || $hostIndex >= count($hostsSettings)) {
-            throw new \InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
+            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
         }
 
         $host = $hostsSettings[$hostIndex];
@@ -522,7 +520,7 @@ class Configuration
                 if (!isset($variable['enum_values']) || in_array($variables[$name], $variable["enum_values"], true)) { // check to see if the value is in the enum
                     $url = str_replace("{".$name."}", $variables[$name], $url);
                 } else {
-                    throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                    throw new InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
                 }
             } else {
                 // use default value

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ModelInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ModelInterface.mustache
@@ -32,49 +32,49 @@ interface ModelInterface
      *
      * @return string
      */
-    public function getModelName();
+    public function getModelName(): string;
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function openAPITypes();
+    public static function openAPITypes(): array;
 
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function openAPIFormats();
+    public static function openAPIFormats(): array;
 
     /**
      * Array of attributes where the key is the local name, and the value is the original name
      *
      * @return array
      */
-    public static function attributeMap();
+    public static function attributeMap(): array;
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
      * @return array
      */
-    public static function setters();
+    public static function setters(): array;
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
      * @return array
      */
-    public static function getters();
+    public static function getters(): array;
 
     /**
      * Show all the invalid properties with reasons.
      *
      * @return array
      */
-    public function listInvalidProperties();
+    public function listInvalidProperties(): array;
 
     /**
      * Validate all the properties in the model
@@ -82,7 +82,7 @@ interface ModelInterface
      *
      * @return bool
      */
-    public function valid();
+    public function valid(): bool;
 
     /**
      * Checks if a property is nullable

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -33,14 +33,14 @@ use {{modelPackage}}\ModelInterface;
 class ObjectSerializer
 {
     /** @var string */
-    private static $dateTimeFormat = \DateTime::ATOM;
+    private static string $dateTimeFormat = \DateTime::ATOM;
 
     /**
      * Change the date format
      *
      * @param string $format   the new date format to use
      */
-    public static function setDateTimeFormat($format)
+    public static function setDateTimeFormat(string $format)
     {
         self::$dateTimeFormat = $format;
     }
@@ -54,7 +54,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization($data, $type = null, $format = null)
+    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null)
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -110,7 +110,7 @@ class ObjectSerializer
      *
      * @return string the sanitized filename
      */
-    public static function sanitizeFilename($filename)
+    public static function sanitizeFilename(string $filename): string
     {
         if (preg_match("/.*[\/\\\\](.*)$/", $filename, $match)) {
             return $match[1];
@@ -126,7 +126,7 @@ class ObjectSerializer
      *
      * @return string the shorten timestamp
      */
-    public static function sanitizeTimestamp($timestamp)
+    public static function sanitizeTimestamp(string $timestamp): string
     {
         if (!is_string($timestamp)) return $timestamp;
 
@@ -141,7 +141,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
-    public static function toPathValue($value)
+    public static function toPathValue(string $value): string
     {
         return rawurlencode(self::toString($value));
     }
@@ -154,7 +154,7 @@ class ObjectSerializer
      *
      * @return bool true if $value is empty
      */
-    private static function isEmptyValue($value, string $openApiType): bool
+    private static function isEmptyValue(mixed $value, string $openApiType): bool
     {
         # If empty() returns false, it is not empty regardless of its type.
         if (!empty($value)) {
@@ -203,7 +203,7 @@ class ObjectSerializer
      * @return array
      */
     public static function toQueryValue(
-        $value,
+        mixed $value,
         string $paramName,
         string $openApiType = 'string',
         string $style = 'form',
@@ -275,7 +275,7 @@ class ObjectSerializer
      *
      * @return int|string Boolean value in format
      */
-    public static function convertBoolToQueryStringFormat(bool $value)
+    public static function convertBoolToQueryStringFormat(bool $value): int|string
     {
         if (Configuration::BOOLEAN_FORMAT_STRING == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()) {
             return $value ? 'true' : 'false';
@@ -293,7 +293,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toHeaderValue($value)
+    public static function toHeaderValue(string $value): string
     {
         $callable = [$value, 'toHeaderValue'];
         if (is_callable($callable)) {
@@ -312,7 +312,7 @@ class ObjectSerializer
      *
      * @return string the form string
      */
-    public static function toFormValue($value)
+    public static function toFormValue(string|\SplFileObject $value): string
     {
         if ($value instanceof \SplFileObject) {
             return $value->getRealPath();
@@ -331,7 +331,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toString($value)
+    public static function toString(string|bool|\DateTime $value): string
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
             return $value->format(self::$dateTimeFormat);
@@ -352,7 +352,7 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, string $style, bool $allowCollectionFormatMulti = false): string
     {
         if ($allowCollectionFormatMulti && ('multi' === $style)) {
             // http_build_query() almost does the job for us. We just
@@ -389,7 +389,7 @@ class ObjectSerializer
      *
      * @return object|array|null a single or an array of $class instances
      */
-    public static function deserialize($data, $class, $httpHeaders = null)
+    public static function deserialize(mixed $data, string $class, string $httpHeaders = null): object|array|null
     {
         if (null === $data) {
             return null;

--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -19,6 +19,8 @@
 
 namespace {{invokerPackage}};
 
+use DateTimeInterface;
+use DateTime;
 use GuzzleHttp\Psr7\Utils;
 use {{modelPackage}}\ModelInterface;
 
@@ -33,14 +35,16 @@ use {{modelPackage}}\ModelInterface;
 class ObjectSerializer
 {
     /** @var string */
-    private static string $dateTimeFormat = \DateTime::ATOM;
+    private static string $dateTimeFormat = DateTimeInterface::ATOM;
 
     /**
      * Change the date format
      *
      * @param string $format   the new date format to use
+     *
+     * @return void
      */
-    public static function setDateTimeFormat(string $format)
+    public static function setDateTimeFormat(string $format): void
     {
         self::$dateTimeFormat = $format;
     }
@@ -48,19 +52,19 @@ class ObjectSerializer
     /**
      * Serialize data
      *
-     * @param mixed  $data   the data to serialize
-     * @param string $type   the OpenAPIToolsType of the data
-     * @param string $format the format of the OpenAPITools type of the data
+     * @param mixed       $data   the data to serialize
+     * @param string|null $type   the OpenAPIToolsType of the data
+     * @param string|null $format the format of the OpenAPITools type of the data
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null)
+    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
         }
 
-        if ($data instanceof \DateTime) {
+        if ($data instanceof DateTime) {
             return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
         }
 
@@ -128,8 +132,6 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp(string $timestamp): string
     {
-        if (!is_string($timestamp)) return $timestamp;
-
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }
 
@@ -166,27 +168,19 @@ class ObjectSerializer
             return true;
         }
 
-        switch ($openApiType) {
+        return match ($openApiType) {
             # For numeric values, false and '' are considered empty.
             # This comparison is safe for floating point values, since the previous call to empty() will
             # filter out values that don't match 0.
-            case 'int':
-            case 'integer':
-                return $value !== 0;
-
-            case 'number':
-            case 'float':
-                return $value !== 0 && $value !== 0.0;
+            'int','integer' => $value !== 0,
+            'number'|'float' => $value !== 0 && $value !== 0.0,
 
             # For boolean values, '' is considered empty
-            case 'bool':
-            case 'boolean':
-                return !in_array($value, [false, 0], true);
+            'bool','boolean' => !in_array($value, [false, 0], true),
 
             # For all the other types, any value at this point can be considered empty.
-            default:
-                return true;
-        }
+            default => true
+        };
     }
 
     /**
@@ -195,7 +189,7 @@ class ObjectSerializer
      *
      * @param mixed  $value       Parameter value
      * @param string $paramName   Parameter name
-     * @param string $openApiType OpenAPIType eg. array or object
+     * @param string $openApiType OpenAPIType e.g. array or object
      * @param string $style       Parameter serialization style
      * @param bool   $explode     Parameter explode option
      * @param bool   $required    Whether query param is required or not
@@ -224,7 +218,7 @@ class ObjectSerializer
         }
 
         # Handle DateTime objects in query
-        if($openApiType === "\\DateTime" && $value instanceof \DateTime) {
+        if($openApiType === "\DateTime" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
@@ -237,7 +231,7 @@ class ObjectSerializer
             if (!is_array($arr)) return $arr;
 
             foreach ($arr as $k => $v) {
-                $prop = ($style === 'deepObject') ? $prop = "{$name}[{$k}]" : $k;
+                $prop = ($style === 'deepObject') ? "{$name}[{$k}]" : $k;
 
                 if (is_array($v)) {
                     $flattenArray($v, $prop, $result);
@@ -327,13 +321,13 @@ class ObjectSerializer
      * If it's a datetime object, format it in ISO8601
      * If it's a boolean, convert it to "true" or "false".
      *
-     * @param string|bool|\DateTime $value the value of the parameter
+     * @param string|bool|DateTime $value the value of the parameter
      *
      * @return string the header string
      */
-    public static function toString(string|bool|\DateTime $value): string
+    public static function toString(string|bool|DateTime $value): string
     {
-        if ($value instanceof \DateTime) { // datetime in ISO8601 format
+        if ($value instanceof DateTime) { // datetime in ISO8601 format
             return $value->format(self::$dateTimeFormat);
         } elseif (is_bool($value)) {
             return $value ? 'true' : 'false';
@@ -359,33 +353,21 @@ class ObjectSerializer
             // need to fix the result of multidimensional arrays.
             return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($style) {
-            case 'pipeDelimited':
-            case 'pipes':
-                return implode('|', $collection);
-
-            case 'tsv':
-                return implode("\t", $collection);
-
-            case 'spaceDelimited':
-            case 'ssv':
-                return implode(' ', $collection);
-
-            case 'simple':
-            case 'csv':
-                // Deliberate fall through. CSV is default format.
-            default:
-                return implode(',', $collection);
-        }
+        return match ($style) {
+            'pipeDelimited', 'pipes' => implode('|', $collection),
+            'tsv' => implode("\t", $collection),
+            'spaceDelimited', 'ssv' => implode(' ', $collection),
+            default => implode(',', $collection),
+        };
     }
 
     /**
      * Deserialize a JSON string into an object
      *
-     * @param mixed    $data          object or primitive to be deserialized
-     * @param string   $class         class name is passed as a string
-     * @param string[] $httpHeaders   HTTP headers
-     * @param string   $discriminator discriminator if polymorphism is used
+     * @param mixed         $data          object or primitive to be deserialized
+     * @param string        $class         class name is passed as a string
+     * @param string[]|null $httpHeaders   HTTP headers
+     * @param string|null   $discriminator discriminator if polymorphism is used
      *
      * @return object|array|null a single or an array of $class instances
      */
@@ -433,7 +415,7 @@ class ObjectSerializer
             return $data;
         }
 
-        if ($class === '\DateTime') {
+        if ($class === 'DateTime') {
             // Some APIs return an invalid, empty string as a
             // date-time property. DateTime::__construct() will return
             // the current time for empty input which is probably not
@@ -442,12 +424,12 @@ class ObjectSerializer
             // this graceful.
             if (!empty($data)) {
                 try {
-                    return new \DateTime($data);
+                    return new DateTime($data);
                 } catch (\Exception $exception) {
                     // Some APIs return a date-time with too high nanosecond
                     // precision for php's DateTime to handle.
                     // With provided regexp 6 digits of microseconds saved
-                    return new \DateTime(self::sanitizeTimestamp($data));
+                    return new DateTime(self::sanitizeTimestamp($data));
                 }
             } else {
                 return null;
@@ -547,10 +529,10 @@ class ObjectSerializer
      * @return string
      */
     public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
+        array|object $data,
+        string       $numeric_prefix = '',
+        ?string      $arg_separator = null,
+        int          $encoding_type = \PHP_QUERY_RFC3986
     ): string {
         return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -43,22 +43,22 @@ use {{invokerPackage}}\ObjectSerializer;
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [{{#operation}}
@@ -69,7 +69,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/consumes}}        ],{{/operation}}
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -79,7 +79,7 @@ use {{invokerPackage}}\ObjectSerializer;
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -92,7 +92,7 @@ use {{invokerPackage}}\ObjectSerializer;
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -102,7 +102,7 @@ use {{invokerPackage}}\ObjectSerializer;
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -110,7 +110,7 @@ use {{invokerPackage}}\ObjectSerializer;
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -70,10 +70,10 @@ use {{invokerPackage}}\ObjectSerializer;
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -152,7 +152,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{.}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
+     * @param  {{{dataType}}}{{^required}}|null{{/required}} ${{paramName}}{{#description}} {{.}}{{/description}}{{^description}} {{paramName}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
 {{#servers}}
 {{#-first}}
@@ -169,7 +169,23 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}(
+    {{^vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+    {{/allParams}}
+    {{#servers}}
+    {{#-first}}
+        ?int $hostIndex = null,
+        array $variables = [],
+    {{/-first}}
+    {{/servers}}
+        string $contentType = self::contentTypes['{{{operationId}}}'][0]
+    {{/vendorExtensions.x-group-parameters}}
+    {{#vendorExtensions.x-group-parameters}}
+        array $associative_array
+    {{/vendorExtensions.x-group-parameters}}
+    ): {{vendorExtensions.x-php-return-type}}
     {
         {{#returnType}}list($response) = {{/returnType}}$this->{{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});{{#returnType}}
         return $response;{{/returnType}}
@@ -211,7 +227,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
+     * @param  {{{dataType}}}{{^required}}|null{{/required}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
 {{#servers}}
 {{#-first}}
@@ -228,7 +244,23 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}WithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}WithHttpInfo(
+    {{^vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+    {{/allParams}}
+    {{#servers}}
+    {{#-first}}
+        ?int $hostIndex = null,
+        array $variables = [],
+    {{/-first}}
+    {{/servers}}
+        string $contentType = self::contentTypes['{{{operationId}}}'][0]
+    {{/vendorExtensions.x-group-parameters}}
+    {{#vendorExtensions.x-group-parameters}}
+        array $associative_array
+    {{/vendorExtensions.x-group-parameters}}
+    ): array
     {
         $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
 
@@ -370,7 +402,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
+     * @param  {{{dataType}}}{{^required}}|null{{/required}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
 {{#servers}}
 {{#-first}}
@@ -386,7 +418,23 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}Async({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}Async(
+    {{^vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+        {{^required}}?{{/required}}{{vendorExtensions.x-php-param-type}} ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+    {{/allParams}}
+    {{#servers}}
+    {{#-first}}
+        ?int $hostIndex = null,
+        array $variables = [],
+    {{/-first}}
+    {{/servers}}
+        string $contentType = self::contentTypes['{{{operationId}}}'][0]
+    {{/vendorExtensions.x-group-parameters}}
+    {{#vendorExtensions.x-group-parameters}}
+        array $associative_array
+    {{/vendorExtensions.x-group-parameters}}
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->{{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
             ->then(
@@ -432,7 +480,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
+     * @param  {{{dataType}}}{{^required}}|null{{/required}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
 {{#servers}}
 {{#-first}}
@@ -448,7 +496,23 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}AsyncWithHttpInfo(
+    {{^vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+        ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+    {{/allParams}}
+    {{#servers}}
+    {{#-first}}
+        ?int $hostIndex = null,
+        array $variables = [],
+    {{/-first}}
+    {{/servers}}
+        string $contentType = self::contentTypes['{{{operationId}}}'][0]
+    {{/vendorExtensions.x-group-parameters}}
+    {{#vendorExtensions.x-group-parameters}}
+        array $associative_array
+    {{/vendorExtensions.x-group-parameters}}
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '{{{returnType}}}';
         $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
@@ -522,7 +586,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/-last}}
 {{/servers}}
 {{#allParams}}
-     * @param  {{{dataType}}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
+     * @param  {{{dataType}}}{{^required}}|null{{/required}} ${{paramName}}{{#description}} {{.}}{{/description}} {{#required}}(required){{/required}}{{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}{{#isDeprecated}} (deprecated){{/isDeprecated}}
 {{/allParams}}
 {{#servers}}
 {{#-first}}
@@ -538,7 +602,23 @@ use {{invokerPackage}}\ObjectSerializer;
      * @deprecated
     {{/isDeprecated}}
      */
-    public function {{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}}, {{/allParams}}{{#servers}}{{#-first}}?int $hostIndex = null, array $variables = [], {{/-first}}{{/servers}}string $contentType = self::contentTypes['{{{operationId}}}'][0]{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
+    public function {{operationId}}Request(
+    {{^vendorExtensions.x-group-parameters}}
+    {{#allParams}}
+        ${{paramName}}{{^required}} = {{#defaultValue}}{{{.}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}}{{/required}},
+    {{/allParams}}
+    {{#servers}}
+    {{#-first}}
+        ?int $hostIndex = null,
+        array $variables = [],
+    {{/-first}}
+    {{/servers}}
+        string $contentType = self::contentTypes['{{{operationId}}}'][0]
+    {{/vendorExtensions.x-group-parameters}}
+    {{#vendorExtensions.x-group-parameters}}
+        array $associative_array
+    {{/vendorExtensions.x-group-parameters}}
+    ): Request
     {
         {{#vendorExtensions.x-group-parameters}}
         // unbox the parameters from the associative array
@@ -819,7 +899,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -18,6 +18,7 @@
 
 namespace {{apiPackage}};
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -25,6 +26,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use {{invokerPackage}}\ApiException;
 use {{invokerPackage}}\Configuration;
 use {{invokerPackage}}\HeaderSelector;
@@ -73,7 +75,7 @@ use {{invokerPackage}}\ObjectSerializer;
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -162,8 +164,8 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/servers}}
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
-     * @throws \{{invokerPackage}}\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return {{#returnType}}{{#responses}}{{#dataType}}{{^-first}}|{{/-first}}{{/dataType}}{{{dataType}}}{{/responses}}{{/returnType}}{{^returnType}}void{{/returnType}}
     {{#isDeprecated}}
      * @deprecated
@@ -237,8 +239,8 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/servers}}
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
-     * @throws \{{invokerPackage}}\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of {{#returnType}}{{#responses}}{{#dataType}}{{^-first}}|{{/-first}}{{/dataType}}{{{dataType}}}{{/responses}}{{/returnType}}{{^returnType}}null{{/returnType}}, HTTP status code, HTTP response headers (array of strings)
     {{#isDeprecated}}
      * @deprecated
@@ -412,8 +414,8 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/servers}}
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
     {{#isDeprecated}}
      * @deprecated
     {{/isDeprecated}}
@@ -434,7 +436,7 @@ use {{invokerPackage}}\ObjectSerializer;
     {{#vendorExtensions.x-group-parameters}}
         array $associative_array
     {{/vendorExtensions.x-group-parameters}}
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->{{operationId}}AsyncWithHttpInfo({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}})
             ->then(
@@ -490,8 +492,8 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/servers}}
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
     {{#isDeprecated}}
      * @deprecated
     {{/isDeprecated}}
@@ -512,7 +514,7 @@ use {{invokerPackage}}\ObjectSerializer;
     {{#vendorExtensions.x-group-parameters}}
         array $associative_array
     {{/vendorExtensions.x-group-parameters}}
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '{{{returnType}}}';
         $request = $this->{{operationId}}Request({{^vendorExtensions.x-group-parameters}}{{#allParams}}${{paramName}}, {{/allParams}}{{#servers}}{{#-first}}$hostIndex, $variables, {{/-first}}{{/servers}}$contentType{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}$associative_array{{/vendorExtensions.x-group-parameters}});
@@ -596,7 +598,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {{/servers}}
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['{{{operationId}}}'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
     {{#isDeprecated}}
      * @deprecated
@@ -633,7 +635,7 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#required}}
         // verify the required parameter '{{paramName}}' is set
         if (${{paramName}} === null || (is_array(${{paramName}}) && count(${{paramName}}) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter ${{paramName}} when calling {{operationId}}'
             );
         }
@@ -641,37 +643,37 @@ use {{invokerPackage}}\ObjectSerializer;
         {{#hasValidation}}
         {{#maxLength}}
         if ({{^required}}${{paramName}} !== null && {{/required}}strlen(${{paramName}}) > {{maxLength}}) {
-            throw new \InvalidArgumentException('invalid length for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
+            throw new InvalidArgumentException('invalid length for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
         }
         {{/maxLength}}
         {{#minLength}}
         if ({{^required}}${{paramName}} !== null && {{/required}}strlen(${{paramName}}) < {{minLength}}) {
-            throw new \InvalidArgumentException('invalid length for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
+            throw new InvalidArgumentException('invalid length for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
         {{#maximum}}
         if ({{^required}}${{paramName}} !== null && {{/required}}${{paramName}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}}) {
-            throw new \InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
+            throw new InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
         }
         {{/maximum}}
         {{#minimum}}
         if ({{^required}}${{paramName}} !== null && {{/required}}${{paramName}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}}) {
-            throw new \InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
+            throw new InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
         }
         {{/minimum}}
         {{#pattern}}
         if ({{^required}}${{paramName}} !== null && {{/required}}!preg_match("{{{pattern}}}", ${{paramName}})) {
-            throw new \InvalidArgumentException("invalid value for \"{{paramName}}\" when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
+            throw new InvalidArgumentException("invalid value for \"{{paramName}}\" when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
         }
         {{/pattern}}
         {{#maxItems}}
         if ({{^required}}${{paramName}} !== null && {{/required}}count(${{paramName}}) > {{maxItems}}) {
-            throw new \InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
+            throw new InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
         }
         {{/maxItems}}
         {{#minItems}}
         if ({{^required}}${{paramName}} !== null && {{/required}}count(${{paramName}}) < {{minItems}}) {
-            throw new \InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
+            throw new InvalidArgumentException('invalid value for "${{paramName}}" when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
         }
         {{/minItems}}
         {{/hasValidation}}{{/allParams}}
@@ -836,7 +838,7 @@ use {{invokerPackage}}\ObjectSerializer;
         $hostSettings = $this->getHostSettingsFor{{operationId}}();
 
         if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new \InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
         }
         $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         {{/servers.0}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
@@ -18,9 +18,9 @@
 
 namespace {{invokerPackage}}\Test\Api;
 
-use \{{invokerPackage}}\Configuration;
-use \{{invokerPackage}}\ApiException;
-use \{{invokerPackage}}\ObjectSerializer;
+use {{invokerPackage}}\Configuration;
+use {{invokerPackage}}\ApiException;
+use {{invokerPackage}}\ObjectSerializer;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model.mustache
@@ -23,10 +23,13 @@ namespace {{modelPackage}};
 {{^isEnum}}
 {{^parentSchema}}
 
-use \ArrayAccess;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use {{invokerPackage}}\ObjectSerializer;
 {{/parentSchema}}
 {{/isEnum}}
-use \{{invokerPackage}}\ObjectSerializer;
 
 /**
  * {{classname}} Class Doc Comment
@@ -39,7 +42,7 @@ use \{{invokerPackage}}\ObjectSerializer;
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
 {{^isEnum}}
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
 {{/isEnum}}
  */
 {{#isEnum}}{{>model_enum}}{{/isEnum}}{{^isEnum}}{{>model_generic}}{{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -7,14 +7,14 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
       *
       * @var string
       */
-    protected static $openAPIModelName = '{{name}}';
+    protected static string $openAPIModelName = '{{name}}';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         {{#vars}}'{{name}}' => '{{{dataType}}}'{{^-last}},
         {{/-last}}{{/vars}}
     ];
@@ -22,11 +22,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         {{#vars}}'{{name}}' => {{#dataFormat}}'{{{.}}}'{{/dataFormat}}{{^dataFormat}}null{{/dataFormat}}{{^-last}},
         {{/-last}}{{/vars}}
     ];
@@ -34,7 +32,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         {{#vars}}'{{name}}' => {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{^-last}},
@@ -44,16 +42,16 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes{{#parentSchema}} + parent::openAPITypes(){{/parentSchema}};
     }
@@ -61,9 +59,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats{{#parentSchema}} + parent::openAPIFormats(){{/parentSchema}};
     }
@@ -71,7 +69,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -81,7 +79,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -91,7 +89,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -124,9 +122,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         {{#vars}}'{{name}}' => '{{baseName}}'{{^-last}},
         {{/-last}}{{/vars}}
     ];
@@ -134,9 +132,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         {{#vars}}'{{name}}' => '{{setter}}'{{^-last}},
         {{/-last}}{{/vars}}
     ];
@@ -144,9 +142,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         {{#vars}}'{{name}}' => '{{getter}}'{{^-last}},
         {{/-last}}{{/vars}}
     ];
@@ -155,9 +153,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return {{#parentSchema}}parent::attributeMap() + {{/parentSchema}}self::$attributeMap;
     }
@@ -165,9 +163,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return {{#parentSchema}}parent::setters() + {{/parentSchema}}self::$setters;
     }
@@ -175,9 +173,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return {{#parentSchema}}parent::getters() + {{/parentSchema}}self::$getters;
     }
@@ -187,7 +185,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -223,9 +221,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
     {{/parentSchema}}
 
     /**
@@ -259,7 +257,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -271,9 +269,9 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         {{#parentSchema}}
         $invalidProperties = parent::listInvalidProperties();
@@ -355,7 +353,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -370,7 +368,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @deprecated
     {{/deprecated}}
      */
-    public function {{getter}}()
+    public function {{getter}}(): {{^required}}?{{/required}}{{vendorExtensions.x-php-prop-type}}
     {
         return $this->container['{{name}}'];
     }
@@ -380,12 +378,12 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @param {{{dataType}}}{{^required}}|null{{/required}} ${{name}}{{#description}} {{{.}}}{{/description}}{{^description}} {{{name}}}{{/description}}
      *
-     * @return self
+     * @return $this
     {{#deprecated}}
      * @deprecated
     {{/deprecated}}
      */
-    public function {{setter}}(${{name}})
+    public function {{setter}}({{^required}}?{{/required}}{{vendorExtensions.x-php-prop-type}} ${{name}}): static
     {
         {{#isNullable}}
         if (is_null(${{name}})) {
@@ -475,7 +473,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -488,7 +486,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -501,7 +499,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -517,7 +515,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -530,7 +528,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -540,7 +538,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -553,7 +551,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -1,4 +1,4 @@
-class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^parentSchema}}implements ModelInterface, ArrayAccess, \JsonSerializable{{/parentSchema}}
+class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^parentSchema}}implements ModelInterface, ArrayAccess, JsonSerializable{{/parentSchema}}
 {
     public const DISCRIMINATOR = {{#discriminator}}'{{discriminatorName}}'{{/discriminator}}{{^discriminator}}null{{/discriminator}};
 
@@ -229,8 +229,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -399,14 +398,14 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isNullable}}
         {{^isNullable}}
         if (is_null(${{name}})) {
-            throw new \InvalidArgumentException('non-nullable {{name}} cannot be null');
+            throw new InvalidArgumentException('non-nullable {{name}} cannot be null');
         }
         {{/isNullable}}
         {{#isEnum}}
         $allowedValues = $this->{{getter}}AllowableValues();
         {{^isContainer}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}!in_array(${{{name}}}, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for '{{name}}', must be one of '%s'",
                     ${{{name}}},
@@ -417,7 +416,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{/isContainer}}
         {{#isContainer}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}array_diff(${{{name}}}, $allowedValues)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value for '{{name}}', must be one of '%s'",
                     implode("', '", $allowedValues)
@@ -429,35 +428,35 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
         {{#hasValidation}}
         {{#maxLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) > {{maxLength}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
+            throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than or equal to {{maxLength}}.');
         }{{/maxLength}}
         {{#minLength}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(mb_strlen(${{name}}) < {{minLength}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
+            throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than or equal to {{minLength}}.');
         }
         {{/minLength}}
         {{#maximum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} >{{#exclusiveMaximum}}={{/exclusiveMaximum}} {{maximum}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
+            throw new InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be smaller than {{^exclusiveMaximum}}or equal to {{/exclusiveMaximum}}{{maximum}}.');
         }
         {{/maximum}}
         {{#minimum}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(${{name}} <{{#exclusiveMinimum}}={{/exclusiveMinimum}} {{minimum}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
+            throw new InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, must be bigger than {{^exclusiveMinimum}}or equal to {{/exclusiveMinimum}}{{minimum}}.');
         }
         {{/minimum}}
         {{#pattern}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(!preg_match("{{{pattern}}}", ${{name}}))) {
-            throw new \InvalidArgumentException("invalid value for \${{name}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
+            throw new InvalidArgumentException("invalid value for \${{name}} when calling {{classname}}.{{operationId}}, must conform to the pattern {{{pattern}}}.");
         }
         {{/pattern}}
         {{#maxItems}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(count(${{name}}) > {{maxItems}})) {
-            throw new \InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
+            throw new InvalidArgumentException('invalid value for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be less than or equal to {{maxItems}}.');
         }{{/maxItems}}
         {{#minItems}}
         if ({{#isNullable}}!is_null(${{name}}) && {{/isNullable}}(count(${{name}}) < {{minItems}})) {
-            throw new \InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
+            throw new InvalidArgumentException('invalid length for ${{name}} when calling {{classname}}.{{operationId}}, number of items must be greater than or equal to {{minItems}}.');
         }
         {{/minItems}}
         {{/hasValidation}}
@@ -485,7 +484,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -527,7 +526,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -80,7 +82,7 @@ class AnotherFakeApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -130,8 +132,8 @@ class AnotherFakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
     public function call123TestSpecialTags(
@@ -151,8 +153,8 @@ class AnotherFakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
     public function call123TestSpecialTagsWithHttpInfo(
@@ -254,13 +256,13 @@ class AnotherFakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function call123TestSpecialTagsAsync(
         \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['call123TestSpecialTags'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->call123TestSpecialTagsAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -278,13 +280,13 @@ class AnotherFakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function call123TestSpecialTagsAsyncWithHttpInfo(
         $client,
         string $contentType = self::contentTypes['call123TestSpecialTags'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->call123TestSpecialTagsRequest($client, $contentType);
@@ -331,7 +333,7 @@ class AnotherFakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['call123TestSpecialTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function call123TestSpecialTagsRequest(
@@ -342,7 +344,7 @@ class AnotherFakeApi
 
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling call123TestSpecialTags'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -77,10 +77,10 @@ class AnotherFakeApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -134,7 +134,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function call123TestSpecialTags($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
+    public function call123TestSpecialTags(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['call123TestSpecialTags'][0]
+    ): \OpenAPI\Client\Model\Client
     {
         list($response) = $this->call123TestSpecialTagsWithHttpInfo($client, $contentType);
         return $response;
@@ -152,7 +155,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function call123TestSpecialTagsWithHttpInfo($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
+    public function call123TestSpecialTagsWithHttpInfo(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['call123TestSpecialTags'][0]
+    ): array
     {
         $request = $this->call123TestSpecialTagsRequest($client, $contentType);
 
@@ -251,7 +257,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function call123TestSpecialTagsAsync($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
+    public function call123TestSpecialTagsAsync(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['call123TestSpecialTags'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->call123TestSpecialTagsAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -272,7 +281,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function call123TestSpecialTagsAsyncWithHttpInfo($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
+    public function call123TestSpecialTagsAsyncWithHttpInfo(
+        $client,
+        string $contentType = self::contentTypes['call123TestSpecialTags'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->call123TestSpecialTagsRequest($client, $contentType);
@@ -322,7 +334,10 @@ class AnotherFakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function call123TestSpecialTagsRequest($client, string $contentType = self::contentTypes['call123TestSpecialTags'][0])
+    public function call123TestSpecialTagsRequest(
+        $client,
+        string $contentType = self::contentTypes['call123TestSpecialTags'][0]
+    ): Request
     {
 
         // verify the required parameter 'client' is set
@@ -410,7 +425,7 @@ class AnotherFakeApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -52,22 +52,22 @@ class AnotherFakeApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -76,7 +76,7 @@ class AnotherFakeApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -86,7 +86,7 @@ class AnotherFakeApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -99,7 +99,7 @@ class AnotherFakeApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -109,7 +109,7 @@ class AnotherFakeApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -117,7 +117,7 @@ class AnotherFakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -80,7 +82,7 @@ class DefaultApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -127,8 +129,8 @@ class DefaultApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\FooGetDefaultResponse
      */
     public function fooGet(
@@ -144,8 +146,8 @@ class DefaultApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\FooGetDefaultResponse, HTTP status code, HTTP response headers (array of strings)
      */
     public function fooGetWithHttpInfo(
@@ -243,12 +245,12 @@ class DefaultApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fooGetAsync(
         string $contentType = self::contentTypes['fooGet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fooGetAsyncWithHttpInfo($contentType)
             ->then(
@@ -263,12 +265,12 @@ class DefaultApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fooGetAsyncWithHttpInfo(
         string $contentType = self::contentTypes['fooGet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\FooGetDefaultResponse';
         $request = $this->fooGetRequest($contentType);
@@ -314,7 +316,7 @@ class DefaultApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fooGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fooGetRequest(

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -77,10 +77,10 @@ class DefaultApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -131,7 +131,9 @@ class DefaultApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\FooGetDefaultResponse
      */
-    public function fooGet(string $contentType = self::contentTypes['fooGet'][0])
+    public function fooGet(
+        string $contentType = self::contentTypes['fooGet'][0]
+    ): \OpenAPI\Client\Model\FooGetDefaultResponse
     {
         list($response) = $this->fooGetWithHttpInfo($contentType);
         return $response;
@@ -146,7 +148,9 @@ class DefaultApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\FooGetDefaultResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fooGetWithHttpInfo(string $contentType = self::contentTypes['fooGet'][0])
+    public function fooGetWithHttpInfo(
+        string $contentType = self::contentTypes['fooGet'][0]
+    ): array
     {
         $request = $this->fooGetRequest($contentType);
 
@@ -242,7 +246,9 @@ class DefaultApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fooGetAsync(string $contentType = self::contentTypes['fooGet'][0])
+    public function fooGetAsync(
+        string $contentType = self::contentTypes['fooGet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fooGetAsyncWithHttpInfo($contentType)
             ->then(
@@ -260,7 +266,9 @@ class DefaultApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fooGetAsyncWithHttpInfo(string $contentType = self::contentTypes['fooGet'][0])
+    public function fooGetAsyncWithHttpInfo(
+        string $contentType = self::contentTypes['fooGet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\FooGetDefaultResponse';
         $request = $this->fooGetRequest($contentType);
@@ -309,7 +317,9 @@ class DefaultApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fooGetRequest(string $contentType = self::contentTypes['fooGet'][0])
+    public function fooGetRequest(
+        string $contentType = self::contentTypes['fooGet'][0]
+    ): Request
     {
 
 
@@ -383,7 +393,7 @@ class DefaultApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -52,22 +52,22 @@ class DefaultApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -76,7 +76,7 @@ class DefaultApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -86,7 +86,7 @@ class DefaultApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -99,7 +99,7 @@ class DefaultApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -109,7 +109,7 @@ class DefaultApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -117,7 +117,7 @@ class DefaultApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -129,10 +129,10 @@ class FakeApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -183,7 +183,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\FakeBigDecimalMap200Response
      */
-    public function fakeBigDecimalMap(string $contentType = self::contentTypes['fakeBigDecimalMap'][0])
+    public function fakeBigDecimalMap(
+        string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
+    ): \OpenAPI\Client\Model\FakeBigDecimalMap200Response
     {
         list($response) = $this->fakeBigDecimalMapWithHttpInfo($contentType);
         return $response;
@@ -198,7 +200,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\FakeBigDecimalMap200Response, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeBigDecimalMapWithHttpInfo(string $contentType = self::contentTypes['fakeBigDecimalMap'][0])
+    public function fakeBigDecimalMapWithHttpInfo(
+        string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
+    ): array
     {
         $request = $this->fakeBigDecimalMapRequest($contentType);
 
@@ -294,7 +298,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeBigDecimalMapAsync(string $contentType = self::contentTypes['fakeBigDecimalMap'][0])
+    public function fakeBigDecimalMapAsync(
+        string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeBigDecimalMapAsyncWithHttpInfo($contentType)
             ->then(
@@ -312,7 +318,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeBigDecimalMapAsyncWithHttpInfo(string $contentType = self::contentTypes['fakeBigDecimalMap'][0])
+    public function fakeBigDecimalMapAsyncWithHttpInfo(
+        string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\FakeBigDecimalMap200Response';
         $request = $this->fakeBigDecimalMapRequest($contentType);
@@ -361,7 +369,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeBigDecimalMapRequest(string $contentType = self::contentTypes['fakeBigDecimalMap'][0])
+    public function fakeBigDecimalMapRequest(
+        string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
+    ): Request
     {
 
 
@@ -440,7 +450,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\HealthCheckResult
      */
-    public function fakeHealthGet(string $contentType = self::contentTypes['fakeHealthGet'][0])
+    public function fakeHealthGet(
+        string $contentType = self::contentTypes['fakeHealthGet'][0]
+    ): \OpenAPI\Client\Model\HealthCheckResult
     {
         list($response) = $this->fakeHealthGetWithHttpInfo($contentType);
         return $response;
@@ -457,7 +469,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\HealthCheckResult, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeHealthGetWithHttpInfo(string $contentType = self::contentTypes['fakeHealthGet'][0])
+    public function fakeHealthGetWithHttpInfo(
+        string $contentType = self::contentTypes['fakeHealthGet'][0]
+    ): array
     {
         $request = $this->fakeHealthGetRequest($contentType);
 
@@ -555,7 +569,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHealthGetAsync(string $contentType = self::contentTypes['fakeHealthGet'][0])
+    public function fakeHealthGetAsync(
+        string $contentType = self::contentTypes['fakeHealthGet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeHealthGetAsyncWithHttpInfo($contentType)
             ->then(
@@ -575,7 +591,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHealthGetAsyncWithHttpInfo(string $contentType = self::contentTypes['fakeHealthGet'][0])
+    public function fakeHealthGetAsyncWithHttpInfo(
+        string $contentType = self::contentTypes['fakeHealthGet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\HealthCheckResult';
         $request = $this->fakeHealthGetRequest($contentType);
@@ -624,7 +642,9 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeHealthGetRequest(string $contentType = self::contentTypes['fakeHealthGet'][0])
+    public function fakeHealthGetRequest(
+        string $contentType = self::contentTypes['fakeHealthGet'][0]
+    ): Request
     {
 
 
@@ -698,15 +718,20 @@ class FakeApi
      * test http signature authentication
      *
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
-     * @param  string $query_1 query parameter (optional)
-     * @param  string $header_1 header parameter (optional)
+     * @param  string|null $query_1 query parameter (optional)
+     * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function fakeHttpSignatureTest($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
+    public function fakeHttpSignatureTest(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?string $query_1 = null,
+        ?string $header_1 = null,
+        string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
+    ): void
     {
         $this->fakeHttpSignatureTestWithHttpInfo($pet, $query_1, $header_1, $contentType);
     }
@@ -717,15 +742,20 @@ class FakeApi
      * test http signature authentication
      *
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
-     * @param  string $query_1 query parameter (optional)
-     * @param  string $header_1 header parameter (optional)
+     * @param  string|null $query_1 query parameter (optional)
+     * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeHttpSignatureTestWithHttpInfo($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
+    public function fakeHttpSignatureTestWithHttpInfo(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?string $query_1 = null,
+        ?string $header_1 = null,
+        string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
+    ): array
     {
         $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1, $contentType);
 
@@ -779,14 +809,19 @@ class FakeApi
      * test http signature authentication
      *
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
-     * @param  string $query_1 query parameter (optional)
-     * @param  string $header_1 header parameter (optional)
+     * @param  string|null $query_1 query parameter (optional)
+     * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHttpSignatureTestAsync($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
+    public function fakeHttpSignatureTestAsync(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?string $query_1 = null,
+        ?string $header_1 = null,
+        string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1, $header_1, $contentType)
             ->then(
@@ -802,14 +837,19 @@ class FakeApi
      * test http signature authentication
      *
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
-     * @param  string $query_1 query parameter (optional)
-     * @param  string $header_1 header parameter (optional)
+     * @param  string|null $query_1 query parameter (optional)
+     * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
+    public function fakeHttpSignatureTestAsyncWithHttpInfo(
+        $pet,
+        $query_1 = null,
+        $header_1 = null,
+        string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1, $contentType);
@@ -841,14 +881,19 @@ class FakeApi
      * Create request for operation 'fakeHttpSignatureTest'
      *
      * @param  \OpenAPI\Client\Model\Pet $pet Pet object that needs to be added to the store (required)
-     * @param  string $query_1 query parameter (optional)
-     * @param  string $header_1 header parameter (optional)
+     * @param  string|null $query_1 query parameter (optional)
+     * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeHttpSignatureTestRequest($pet, $query_1 = null, $header_1 = null, string $contentType = self::contentTypes['fakeHttpSignatureTest'][0])
+    public function fakeHttpSignatureTestRequest(
+        $pet,
+        $query_1 = null,
+        $header_1 = null,
+        string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet' is set
@@ -948,14 +993,17 @@ class FakeApi
     /**
      * Operation fakeOuterBooleanSerialize
      *
-     * @param  bool $body Input boolean as post body (optional)
+     * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return bool
      */
-    public function fakeOuterBooleanSerialize($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
+    public function fakeOuterBooleanSerialize(
+        ?bool $body = null,
+        string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
+    ): bool
     {
         list($response) = $this->fakeOuterBooleanSerializeWithHttpInfo($body, $contentType);
         return $response;
@@ -964,14 +1012,17 @@ class FakeApi
     /**
      * Operation fakeOuterBooleanSerializeWithHttpInfo
      *
-     * @param  bool $body Input boolean as post body (optional)
+     * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of bool, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterBooleanSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
+    public function fakeOuterBooleanSerializeWithHttpInfo(
+        ?bool $body = null,
+        string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
+    ): array
     {
         $request = $this->fakeOuterBooleanSerializeRequest($body, $contentType);
 
@@ -1062,13 +1113,16 @@ class FakeApi
     /**
      * Operation fakeOuterBooleanSerializeAsync
      *
-     * @param  bool $body Input boolean as post body (optional)
+     * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterBooleanSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
+    public function fakeOuterBooleanSerializeAsync(
+        ?bool $body = null,
+        string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeOuterBooleanSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1081,13 +1135,16 @@ class FakeApi
     /**
      * Operation fakeOuterBooleanSerializeAsyncWithHttpInfo
      *
-     * @param  bool $body Input boolean as post body (optional)
+     * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterBooleanSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
+    public function fakeOuterBooleanSerializeAsyncWithHttpInfo(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = 'bool';
         $request = $this->fakeOuterBooleanSerializeRequest($body, $contentType);
@@ -1131,13 +1188,16 @@ class FakeApi
     /**
      * Create request for operation 'fakeOuterBooleanSerialize'
      *
-     * @param  bool $body Input boolean as post body (optional)
+     * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterBooleanSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0])
+    public function fakeOuterBooleanSerializeRequest(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
+    ): Request
     {
 
 
@@ -1216,14 +1276,17 @@ class FakeApi
     /**
      * Operation fakeOuterCompositeSerialize
      *
-     * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterComposite
      */
-    public function fakeOuterCompositeSerialize($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
+    public function fakeOuterCompositeSerialize(
+        ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
+        string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
+    ): \OpenAPI\Client\Model\OuterComposite
     {
         list($response) = $this->fakeOuterCompositeSerializeWithHttpInfo($outer_composite, $contentType);
         return $response;
@@ -1232,14 +1295,17 @@ class FakeApi
     /**
      * Operation fakeOuterCompositeSerializeWithHttpInfo
      *
-     * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterComposite, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterCompositeSerializeWithHttpInfo($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
+    public function fakeOuterCompositeSerializeWithHttpInfo(
+        ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
+        string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
+    ): array
     {
         $request = $this->fakeOuterCompositeSerializeRequest($outer_composite, $contentType);
 
@@ -1330,13 +1396,16 @@ class FakeApi
     /**
      * Operation fakeOuterCompositeSerializeAsync
      *
-     * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterCompositeSerializeAsync($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
+    public function fakeOuterCompositeSerializeAsync(
+        ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
+        string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite, $contentType)
             ->then(
@@ -1349,13 +1418,16 @@ class FakeApi
     /**
      * Operation fakeOuterCompositeSerializeAsyncWithHttpInfo
      *
-     * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
+    public function fakeOuterCompositeSerializeAsyncWithHttpInfo(
+        $outer_composite = null,
+        string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\OuterComposite';
         $request = $this->fakeOuterCompositeSerializeRequest($outer_composite, $contentType);
@@ -1399,13 +1471,16 @@ class FakeApi
     /**
      * Create request for operation 'fakeOuterCompositeSerialize'
      *
-     * @param  \OpenAPI\Client\Model\OuterComposite $outer_composite Input composite as post body (optional)
+     * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterCompositeSerializeRequest($outer_composite = null, string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0])
+    public function fakeOuterCompositeSerializeRequest(
+        $outer_composite = null,
+        string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
+    ): Request
     {
 
 
@@ -1484,14 +1559,17 @@ class FakeApi
     /**
      * Operation fakeOuterNumberSerialize
      *
-     * @param  float $body Input number as post body (optional)
+     * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return float
      */
-    public function fakeOuterNumberSerialize($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
+    public function fakeOuterNumberSerialize(
+        ?float $body = null,
+        string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
+    ): float
     {
         list($response) = $this->fakeOuterNumberSerializeWithHttpInfo($body, $contentType);
         return $response;
@@ -1500,14 +1578,17 @@ class FakeApi
     /**
      * Operation fakeOuterNumberSerializeWithHttpInfo
      *
-     * @param  float $body Input number as post body (optional)
+     * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of float, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterNumberSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
+    public function fakeOuterNumberSerializeWithHttpInfo(
+        ?float $body = null,
+        string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
+    ): array
     {
         $request = $this->fakeOuterNumberSerializeRequest($body, $contentType);
 
@@ -1598,13 +1679,16 @@ class FakeApi
     /**
      * Operation fakeOuterNumberSerializeAsync
      *
-     * @param  float $body Input number as post body (optional)
+     * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterNumberSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
+    public function fakeOuterNumberSerializeAsync(
+        ?float $body = null,
+        string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeOuterNumberSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1617,13 +1701,16 @@ class FakeApi
     /**
      * Operation fakeOuterNumberSerializeAsyncWithHttpInfo
      *
-     * @param  float $body Input number as post body (optional)
+     * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterNumberSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
+    public function fakeOuterNumberSerializeAsyncWithHttpInfo(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = 'float';
         $request = $this->fakeOuterNumberSerializeRequest($body, $contentType);
@@ -1667,13 +1754,16 @@ class FakeApi
     /**
      * Create request for operation 'fakeOuterNumberSerialize'
      *
-     * @param  float $body Input number as post body (optional)
+     * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterNumberSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0])
+    public function fakeOuterNumberSerializeRequest(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
+    ): Request
     {
 
 
@@ -1752,14 +1842,17 @@ class FakeApi
     /**
      * Operation fakeOuterStringSerialize
      *
-     * @param  string $body Input string as post body (optional)
+     * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function fakeOuterStringSerialize($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
+    public function fakeOuterStringSerialize(
+        ?string $body = null,
+        string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
+    ): string
     {
         list($response) = $this->fakeOuterStringSerializeWithHttpInfo($body, $contentType);
         return $response;
@@ -1768,14 +1861,17 @@ class FakeApi
     /**
      * Operation fakeOuterStringSerializeWithHttpInfo
      *
-     * @param  string $body Input string as post body (optional)
+     * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakeOuterStringSerializeWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
+    public function fakeOuterStringSerializeWithHttpInfo(
+        ?string $body = null,
+        string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
+    ): array
     {
         $request = $this->fakeOuterStringSerializeRequest($body, $contentType);
 
@@ -1866,13 +1962,16 @@ class FakeApi
     /**
      * Operation fakeOuterStringSerializeAsync
      *
-     * @param  string $body Input string as post body (optional)
+     * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterStringSerializeAsync($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
+    public function fakeOuterStringSerializeAsync(
+        ?string $body = null,
+        string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakeOuterStringSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1885,13 +1984,16 @@ class FakeApi
     /**
      * Operation fakeOuterStringSerializeAsyncWithHttpInfo
      *
-     * @param  string $body Input string as post body (optional)
+     * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakeOuterStringSerializeAsyncWithHttpInfo($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
+    public function fakeOuterStringSerializeAsyncWithHttpInfo(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = 'string';
         $request = $this->fakeOuterStringSerializeRequest($body, $contentType);
@@ -1935,13 +2037,16 @@ class FakeApi
     /**
      * Create request for operation 'fakeOuterStringSerialize'
      *
-     * @param  string $body Input string as post body (optional)
+     * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakeOuterStringSerializeRequest($body = null, string $contentType = self::contentTypes['fakeOuterStringSerialize'][0])
+    public function fakeOuterStringSerializeRequest(
+        $body = null,
+        string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
+    ): Request
     {
 
 
@@ -2027,7 +2132,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterObjectWithEnumProperty
      */
-    public function fakePropertyEnumIntegerSerialize($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
+    public function fakePropertyEnumIntegerSerialize(
+        \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
+        string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
+    ): \OpenAPI\Client\Model\OuterObjectWithEnumProperty
     {
         list($response) = $this->fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property, $contentType);
         return $response;
@@ -2043,7 +2151,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterObjectWithEnumProperty, HTTP status code, HTTP response headers (array of strings)
      */
-    public function fakePropertyEnumIntegerSerializeWithHttpInfo($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
+    public function fakePropertyEnumIntegerSerializeWithHttpInfo(
+        \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
+        string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
+    ): array
     {
         $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, $contentType);
 
@@ -2140,7 +2251,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakePropertyEnumIntegerSerializeAsync($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
+    public function fakePropertyEnumIntegerSerializeAsync(
+        \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
+        string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property, $contentType)
             ->then(
@@ -2159,7 +2273,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
+    public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo(
+        $outer_object_with_enum_property,
+        string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\OuterObjectWithEnumProperty';
         $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, $contentType);
@@ -2209,7 +2326,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0])
+    public function fakePropertyEnumIntegerSerializeRequest(
+        $outer_object_with_enum_property,
+        string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
+    ): Request
     {
 
         // verify the required parameter 'outer_object_with_enum_property' is set
@@ -2301,7 +2421,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithBinary($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
+    public function testBodyWithBinary(
+        \SplFileObject $body,
+        string $contentType = self::contentTypes['testBodyWithBinary'][0]
+    ): void
     {
         $this->testBodyWithBinaryWithHttpInfo($body, $contentType);
     }
@@ -2316,7 +2439,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithBinaryWithHttpInfo($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
+    public function testBodyWithBinaryWithHttpInfo(
+        \SplFileObject $body,
+        string $contentType = self::contentTypes['testBodyWithBinary'][0]
+    ): array
     {
         $request = $this->testBodyWithBinaryRequest($body, $contentType);
 
@@ -2373,7 +2499,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithBinaryAsync($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
+    public function testBodyWithBinaryAsync(
+        \SplFileObject $body,
+        string $contentType = self::contentTypes['testBodyWithBinary'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testBodyWithBinaryAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -2392,7 +2521,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithBinaryAsyncWithHttpInfo($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
+    public function testBodyWithBinaryAsyncWithHttpInfo(
+        $body,
+        string $contentType = self::contentTypes['testBodyWithBinary'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithBinaryRequest($body, $contentType);
@@ -2429,7 +2561,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithBinaryRequest($body, string $contentType = self::contentTypes['testBodyWithBinary'][0])
+    public function testBodyWithBinaryRequest(
+        $body,
+        string $contentType = self::contentTypes['testBodyWithBinary'][0]
+    ): Request
     {
 
         // verify the required parameter 'body' is set
@@ -2521,7 +2656,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithFileSchema($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
+    public function testBodyWithFileSchema(
+        \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
+        string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
+    ): void
     {
         $this->testBodyWithFileSchemaWithHttpInfo($file_schema_test_class, $contentType);
     }
@@ -2536,7 +2674,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithFileSchemaWithHttpInfo($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
+    public function testBodyWithFileSchemaWithHttpInfo(
+        \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
+        string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
+    ): array
     {
         $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class, $contentType);
 
@@ -2593,7 +2734,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithFileSchemaAsync($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
+    public function testBodyWithFileSchemaAsync(
+        \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
+        string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class, $contentType)
             ->then(
@@ -2612,7 +2756,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
+    public function testBodyWithFileSchemaAsyncWithHttpInfo(
+        $file_schema_test_class,
+        string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class, $contentType);
@@ -2649,7 +2796,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithFileSchemaRequest($file_schema_test_class, string $contentType = self::contentTypes['testBodyWithFileSchema'][0])
+    public function testBodyWithFileSchemaRequest(
+        $file_schema_test_class,
+        string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
+    ): Request
     {
 
         // verify the required parameter 'file_schema_test_class' is set
@@ -2742,7 +2892,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testBodyWithQueryParams($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
+    public function testBodyWithQueryParams(
+        string $query,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
+    ): void
     {
         $this->testBodyWithQueryParamsWithHttpInfo($query, $user, $contentType);
     }
@@ -2758,7 +2912,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testBodyWithQueryParamsWithHttpInfo($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
+    public function testBodyWithQueryParamsWithHttpInfo(
+        string $query,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
+    ): array
     {
         $request = $this->testBodyWithQueryParamsRequest($query, $user, $contentType);
 
@@ -2816,7 +2974,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithQueryParamsAsync($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
+    public function testBodyWithQueryParamsAsync(
+        string $query,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testBodyWithQueryParamsAsyncWithHttpInfo($query, $user, $contentType)
             ->then(
@@ -2836,7 +2998,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testBodyWithQueryParamsAsyncWithHttpInfo($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
+    public function testBodyWithQueryParamsAsyncWithHttpInfo(
+        $query,
+        $user,
+        string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithQueryParamsRequest($query, $user, $contentType);
@@ -2874,7 +3040,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testBodyWithQueryParamsRequest($query, $user, string $contentType = self::contentTypes['testBodyWithQueryParams'][0])
+    public function testBodyWithQueryParamsRequest(
+        $query,
+        $user,
+        string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
+    ): Request
     {
 
         // verify the required parameter 'query' is set
@@ -2984,7 +3154,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function testClientModel($client, string $contentType = self::contentTypes['testClientModel'][0])
+    public function testClientModel(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClientModel'][0]
+    ): \OpenAPI\Client\Model\Client
     {
         list($response) = $this->testClientModelWithHttpInfo($client, $contentType);
         return $response;
@@ -3002,7 +3175,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testClientModelWithHttpInfo($client, string $contentType = self::contentTypes['testClientModel'][0])
+    public function testClientModelWithHttpInfo(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClientModel'][0]
+    ): array
     {
         $request = $this->testClientModelRequest($client, $contentType);
 
@@ -3101,7 +3277,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClientModelAsync($client, string $contentType = self::contentTypes['testClientModel'][0])
+    public function testClientModelAsync(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClientModel'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testClientModelAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -3122,7 +3301,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClientModelAsyncWithHttpInfo($client, string $contentType = self::contentTypes['testClientModel'][0])
+    public function testClientModelAsyncWithHttpInfo(
+        $client,
+        string $contentType = self::contentTypes['testClientModel'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->testClientModelRequest($client, $contentType);
@@ -3172,7 +3354,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testClientModelRequest($client, string $contentType = self::contentTypes['testClientModel'][0])
+    public function testClientModelRequest(
+        $client,
+        string $contentType = self::contentTypes['testClientModel'][0]
+    ): Request
     {
 
         // verify the required parameter 'client' is set
@@ -3263,23 +3448,39 @@ class FakeApi
      * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
-     * @param  int $integer None (optional)
-     * @param  int $int32 None (optional)
-     * @param  int $int64 None (optional)
-     * @param  float $float None (optional)
-     * @param  string $string None (optional)
-     * @param  \SplFileObject $binary None (optional)
-     * @param  \DateTime $date None (optional)
-     * @param  \DateTime $date_time None (optional)
-     * @param  string $password None (optional)
-     * @param  string $callback None (optional)
+     * @param  int|null $integer None (optional)
+     * @param  int|null $int32 None (optional)
+     * @param  int|null $int64 None (optional)
+     * @param  float|null $float None (optional)
+     * @param  string|null $string None (optional)
+     * @param  \SplFileObject|null $binary None (optional)
+     * @param  \DateTime|null $date None (optional)
+     * @param  \DateTime|null $date_time None (optional)
+     * @param  string|null $password None (optional)
+     * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testEndpointParameters($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
+    public function testEndpointParameters(
+        float $number,
+        float $double,
+        string $pattern_without_delimiter,
+        string $byte,
+        ?int $integer = null,
+        ?int $int32 = null,
+        ?int $int64 = null,
+        ?float $float = null,
+        ?string $string = null,
+        ?\SplFileObject $binary = null,
+        ?\DateTime $date = null,
+        ?\DateTime $date_time = null,
+        ?string $password = null,
+        ?string $callback = null,
+        string $contentType = self::contentTypes['testEndpointParameters'][0]
+    ): void
     {
         $this->testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
     }
@@ -3293,23 +3494,39 @@ class FakeApi
      * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
-     * @param  int $integer None (optional)
-     * @param  int $int32 None (optional)
-     * @param  int $int64 None (optional)
-     * @param  float $float None (optional)
-     * @param  string $string None (optional)
-     * @param  \SplFileObject $binary None (optional)
-     * @param  \DateTime $date None (optional)
-     * @param  \DateTime $date_time None (optional)
-     * @param  string $password None (optional)
-     * @param  string $callback None (optional)
+     * @param  int|null $integer None (optional)
+     * @param  int|null $int32 None (optional)
+     * @param  int|null $int64 None (optional)
+     * @param  float|null $float None (optional)
+     * @param  string|null $string None (optional)
+     * @param  \SplFileObject|null $binary None (optional)
+     * @param  \DateTime|null $date None (optional)
+     * @param  \DateTime|null $date_time None (optional)
+     * @param  string|null $password None (optional)
+     * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testEndpointParametersWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
+    public function testEndpointParametersWithHttpInfo(
+        float $number,
+        float $double,
+        string $pattern_without_delimiter,
+        string $byte,
+        ?int $integer = null,
+        ?int $int32 = null,
+        ?int $int64 = null,
+        ?float $float = null,
+        ?string $string = null,
+        ?\SplFileObject $binary = null,
+        ?\DateTime $date = null,
+        ?\DateTime $date_time = null,
+        ?string $password = null,
+        ?string $callback = null,
+        string $contentType = self::contentTypes['testEndpointParameters'][0]
+    ): array
     {
         $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
 
@@ -3366,22 +3583,38 @@ class FakeApi
      * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
-     * @param  int $integer None (optional)
-     * @param  int $int32 None (optional)
-     * @param  int $int64 None (optional)
-     * @param  float $float None (optional)
-     * @param  string $string None (optional)
-     * @param  \SplFileObject $binary None (optional)
-     * @param  \DateTime $date None (optional)
-     * @param  \DateTime $date_time None (optional)
-     * @param  string $password None (optional)
-     * @param  string $callback None (optional)
+     * @param  int|null $integer None (optional)
+     * @param  int|null $int32 None (optional)
+     * @param  int|null $int64 None (optional)
+     * @param  float|null $float None (optional)
+     * @param  string|null $string None (optional)
+     * @param  \SplFileObject|null $binary None (optional)
+     * @param  \DateTime|null $date None (optional)
+     * @param  \DateTime|null $date_time None (optional)
+     * @param  string|null $password None (optional)
+     * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEndpointParametersAsync($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
+    public function testEndpointParametersAsync(
+        float $number,
+        float $double,
+        string $pattern_without_delimiter,
+        string $byte,
+        ?int $integer = null,
+        ?int $int32 = null,
+        ?int $int64 = null,
+        ?float $float = null,
+        ?string $string = null,
+        ?\SplFileObject $binary = null,
+        ?\DateTime $date = null,
+        ?\DateTime $date_time = null,
+        ?string $password = null,
+        ?string $callback = null,
+        string $contentType = self::contentTypes['testEndpointParameters'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType)
             ->then(
@@ -3400,22 +3633,38 @@ class FakeApi
      * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
-     * @param  int $integer None (optional)
-     * @param  int $int32 None (optional)
-     * @param  int $int64 None (optional)
-     * @param  float $float None (optional)
-     * @param  string $string None (optional)
-     * @param  \SplFileObject $binary None (optional)
-     * @param  \DateTime $date None (optional)
-     * @param  \DateTime $date_time None (optional)
-     * @param  string $password None (optional)
-     * @param  string $callback None (optional)
+     * @param  int|null $integer None (optional)
+     * @param  int|null $int32 None (optional)
+     * @param  int|null $int64 None (optional)
+     * @param  float|null $float None (optional)
+     * @param  string|null $string None (optional)
+     * @param  \SplFileObject|null $binary None (optional)
+     * @param  \DateTime|null $date None (optional)
+     * @param  \DateTime|null $date_time None (optional)
+     * @param  string|null $password None (optional)
+     * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
+    public function testEndpointParametersAsyncWithHttpInfo(
+        $number,
+        $double,
+        $pattern_without_delimiter,
+        $byte,
+        $integer = null,
+        $int32 = null,
+        $int64 = null,
+        $float = null,
+        $string = null,
+        $binary = null,
+        $date = null,
+        $date_time = null,
+        $password = null,
+        $callback = null,
+        string $contentType = self::contentTypes['testEndpointParameters'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
@@ -3450,22 +3699,38 @@ class FakeApi
      * @param  float $double None (required)
      * @param  string $pattern_without_delimiter None (required)
      * @param  string $byte None (required)
-     * @param  int $integer None (optional)
-     * @param  int $int32 None (optional)
-     * @param  int $int64 None (optional)
-     * @param  float $float None (optional)
-     * @param  string $string None (optional)
-     * @param  \SplFileObject $binary None (optional)
-     * @param  \DateTime $date None (optional)
-     * @param  \DateTime $date_time None (optional)
-     * @param  string $password None (optional)
-     * @param  string $callback None (optional)
+     * @param  int|null $integer None (optional)
+     * @param  int|null $int32 None (optional)
+     * @param  int|null $int64 None (optional)
+     * @param  float|null $float None (optional)
+     * @param  string|null $string None (optional)
+     * @param  \SplFileObject|null $binary None (optional)
+     * @param  \DateTime|null $date None (optional)
+     * @param  \DateTime|null $date_time None (optional)
+     * @param  string|null $password None (optional)
+     * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer = null, $int32 = null, $int64 = null, $float = null, $string = null, $binary = null, $date = null, $date_time = null, $password = null, $callback = null, string $contentType = self::contentTypes['testEndpointParameters'][0])
+    public function testEndpointParametersRequest(
+        $number,
+        $double,
+        $pattern_without_delimiter,
+        $byte,
+        $integer = null,
+        $int32 = null,
+        $int64 = null,
+        $float = null,
+        $string = null,
+        $binary = null,
+        $date = null,
+        $date_time = null,
+        $password = null,
+        $callback = null,
+        string $contentType = self::contentTypes['testEndpointParameters'][0]
+    ): Request
     {
 
         // verify the required parameter 'number' is set
@@ -3683,22 +3948,33 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[] $enum_header_string_array Header parameter enum test (string array) (optional)
-     * @param  string $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
-     * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
-     * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  float $enum_query_double Query parameter enum test (double) (optional)
-     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array enum_query_model_array (optional)
-     * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
-     * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
+     * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
+     * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
+     * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array enum_query_model_array (optional)
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testEnumParameters($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
+    public function testEnumParameters(
+        ?array $enum_header_string_array = null,
+        ?string $enum_header_string = '-efg',
+        ?array $enum_query_string_array = null,
+        ?string $enum_query_string = '-efg',
+        ?int $enum_query_integer = null,
+        ?float $enum_query_double = null,
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = '$',
+        ?string $enum_form_string = '-efg',
+        string $contentType = self::contentTypes['testEnumParameters'][0]
+    ): void
     {
         $this->testEnumParametersWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
     }
@@ -3708,22 +3984,33 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[] $enum_header_string_array Header parameter enum test (string array) (optional)
-     * @param  string $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
-     * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
-     * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  float $enum_query_double Query parameter enum test (double) (optional)
-     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
-     * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
-     * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
+     * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
+     * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
+     * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testEnumParametersWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
+    public function testEnumParametersWithHttpInfo(
+        ?array $enum_header_string_array = null,
+        ?string $enum_header_string = '-efg',
+        ?array $enum_query_string_array = null,
+        ?string $enum_query_string = '-efg',
+        ?int $enum_query_integer = null,
+        ?float $enum_query_double = null,
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = '$',
+        ?string $enum_form_string = '-efg',
+        string $contentType = self::contentTypes['testEnumParameters'][0]
+    ): array
     {
         $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
 
@@ -3776,21 +4063,32 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[] $enum_header_string_array Header parameter enum test (string array) (optional)
-     * @param  string $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
-     * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
-     * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  float $enum_query_double Query parameter enum test (double) (optional)
-     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
-     * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
-     * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
+     * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
+     * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
+     * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEnumParametersAsync($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
+    public function testEnumParametersAsync(
+        ?array $enum_header_string_array = null,
+        ?string $enum_header_string = '-efg',
+        ?array $enum_query_string_array = null,
+        ?string $enum_query_string = '-efg',
+        ?int $enum_query_integer = null,
+        ?float $enum_query_double = null,
+        ?array $enum_query_model_array = null,
+        ?array $enum_form_string_array = '$',
+        ?string $enum_form_string = '-efg',
+        string $contentType = self::contentTypes['testEnumParameters'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testEnumParametersAsyncWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType)
             ->then(
@@ -3805,21 +4103,32 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[] $enum_header_string_array Header parameter enum test (string array) (optional)
-     * @param  string $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
-     * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
-     * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  float $enum_query_double Query parameter enum test (double) (optional)
-     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
-     * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
-     * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
+     * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
+     * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
+     * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testEnumParametersAsyncWithHttpInfo($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
+    public function testEnumParametersAsyncWithHttpInfo(
+        $enum_header_string_array = null,
+        $enum_header_string = '-efg',
+        $enum_query_string_array = null,
+        $enum_query_string = '-efg',
+        $enum_query_integer = null,
+        $enum_query_double = null,
+        $enum_query_model_array = null,
+        $enum_form_string_array = '$',
+        $enum_form_string = '-efg',
+        string $contentType = self::contentTypes['testEnumParameters'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
@@ -3850,21 +4159,32 @@ class FakeApi
     /**
      * Create request for operation 'testEnumParameters'
      *
-     * @param  string[] $enum_header_string_array Header parameter enum test (string array) (optional)
-     * @param  string $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[] $enum_query_string_array Query parameter enum test (string array) (optional)
-     * @param  string $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
-     * @param  int $enum_query_integer Query parameter enum test (double) (optional)
-     * @param  float $enum_query_double Query parameter enum test (double) (optional)
-     * @param  \OpenAPI\Client\Model\EnumClass[] $enum_query_model_array (optional)
-     * @param  string[] $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
-     * @param  string $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
+     * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
+     * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
+     * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testEnumParametersRequest($enum_header_string_array = null, $enum_header_string = '-efg', $enum_query_string_array = null, $enum_query_string = '-efg', $enum_query_integer = null, $enum_query_double = null, $enum_query_model_array = null, $enum_form_string_array = '$', $enum_form_string = '-efg', string $contentType = self::contentTypes['testEnumParameters'][0])
+    public function testEnumParametersRequest(
+        $enum_header_string_array = null,
+        $enum_header_string = '-efg',
+        $enum_query_string_array = null,
+        $enum_query_string = '-efg',
+        $enum_query_integer = null,
+        $enum_query_double = null,
+        $enum_query_model_array = null,
+        $enum_form_string_array = '$',
+        $enum_form_string = '-efg',
+        string $contentType = self::contentTypes['testEnumParameters'][0]
+    ): Request
     {
 
 
@@ -4015,16 +4335,18 @@ class FakeApi
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
      * @param  int $required_int64_group Required Integer in group parameters (required)
-     * @param  int $string_group String in group parameters (optional)
-     * @param  bool $boolean_group Boolean in group parameters (optional)
-     * @param  int $int64_group Integer in group parameters (optional)
+     * @param  int|null $string_group String in group parameters (optional)
+     * @param  bool|null $boolean_group Boolean in group parameters (optional)
+     * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testGroupParameters($associative_array)
+    public function testGroupParameters(
+        array $associative_array
+    ): void
     {
         $this->testGroupParametersWithHttpInfo($associative_array);
     }
@@ -4039,16 +4361,18 @@ class FakeApi
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
      * @param  int $required_int64_group Required Integer in group parameters (required)
-     * @param  int $string_group String in group parameters (optional)
-     * @param  bool $boolean_group Boolean in group parameters (optional)
-     * @param  int $int64_group Integer in group parameters (optional)
+     * @param  int|null $string_group String in group parameters (optional)
+     * @param  bool|null $boolean_group Boolean in group parameters (optional)
+     * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testGroupParametersWithHttpInfo($associative_array)
+    public function testGroupParametersWithHttpInfo(
+        array $associative_array
+    ): array
     {
         $request = $this->testGroupParametersRequest($associative_array);
 
@@ -4106,15 +4430,17 @@ class FakeApi
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
      * @param  int $required_int64_group Required Integer in group parameters (required)
-     * @param  int $string_group String in group parameters (optional)
-     * @param  bool $boolean_group Boolean in group parameters (optional)
-     * @param  int $int64_group Integer in group parameters (optional)
+     * @param  int|null $string_group String in group parameters (optional)
+     * @param  bool|null $boolean_group Boolean in group parameters (optional)
+     * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testGroupParametersAsync($associative_array)
+    public function testGroupParametersAsync(
+        array $associative_array
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testGroupParametersAsyncWithHttpInfo($associative_array)
             ->then(
@@ -4134,15 +4460,17 @@ class FakeApi
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
      * @param  int $required_int64_group Required Integer in group parameters (required)
-     * @param  int $string_group String in group parameters (optional)
-     * @param  bool $boolean_group Boolean in group parameters (optional)
-     * @param  int $int64_group Integer in group parameters (optional)
+     * @param  int|null $string_group String in group parameters (optional)
+     * @param  bool|null $boolean_group Boolean in group parameters (optional)
+     * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testGroupParametersAsyncWithHttpInfo($associative_array)
+    public function testGroupParametersAsyncWithHttpInfo(
+        array $associative_array
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testGroupParametersRequest($associative_array);
@@ -4178,15 +4506,17 @@ class FakeApi
      * @param  int $required_string_group Required String in group parameters (required)
      * @param  bool $required_boolean_group Required Boolean in group parameters (required)
      * @param  int $required_int64_group Required Integer in group parameters (required)
-     * @param  int $string_group String in group parameters (optional)
-     * @param  bool $boolean_group Boolean in group parameters (optional)
-     * @param  int $int64_group Integer in group parameters (optional)
+     * @param  int|null $string_group String in group parameters (optional)
+     * @param  bool|null $boolean_group Boolean in group parameters (optional)
+     * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testGroupParametersRequest($associative_array)
+    public function testGroupParametersRequest(
+        array $associative_array
+    ): Request
     {
         // unbox the parameters from the associative array
         $required_string_group = array_key_exists('required_string_group', $associative_array) ? $associative_array['required_string_group'] : null;
@@ -4346,7 +4676,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testInlineAdditionalProperties($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
+    public function testInlineAdditionalProperties(
+        array $request_body,
+        string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
+    ): void
     {
         $this->testInlineAdditionalPropertiesWithHttpInfo($request_body, $contentType);
     }
@@ -4363,7 +4696,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testInlineAdditionalPropertiesWithHttpInfo($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
+    public function testInlineAdditionalPropertiesWithHttpInfo(
+        array $request_body,
+        string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
+    ): array
     {
         $request = $this->testInlineAdditionalPropertiesRequest($request_body, $contentType);
 
@@ -4422,7 +4758,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testInlineAdditionalPropertiesAsync($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
+    public function testInlineAdditionalPropertiesAsync(
+        array $request_body,
+        string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body, $contentType)
             ->then(
@@ -4443,7 +4782,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
+    public function testInlineAdditionalPropertiesAsyncWithHttpInfo(
+        $request_body,
+        string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testInlineAdditionalPropertiesRequest($request_body, $contentType);
@@ -4480,7 +4822,10 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testInlineAdditionalPropertiesRequest($request_body, string $contentType = self::contentTypes['testInlineAdditionalProperties'][0])
+    public function testInlineAdditionalPropertiesRequest(
+        $request_body,
+        string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
+    ): Request
     {
 
         // verify the required parameter 'request_body' is set
@@ -4575,7 +4920,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testJsonFormData($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
+    public function testJsonFormData(
+        string $param,
+        string $param2,
+        string $contentType = self::contentTypes['testJsonFormData'][0]
+    ): void
     {
         $this->testJsonFormDataWithHttpInfo($param, $param2, $contentType);
     }
@@ -4593,7 +4942,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testJsonFormDataWithHttpInfo($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
+    public function testJsonFormDataWithHttpInfo(
+        string $param,
+        string $param2,
+        string $contentType = self::contentTypes['testJsonFormData'][0]
+    ): array
     {
         $request = $this->testJsonFormDataRequest($param, $param2, $contentType);
 
@@ -4653,7 +5006,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testJsonFormDataAsync($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
+    public function testJsonFormDataAsync(
+        string $param,
+        string $param2,
+        string $contentType = self::contentTypes['testJsonFormData'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testJsonFormDataAsyncWithHttpInfo($param, $param2, $contentType)
             ->then(
@@ -4675,7 +5032,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testJsonFormDataAsyncWithHttpInfo($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
+    public function testJsonFormDataAsyncWithHttpInfo(
+        $param,
+        $param2,
+        string $contentType = self::contentTypes['testJsonFormData'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testJsonFormDataRequest($param, $param2, $contentType);
@@ -4713,7 +5074,11 @@ class FakeApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testJsonFormDataRequest($param, $param2, string $contentType = self::contentTypes['testJsonFormData'][0])
+    public function testJsonFormDataRequest(
+        $param,
+        $param2,
+        string $contentType = self::contentTypes['testJsonFormData'][0]
+    ): Request
     {
 
         // verify the required parameter 'param' is set
@@ -4812,14 +5177,23 @@ class FakeApi
      * @param  string[] $url url (required)
      * @param  string[] $context context (required)
      * @param  string $allow_empty allow_empty (required)
-     * @param  array<string,string> $language language (optional)
+     * @param  array<string,string>|null $language language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function testQueryParameterCollectionFormat($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
+    public function testQueryParameterCollectionFormat(
+        array $pipe,
+        array $ioutil,
+        array $http,
+        array $url,
+        array $context,
+        string $allow_empty,
+        ?array $language = null,
+        string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
+    ): void
     {
         $this->testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
     }
@@ -4833,14 +5207,23 @@ class FakeApi
      * @param  string[] $url (required)
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
-     * @param  array<string,string> $language (optional)
+     * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testQueryParameterCollectionFormatWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
+    public function testQueryParameterCollectionFormatWithHttpInfo(
+        array $pipe,
+        array $ioutil,
+        array $http,
+        array $url,
+        array $context,
+        string $allow_empty,
+        ?array $language = null,
+        string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
+    ): array
     {
         $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
 
@@ -4897,13 +5280,22 @@ class FakeApi
      * @param  string[] $url (required)
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
-     * @param  array<string,string> $language (optional)
+     * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsync($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
+    public function testQueryParameterCollectionFormatAsync(
+        array $pipe,
+        array $ioutil,
+        array $http,
+        array $url,
+        array $context,
+        string $allow_empty,
+        ?array $language = null,
+        string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType)
             ->then(
@@ -4922,13 +5314,22 @@ class FakeApi
      * @param  string[] $url (required)
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
-     * @param  array<string,string> $language (optional)
+     * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
+    public function testQueryParameterCollectionFormatAsyncWithHttpInfo(
+        $pipe,
+        $ioutil,
+        $http,
+        $url,
+        $context,
+        $allow_empty,
+        $language = null,
+        string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
@@ -4965,13 +5366,22 @@ class FakeApi
      * @param  string[] $url (required)
      * @param  string[] $context (required)
      * @param  string $allow_empty (required)
-     * @param  array<string,string> $language (optional)
+     * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language = null, string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0])
+    public function testQueryParameterCollectionFormatRequest(
+        $pipe,
+        $ioutil,
+        $http,
+        $url,
+        $context,
+        $allow_empty,
+        $language = null,
+        string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
+    ): Request
     {
 
         // verify the required parameter 'pipe' is set
@@ -5151,7 +5561,7 @@ class FakeApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -132,7 +134,7 @@ class FakeApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -179,8 +181,8 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeBigDecimalMap'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\FakeBigDecimalMap200Response
      */
     public function fakeBigDecimalMap(
@@ -196,8 +198,8 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeBigDecimalMap'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\FakeBigDecimalMap200Response, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeBigDecimalMapWithHttpInfo(
@@ -295,12 +297,12 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeBigDecimalMap'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeBigDecimalMapAsync(
         string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeBigDecimalMapAsyncWithHttpInfo($contentType)
             ->then(
@@ -315,12 +317,12 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeBigDecimalMap'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeBigDecimalMapAsyncWithHttpInfo(
         string $contentType = self::contentTypes['fakeBigDecimalMap'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\FakeBigDecimalMap200Response';
         $request = $this->fakeBigDecimalMapRequest($contentType);
@@ -366,7 +368,7 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeBigDecimalMap'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeBigDecimalMapRequest(
@@ -446,8 +448,8 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\HealthCheckResult
      */
     public function fakeHealthGet(
@@ -465,8 +467,8 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\HealthCheckResult, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeHealthGetWithHttpInfo(
@@ -566,12 +568,12 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeHealthGetAsync(
         string $contentType = self::contentTypes['fakeHealthGet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeHealthGetAsyncWithHttpInfo($contentType)
             ->then(
@@ -588,12 +590,12 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeHealthGetAsyncWithHttpInfo(
         string $contentType = self::contentTypes['fakeHealthGet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\HealthCheckResult';
         $request = $this->fakeHealthGetRequest($contentType);
@@ -639,7 +641,7 @@ class FakeApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHealthGet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeHealthGetRequest(
@@ -722,8 +724,8 @@ class FakeApi
      * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function fakeHttpSignatureTest(
@@ -746,8 +748,8 @@ class FakeApi
      * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeHttpSignatureTestWithHttpInfo(
@@ -813,15 +815,15 @@ class FakeApi
      * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeHttpSignatureTestAsync(
         \OpenAPI\Client\Model\Pet $pet,
         ?string $query_1 = null,
         ?string $header_1 = null,
         string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeHttpSignatureTestAsyncWithHttpInfo($pet, $query_1, $header_1, $contentType)
             ->then(
@@ -841,15 +843,15 @@ class FakeApi
      * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeHttpSignatureTestAsyncWithHttpInfo(
         $pet,
         $query_1 = null,
         $header_1 = null,
         string $contentType = self::contentTypes['fakeHttpSignatureTest'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->fakeHttpSignatureTestRequest($pet, $query_1, $header_1, $contentType);
@@ -885,7 +887,7 @@ class FakeApi
      * @param  string|null $header_1 header parameter (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeHttpSignatureTest'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeHttpSignatureTestRequest(
@@ -898,7 +900,7 @@ class FakeApi
 
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling fakeHttpSignatureTest'
             );
         }
@@ -996,8 +998,8 @@ class FakeApi
      * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return bool
      */
     public function fakeOuterBooleanSerialize(
@@ -1015,8 +1017,8 @@ class FakeApi
      * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of bool, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeOuterBooleanSerializeWithHttpInfo(
@@ -1116,13 +1118,13 @@ class FakeApi
      * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterBooleanSerializeAsync(
         ?bool $body = null,
         string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeOuterBooleanSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1138,13 +1140,13 @@ class FakeApi
      * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterBooleanSerializeAsyncWithHttpInfo(
         $body = null,
         string $contentType = self::contentTypes['fakeOuterBooleanSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = 'bool';
         $request = $this->fakeOuterBooleanSerializeRequest($body, $contentType);
@@ -1191,7 +1193,7 @@ class FakeApi
      * @param  bool|null $body Input boolean as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterBooleanSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterBooleanSerializeRequest(
@@ -1279,8 +1281,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterComposite
      */
     public function fakeOuterCompositeSerialize(
@@ -1298,8 +1300,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterComposite, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeOuterCompositeSerializeWithHttpInfo(
@@ -1399,13 +1401,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterCompositeSerializeAsync(
         ?\OpenAPI\Client\Model\OuterComposite $outer_composite = null,
         string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeOuterCompositeSerializeAsyncWithHttpInfo($outer_composite, $contentType)
             ->then(
@@ -1421,13 +1423,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterCompositeSerializeAsyncWithHttpInfo(
         $outer_composite = null,
         string $contentType = self::contentTypes['fakeOuterCompositeSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\OuterComposite';
         $request = $this->fakeOuterCompositeSerializeRequest($outer_composite, $contentType);
@@ -1474,7 +1476,7 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterComposite|null $outer_composite Input composite as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterCompositeSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterCompositeSerializeRequest(
@@ -1562,8 +1564,8 @@ class FakeApi
      * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return float
      */
     public function fakeOuterNumberSerialize(
@@ -1581,8 +1583,8 @@ class FakeApi
      * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of float, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeOuterNumberSerializeWithHttpInfo(
@@ -1682,13 +1684,13 @@ class FakeApi
      * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterNumberSerializeAsync(
         ?float $body = null,
         string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeOuterNumberSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1704,13 +1706,13 @@ class FakeApi
      * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterNumberSerializeAsyncWithHttpInfo(
         $body = null,
         string $contentType = self::contentTypes['fakeOuterNumberSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = 'float';
         $request = $this->fakeOuterNumberSerializeRequest($body, $contentType);
@@ -1757,7 +1759,7 @@ class FakeApi
      * @param  float|null $body Input number as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterNumberSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterNumberSerializeRequest(
@@ -1845,8 +1847,8 @@ class FakeApi
      * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return string
      */
     public function fakeOuterStringSerialize(
@@ -1864,8 +1866,8 @@ class FakeApi
      * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakeOuterStringSerializeWithHttpInfo(
@@ -1965,13 +1967,13 @@ class FakeApi
      * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterStringSerializeAsync(
         ?string $body = null,
         string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakeOuterStringSerializeAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -1987,13 +1989,13 @@ class FakeApi
      * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakeOuterStringSerializeAsyncWithHttpInfo(
         $body = null,
         string $contentType = self::contentTypes['fakeOuterStringSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = 'string';
         $request = $this->fakeOuterStringSerializeRequest($body, $contentType);
@@ -2040,7 +2042,7 @@ class FakeApi
      * @param  string|null $body Input string as post body (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakeOuterStringSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakeOuterStringSerializeRequest(
@@ -2128,8 +2130,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\OuterObjectWithEnumProperty
      */
     public function fakePropertyEnumIntegerSerialize(
@@ -2147,8 +2149,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\OuterObjectWithEnumProperty, HTTP status code, HTTP response headers (array of strings)
      */
     public function fakePropertyEnumIntegerSerializeWithHttpInfo(
@@ -2248,13 +2250,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakePropertyEnumIntegerSerializeAsync(
         \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property,
         string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->fakePropertyEnumIntegerSerializeAsyncWithHttpInfo($outer_object_with_enum_property, $contentType)
             ->then(
@@ -2270,13 +2272,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function fakePropertyEnumIntegerSerializeAsyncWithHttpInfo(
         $outer_object_with_enum_property,
         string $contentType = self::contentTypes['fakePropertyEnumIntegerSerialize'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\OuterObjectWithEnumProperty';
         $request = $this->fakePropertyEnumIntegerSerializeRequest($outer_object_with_enum_property, $contentType);
@@ -2323,7 +2325,7 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\OuterObjectWithEnumProperty $outer_object_with_enum_property Input enum (int) as post body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['fakePropertyEnumIntegerSerialize'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function fakePropertyEnumIntegerSerializeRequest(
@@ -2334,7 +2336,7 @@ class FakeApi
 
         // verify the required parameter 'outer_object_with_enum_property' is set
         if ($outer_object_with_enum_property === null || (is_array($outer_object_with_enum_property) && count($outer_object_with_enum_property) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $outer_object_with_enum_property when calling fakePropertyEnumIntegerSerialize'
             );
         }
@@ -2417,8 +2419,8 @@ class FakeApi
      * @param  \SplFileObject $body image to upload (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testBodyWithBinary(
@@ -2435,8 +2437,8 @@ class FakeApi
      * @param  \SplFileObject $body image to upload (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testBodyWithBinaryWithHttpInfo(
@@ -2496,13 +2498,13 @@ class FakeApi
      * @param  \SplFileObject $body image to upload (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithBinaryAsync(
         \SplFileObject $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testBodyWithBinaryAsyncWithHttpInfo($body, $contentType)
             ->then(
@@ -2518,13 +2520,13 @@ class FakeApi
      * @param  \SplFileObject $body image to upload (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithBinaryAsyncWithHttpInfo(
         $body,
         string $contentType = self::contentTypes['testBodyWithBinary'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithBinaryRequest($body, $contentType);
@@ -2558,7 +2560,7 @@ class FakeApi
      * @param  \SplFileObject $body image to upload (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithBinary'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithBinaryRequest(
@@ -2569,7 +2571,7 @@ class FakeApi
 
         // verify the required parameter 'body' is set
         if ($body === null || (is_array($body) && count($body) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $body when calling testBodyWithBinary'
             );
         }
@@ -2652,8 +2654,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class file_schema_test_class (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testBodyWithFileSchema(
@@ -2670,8 +2672,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testBodyWithFileSchemaWithHttpInfo(
@@ -2731,13 +2733,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithFileSchemaAsync(
         \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class,
         string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testBodyWithFileSchemaAsyncWithHttpInfo($file_schema_test_class, $contentType)
             ->then(
@@ -2753,13 +2755,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithFileSchemaAsyncWithHttpInfo(
         $file_schema_test_class,
         string $contentType = self::contentTypes['testBodyWithFileSchema'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithFileSchemaRequest($file_schema_test_class, $contentType);
@@ -2793,7 +2795,7 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\FileSchemaTestClass $file_schema_test_class (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithFileSchema'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithFileSchemaRequest(
@@ -2804,7 +2806,7 @@ class FakeApi
 
         // verify the required parameter 'file_schema_test_class' is set
         if ($file_schema_test_class === null || (is_array($file_schema_test_class) && count($file_schema_test_class) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $file_schema_test_class when calling testBodyWithFileSchema'
             );
         }
@@ -2888,8 +2890,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\User $user user (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testBodyWithQueryParams(
@@ -2908,8 +2910,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\User $user (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testBodyWithQueryParamsWithHttpInfo(
@@ -2971,14 +2973,14 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\User $user (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithQueryParamsAsync(
         string $query,
         \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testBodyWithQueryParamsAsyncWithHttpInfo($query, $user, $contentType)
             ->then(
@@ -2995,14 +2997,14 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\User $user (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testBodyWithQueryParamsAsyncWithHttpInfo(
         $query,
         $user,
         string $contentType = self::contentTypes['testBodyWithQueryParams'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testBodyWithQueryParamsRequest($query, $user, $contentType);
@@ -3037,7 +3039,7 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\User $user (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testBodyWithQueryParams'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testBodyWithQueryParamsRequest(
@@ -3049,14 +3051,14 @@ class FakeApi
 
         // verify the required parameter 'query' is set
         if ($query === null || (is_array($query) && count($query) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $query when calling testBodyWithQueryParams'
             );
         }
 
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling testBodyWithQueryParams'
             );
         }
@@ -3150,8 +3152,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
     public function testClientModel(
@@ -3171,8 +3173,8 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
     public function testClientModelWithHttpInfo(
@@ -3274,13 +3276,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testClientModelAsync(
         \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClientModel'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testClientModelAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -3298,13 +3300,13 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testClientModelAsyncWithHttpInfo(
         $client,
         string $contentType = self::contentTypes['testClientModel'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->testClientModelRequest($client, $contentType);
@@ -3351,7 +3353,7 @@ class FakeApi
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClientModel'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testClientModelRequest(
@@ -3362,7 +3364,7 @@ class FakeApi
 
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling testClientModel'
             );
         }
@@ -3460,8 +3462,8 @@ class FakeApi
      * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testEndpointParameters(
@@ -3506,8 +3508,8 @@ class FakeApi
      * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEndpointParametersWithHttpInfo(
@@ -3595,8 +3597,8 @@ class FakeApi
      * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testEndpointParametersAsync(
         float $number,
@@ -3614,7 +3616,7 @@ class FakeApi
         ?string $password = null,
         ?string $callback = null,
         string $contentType = self::contentTypes['testEndpointParameters'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testEndpointParametersAsyncWithHttpInfo($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType)
             ->then(
@@ -3645,8 +3647,8 @@ class FakeApi
      * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testEndpointParametersAsyncWithHttpInfo(
         $number,
@@ -3664,7 +3666,7 @@ class FakeApi
         $password = null,
         $callback = null,
         string $contentType = self::contentTypes['testEndpointParameters'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testEndpointParametersRequest($number, $double, $pattern_without_delimiter, $byte, $integer, $int32, $int64, $float, $string, $binary, $date, $date_time, $password, $callback, $contentType);
@@ -3711,7 +3713,7 @@ class FakeApi
      * @param  string|null $callback None (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEndpointParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEndpointParametersRequest(
@@ -3735,78 +3737,78 @@ class FakeApi
 
         // verify the required parameter 'number' is set
         if ($number === null || (is_array($number) && count($number) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $number when calling testEndpointParameters'
             );
         }
         if ($number > 543.2) {
-            throw new \InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 543.2.');
+            throw new InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 543.2.');
         }
         if ($number < 32.1) {
-            throw new \InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
+            throw new InvalidArgumentException('invalid value for "$number" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 32.1.');
         }
         
         // verify the required parameter 'double' is set
         if ($double === null || (is_array($double) && count($double) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $double when calling testEndpointParameters'
             );
         }
         if ($double > 123.4) {
-            throw new \InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 123.4.');
+            throw new InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 123.4.');
         }
         if ($double < 67.8) {
-            throw new \InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
+            throw new InvalidArgumentException('invalid value for "$double" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 67.8.');
         }
         
         // verify the required parameter 'pattern_without_delimiter' is set
         if ($pattern_without_delimiter === null || (is_array($pattern_without_delimiter) && count($pattern_without_delimiter) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pattern_without_delimiter when calling testEndpointParameters'
             );
         }
         if (!preg_match("/^[A-Z].*/", $pattern_without_delimiter)) {
-            throw new \InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
+            throw new InvalidArgumentException("invalid value for \"pattern_without_delimiter\" when calling FakeApi.testEndpointParameters, must conform to the pattern /^[A-Z].*/.");
         }
         
         // verify the required parameter 'byte' is set
         if ($byte === null || (is_array($byte) && count($byte) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $byte when calling testEndpointParameters'
             );
         }
 
         if ($integer !== null && $integer > 100) {
-            throw new \InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 100.');
+            throw new InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 100.');
         }
         if ($integer !== null && $integer < 10) {
-            throw new \InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
+            throw new InvalidArgumentException('invalid value for "$integer" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
         
         if ($int32 !== null && $int32 > 200) {
-            throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
+            throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 200.');
         }
         if ($int32 !== null && $int32 < 20) {
-            throw new \InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
+            throw new InvalidArgumentException('invalid value for "$int32" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 20.');
         }
         
 
         if ($float !== null && $float > 987.6) {
-            throw new \InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
+            throw new InvalidArgumentException('invalid value for "$float" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 987.6.');
         }
         
         if ($string !== null && !preg_match("/[a-z]/i", $string)) {
-            throw new \InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
+            throw new InvalidArgumentException("invalid value for \"string\" when calling FakeApi.testEndpointParameters, must conform to the pattern /[a-z]/i.");
         }
         
 
 
 
         if ($password !== null && strlen($password) > 64) {
-            throw new \InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 64.');
+            throw new InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be smaller than or equal to 64.');
         }
         if ($password !== null && strlen($password) < 10) {
-            throw new \InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
+            throw new InvalidArgumentException('invalid length for "$password" when calling FakeApi.testEndpointParameters, must be bigger than or equal to 10.');
         }
         
 
@@ -3959,8 +3961,8 @@ class FakeApi
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testEnumParameters(
@@ -3995,8 +3997,8 @@ class FakeApi
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEnumParametersWithHttpInfo(
@@ -4074,8 +4076,8 @@ class FakeApi
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testEnumParametersAsync(
         ?array $enum_header_string_array = null,
@@ -4088,7 +4090,7 @@ class FakeApi
         ?array $enum_form_string_array = '$',
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testEnumParametersAsyncWithHttpInfo($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType)
             ->then(
@@ -4114,8 +4116,8 @@ class FakeApi
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testEnumParametersAsyncWithHttpInfo(
         $enum_header_string_array = null,
@@ -4128,7 +4130,7 @@ class FakeApi
         $enum_form_string_array = '$',
         $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testEnumParametersRequest($enum_header_string_array, $enum_header_string, $enum_query_string_array, $enum_query_string, $enum_query_integer, $enum_query_double, $enum_query_model_array, $enum_form_string_array, $enum_form_string, $contentType);
@@ -4170,7 +4172,7 @@ class FakeApi
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumParametersRequest(
@@ -4340,8 +4342,8 @@ class FakeApi
      * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testGroupParameters(
@@ -4366,8 +4368,8 @@ class FakeApi
      * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testGroupParametersWithHttpInfo(
@@ -4435,12 +4437,12 @@ class FakeApi
      * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testGroupParametersAsync(
         array $associative_array
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testGroupParametersAsyncWithHttpInfo($associative_array)
             ->then(
@@ -4465,12 +4467,12 @@ class FakeApi
      * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testGroupParametersAsyncWithHttpInfo(
         array $associative_array
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testGroupParametersRequest($associative_array);
@@ -4511,7 +4513,7 @@ class FakeApi
      * @param  int|null $int64_group Integer in group parameters (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testGroupParameters'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testGroupParametersRequest(
@@ -4529,21 +4531,21 @@ class FakeApi
         
         // verify the required parameter 'required_string_group' is set
         if ($required_string_group === null || (is_array($required_string_group) && count($required_string_group) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $required_string_group when calling testGroupParameters'
             );
         }
 
         // verify the required parameter 'required_boolean_group' is set
         if ($required_boolean_group === null || (is_array($required_boolean_group) && count($required_boolean_group) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $required_boolean_group when calling testGroupParameters'
             );
         }
 
         // verify the required parameter 'required_int64_group' is set
         if ($required_int64_group === null || (is_array($required_int64_group) && count($required_int64_group) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $required_int64_group when calling testGroupParameters'
             );
         }
@@ -4672,8 +4674,8 @@ class FakeApi
      * @param  array<string,string> $request_body request body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testInlineAdditionalProperties(
@@ -4692,8 +4694,8 @@ class FakeApi
      * @param  array<string,string> $request_body request body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testInlineAdditionalPropertiesWithHttpInfo(
@@ -4755,13 +4757,13 @@ class FakeApi
      * @param  array<string,string> $request_body request body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testInlineAdditionalPropertiesAsync(
         array $request_body,
         string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testInlineAdditionalPropertiesAsyncWithHttpInfo($request_body, $contentType)
             ->then(
@@ -4779,13 +4781,13 @@ class FakeApi
      * @param  array<string,string> $request_body request body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testInlineAdditionalPropertiesAsyncWithHttpInfo(
         $request_body,
         string $contentType = self::contentTypes['testInlineAdditionalProperties'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testInlineAdditionalPropertiesRequest($request_body, $contentType);
@@ -4819,7 +4821,7 @@ class FakeApi
      * @param  array<string,string> $request_body request body (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testInlineAdditionalProperties'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testInlineAdditionalPropertiesRequest(
@@ -4830,7 +4832,7 @@ class FakeApi
 
         // verify the required parameter 'request_body' is set
         if ($request_body === null || (is_array($request_body) && count($request_body) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $request_body when calling testInlineAdditionalProperties'
             );
         }
@@ -4916,8 +4918,8 @@ class FakeApi
      * @param  string $param2 field2 (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testJsonFormData(
@@ -4938,8 +4940,8 @@ class FakeApi
      * @param  string $param2 field2 (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testJsonFormDataWithHttpInfo(
@@ -5003,14 +5005,14 @@ class FakeApi
      * @param  string $param2 field2 (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testJsonFormDataAsync(
         string $param,
         string $param2,
         string $contentType = self::contentTypes['testJsonFormData'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testJsonFormDataAsyncWithHttpInfo($param, $param2, $contentType)
             ->then(
@@ -5029,14 +5031,14 @@ class FakeApi
      * @param  string $param2 field2 (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testJsonFormDataAsyncWithHttpInfo(
         $param,
         $param2,
         string $contentType = self::contentTypes['testJsonFormData'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testJsonFormDataRequest($param, $param2, $contentType);
@@ -5071,7 +5073,7 @@ class FakeApi
      * @param  string $param2 field2 (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testJsonFormData'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testJsonFormDataRequest(
@@ -5083,14 +5085,14 @@ class FakeApi
 
         // verify the required parameter 'param' is set
         if ($param === null || (is_array($param) && count($param) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $param when calling testJsonFormData'
             );
         }
 
         // verify the required parameter 'param2' is set
         if ($param2 === null || (is_array($param2) && count($param2) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $param2 when calling testJsonFormData'
             );
         }
@@ -5180,8 +5182,8 @@ class FakeApi
      * @param  array<string,string>|null $language language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function testQueryParameterCollectionFormat(
@@ -5210,8 +5212,8 @@ class FakeApi
      * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testQueryParameterCollectionFormatWithHttpInfo(
@@ -5283,8 +5285,8 @@ class FakeApi
      * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testQueryParameterCollectionFormatAsync(
         array $pipe,
@@ -5295,7 +5297,7 @@ class FakeApi
         string $allow_empty,
         ?array $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testQueryParameterCollectionFormatAsyncWithHttpInfo($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType)
             ->then(
@@ -5317,8 +5319,8 @@ class FakeApi
      * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testQueryParameterCollectionFormatAsyncWithHttpInfo(
         $pipe,
@@ -5329,7 +5331,7 @@ class FakeApi
         $allow_empty,
         $language = null,
         string $contentType = self::contentTypes['testQueryParameterCollectionFormat'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->testQueryParameterCollectionFormatRequest($pipe, $ioutil, $http, $url, $context, $allow_empty, $language, $contentType);
@@ -5369,7 +5371,7 @@ class FakeApi
      * @param  array<string,string>|null $language (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testQueryParameterCollectionFormat'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testQueryParameterCollectionFormatRequest(
@@ -5386,42 +5388,42 @@ class FakeApi
 
         // verify the required parameter 'pipe' is set
         if ($pipe === null || (is_array($pipe) && count($pipe) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pipe when calling testQueryParameterCollectionFormat'
             );
         }
 
         // verify the required parameter 'ioutil' is set
         if ($ioutil === null || (is_array($ioutil) && count($ioutil) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $ioutil when calling testQueryParameterCollectionFormat'
             );
         }
 
         // verify the required parameter 'http' is set
         if ($http === null || (is_array($http) && count($http) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $http when calling testQueryParameterCollectionFormat'
             );
         }
 
         // verify the required parameter 'url' is set
         if ($url === null || (is_array($url) && count($url) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $url when calling testQueryParameterCollectionFormat'
             );
         }
 
         // verify the required parameter 'context' is set
         if ($context === null || (is_array($context) && count($context) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $context when calling testQueryParameterCollectionFormat'
             );
         }
 
         // verify the required parameter 'allow_empty' is set
         if ($allow_empty === null || (is_array($allow_empty) && count($allow_empty) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $allow_empty when calling testQueryParameterCollectionFormat'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -52,22 +52,22 @@ class FakeApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -128,7 +128,7 @@ class FakeApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -138,7 +138,7 @@ class FakeApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -151,7 +151,7 @@ class FakeApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -161,7 +161,7 @@ class FakeApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -169,7 +169,7 @@ class FakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -52,22 +52,22 @@ class FakeClassnameTags123Api
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -76,7 +76,7 @@ class FakeClassnameTags123Api
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -86,7 +86,7 @@ class FakeClassnameTags123Api
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -99,7 +99,7 @@ class FakeClassnameTags123Api
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -109,7 +109,7 @@ class FakeClassnameTags123Api
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -117,7 +117,7 @@ class FakeClassnameTags123Api
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -80,7 +82,7 @@ class FakeClassnameTags123Api
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -130,8 +132,8 @@ class FakeClassnameTags123Api
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
     public function testClassname(
@@ -151,8 +153,8 @@ class FakeClassnameTags123Api
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
     public function testClassnameWithHttpInfo(
@@ -254,13 +256,13 @@ class FakeClassnameTags123Api
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testClassnameAsync(
         \OpenAPI\Client\Model\Client $client,
         string $contentType = self::contentTypes['testClassname'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->testClassnameAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -278,13 +280,13 @@ class FakeClassnameTags123Api
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function testClassnameAsyncWithHttpInfo(
         $client,
         string $contentType = self::contentTypes['testClassname'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->testClassnameRequest($client, $contentType);
@@ -331,7 +333,7 @@ class FakeClassnameTags123Api
      * @param  \OpenAPI\Client\Model\Client $client client model (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testClassname'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testClassnameRequest(
@@ -342,7 +344,7 @@ class FakeClassnameTags123Api
 
         // verify the required parameter 'client' is set
         if ($client === null || (is_array($client) && count($client) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $client when calling testClassname'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -77,10 +77,10 @@ class FakeClassnameTags123Api
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -134,7 +134,10 @@ class FakeClassnameTags123Api
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Client
      */
-    public function testClassname($client, string $contentType = self::contentTypes['testClassname'][0])
+    public function testClassname(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClassname'][0]
+    ): \OpenAPI\Client\Model\Client
     {
         list($response) = $this->testClassnameWithHttpInfo($client, $contentType);
         return $response;
@@ -152,7 +155,10 @@ class FakeClassnameTags123Api
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Client, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testClassnameWithHttpInfo($client, string $contentType = self::contentTypes['testClassname'][0])
+    public function testClassnameWithHttpInfo(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClassname'][0]
+    ): array
     {
         $request = $this->testClassnameRequest($client, $contentType);
 
@@ -251,7 +257,10 @@ class FakeClassnameTags123Api
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClassnameAsync($client, string $contentType = self::contentTypes['testClassname'][0])
+    public function testClassnameAsync(
+        \OpenAPI\Client\Model\Client $client,
+        string $contentType = self::contentTypes['testClassname'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->testClassnameAsyncWithHttpInfo($client, $contentType)
             ->then(
@@ -272,7 +281,10 @@ class FakeClassnameTags123Api
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function testClassnameAsyncWithHttpInfo($client, string $contentType = self::contentTypes['testClassname'][0])
+    public function testClassnameAsyncWithHttpInfo(
+        $client,
+        string $contentType = self::contentTypes['testClassname'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Client';
         $request = $this->testClassnameRequest($client, $contentType);
@@ -322,7 +334,10 @@ class FakeClassnameTags123Api
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testClassnameRequest($client, string $contentType = self::contentTypes['testClassname'][0])
+    public function testClassnameRequest(
+        $client,
+        string $contentType = self::contentTypes['testClassname'][0]
+    ): Request
     {
 
         // verify the required parameter 'client' is set
@@ -415,7 +430,7 @@ class FakeClassnameTags123Api
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -103,10 +103,10 @@ class PetApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -178,7 +178,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function addPet($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
+    public function addPet(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['addPet'][0]
+    ): void
     {
         $this->addPetWithHttpInfo($pet, $hostIndex, $variables, $contentType);
     }
@@ -213,7 +218,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function addPetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
+    public function addPetWithHttpInfo(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['addPet'][0]
+    ): array
     {
         $request = $this->addPetRequest($pet, $hostIndex, $variables, $contentType);
 
@@ -290,7 +300,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function addPetAsync($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
+    public function addPetAsync(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['addPet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->addPetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
@@ -329,7 +344,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function addPetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
+    public function addPetAsyncWithHttpInfo(
+        $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['addPet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->addPetRequest($pet, $hostIndex, $variables, $contentType);
@@ -384,7 +404,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function addPetRequest($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['addPet'][0])
+    public function addPetRequest(
+        $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['addPet'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet' is set
@@ -528,14 +553,18 @@ class PetApi
      * Deletes a pet
      *
      * @param  int $pet_id Pet id to delete (required)
-     * @param  string $api_key api_key (optional)
+     * @param  string|null $api_key api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deletePet($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
+    public function deletePet(
+        int $pet_id,
+        ?string $api_key = null,
+        string $contentType = self::contentTypes['deletePet'][0]
+    ): void
     {
         $this->deletePetWithHttpInfo($pet_id, $api_key, $contentType);
     }
@@ -546,14 +575,18 @@ class PetApi
      * Deletes a pet
      *
      * @param  int $pet_id Pet id to delete (required)
-     * @param  string $api_key (optional)
+     * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deletePetWithHttpInfo($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
+    public function deletePetWithHttpInfo(
+        int $pet_id,
+        ?string $api_key = null,
+        string $contentType = self::contentTypes['deletePet'][0]
+    ): array
     {
         $request = $this->deletePetRequest($pet_id, $api_key, $contentType);
 
@@ -607,13 +640,17 @@ class PetApi
      * Deletes a pet
      *
      * @param  int $pet_id Pet id to delete (required)
-     * @param  string $api_key (optional)
+     * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deletePetAsync($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
+    public function deletePetAsync(
+        int $pet_id,
+        ?string $api_key = null,
+        string $contentType = self::contentTypes['deletePet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->deletePetAsyncWithHttpInfo($pet_id, $api_key, $contentType)
             ->then(
@@ -629,13 +666,17 @@ class PetApi
      * Deletes a pet
      *
      * @param  int $pet_id Pet id to delete (required)
-     * @param  string $api_key (optional)
+     * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deletePetAsyncWithHttpInfo($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
+    public function deletePetAsyncWithHttpInfo(
+        $pet_id,
+        $api_key = null,
+        string $contentType = self::contentTypes['deletePet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->deletePetRequest($pet_id, $api_key, $contentType);
@@ -667,13 +708,17 @@ class PetApi
      * Create request for operation 'deletePet'
      *
      * @param  int $pet_id Pet id to delete (required)
-     * @param  string $api_key (optional)
+     * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deletePetRequest($pet_id, $api_key = null, string $contentType = self::contentTypes['deletePet'][0])
+    public function deletePetRequest(
+        $pet_id,
+        $api_key = null,
+        string $contentType = self::contentTypes['deletePet'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet_id' is set
@@ -777,7 +822,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
      */
-    public function findPetsByStatus($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
+    public function findPetsByStatus(
+        array $status,
+        string $contentType = self::contentTypes['findPetsByStatus'][0]
+    ): \OpenAPI\Client\Model\Pet[]
     {
         list($response) = $this->findPetsByStatusWithHttpInfo($status, $contentType);
         return $response;
@@ -795,7 +843,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      */
-    public function findPetsByStatusWithHttpInfo($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
+    public function findPetsByStatusWithHttpInfo(
+        array $status,
+        string $contentType = self::contentTypes['findPetsByStatus'][0]
+    ): array
     {
         $request = $this->findPetsByStatusRequest($status, $contentType);
 
@@ -894,7 +945,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function findPetsByStatusAsync($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
+    public function findPetsByStatusAsync(
+        array $status,
+        string $contentType = self::contentTypes['findPetsByStatus'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->findPetsByStatusAsyncWithHttpInfo($status, $contentType)
             ->then(
@@ -915,7 +969,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function findPetsByStatusAsyncWithHttpInfo($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
+    public function findPetsByStatusAsyncWithHttpInfo(
+        $status,
+        string $contentType = self::contentTypes['findPetsByStatus'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
         $request = $this->findPetsByStatusRequest($status, $contentType);
@@ -965,7 +1022,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function findPetsByStatusRequest($status, string $contentType = self::contentTypes['findPetsByStatus'][0])
+    public function findPetsByStatusRequest(
+        $status,
+        string $contentType = self::contentTypes['findPetsByStatus'][0]
+    ): Request
     {
 
         // verify the required parameter 'status' is set
@@ -1066,7 +1126,10 @@ class PetApi
      * @return \OpenAPI\Client\Model\Pet[]
      * @deprecated
      */
-    public function findPetsByTags($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
+    public function findPetsByTags(
+        array $tags,
+        string $contentType = self::contentTypes['findPetsByTags'][0]
+    ): \OpenAPI\Client\Model\Pet[]
     {
         list($response) = $this->findPetsByTagsWithHttpInfo($tags, $contentType);
         return $response;
@@ -1085,7 +1148,10 @@ class PetApi
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      * @deprecated
      */
-    public function findPetsByTagsWithHttpInfo($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
+    public function findPetsByTagsWithHttpInfo(
+        array $tags,
+        string $contentType = self::contentTypes['findPetsByTags'][0]
+    ): array
     {
         $request = $this->findPetsByTagsRequest($tags, $contentType);
 
@@ -1185,7 +1251,10 @@ class PetApi
      * @return \GuzzleHttp\Promise\PromiseInterface
      * @deprecated
      */
-    public function findPetsByTagsAsync($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
+    public function findPetsByTagsAsync(
+        array $tags,
+        string $contentType = self::contentTypes['findPetsByTags'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->findPetsByTagsAsyncWithHttpInfo($tags, $contentType)
             ->then(
@@ -1207,7 +1276,10 @@ class PetApi
      * @return \GuzzleHttp\Promise\PromiseInterface
      * @deprecated
      */
-    public function findPetsByTagsAsyncWithHttpInfo($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
+    public function findPetsByTagsAsyncWithHttpInfo(
+        $tags,
+        string $contentType = self::contentTypes['findPetsByTags'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
         $request = $this->findPetsByTagsRequest($tags, $contentType);
@@ -1258,7 +1330,10 @@ class PetApi
      * @return \GuzzleHttp\Psr7\Request
      * @deprecated
      */
-    public function findPetsByTagsRequest($tags, string $contentType = self::contentTypes['findPetsByTags'][0])
+    public function findPetsByTagsRequest(
+        $tags,
+        string $contentType = self::contentTypes['findPetsByTags'][0]
+    ): Request
     {
 
         // verify the required parameter 'tags' is set
@@ -1358,7 +1433,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet
      */
-    public function getPetById($pet_id, string $contentType = self::contentTypes['getPetById'][0])
+    public function getPetById(
+        int $pet_id,
+        string $contentType = self::contentTypes['getPetById'][0]
+    ): \OpenAPI\Client\Model\Pet
     {
         list($response) = $this->getPetByIdWithHttpInfo($pet_id, $contentType);
         return $response;
@@ -1376,7 +1454,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getPetByIdWithHttpInfo($pet_id, string $contentType = self::contentTypes['getPetById'][0])
+    public function getPetByIdWithHttpInfo(
+        int $pet_id,
+        string $contentType = self::contentTypes['getPetById'][0]
+    ): array
     {
         $request = $this->getPetByIdRequest($pet_id, $contentType);
 
@@ -1475,7 +1556,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPetByIdAsync($pet_id, string $contentType = self::contentTypes['getPetById'][0])
+    public function getPetByIdAsync(
+        int $pet_id,
+        string $contentType = self::contentTypes['getPetById'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->getPetByIdAsyncWithHttpInfo($pet_id, $contentType)
             ->then(
@@ -1496,7 +1580,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getPetByIdAsyncWithHttpInfo($pet_id, string $contentType = self::contentTypes['getPetById'][0])
+    public function getPetByIdAsyncWithHttpInfo(
+        $pet_id,
+        string $contentType = self::contentTypes['getPetById'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet';
         $request = $this->getPetByIdRequest($pet_id, $contentType);
@@ -1546,7 +1633,10 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getPetByIdRequest($pet_id, string $contentType = self::contentTypes['getPetById'][0])
+    public function getPetByIdRequest(
+        $pet_id,
+        string $contentType = self::contentTypes['getPetById'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet_id' is set
@@ -1664,7 +1754,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updatePet($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
+    public function updatePet(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['updatePet'][0]
+    ): void
     {
         $this->updatePetWithHttpInfo($pet, $hostIndex, $variables, $contentType);
     }
@@ -1699,7 +1794,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updatePetWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
+    public function updatePetWithHttpInfo(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['updatePet'][0]
+    ): array
     {
         $request = $this->updatePetRequest($pet, $hostIndex, $variables, $contentType);
 
@@ -1776,7 +1876,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetAsync($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
+    public function updatePetAsync(
+        \OpenAPI\Client\Model\Pet $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['updatePet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->updatePetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
@@ -1815,7 +1920,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetAsyncWithHttpInfo($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
+    public function updatePetAsyncWithHttpInfo(
+        $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['updatePet'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->updatePetRequest($pet, $hostIndex, $variables, $contentType);
@@ -1870,7 +1980,12 @@ class PetApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updatePetRequest($pet, ?int $hostIndex = null, array $variables = [], string $contentType = self::contentTypes['updatePet'][0])
+    public function updatePetRequest(
+        $pet,
+        ?int $hostIndex = null,
+        array $variables = [],
+        string $contentType = self::contentTypes['updatePet'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet' is set
@@ -2014,15 +2129,20 @@ class PetApi
      * Updates a pet in the store with form data
      *
      * @param  int $pet_id ID of pet that needs to be updated (required)
-     * @param  string $name Updated name of the pet (optional)
-     * @param  string $status Updated status of the pet (optional)
+     * @param  string|null $name Updated name of the pet (optional)
+     * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updatePetWithForm($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
+    public function updatePetWithForm(
+        int $pet_id,
+        ?string $name = null,
+        ?string $status = null,
+        string $contentType = self::contentTypes['updatePetWithForm'][0]
+    ): void
     {
         $this->updatePetWithFormWithHttpInfo($pet_id, $name, $status, $contentType);
     }
@@ -2033,15 +2153,20 @@ class PetApi
      * Updates a pet in the store with form data
      *
      * @param  int $pet_id ID of pet that needs to be updated (required)
-     * @param  string $name Updated name of the pet (optional)
-     * @param  string $status Updated status of the pet (optional)
+     * @param  string|null $name Updated name of the pet (optional)
+     * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updatePetWithFormWithHttpInfo($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
+    public function updatePetWithFormWithHttpInfo(
+        int $pet_id,
+        ?string $name = null,
+        ?string $status = null,
+        string $contentType = self::contentTypes['updatePetWithForm'][0]
+    ): array
     {
         $request = $this->updatePetWithFormRequest($pet_id, $name, $status, $contentType);
 
@@ -2095,14 +2220,19 @@ class PetApi
      * Updates a pet in the store with form data
      *
      * @param  int $pet_id ID of pet that needs to be updated (required)
-     * @param  string $name Updated name of the pet (optional)
-     * @param  string $status Updated status of the pet (optional)
+     * @param  string|null $name Updated name of the pet (optional)
+     * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetWithFormAsync($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
+    public function updatePetWithFormAsync(
+        int $pet_id,
+        ?string $name = null,
+        ?string $status = null,
+        string $contentType = self::contentTypes['updatePetWithForm'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->updatePetWithFormAsyncWithHttpInfo($pet_id, $name, $status, $contentType)
             ->then(
@@ -2118,14 +2248,19 @@ class PetApi
      * Updates a pet in the store with form data
      *
      * @param  int $pet_id ID of pet that needs to be updated (required)
-     * @param  string $name Updated name of the pet (optional)
-     * @param  string $status Updated status of the pet (optional)
+     * @param  string|null $name Updated name of the pet (optional)
+     * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updatePetWithFormAsyncWithHttpInfo($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
+    public function updatePetWithFormAsyncWithHttpInfo(
+        $pet_id,
+        $name = null,
+        $status = null,
+        string $contentType = self::contentTypes['updatePetWithForm'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->updatePetWithFormRequest($pet_id, $name, $status, $contentType);
@@ -2157,14 +2292,19 @@ class PetApi
      * Create request for operation 'updatePetWithForm'
      *
      * @param  int $pet_id ID of pet that needs to be updated (required)
-     * @param  string $name Updated name of the pet (optional)
-     * @param  string $status Updated status of the pet (optional)
+     * @param  string|null $name Updated name of the pet (optional)
+     * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updatePetWithFormRequest($pet_id, $name = null, $status = null, string $contentType = self::contentTypes['updatePetWithForm'][0])
+    public function updatePetWithFormRequest(
+        $pet_id,
+        $name = null,
+        $status = null,
+        string $contentType = self::contentTypes['updatePetWithForm'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2267,15 +2407,20 @@ class PetApi
      * uploads an image
      *
      * @param  int $pet_id ID of pet to update (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
-     * @param  \SplFileObject $file file to upload (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
+     * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
-    public function uploadFile($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
+    public function uploadFile(
+        int $pet_id,
+        ?string $additional_metadata = null,
+        ?\SplFileObject $file = null,
+        string $contentType = self::contentTypes['uploadFile'][0]
+    ): \OpenAPI\Client\Model\ApiResponse
     {
         list($response) = $this->uploadFileWithHttpInfo($pet_id, $additional_metadata, $file, $contentType);
         return $response;
@@ -2287,15 +2432,20 @@ class PetApi
      * uploads an image
      *
      * @param  int $pet_id ID of pet to update (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
-     * @param  \SplFileObject $file file to upload (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
+     * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function uploadFileWithHttpInfo($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
+    public function uploadFileWithHttpInfo(
+        int $pet_id,
+        ?string $additional_metadata = null,
+        ?\SplFileObject $file = null,
+        string $contentType = self::contentTypes['uploadFile'][0]
+    ): array
     {
         $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file, $contentType);
 
@@ -2389,14 +2539,19 @@ class PetApi
      * uploads an image
      *
      * @param  int $pet_id ID of pet to update (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
-     * @param  \SplFileObject $file file to upload (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
+     * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileAsync($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
+    public function uploadFileAsync(
+        int $pet_id,
+        ?string $additional_metadata = null,
+        ?\SplFileObject $file = null,
+        string $contentType = self::contentTypes['uploadFile'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata, $file, $contentType)
             ->then(
@@ -2412,14 +2567,19 @@ class PetApi
      * uploads an image
      *
      * @param  int $pet_id ID of pet to update (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
-     * @param  \SplFileObject $file file to upload (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
+     * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
+    public function uploadFileAsyncWithHttpInfo(
+        $pet_id,
+        $additional_metadata = null,
+        $file = null,
+        string $contentType = self::contentTypes['uploadFile'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
         $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file, $contentType);
@@ -2464,14 +2624,19 @@ class PetApi
      * Create request for operation 'uploadFile'
      *
      * @param  int $pet_id ID of pet to update (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
-     * @param  \SplFileObject $file file to upload (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
+     * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function uploadFileRequest($pet_id, $additional_metadata = null, $file = null, string $contentType = self::contentTypes['uploadFile'][0])
+    public function uploadFileRequest(
+        $pet_id,
+        $additional_metadata = null,
+        $file = null,
+        string $contentType = self::contentTypes['uploadFile'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2583,14 +2748,19 @@ class PetApi
      *
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
-    public function uploadFileWithRequiredFile($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
+    public function uploadFileWithRequiredFile(
+        int $pet_id,
+        \SplFileObject $required_file,
+        ?string $additional_metadata = null,
+        string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
+    ): \OpenAPI\Client\Model\ApiResponse
     {
         list($response) = $this->uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata, $contentType);
         return $response;
@@ -2603,14 +2773,19 @@ class PetApi
      *
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \OpenAPI\Client\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
-    public function uploadFileWithRequiredFileWithHttpInfo($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
+    public function uploadFileWithRequiredFileWithHttpInfo(
+        int $pet_id,
+        \SplFileObject $required_file,
+        ?string $additional_metadata = null,
+        string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
+    ): array
     {
         $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata, $contentType);
 
@@ -2705,13 +2880,18 @@ class PetApi
      *
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileWithRequiredFileAsync($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
+    public function uploadFileWithRequiredFileAsync(
+        int $pet_id,
+        \SplFileObject $required_file,
+        ?string $additional_metadata = null,
+        string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata, $contentType)
             ->then(
@@ -2728,13 +2908,18 @@ class PetApi
      *
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
+    public function uploadFileWithRequiredFileAsyncWithHttpInfo(
+        $pet_id,
+        $required_file,
+        $additional_metadata = null,
+        string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
         $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata, $contentType);
@@ -2780,13 +2965,18 @@ class PetApi
      *
      * @param  int $pet_id ID of pet to update (required)
      * @param  \SplFileObject $required_file file to upload (required)
-     * @param  string $additional_metadata Additional data to pass to server (optional)
+     * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata = null, string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0])
+    public function uploadFileWithRequiredFileRequest(
+        $pet_id,
+        $required_file,
+        $additional_metadata = null,
+        string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
+    ): Request
     {
 
         // verify the required parameter 'pet_id' is set
@@ -2903,7 +3093,7 @@ class PetApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -52,22 +52,22 @@ class PetApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -102,7 +102,7 @@ class PetApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -112,7 +112,7 @@ class PetApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -125,7 +125,7 @@ class PetApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -135,7 +135,7 @@ class PetApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -143,7 +143,7 @@ class PetApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -106,7 +108,7 @@ class PetApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -174,8 +176,8 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function addPet(
@@ -214,8 +216,8 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function addPetWithHttpInfo(
@@ -297,15 +299,15 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function addPetAsync(
         \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['addPet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->addPetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
@@ -341,15 +343,15 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function addPetAsyncWithHttpInfo(
         $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['addPet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->addPetRequest($pet, $hostIndex, $variables, $contentType);
@@ -401,7 +403,7 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['addPet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function addPetRequest(
@@ -414,7 +416,7 @@ class PetApi
 
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling addPet'
             );
         }
@@ -493,7 +495,7 @@ class PetApi
         $hostSettings = $this->getHostSettingsForaddPet();
 
         if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new \InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
         }
         $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         $query = ObjectSerializer::buildQuery($queryParams);
@@ -556,8 +558,8 @@ class PetApi
      * @param  string|null $api_key api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function deletePet(
@@ -578,8 +580,8 @@ class PetApi
      * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function deletePetWithHttpInfo(
@@ -643,14 +645,14 @@ class PetApi
      * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deletePetAsync(
         int $pet_id,
         ?string $api_key = null,
         string $contentType = self::contentTypes['deletePet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->deletePetAsyncWithHttpInfo($pet_id, $api_key, $contentType)
             ->then(
@@ -669,14 +671,14 @@ class PetApi
      * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deletePetAsyncWithHttpInfo(
         $pet_id,
         $api_key = null,
         string $contentType = self::contentTypes['deletePet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->deletePetRequest($pet_id, $api_key, $contentType);
@@ -711,7 +713,7 @@ class PetApi
      * @param  string|null $api_key (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deletePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deletePetRequest(
@@ -723,7 +725,7 @@ class PetApi
 
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling deletePet'
             );
         }
@@ -818,8 +820,8 @@ class PetApi
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
      */
     public function findPetsByStatus(
@@ -839,8 +841,8 @@ class PetApi
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      */
     public function findPetsByStatusWithHttpInfo(
@@ -942,13 +944,13 @@ class PetApi
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function findPetsByStatusAsync(
         array $status,
         string $contentType = self::contentTypes['findPetsByStatus'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->findPetsByStatusAsyncWithHttpInfo($status, $contentType)
             ->then(
@@ -966,13 +968,13 @@ class PetApi
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function findPetsByStatusAsyncWithHttpInfo(
         $status,
         string $contentType = self::contentTypes['findPetsByStatus'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
         $request = $this->findPetsByStatusRequest($status, $contentType);
@@ -1019,7 +1021,7 @@ class PetApi
      * @param  string[] $status Status values that need to be considered for filter (required) (deprecated)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByStatus'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function findPetsByStatusRequest(
@@ -1030,7 +1032,7 @@ class PetApi
 
         // verify the required parameter 'status' is set
         if ($status === null || (is_array($status) && count($status) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $status when calling findPetsByStatus'
             );
         }
@@ -1121,8 +1123,8 @@ class PetApi
      * @param  string[] $tags Tags to filter by (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet[]
      * @deprecated
      */
@@ -1143,8 +1145,8 @@ class PetApi
      * @param  string[] $tags Tags to filter by (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet[], HTTP status code, HTTP response headers (array of strings)
      * @deprecated
      */
@@ -1247,14 +1249,14 @@ class PetApi
      * @param  string[] $tags Tags to filter by (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      * @deprecated
      */
     public function findPetsByTagsAsync(
         array $tags,
         string $contentType = self::contentTypes['findPetsByTags'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->findPetsByTagsAsyncWithHttpInfo($tags, $contentType)
             ->then(
@@ -1272,14 +1274,14 @@ class PetApi
      * @param  string[] $tags Tags to filter by (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      * @deprecated
      */
     public function findPetsByTagsAsyncWithHttpInfo(
         $tags,
         string $contentType = self::contentTypes['findPetsByTags'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet[]';
         $request = $this->findPetsByTagsRequest($tags, $contentType);
@@ -1326,7 +1328,7 @@ class PetApi
      * @param  string[] $tags Tags to filter by (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['findPetsByTags'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      * @deprecated
      */
@@ -1338,7 +1340,7 @@ class PetApi
 
         // verify the required parameter 'tags' is set
         if ($tags === null || (is_array($tags) && count($tags) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $tags when calling findPetsByTags'
             );
         }
@@ -1429,8 +1431,8 @@ class PetApi
      * @param  int $pet_id ID of pet to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Pet
      */
     public function getPetById(
@@ -1450,8 +1452,8 @@ class PetApi
      * @param  int $pet_id ID of pet to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Pet, HTTP status code, HTTP response headers (array of strings)
      */
     public function getPetByIdWithHttpInfo(
@@ -1553,13 +1555,13 @@ class PetApi
      * @param  int $pet_id ID of pet to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getPetByIdAsync(
         int $pet_id,
         string $contentType = self::contentTypes['getPetById'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->getPetByIdAsyncWithHttpInfo($pet_id, $contentType)
             ->then(
@@ -1577,13 +1579,13 @@ class PetApi
      * @param  int $pet_id ID of pet to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getPetByIdAsyncWithHttpInfo(
         $pet_id,
         string $contentType = self::contentTypes['getPetById'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Pet';
         $request = $this->getPetByIdRequest($pet_id, $contentType);
@@ -1630,7 +1632,7 @@ class PetApi
      * @param  int $pet_id ID of pet to return (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getPetById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getPetByIdRequest(
@@ -1641,7 +1643,7 @@ class PetApi
 
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling getPetById'
             );
         }
@@ -1750,8 +1752,8 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function updatePet(
@@ -1790,8 +1792,8 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function updatePetWithHttpInfo(
@@ -1873,15 +1875,15 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updatePetAsync(
         \OpenAPI\Client\Model\Pet $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['updatePet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->updatePetAsyncWithHttpInfo($pet, $hostIndex, $variables, $contentType)
             ->then(
@@ -1917,15 +1919,15 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updatePetAsyncWithHttpInfo(
         $pet,
         ?int $hostIndex = null,
         array $variables = [],
         string $contentType = self::contentTypes['updatePet'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->updatePetRequest($pet, $hostIndex, $variables, $contentType);
@@ -1977,7 +1979,7 @@ class PetApi
      * @param  array $variables Associative array of variables to pass to the host. Defaults to empty array.
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePet'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updatePetRequest(
@@ -1990,7 +1992,7 @@ class PetApi
 
         // verify the required parameter 'pet' is set
         if ($pet === null || (is_array($pet) && count($pet) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet when calling updatePet'
             );
         }
@@ -2069,7 +2071,7 @@ class PetApi
         $hostSettings = $this->getHostSettingsForupdatePet();
 
         if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
-            throw new \InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
+            throw new InvalidArgumentException("Invalid index {$hostIndex} when selecting the host. Must be less than ".count($hostSettings));
         }
         $operationHost = Configuration::getHostString($hostSettings, $hostIndex, $variables);
         $query = ObjectSerializer::buildQuery($queryParams);
@@ -2133,8 +2135,8 @@ class PetApi
      * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function updatePetWithForm(
@@ -2157,8 +2159,8 @@ class PetApi
      * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function updatePetWithFormWithHttpInfo(
@@ -2224,15 +2226,15 @@ class PetApi
      * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updatePetWithFormAsync(
         int $pet_id,
         ?string $name = null,
         ?string $status = null,
         string $contentType = self::contentTypes['updatePetWithForm'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->updatePetWithFormAsyncWithHttpInfo($pet_id, $name, $status, $contentType)
             ->then(
@@ -2252,15 +2254,15 @@ class PetApi
      * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updatePetWithFormAsyncWithHttpInfo(
         $pet_id,
         $name = null,
         $status = null,
         string $contentType = self::contentTypes['updatePetWithForm'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->updatePetWithFormRequest($pet_id, $name, $status, $contentType);
@@ -2296,7 +2298,7 @@ class PetApi
      * @param  string|null $status Updated status of the pet (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updatePetWithForm'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updatePetWithFormRequest(
@@ -2309,7 +2311,7 @@ class PetApi
 
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling updatePetWithForm'
             );
         }
@@ -2411,8 +2413,8 @@ class PetApi
      * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
     public function uploadFile(
@@ -2436,8 +2438,8 @@ class PetApi
      * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
     public function uploadFileWithHttpInfo(
@@ -2543,15 +2545,15 @@ class PetApi
      * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function uploadFileAsync(
         int $pet_id,
         ?string $additional_metadata = null,
         ?\SplFileObject $file = null,
         string $contentType = self::contentTypes['uploadFile'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->uploadFileAsyncWithHttpInfo($pet_id, $additional_metadata, $file, $contentType)
             ->then(
@@ -2571,15 +2573,15 @@ class PetApi
      * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function uploadFileAsyncWithHttpInfo(
         $pet_id,
         $additional_metadata = null,
         $file = null,
         string $contentType = self::contentTypes['uploadFile'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
         $request = $this->uploadFileRequest($pet_id, $additional_metadata, $file, $contentType);
@@ -2628,7 +2630,7 @@ class PetApi
      * @param  \SplFileObject|null $file file to upload (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function uploadFileRequest(
@@ -2641,7 +2643,7 @@ class PetApi
 
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling uploadFile'
             );
         }
@@ -2751,8 +2753,8 @@ class PetApi
      * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\ApiResponse
      */
     public function uploadFileWithRequiredFile(
@@ -2776,8 +2778,8 @@ class PetApi
      * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\ApiResponse, HTTP status code, HTTP response headers (array of strings)
      */
     public function uploadFileWithRequiredFileWithHttpInfo(
@@ -2883,15 +2885,15 @@ class PetApi
      * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function uploadFileWithRequiredFileAsync(
         int $pet_id,
         \SplFileObject $required_file,
         ?string $additional_metadata = null,
         string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->uploadFileWithRequiredFileAsyncWithHttpInfo($pet_id, $required_file, $additional_metadata, $contentType)
             ->then(
@@ -2911,15 +2913,15 @@ class PetApi
      * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function uploadFileWithRequiredFileAsyncWithHttpInfo(
         $pet_id,
         $required_file,
         $additional_metadata = null,
         string $contentType = self::contentTypes['uploadFileWithRequiredFile'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\ApiResponse';
         $request = $this->uploadFileWithRequiredFileRequest($pet_id, $required_file, $additional_metadata, $contentType);
@@ -2968,7 +2970,7 @@ class PetApi
      * @param  string|null $additional_metadata Additional data to pass to server (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['uploadFileWithRequiredFile'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function uploadFileWithRequiredFileRequest(
@@ -2981,14 +2983,14 @@ class PetApi
 
         // verify the required parameter 'pet_id' is set
         if ($pet_id === null || (is_array($pet_id) && count($pet_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $pet_id when calling uploadFileWithRequiredFile'
             );
         }
 
         // verify the required parameter 'required_file' is set
         if ($required_file === null || (is_array($required_file) && count($required_file) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $required_file when calling uploadFileWithRequiredFile'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -86,10 +86,10 @@ class StoreApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -143,7 +143,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteOrder($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
+    public function deleteOrder(
+        string $order_id,
+        string $contentType = self::contentTypes['deleteOrder'][0]
+    ): void
     {
         $this->deleteOrderWithHttpInfo($order_id, $contentType);
     }
@@ -160,7 +163,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteOrderWithHttpInfo($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
+    public function deleteOrderWithHttpInfo(
+        string $order_id,
+        string $contentType = self::contentTypes['deleteOrder'][0]
+    ): array
     {
         $request = $this->deleteOrderRequest($order_id, $contentType);
 
@@ -219,7 +225,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteOrderAsync($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
+    public function deleteOrderAsync(
+        string $order_id,
+        string $contentType = self::contentTypes['deleteOrder'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->deleteOrderAsyncWithHttpInfo($order_id, $contentType)
             ->then(
@@ -240,7 +249,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteOrderAsyncWithHttpInfo($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
+    public function deleteOrderAsyncWithHttpInfo(
+        $order_id,
+        string $contentType = self::contentTypes['deleteOrder'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->deleteOrderRequest($order_id, $contentType);
@@ -277,7 +289,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deleteOrderRequest($order_id, string $contentType = self::contentTypes['deleteOrder'][0])
+    public function deleteOrderRequest(
+        $order_id,
+        string $contentType = self::contentTypes['deleteOrder'][0]
+    ): Request
     {
 
         // verify the required parameter 'order_id' is set
@@ -371,7 +386,9 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return array<string,int>
      */
-    public function getInventory(string $contentType = self::contentTypes['getInventory'][0])
+    public function getInventory(
+        string $contentType = self::contentTypes['getInventory'][0]
+    ): array&lt;string,int&gt;
     {
         list($response) = $this->getInventoryWithHttpInfo($contentType);
         return $response;
@@ -388,7 +405,9 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return array of array<string,int>, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getInventoryWithHttpInfo(string $contentType = self::contentTypes['getInventory'][0])
+    public function getInventoryWithHttpInfo(
+        string $contentType = self::contentTypes['getInventory'][0]
+    ): array
     {
         $request = $this->getInventoryRequest($contentType);
 
@@ -486,7 +505,9 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getInventoryAsync(string $contentType = self::contentTypes['getInventory'][0])
+    public function getInventoryAsync(
+        string $contentType = self::contentTypes['getInventory'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->getInventoryAsyncWithHttpInfo($contentType)
             ->then(
@@ -506,7 +527,9 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getInventoryAsyncWithHttpInfo(string $contentType = self::contentTypes['getInventory'][0])
+    public function getInventoryAsyncWithHttpInfo(
+        string $contentType = self::contentTypes['getInventory'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = 'array<string,int>';
         $request = $this->getInventoryRequest($contentType);
@@ -555,7 +578,9 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getInventoryRequest(string $contentType = self::contentTypes['getInventory'][0])
+    public function getInventoryRequest(
+        string $contentType = self::contentTypes['getInventory'][0]
+    ): Request
     {
 
 
@@ -640,7 +665,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
-    public function getOrderById($order_id, string $contentType = self::contentTypes['getOrderById'][0])
+    public function getOrderById(
+        int $order_id,
+        string $contentType = self::contentTypes['getOrderById'][0]
+    ): \OpenAPI\Client\Model\Order
     {
         list($response) = $this->getOrderByIdWithHttpInfo($order_id, $contentType);
         return $response;
@@ -658,7 +686,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getOrderByIdWithHttpInfo($order_id, string $contentType = self::contentTypes['getOrderById'][0])
+    public function getOrderByIdWithHttpInfo(
+        int $order_id,
+        string $contentType = self::contentTypes['getOrderById'][0]
+    ): array
     {
         $request = $this->getOrderByIdRequest($order_id, $contentType);
 
@@ -757,7 +788,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getOrderByIdAsync($order_id, string $contentType = self::contentTypes['getOrderById'][0])
+    public function getOrderByIdAsync(
+        int $order_id,
+        string $contentType = self::contentTypes['getOrderById'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->getOrderByIdAsyncWithHttpInfo($order_id, $contentType)
             ->then(
@@ -778,7 +812,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getOrderByIdAsyncWithHttpInfo($order_id, string $contentType = self::contentTypes['getOrderById'][0])
+    public function getOrderByIdAsyncWithHttpInfo(
+        $order_id,
+        string $contentType = self::contentTypes['getOrderById'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Order';
         $request = $this->getOrderByIdRequest($order_id, $contentType);
@@ -828,7 +865,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getOrderByIdRequest($order_id, string $contentType = self::contentTypes['getOrderById'][0])
+    public function getOrderByIdRequest(
+        $order_id,
+        string $contentType = self::contentTypes['getOrderById'][0]
+    ): Request
     {
 
         // verify the required parameter 'order_id' is set
@@ -929,7 +969,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
-    public function placeOrder($order, string $contentType = self::contentTypes['placeOrder'][0])
+    public function placeOrder(
+        \OpenAPI\Client\Model\Order $order,
+        string $contentType = self::contentTypes['placeOrder'][0]
+    ): \OpenAPI\Client\Model\Order
     {
         list($response) = $this->placeOrderWithHttpInfo($order, $contentType);
         return $response;
@@ -947,7 +990,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
-    public function placeOrderWithHttpInfo($order, string $contentType = self::contentTypes['placeOrder'][0])
+    public function placeOrderWithHttpInfo(
+        \OpenAPI\Client\Model\Order $order,
+        string $contentType = self::contentTypes['placeOrder'][0]
+    ): array
     {
         $request = $this->placeOrderRequest($order, $contentType);
 
@@ -1046,7 +1092,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function placeOrderAsync($order, string $contentType = self::contentTypes['placeOrder'][0])
+    public function placeOrderAsync(
+        \OpenAPI\Client\Model\Order $order,
+        string $contentType = self::contentTypes['placeOrder'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->placeOrderAsyncWithHttpInfo($order, $contentType)
             ->then(
@@ -1067,7 +1116,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function placeOrderAsyncWithHttpInfo($order, string $contentType = self::contentTypes['placeOrder'][0])
+    public function placeOrderAsyncWithHttpInfo(
+        $order,
+        string $contentType = self::contentTypes['placeOrder'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Order';
         $request = $this->placeOrderRequest($order, $contentType);
@@ -1117,7 +1169,10 @@ class StoreApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function placeOrderRequest($order, string $contentType = self::contentTypes['placeOrder'][0])
+    public function placeOrderRequest(
+        $order,
+        string $contentType = self::contentTypes['placeOrder'][0]
+    ): Request
     {
 
         // verify the required parameter 'order' is set
@@ -1205,7 +1260,7 @@ class StoreApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -89,7 +91,7 @@ class StoreApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -139,8 +141,8 @@ class StoreApi
      * @param  string $order_id ID of the order that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function deleteOrder(
@@ -159,8 +161,8 @@ class StoreApi
      * @param  string $order_id ID of the order that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function deleteOrderWithHttpInfo(
@@ -222,13 +224,13 @@ class StoreApi
      * @param  string $order_id ID of the order that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deleteOrderAsync(
         string $order_id,
         string $contentType = self::contentTypes['deleteOrder'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->deleteOrderAsyncWithHttpInfo($order_id, $contentType)
             ->then(
@@ -246,13 +248,13 @@ class StoreApi
      * @param  string $order_id ID of the order that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deleteOrderAsyncWithHttpInfo(
         $order_id,
         string $contentType = self::contentTypes['deleteOrder'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->deleteOrderRequest($order_id, $contentType);
@@ -286,7 +288,7 @@ class StoreApi
      * @param  string $order_id ID of the order that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deleteOrderRequest(
@@ -297,7 +299,7 @@ class StoreApi
 
         // verify the required parameter 'order_id' is set
         if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $order_id when calling deleteOrder'
             );
         }
@@ -382,8 +384,8 @@ class StoreApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array<string,int>
      */
     public function getInventory(
@@ -401,8 +403,8 @@ class StoreApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of array<string,int>, HTTP status code, HTTP response headers (array of strings)
      */
     public function getInventoryWithHttpInfo(
@@ -502,12 +504,12 @@ class StoreApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getInventoryAsync(
         string $contentType = self::contentTypes['getInventory'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->getInventoryAsyncWithHttpInfo($contentType)
             ->then(
@@ -524,12 +526,12 @@ class StoreApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getInventoryAsyncWithHttpInfo(
         string $contentType = self::contentTypes['getInventory'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = 'array<string,int>';
         $request = $this->getInventoryRequest($contentType);
@@ -575,7 +577,7 @@ class StoreApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getInventory'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getInventoryRequest(
@@ -661,8 +663,8 @@ class StoreApi
      * @param  int $order_id ID of pet that needs to be fetched (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
     public function getOrderById(
@@ -682,8 +684,8 @@ class StoreApi
      * @param  int $order_id ID of pet that needs to be fetched (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
     public function getOrderByIdWithHttpInfo(
@@ -785,13 +787,13 @@ class StoreApi
      * @param  int $order_id ID of pet that needs to be fetched (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getOrderByIdAsync(
         int $order_id,
         string $contentType = self::contentTypes['getOrderById'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->getOrderByIdAsyncWithHttpInfo($order_id, $contentType)
             ->then(
@@ -809,13 +811,13 @@ class StoreApi
      * @param  int $order_id ID of pet that needs to be fetched (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getOrderByIdAsyncWithHttpInfo(
         $order_id,
         string $contentType = self::contentTypes['getOrderById'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Order';
         $request = $this->getOrderByIdRequest($order_id, $contentType);
@@ -862,7 +864,7 @@ class StoreApi
      * @param  int $order_id ID of pet that needs to be fetched (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getOrderById'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getOrderByIdRequest(
@@ -873,15 +875,15 @@ class StoreApi
 
         // verify the required parameter 'order_id' is set
         if ($order_id === null || (is_array($order_id) && count($order_id) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $order_id when calling getOrderById'
             );
         }
         if ($order_id > 5) {
-            throw new \InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be smaller than or equal to 5.');
+            throw new InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be smaller than or equal to 5.');
         }
         if ($order_id < 1) {
-            throw new \InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
+            throw new InvalidArgumentException('invalid value for "$order_id" when calling StoreApi.getOrderById, must be bigger than or equal to 1.');
         }
         
 
@@ -965,8 +967,8 @@ class StoreApi
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\Order
      */
     public function placeOrder(
@@ -986,8 +988,8 @@ class StoreApi
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\Order, HTTP status code, HTTP response headers (array of strings)
      */
     public function placeOrderWithHttpInfo(
@@ -1089,13 +1091,13 @@ class StoreApi
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function placeOrderAsync(
         \OpenAPI\Client\Model\Order $order,
         string $contentType = self::contentTypes['placeOrder'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->placeOrderAsyncWithHttpInfo($order, $contentType)
             ->then(
@@ -1113,13 +1115,13 @@ class StoreApi
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function placeOrderAsyncWithHttpInfo(
         $order,
         string $contentType = self::contentTypes['placeOrder'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\Order';
         $request = $this->placeOrderRequest($order, $contentType);
@@ -1166,7 +1168,7 @@ class StoreApi
      * @param  \OpenAPI\Client\Model\Order $order order placed for purchasing the pet (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['placeOrder'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function placeOrderRequest(
@@ -1177,7 +1179,7 @@ class StoreApi
 
         // verify the required parameter 'order' is set
         if ($order === null || (is_array($order) && count($order) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $order when calling placeOrder'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -52,22 +52,22 @@ class StoreApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -85,7 +85,7 @@ class StoreApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -95,7 +95,7 @@ class StoreApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -108,7 +108,7 @@ class StoreApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -118,7 +118,7 @@ class StoreApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -126,7 +126,7 @@ class StoreApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -27,6 +27,7 @@
 
 namespace OpenAPI\Client\Api;
 
+use InvalidArgumentException;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -34,6 +35,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
+use GuzzleHttp\Promise\PromiseInterface;
 use OpenAPI\Client\ApiException;
 use OpenAPI\Client\Configuration;
 use OpenAPI\Client\HeaderSelector;
@@ -101,7 +103,7 @@ class UserApi
      * @param ClientInterface|null $client
      * @param Configuration|null   $config
      * @param HeaderSelector|null  $selector
-     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param int                  $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -151,8 +153,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function createUser(
@@ -171,8 +173,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function createUserWithHttpInfo(
@@ -234,13 +236,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUserAsync(
         \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['createUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->createUserAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -258,13 +260,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUserAsyncWithHttpInfo(
         $user,
         string $contentType = self::contentTypes['createUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->createUserRequest($user, $contentType);
@@ -298,7 +300,7 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Created user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUserRequest(
@@ -309,7 +311,7 @@ class UserApi
 
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUser'
             );
         }
@@ -394,8 +396,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function createUsersWithArrayInput(
@@ -414,8 +416,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function createUsersWithArrayInputWithHttpInfo(
@@ -477,13 +479,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUsersWithArrayInputAsync(
         array $user,
         string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->createUsersWithArrayInputAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -501,13 +503,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUsersWithArrayInputAsyncWithHttpInfo(
         $user,
         string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->createUsersWithArrayInputRequest($user, $contentType);
@@ -541,7 +543,7 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithArrayInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUsersWithArrayInputRequest(
@@ -552,7 +554,7 @@ class UserApi
 
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithArrayInput'
             );
         }
@@ -637,8 +639,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function createUsersWithListInput(
@@ -657,8 +659,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function createUsersWithListInputWithHttpInfo(
@@ -720,13 +722,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUsersWithListInputAsync(
         array $user,
         string $contentType = self::contentTypes['createUsersWithListInput'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->createUsersWithListInputAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -744,13 +746,13 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function createUsersWithListInputAsyncWithHttpInfo(
         $user,
         string $contentType = self::contentTypes['createUsersWithListInput'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->createUsersWithListInputRequest($user, $contentType);
@@ -784,7 +786,7 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User[] $user List of user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['createUsersWithListInput'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function createUsersWithListInputRequest(
@@ -795,7 +797,7 @@ class UserApi
 
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling createUsersWithListInput'
             );
         }
@@ -880,8 +882,8 @@ class UserApi
      * @param  string $username The name that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function deleteUser(
@@ -900,8 +902,8 @@ class UserApi
      * @param  string $username The name that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function deleteUserWithHttpInfo(
@@ -963,13 +965,13 @@ class UserApi
      * @param  string $username The name that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deleteUserAsync(
         string $username,
         string $contentType = self::contentTypes['deleteUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->deleteUserAsyncWithHttpInfo($username, $contentType)
             ->then(
@@ -987,13 +989,13 @@ class UserApi
      * @param  string $username The name that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function deleteUserAsyncWithHttpInfo(
         $username,
         string $contentType = self::contentTypes['deleteUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->deleteUserRequest($username, $contentType);
@@ -1027,7 +1029,7 @@ class UserApi
      * @param  string $username The name that needs to be deleted (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['deleteUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function deleteUserRequest(
@@ -1038,7 +1040,7 @@ class UserApi
 
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling deleteUser'
             );
         }
@@ -1124,8 +1126,8 @@ class UserApi
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return \OpenAPI\Client\Model\User
      */
     public function getUserByName(
@@ -1145,8 +1147,8 @@ class UserApi
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\User, HTTP status code, HTTP response headers (array of strings)
      */
     public function getUserByNameWithHttpInfo(
@@ -1248,13 +1250,13 @@ class UserApi
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getUserByNameAsync(
         string $username,
         string $contentType = self::contentTypes['getUserByName'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->getUserByNameAsyncWithHttpInfo($username, $contentType)
             ->then(
@@ -1272,13 +1274,13 @@ class UserApi
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function getUserByNameAsyncWithHttpInfo(
         $username,
         string $contentType = self::contentTypes['getUserByName'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\User';
         $request = $this->getUserByNameRequest($username, $contentType);
@@ -1325,7 +1327,7 @@ class UserApi
      * @param  string $username The name that needs to be fetched. Use user1 for testing. (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['getUserByName'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function getUserByNameRequest(
@@ -1336,7 +1338,7 @@ class UserApi
 
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling getUserByName'
             );
         }
@@ -1423,8 +1425,8 @@ class UserApi
      * @param  string $password The password for login in clear text (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return string
      */
     public function loginUser(
@@ -1446,8 +1448,8 @@ class UserApi
      * @param  string $password The password for login in clear text (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function loginUserWithHttpInfo(
@@ -1551,14 +1553,14 @@ class UserApi
      * @param  string $password The password for login in clear text (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function loginUserAsync(
         string $username,
         string $password,
         string $contentType = self::contentTypes['loginUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->loginUserAsyncWithHttpInfo($username, $password, $contentType)
             ->then(
@@ -1577,14 +1579,14 @@ class UserApi
      * @param  string $password The password for login in clear text (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function loginUserAsyncWithHttpInfo(
         $username,
         $password,
         string $contentType = self::contentTypes['loginUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = 'string';
         $request = $this->loginUserRequest($username, $password, $contentType);
@@ -1632,7 +1634,7 @@ class UserApi
      * @param  string $password The password for login in clear text (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['loginUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function loginUserRequest(
@@ -1644,14 +1646,14 @@ class UserApi
 
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling loginUser'
             );
         }
 
         // verify the required parameter 'password' is set
         if ($password === null || (is_array($password) && count($password) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $password when calling loginUser'
             );
         }
@@ -1746,8 +1748,8 @@ class UserApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function logoutUser(
@@ -1764,8 +1766,8 @@ class UserApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function logoutUserWithHttpInfo(
@@ -1825,12 +1827,12 @@ class UserApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function logoutUserAsync(
         string $contentType = self::contentTypes['logoutUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->logoutUserAsyncWithHttpInfo($contentType)
             ->then(
@@ -1847,12 +1849,12 @@ class UserApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function logoutUserAsyncWithHttpInfo(
         string $contentType = self::contentTypes['logoutUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->logoutUserRequest($contentType);
@@ -1885,7 +1887,7 @@ class UserApi
      *
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['logoutUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function logoutUserRequest(
@@ -1967,8 +1969,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return void
      */
     public function updateUser(
@@ -1989,8 +1991,8 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
-     * @throws \OpenAPI\Client\ApiException on non-2xx response
-     * @throws \InvalidArgumentException
+     * @throws ApiException on non-2xx response
+     * @throws InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function updateUserWithHttpInfo(
@@ -2054,14 +2056,14 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updateUserAsync(
         string $username,
         \OpenAPI\Client\Model\User $user,
         string $contentType = self::contentTypes['updateUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         return $this->updateUserAsyncWithHttpInfo($username, $user, $contentType)
             ->then(
@@ -2080,14 +2082,14 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
-     * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
      */
     public function updateUserAsyncWithHttpInfo(
         $username,
         $user,
         string $contentType = self::contentTypes['updateUser'][0]
-    ): \GuzzleHttp\Promise\PromiseInterface
+    ): PromiseInterface
     {
         $returnType = '';
         $request = $this->updateUserRequest($username, $user, $contentType);
@@ -2122,7 +2124,7 @@ class UserApi
      * @param  \OpenAPI\Client\Model\User $user Updated user object (required)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['updateUser'] to see the possible values for this operation
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
     public function updateUserRequest(
@@ -2134,14 +2136,14 @@ class UserApi
 
         // verify the required parameter 'username' is set
         if ($username === null || (is_array($username) && count($username) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $username when calling updateUser'
             );
         }
 
         // verify the required parameter 'user' is set
         if ($user === null || (is_array($user) && count($user) === 0)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Missing the required parameter $user when calling updateUser'
             );
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -52,22 +52,22 @@ class UserApi
     /**
      * @var ClientInterface
      */
-    protected $client;
+    protected ClientInterface $client;
 
     /**
      * @var Configuration
      */
-    protected $config;
+    protected Configuration $config;
 
     /**
      * @var HeaderSelector
      */
-    protected $headerSelector;
+    protected HeaderSelector $headerSelector;
 
     /**
      * @var int Host index
      */
-    protected $hostIndex;
+    protected int $hostIndex;
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
@@ -97,7 +97,7 @@ class UserApi
         ],
     ];
 
-/**
+    /**
      * @param ClientInterface $client
      * @param Configuration   $config
      * @param HeaderSelector  $selector
@@ -107,7 +107,7 @@ class UserApi
         ClientInterface $client = null,
         Configuration $config = null,
         HeaderSelector $selector = null,
-        $hostIndex = 0
+        int $hostIndex = 0
     ) {
         $this->client = $client ?: new Client();
         $this->config = $config ?: new Configuration();
@@ -120,7 +120,7 @@ class UserApi
      *
      * @param int $hostIndex Host index (required)
      */
-    public function setHostIndex($hostIndex): void
+    public function setHostIndex(int $hostIndex): void
     {
         $this->hostIndex = $hostIndex;
     }
@@ -130,7 +130,7 @@ class UserApi
      *
      * @return int Host index
      */
-    public function getHostIndex()
+    public function getHostIndex(): int
     {
         return $this->hostIndex;
     }
@@ -138,7 +138,7 @@ class UserApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function getConfig(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -98,10 +98,10 @@ class UserApi
     ];
 
     /**
-     * @param ClientInterface $client
-     * @param Configuration   $config
-     * @param HeaderSelector  $selector
-     * @param int             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
+     * @param ClientInterface|null $client
+     * @param Configuration|null   $config
+     * @param HeaderSelector|null  $selector
+     * @param int|null             $hostIndex (Optional) host index to select the list of hosts if defined in the OpenAPI spec
      */
     public function __construct(
         ClientInterface $client = null,
@@ -155,7 +155,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUser($user, string $contentType = self::contentTypes['createUser'][0])
+    public function createUser(
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['createUser'][0]
+    ): void
     {
         $this->createUserWithHttpInfo($user, $contentType);
     }
@@ -172,7 +175,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUserWithHttpInfo($user, string $contentType = self::contentTypes['createUser'][0])
+    public function createUserWithHttpInfo(
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['createUser'][0]
+    ): array
     {
         $request = $this->createUserRequest($user, $contentType);
 
@@ -231,7 +237,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUserAsync($user, string $contentType = self::contentTypes['createUser'][0])
+    public function createUserAsync(
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['createUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->createUserAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -252,7 +261,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUserAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUser'][0])
+    public function createUserAsyncWithHttpInfo(
+        $user,
+        string $contentType = self::contentTypes['createUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->createUserRequest($user, $contentType);
@@ -289,7 +301,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUserRequest($user, string $contentType = self::contentTypes['createUser'][0])
+    public function createUserRequest(
+        $user,
+        string $contentType = self::contentTypes['createUser'][0]
+    ): Request
     {
 
         // verify the required parameter 'user' is set
@@ -383,7 +398,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUsersWithArrayInput($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
+    public function createUsersWithArrayInput(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
+    ): void
     {
         $this->createUsersWithArrayInputWithHttpInfo($user, $contentType);
     }
@@ -400,7 +418,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUsersWithArrayInputWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
+    public function createUsersWithArrayInputWithHttpInfo(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
+    ): array
     {
         $request = $this->createUsersWithArrayInputRequest($user, $contentType);
 
@@ -459,7 +480,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithArrayInputAsync($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
+    public function createUsersWithArrayInputAsync(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->createUsersWithArrayInputAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -480,7 +504,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithArrayInputAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
+    public function createUsersWithArrayInputAsyncWithHttpInfo(
+        $user,
+        string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->createUsersWithArrayInputRequest($user, $contentType);
@@ -517,7 +544,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUsersWithArrayInputRequest($user, string $contentType = self::contentTypes['createUsersWithArrayInput'][0])
+    public function createUsersWithArrayInputRequest(
+        $user,
+        string $contentType = self::contentTypes['createUsersWithArrayInput'][0]
+    ): Request
     {
 
         // verify the required parameter 'user' is set
@@ -611,7 +641,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function createUsersWithListInput($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
+    public function createUsersWithListInput(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithListInput'][0]
+    ): void
     {
         $this->createUsersWithListInputWithHttpInfo($user, $contentType);
     }
@@ -628,7 +661,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function createUsersWithListInputWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
+    public function createUsersWithListInputWithHttpInfo(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithListInput'][0]
+    ): array
     {
         $request = $this->createUsersWithListInputRequest($user, $contentType);
 
@@ -687,7 +723,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithListInputAsync($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
+    public function createUsersWithListInputAsync(
+        array $user,
+        string $contentType = self::contentTypes['createUsersWithListInput'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->createUsersWithListInputAsyncWithHttpInfo($user, $contentType)
             ->then(
@@ -708,7 +747,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function createUsersWithListInputAsyncWithHttpInfo($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
+    public function createUsersWithListInputAsyncWithHttpInfo(
+        $user,
+        string $contentType = self::contentTypes['createUsersWithListInput'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->createUsersWithListInputRequest($user, $contentType);
@@ -745,7 +787,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function createUsersWithListInputRequest($user, string $contentType = self::contentTypes['createUsersWithListInput'][0])
+    public function createUsersWithListInputRequest(
+        $user,
+        string $contentType = self::contentTypes['createUsersWithListInput'][0]
+    ): Request
     {
 
         // verify the required parameter 'user' is set
@@ -839,7 +884,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function deleteUser($username, string $contentType = self::contentTypes['deleteUser'][0])
+    public function deleteUser(
+        string $username,
+        string $contentType = self::contentTypes['deleteUser'][0]
+    ): void
     {
         $this->deleteUserWithHttpInfo($username, $contentType);
     }
@@ -856,7 +904,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function deleteUserWithHttpInfo($username, string $contentType = self::contentTypes['deleteUser'][0])
+    public function deleteUserWithHttpInfo(
+        string $username,
+        string $contentType = self::contentTypes['deleteUser'][0]
+    ): array
     {
         $request = $this->deleteUserRequest($username, $contentType);
 
@@ -915,7 +966,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteUserAsync($username, string $contentType = self::contentTypes['deleteUser'][0])
+    public function deleteUserAsync(
+        string $username,
+        string $contentType = self::contentTypes['deleteUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->deleteUserAsyncWithHttpInfo($username, $contentType)
             ->then(
@@ -936,7 +990,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function deleteUserAsyncWithHttpInfo($username, string $contentType = self::contentTypes['deleteUser'][0])
+    public function deleteUserAsyncWithHttpInfo(
+        $username,
+        string $contentType = self::contentTypes['deleteUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->deleteUserRequest($username, $contentType);
@@ -973,7 +1030,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function deleteUserRequest($username, string $contentType = self::contentTypes['deleteUser'][0])
+    public function deleteUserRequest(
+        $username,
+        string $contentType = self::contentTypes['deleteUser'][0]
+    ): Request
     {
 
         // verify the required parameter 'username' is set
@@ -1068,7 +1128,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \OpenAPI\Client\Model\User
      */
-    public function getUserByName($username, string $contentType = self::contentTypes['getUserByName'][0])
+    public function getUserByName(
+        string $username,
+        string $contentType = self::contentTypes['getUserByName'][0]
+    ): \OpenAPI\Client\Model\User
     {
         list($response) = $this->getUserByNameWithHttpInfo($username, $contentType);
         return $response;
@@ -1086,7 +1149,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of \OpenAPI\Client\Model\User, HTTP status code, HTTP response headers (array of strings)
      */
-    public function getUserByNameWithHttpInfo($username, string $contentType = self::contentTypes['getUserByName'][0])
+    public function getUserByNameWithHttpInfo(
+        string $username,
+        string $contentType = self::contentTypes['getUserByName'][0]
+    ): array
     {
         $request = $this->getUserByNameRequest($username, $contentType);
 
@@ -1185,7 +1251,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getUserByNameAsync($username, string $contentType = self::contentTypes['getUserByName'][0])
+    public function getUserByNameAsync(
+        string $username,
+        string $contentType = self::contentTypes['getUserByName'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->getUserByNameAsyncWithHttpInfo($username, $contentType)
             ->then(
@@ -1206,7 +1275,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function getUserByNameAsyncWithHttpInfo($username, string $contentType = self::contentTypes['getUserByName'][0])
+    public function getUserByNameAsyncWithHttpInfo(
+        $username,
+        string $contentType = self::contentTypes['getUserByName'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '\OpenAPI\Client\Model\User';
         $request = $this->getUserByNameRequest($username, $contentType);
@@ -1256,7 +1328,10 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function getUserByNameRequest($username, string $contentType = self::contentTypes['getUserByName'][0])
+    public function getUserByNameRequest(
+        $username,
+        string $contentType = self::contentTypes['getUserByName'][0]
+    ): Request
     {
 
         // verify the required parameter 'username' is set
@@ -1352,7 +1427,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function loginUser($username, $password, string $contentType = self::contentTypes['loginUser'][0])
+    public function loginUser(
+        string $username,
+        string $password,
+        string $contentType = self::contentTypes['loginUser'][0]
+    ): string
     {
         list($response) = $this->loginUserWithHttpInfo($username, $password, $contentType);
         return $response;
@@ -1371,7 +1450,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function loginUserWithHttpInfo($username, $password, string $contentType = self::contentTypes['loginUser'][0])
+    public function loginUserWithHttpInfo(
+        string $username,
+        string $password,
+        string $contentType = self::contentTypes['loginUser'][0]
+    ): array
     {
         $request = $this->loginUserRequest($username, $password, $contentType);
 
@@ -1471,7 +1554,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function loginUserAsync($username, $password, string $contentType = self::contentTypes['loginUser'][0])
+    public function loginUserAsync(
+        string $username,
+        string $password,
+        string $contentType = self::contentTypes['loginUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->loginUserAsyncWithHttpInfo($username, $password, $contentType)
             ->then(
@@ -1493,7 +1580,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function loginUserAsyncWithHttpInfo($username, $password, string $contentType = self::contentTypes['loginUser'][0])
+    public function loginUserAsyncWithHttpInfo(
+        $username,
+        $password,
+        string $contentType = self::contentTypes['loginUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = 'string';
         $request = $this->loginUserRequest($username, $password, $contentType);
@@ -1544,7 +1635,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function loginUserRequest($username, $password, string $contentType = self::contentTypes['loginUser'][0])
+    public function loginUserRequest(
+        $username,
+        $password,
+        string $contentType = self::contentTypes['loginUser'][0]
+    ): Request
     {
 
         // verify the required parameter 'username' is set
@@ -1655,7 +1750,9 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function logoutUser(string $contentType = self::contentTypes['logoutUser'][0])
+    public function logoutUser(
+        string $contentType = self::contentTypes['logoutUser'][0]
+    ): void
     {
         $this->logoutUserWithHttpInfo($contentType);
     }
@@ -1671,7 +1768,9 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function logoutUserWithHttpInfo(string $contentType = self::contentTypes['logoutUser'][0])
+    public function logoutUserWithHttpInfo(
+        string $contentType = self::contentTypes['logoutUser'][0]
+    ): array
     {
         $request = $this->logoutUserRequest($contentType);
 
@@ -1729,7 +1828,9 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function logoutUserAsync(string $contentType = self::contentTypes['logoutUser'][0])
+    public function logoutUserAsync(
+        string $contentType = self::contentTypes['logoutUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->logoutUserAsyncWithHttpInfo($contentType)
             ->then(
@@ -1749,7 +1850,9 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function logoutUserAsyncWithHttpInfo(string $contentType = self::contentTypes['logoutUser'][0])
+    public function logoutUserAsyncWithHttpInfo(
+        string $contentType = self::contentTypes['logoutUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->logoutUserRequest($contentType);
@@ -1785,7 +1888,9 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function logoutUserRequest(string $contentType = self::contentTypes['logoutUser'][0])
+    public function logoutUserRequest(
+        string $contentType = self::contentTypes['logoutUser'][0]
+    ): Request
     {
 
 
@@ -1866,7 +1971,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return void
      */
-    public function updateUser($username, $user, string $contentType = self::contentTypes['updateUser'][0])
+    public function updateUser(
+        string $username,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['updateUser'][0]
+    ): void
     {
         $this->updateUserWithHttpInfo($username, $user, $contentType);
     }
@@ -1884,7 +1993,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
-    public function updateUserWithHttpInfo($username, $user, string $contentType = self::contentTypes['updateUser'][0])
+    public function updateUserWithHttpInfo(
+        string $username,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['updateUser'][0]
+    ): array
     {
         $request = $this->updateUserRequest($username, $user, $contentType);
 
@@ -1944,7 +2057,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateUserAsync($username, $user, string $contentType = self::contentTypes['updateUser'][0])
+    public function updateUserAsync(
+        string $username,
+        \OpenAPI\Client\Model\User $user,
+        string $contentType = self::contentTypes['updateUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         return $this->updateUserAsyncWithHttpInfo($username, $user, $contentType)
             ->then(
@@ -1966,7 +2083,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function updateUserAsyncWithHttpInfo($username, $user, string $contentType = self::contentTypes['updateUser'][0])
+    public function updateUserAsyncWithHttpInfo(
+        $username,
+        $user,
+        string $contentType = self::contentTypes['updateUser'][0]
+    ): \GuzzleHttp\Promise\PromiseInterface
     {
         $returnType = '';
         $request = $this->updateUserRequest($username, $user, $contentType);
@@ -2004,7 +2125,11 @@ class UserApi
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function updateUserRequest($username, $user, string $contentType = self::contentTypes['updateUser'][0])
+    public function updateUserRequest(
+        $username,
+        $user,
+        string $contentType = self::contentTypes['updateUser'][0]
+    ): Request
     {
 
         // verify the required parameter 'username' is set
@@ -2107,7 +2232,7 @@ class UserApi
      * @throws \RuntimeException on file opening failure
      * @return array of http client options
      */
-    protected function createHttpClientOption()
+    protected function createHttpClientOption(): array
     {
         $options = [];
         if ($this->config->getDebug()) {

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
@@ -44,21 +44,21 @@ class ApiException extends Exception
      *
      * @var \stdClass|string|null
      */
-    protected $responseBody;
+    protected \stdClass|string|null $responseBody;
 
     /**
      * The HTTP header of the server response.
      *
      * @var string[]|null
      */
-    protected $responseHeaders;
+    protected ?array $responseHeaders;
 
     /**
      * The deserialized response object
      *
-     * @var \stdClass|string|null
+     * @var mixed
      */
-    protected $responseObject;
+    protected mixed $responseObject;
 
     /**
      * Constructor
@@ -66,9 +66,9 @@ class ApiException extends Exception
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
      * @param string[]|null         $responseHeaders HTTP response header
-     * @param \stdClass|string|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
+     * @param mixed $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;
@@ -80,7 +80,7 @@ class ApiException extends Exception
      *
      * @return string[]|null HTTP response header
      */
-    public function getResponseHeaders()
+    public function getResponseHeaders(): ?array
     {
         return $this->responseHeaders;
     }
@@ -90,7 +90,7 @@ class ApiException extends Exception
      *
      * @return \stdClass|string|null HTTP body of the server response either as \stdClass or string
      */
-    public function getResponseBody()
+    public function getResponseBody(): \stdClass|string|null
     {
         return $this->responseBody;
     }
@@ -102,7 +102,7 @@ class ApiException extends Exception
      *
      * @return void
      */
-    public function setResponseObject($obj)
+    public function setResponseObject(mixed $obj): void
     {
         $this->responseObject = $obj;
     }
@@ -112,7 +112,7 @@ class ApiException extends Exception
      *
      * @return mixed the deserialized response object
      */
-    public function getResponseObject()
+    public function getResponseObject(): mixed
     {
         return $this->responseObject;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ApiException.php
@@ -27,7 +27,8 @@
 
 namespace OpenAPI\Client;
 
-use \Exception;
+use Exception;
+use stdClass;
 
 /**
  * ApiException Class Doc Comment
@@ -42,9 +43,9 @@ class ApiException extends Exception
     /**
      * The HTTP body of the server response either as Json or string.
      *
-     * @var \stdClass|string|null
+     * @var stdClass|string|null
      */
-    protected \stdClass|string|null $responseBody;
+    protected stdClass|string|null $responseBody;
 
     /**
      * The HTTP header of the server response.
@@ -66,7 +67,7 @@ class ApiException extends Exception
      * @param string                $message         Error message
      * @param int                   $code            HTTP status code
      * @param string[]|null         $responseHeaders HTTP response header
-     * @param mixed $responseBody    HTTP decoded body of the server response either as \stdClass or string
+     * @param mixed $responseBody    HTTP decoded body of the server response either as stdClass or string
      */
     public function __construct(string $message = "", int $code = 0, ?array $responseHeaders = [], mixed $responseBody = null)
     {
@@ -88,9 +89,9 @@ class ApiException extends Exception
     /**
      * Gets the HTTP body of the server response either as Json or string
      *
-     * @return \stdClass|string|null HTTP body of the server response either as \stdClass or string
+     * @return stdClass|string|null HTTP body of the server response either as \stdClass or string
      */
-    public function getResponseBody(): \stdClass|string|null
+    public function getResponseBody(): stdClass|string|null
     {
         return $this->responseBody;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -43,84 +43,84 @@ class Configuration
     /**
      * @var Configuration
      */
-    private static $defaultConfiguration;
+    private static ?Configuration $defaultConfiguration = null;
 
     /**
      * Associate array to store API key(s)
      *
      * @var string[]
      */
-    protected $apiKeys = [];
+    protected array $apiKeys = [];
 
     /**
      * Associate array to store API prefix (e.g. Bearer)
      *
      * @var string[]
      */
-    protected $apiKeyPrefixes = [];
+    protected array $apiKeyPrefixes = [];
 
     /**
      * Access token for OAuth/Bearer authentication
      *
      * @var string
      */
-    protected $accessToken = '';
+    protected string $accessToken = '';
 
     /**
      * Boolean format for query string
      *
      * @var string
      */
-    protected $booleanFormatForQueryString = self::BOOLEAN_FORMAT_INT;
+    protected string $booleanFormatForQueryString = self::BOOLEAN_FORMAT_INT;
 
     /**
      * Username for HTTP basic authentication
      *
      * @var string
      */
-    protected $username = '';
+    protected string $username = '';
 
     /**
      * Password for HTTP basic authentication
      *
      * @var string
      */
-    protected $password = '';
+    protected string $password = '';
 
     /**
      * The host
      *
      * @var string
      */
-    protected $host = 'http://petstore.swagger.io:80/v2';
+    protected string $host = 'http://petstore.swagger.io:80/v2';
 
     /**
      * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected string $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
 
     /**
      * Debug switch (default set to false)
      *
      * @var bool
      */
-    protected $debug = false;
+    protected bool $debug = false;
 
     /**
      * Debug file location (log to STDOUT by default)
      *
      * @var string
      */
-    protected $debugFile = 'php://output';
+    protected string $debugFile = 'php://output';
 
     /**
      * Debug file location (log to STDOUT by default)
      *
      * @var string
      */
-    protected $tempFolderPath;
+    protected string $tempFolderPath;
 
     /**
      * Constructor
@@ -138,7 +138,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKey($apiKeyIdentifier, $key)
+    public function setApiKey(string $apiKeyIdentifier, string $key): static
     {
         $this->apiKeys[$apiKeyIdentifier] = $key;
         return $this;
@@ -151,9 +151,9 @@ class Configuration
      *
      * @return null|string API key or token
      */
-    public function getApiKey($apiKeyIdentifier)
+    public function getApiKey(string $apiKeyIdentifier): ?string
     {
-        return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
+        return $this->apiKeys[$apiKeyIdentifier] ?? null;
     }
 
     /**
@@ -164,7 +164,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
+    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix)
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
         return $this;
@@ -177,9 +177,9 @@ class Configuration
      *
      * @return null|string
      */
-    public function getApiKeyPrefix($apiKeyIdentifier)
+    public function getApiKeyPrefix(string $apiKeyIdentifier): ?string
     {
-        return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
+        return $this->apiKeyPrefixes[$apiKeyIdentifier] ?? null;
     }
 
     /**
@@ -189,7 +189,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setAccessToken($accessToken)
+    public function setAccessToken(string $accessToken): static
     {
         $this->accessToken = $accessToken;
         return $this;
@@ -200,7 +200,7 @@ class Configuration
      *
      * @return string Access token for OAuth
      */
-    public function getAccessToken()
+    public function getAccessToken(): string
     {
         return $this->accessToken;
     }
@@ -212,7 +212,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setBooleanFormatForQueryString(string $booleanFormat)
+    public function setBooleanFormatForQueryString(string $booleanFormat): static
     {
         $this->booleanFormatForQueryString = $booleanFormat;
 
@@ -236,7 +236,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setUsername($username)
+    public function setUsername(string $username): static
     {
         $this->username = $username;
         return $this;
@@ -247,7 +247,7 @@ class Configuration
      *
      * @return string Username for HTTP basic authentication
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -259,7 +259,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setPassword($password)
+    public function setPassword(string $password): static
     {
         $this->password = $password;
         return $this;
@@ -270,7 +270,7 @@ class Configuration
      *
      * @return string Password for HTTP basic authentication
      */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->password;
     }
@@ -282,7 +282,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setHost($host)
+    public function setHost(string $host): static
     {
         $this->host = $host;
         return $this;
@@ -293,7 +293,7 @@ class Configuration
      *
      * @return string Host
      */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
@@ -306,7 +306,7 @@ class Configuration
      * @throws \InvalidArgumentException
      * @return $this
      */
-    public function setUserAgent($userAgent)
+    public function setUserAgent(string $userAgent): static
     {
         if (!is_string($userAgent)) {
             throw new \InvalidArgumentException('User-agent must be a string.');
@@ -321,7 +321,7 @@ class Configuration
      *
      * @return string user agent
      */
-    public function getUserAgent()
+    public function getUserAgent(): string
     {
         return $this->userAgent;
     }
@@ -333,7 +333,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebug($debug)
+    public function setDebug(bool $debug): static
     {
         $this->debug = $debug;
         return $this;
@@ -344,7 +344,7 @@ class Configuration
      *
      * @return bool
      */
-    public function getDebug()
+    public function getDebug(): bool
     {
         return $this->debug;
     }
@@ -356,7 +356,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setDebugFile($debugFile)
+    public function setDebugFile(string $debugFile): static
     {
         $this->debugFile = $debugFile;
         return $this;
@@ -367,7 +367,7 @@ class Configuration
      *
      * @return string
      */
-    public function getDebugFile()
+    public function getDebugFile(): string
     {
         return $this->debugFile;
     }
@@ -379,7 +379,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setTempFolderPath($tempFolderPath)
+    public function setTempFolderPath(string $tempFolderPath): static
     {
         $this->tempFolderPath = $tempFolderPath;
         return $this;
@@ -390,7 +390,7 @@ class Configuration
      *
      * @return string Temp folder path
      */
-    public function getTempFolderPath()
+    public function getTempFolderPath(): string
     {
         return $this->tempFolderPath;
     }
@@ -400,7 +400,7 @@ class Configuration
      *
      * @return Configuration
      */
-    public static function getDefaultConfiguration()
+    public static function getDefaultConfiguration(): Configuration
     {
         if (self::$defaultConfiguration === null) {
             self::$defaultConfiguration = new Configuration();
@@ -426,7 +426,7 @@ class Configuration
      *
      * @return string The report for debugging
      */
-    public static function toDebugReport()
+    public static function toDebugReport(): string
     {
         $report  = 'PHP SDK (OpenAPI\Client) Debug Report:' . PHP_EOL;
         $report .= '    OS: ' . php_uname() . PHP_EOL;
@@ -444,7 +444,7 @@ class Configuration
      *
      * @return null|string API key with the prefix
      */
-    public function getApiKeyWithPrefix($apiKeyIdentifier)
+    public function getApiKeyWithPrefix(string $apiKeyIdentifier): ?string
     {
         $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->getApiKey($apiKeyIdentifier);
@@ -467,7 +467,7 @@ class Configuration
      *
      * @return array an array of host settings
      */
-    public function getHostSettings()
+    public function getHostSettings(): array
     {
         return [
             [
@@ -522,7 +522,7 @@ class Configuration
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, $hostIndex, array $variables = null)
+    public static function getHostString(array $hostsSettings, int $hostIndex, array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];
@@ -560,7 +560,7 @@ class Configuration
      * @param array|null $variables hash of variable and the corresponding value (optional)
      * @return string URL based on host settings
      */
-    public function getHostFromSettings($index, $variables = null)
+    public function getHostFromSettings(int $index, ?array $variables = null): string
     {
         return self::getHostString($this->getHostSettings(), $index, $variables);
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -27,6 +27,8 @@
 
 namespace OpenAPI\Client;
 
+use InvalidArgumentException;
+
 /**
  * Configuration Class Doc Comment
  *
@@ -41,7 +43,7 @@ class Configuration
     public const BOOLEAN_FORMAT_STRING = 'string';
 
     /**
-     * @var Configuration
+     * @var Configuration|null
      */
     private static ?Configuration $defaultConfiguration = null;
 
@@ -164,7 +166,7 @@ class Configuration
      *
      * @return $this
      */
-    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix)
+    public function setApiKeyPrefix(string $apiKeyIdentifier, string $prefix): static
     {
         $this->apiKeyPrefixes[$apiKeyIdentifier] = $prefix;
         return $this;
@@ -208,7 +210,7 @@ class Configuration
     /**
      * Sets boolean format for query string.
      *
-     * @param string $booleanFormatForQueryString Boolean format for query string
+     * @param string $booleanFormat Boolean format for query string
      *
      * @return $this
      */
@@ -303,15 +305,11 @@ class Configuration
      *
      * @param string $userAgent the user agent of the api client
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return $this
      */
     public function setUserAgent(string $userAgent): static
     {
-        if (!is_string($userAgent)) {
-            throw new \InvalidArgumentException('User-agent must be a string.');
-        }
-
         $this->userAgent = $userAgent;
         return $this;
     }
@@ -416,7 +414,7 @@ class Configuration
      *
      * @return void
      */
-    public static function setDefaultConfiguration(Configuration $config)
+    public static function setDefaultConfiguration(Configuration $config): void
     {
         self::$defaultConfiguration = $config;
     }
@@ -517,7 +515,7 @@ class Configuration
     /**
     * Returns URL based on host settings, index and variables
     *
-    * @param array      $hostSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
+    * @param array      $hostsSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
     * @param int        $hostIndex    index of the host settings
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
@@ -530,7 +528,7 @@ class Configuration
 
         // check array index out of bound
         if ($hostIndex < 0 || $hostIndex >= count($hostsSettings)) {
-            throw new \InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
+            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
         }
 
         $host = $hostsSettings[$hostIndex];
@@ -542,7 +540,7 @@ class Configuration
                 if (!isset($variable['enum_values']) || in_array($variables[$name], $variable["enum_values"], true)) { // check to see if the value is in the enum
                     $url = str_replace("{".$name."}", $variables[$name], $url);
                 } else {
-                    throw new \InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
+                    throw new InvalidArgumentException("The variable `$name` in the host URL has invalid value ".$variables[$name].". Must be ".join(',', $variable["enum_values"]).".");
                 }
             } else {
                 // use default value

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * AdditionalPropertiesClass Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSerializable
+class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     public function setMapProperty(?array $map_property): static
     {
         if (is_null($map_property)) {
-            throw new \InvalidArgumentException('non-nullable map_property cannot be null');
+            throw new InvalidArgumentException('non-nullable map_property cannot be null');
         }
         $this->container['map_property'] = $map_property;
 
@@ -341,7 +343,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     public function setMapOfMapProperty(?array $map_of_map_property): static
     {
         if (is_null($map_of_map_property)) {
-            throw new \InvalidArgumentException('non-nullable map_of_map_property cannot be null');
+            throw new InvalidArgumentException('non-nullable map_of_map_property cannot be null');
         }
         $this->container['map_of_map_property'] = $map_of_map_property;
 
@@ -366,7 +368,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -49,14 +49,14 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
       *
       * @var string
       */
-    protected static $openAPIModelName = 'AdditionalPropertiesClass';
+    protected static string $openAPIModelName = 'AdditionalPropertiesClass';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'map_property' => 'array<string,string>',
         'map_of_map_property' => 'array<string,array<string,string>>'
     ];
@@ -64,11 +64,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'map_property' => null,
         'map_of_map_property' => null
     ];
@@ -76,7 +74,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'map_property' => false,
@@ -86,16 +84,16 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'map_property' => 'map_property',
         'map_of_map_property' => 'map_of_map_property'
     ];
@@ -176,9 +174,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'map_property' => 'setMapProperty',
         'map_of_map_property' => 'setMapOfMapProperty'
     ];
@@ -186,9 +184,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'map_property' => 'getMapProperty',
         'map_of_map_property' => 'getMapOfMapProperty'
     ];
@@ -197,9 +195,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array<string,string>|null
      */
-    public function getMapProperty()
+    public function getMapProperty(): ?array
     {
         return $this->container['map_property'];
     }
@@ -311,9 +309,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @param array<string,string>|null $map_property map_property
      *
-     * @return self
+     * @return $this
      */
-    public function setMapProperty($map_property)
+    public function setMapProperty(?array $map_property): static
     {
         if (is_null($map_property)) {
             throw new \InvalidArgumentException('non-nullable map_property cannot be null');
@@ -328,7 +326,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return array<string,array<string,string>>|null
      */
-    public function getMapOfMapProperty()
+    public function getMapOfMapProperty(): ?array
     {
         return $this->container['map_of_map_property'];
     }
@@ -338,9 +336,9 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @param array<string,array<string,string>>|null $map_of_map_property map_of_map_property
      *
-     * @return self
+     * @return $this
      */
-    public function setMapOfMapProperty($map_of_map_property)
+    public function setMapOfMapProperty(?array $map_of_map_property): static
     {
         if (is_null($map_of_map_property)) {
             throw new \InvalidArgumentException('non-nullable map_of_map_property cannot be null');
@@ -356,7 +354,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -49,14 +49,14 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
       *
       * @var string
       */
-    protected static $openAPIModelName = 'AllOfWithSingleRef';
+    protected static string $openAPIModelName = 'AllOfWithSingleRef';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'username' => 'string',
         'single_ref_type' => '\OpenAPI\Client\Model\SingleRefType'
     ];
@@ -64,11 +64,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'username' => null,
         'single_ref_type' => null
     ];
@@ -76,7 +74,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'username' => false,
@@ -86,16 +84,16 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'username' => 'username',
         'single_ref_type' => 'SingleRefType'
     ];
@@ -176,9 +174,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'username' => 'setUsername',
         'single_ref_type' => 'setSingleRefType'
     ];
@@ -186,9 +184,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'username' => 'getUsername',
         'single_ref_type' => 'getSingleRefType'
     ];
@@ -197,9 +195,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string|null
      */
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->container['username'];
     }
@@ -311,9 +309,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @param string|null $username username
      *
-     * @return self
+     * @return $this
      */
-    public function setUsername($username)
+    public function setUsername(?string $username): static
     {
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
@@ -328,7 +326,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return \OpenAPI\Client\Model\SingleRefType|null
      */
-    public function getSingleRefType()
+    public function getSingleRefType(): ?\OpenAPI\Client\Model\SingleRefType
     {
         return $this->container['single_ref_type'];
     }
@@ -338,9 +336,9 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @param \OpenAPI\Client\Model\SingleRefType|null $single_ref_type single_ref_type
      *
-     * @return self
+     * @return $this
      */
-    public function setSingleRefType($single_ref_type)
+    public function setSingleRefType(?\OpenAPI\Client\Model\SingleRefType $single_ref_type): static
     {
         if (is_null($single_ref_type)) {
             throw new \InvalidArgumentException('non-nullable single_ref_type cannot be null');
@@ -356,7 +354,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * AllOfWithSingleRef Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializable
+class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     public function setUsername(?string $username): static
     {
         if (is_null($username)) {
-            throw new \InvalidArgumentException('non-nullable username cannot be null');
+            throw new InvalidArgumentException('non-nullable username cannot be null');
         }
         $this->container['username'] = $username;
 
@@ -341,7 +343,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
     public function setSingleRefType(?\OpenAPI\Client\Model\SingleRefType $single_ref_type): static
     {
         if (is_null($single_ref_type)) {
-            throw new \InvalidArgumentException('non-nullable single_ref_type cannot be null');
+            throw new InvalidArgumentException('non-nullable single_ref_type cannot be null');
         }
         $this->container['single_ref_type'] = $single_ref_type;
 
@@ -366,7 +368,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Animal Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
+class Animal implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = 'class_name';
 
@@ -243,8 +246,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -320,7 +322,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setClassName(string $class_name): static
     {
         if (is_null($class_name)) {
-            throw new \InvalidArgumentException('non-nullable class_name cannot be null');
+            throw new InvalidArgumentException('non-nullable class_name cannot be null');
         }
         $this->container['class_name'] = $class_name;
 
@@ -347,7 +349,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setColor(?string $color): static
     {
         if (is_null($color)) {
-            throw new \InvalidArgumentException('non-nullable color cannot be null');
+            throw new InvalidArgumentException('non-nullable color cannot be null');
         }
         $this->container['color'] = $color;
 
@@ -372,7 +374,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -414,7 +416,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -49,14 +49,14 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Animal';
+    protected static string $openAPIModelName = 'Animal';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'class_name' => 'string',
         'color' => 'string'
     ];
@@ -64,11 +64,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'class_name' => null,
         'color' => null
     ];
@@ -76,7 +74,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'class_name' => false,
@@ -86,16 +84,16 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'class_name' => 'className',
         'color' => 'color'
     ];
@@ -176,9 +174,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'class_name' => 'setClassName',
         'color' => 'setColor'
     ];
@@ -186,9 +184,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'class_name' => 'getClassName',
         'color' => 'getColor'
     ];
@@ -197,9 +195,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -266,7 +264,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -278,9 +276,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -296,7 +294,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -307,7 +305,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->container['class_name'];
     }
@@ -317,9 +315,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $class_name class_name
      *
-     * @return self
+     * @return $this
      */
-    public function setClassName($class_name)
+    public function setClassName(string $class_name): static
     {
         if (is_null($class_name)) {
             throw new \InvalidArgumentException('non-nullable class_name cannot be null');
@@ -334,7 +332,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getColor()
+    public function getColor(): ?string
     {
         return $this->container['color'];
     }
@@ -344,9 +342,9 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $color color
      *
-     * @return self
+     * @return $this
      */
-    public function setColor($color)
+    public function setColor(?string $color): static
     {
         if (is_null($color)) {
             throw new \InvalidArgumentException('non-nullable color cannot be null');
@@ -362,7 +360,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -375,7 +373,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -388,7 +386,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -404,7 +402,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -417,7 +415,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -427,7 +425,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -440,7 +438,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ApiResponse Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
+class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -249,8 +252,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -321,7 +323,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setCode(?int $code): static
     {
         if (is_null($code)) {
-            throw new \InvalidArgumentException('non-nullable code cannot be null');
+            throw new InvalidArgumentException('non-nullable code cannot be null');
         }
         $this->container['code'] = $code;
 
@@ -348,7 +350,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setType(?string $type): static
     {
         if (is_null($type)) {
-            throw new \InvalidArgumentException('non-nullable type cannot be null');
+            throw new InvalidArgumentException('non-nullable type cannot be null');
         }
         $this->container['type'] = $type;
 
@@ -375,7 +377,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMessage(?string $message): static
     {
         if (is_null($message)) {
-            throw new \InvalidArgumentException('non-nullable message cannot be null');
+            throw new InvalidArgumentException('non-nullable message cannot be null');
         }
         $this->container['message'] = $message;
 
@@ -400,7 +402,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -442,7 +444,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -49,14 +49,14 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ApiResponse';
+    protected static string $openAPIModelName = 'ApiResponse';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'code' => 'int',
         'type' => 'string',
         'message' => 'string'
@@ -65,11 +65,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'code' => 'int32',
         'type' => null,
         'message' => null
@@ -78,7 +76,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'code' => false,
@@ -89,16 +87,16 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -106,9 +104,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -116,7 +114,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -126,7 +124,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -136,7 +134,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -169,9 +167,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'code' => 'code',
         'type' => 'type',
         'message' => 'message'
@@ -180,9 +178,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'code' => 'setCode',
         'type' => 'setType',
         'message' => 'setMessage'
@@ -191,9 +189,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'code' => 'getCode',
         'type' => 'getType',
         'message' => 'getMessage'
@@ -203,9 +201,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -213,9 +211,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -223,9 +221,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -235,7 +233,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -244,9 +242,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -270,7 +268,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -282,9 +280,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -297,7 +295,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -308,7 +306,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getCode()
+    public function getCode(): ?int
     {
         return $this->container['code'];
     }
@@ -318,9 +316,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $code code
      *
-     * @return self
+     * @return $this
      */
-    public function setCode($code)
+    public function setCode(?int $code): static
     {
         if (is_null($code)) {
             throw new \InvalidArgumentException('non-nullable code cannot be null');
@@ -335,7 +333,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->container['type'];
     }
@@ -345,9 +343,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $type type
      *
-     * @return self
+     * @return $this
      */
-    public function setType($type)
+    public function setType(?string $type): static
     {
         if (is_null($type)) {
             throw new \InvalidArgumentException('non-nullable type cannot be null');
@@ -362,7 +360,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getMessage()
+    public function getMessage(): ?string
     {
         return $this->container['message'];
     }
@@ -372,9 +370,9 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $message message
      *
-     * @return self
+     * @return $this
      */
-    public function setMessage($message)
+    public function setMessage(?string $message): static
     {
         if (is_null($message)) {
             throw new \InvalidArgumentException('non-nullable message cannot be null');
@@ -390,7 +388,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -403,7 +401,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -416,7 +414,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -432,7 +430,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -445,7 +443,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -455,7 +453,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -468,7 +466,7 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -49,32 +49,30 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ArrayOfArrayOfNumberOnly';
+    protected static string $openAPIModelName = 'ArrayOfArrayOfNumberOnly';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'array_array_number' => 'float[][]'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'array_array_number' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'array_array_number' => false
@@ -83,16 +81,16 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'array_array_number' => 'ArrayArrayNumber'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'array_array_number' => 'setArrayArrayNumber'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'array_array_number' => 'getArrayArrayNumber'
     ];
 
@@ -191,9 +189,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return float[][]|null
      */
-    public function getArrayArrayNumber()
+    public function getArrayArrayNumber(): ?array
     {
         return $this->container['array_array_number'];
     }
@@ -304,9 +302,9 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @param float[][]|null $array_array_number array_array_number
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayArrayNumber($array_array_number)
+    public function setArrayArrayNumber(?array $array_array_number): static
     {
         if (is_null($array_array_number)) {
             throw new \InvalidArgumentException('non-nullable array_array_number cannot be null');
@@ -322,7 +320,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfArrayOfNumberOnly.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ArrayOfArrayOfNumberOnly Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
+class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
     public function setArrayArrayNumber(?array $array_array_number): static
     {
         if (is_null($array_array_number)) {
-            throw new \InvalidArgumentException('non-nullable array_array_number cannot be null');
+            throw new InvalidArgumentException('non-nullable array_array_number cannot be null');
         }
         $this->container['array_array_number'] = $array_array_number;
 
@@ -332,7 +334,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class ArrayOfArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSeri
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -49,32 +49,30 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ArrayOfNumberOnly';
+    protected static string $openAPIModelName = 'ArrayOfNumberOnly';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'array_number' => 'float[]'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'array_number' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'array_number' => false
@@ -83,16 +81,16 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'array_number' => 'ArrayNumber'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'array_number' => 'setArrayNumber'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'array_number' => 'getArrayNumber'
     ];
 
@@ -191,9 +189,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return float[]|null
      */
-    public function getArrayNumber()
+    public function getArrayNumber(): ?array
     {
         return $this->container['array_number'];
     }
@@ -304,9 +302,9 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @param float[]|null $array_number array_number
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayNumber($array_number)
+    public function setArrayNumber(?array $array_number): static
     {
         if (is_null($array_number)) {
             throw new \InvalidArgumentException('non-nullable array_number cannot be null');
@@ -322,7 +320,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayOfNumberOnly.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ArrayOfNumberOnly Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
+class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
     public function setArrayNumber(?array $array_number): static
     {
         if (is_null($array_number)) {
-            throw new \InvalidArgumentException('non-nullable array_number cannot be null');
+            throw new InvalidArgumentException('non-nullable array_number cannot be null');
         }
         $this->container['array_number'] = $array_number;
 
@@ -332,7 +334,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class ArrayOfNumberOnly implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -49,14 +49,14 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ArrayTest';
+    protected static string $openAPIModelName = 'ArrayTest';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'array_of_string' => 'string[]',
         'array_array_of_integer' => 'int[][]',
         'array_array_of_model' => '\OpenAPI\Client\Model\ReadOnlyFirst[][]'
@@ -65,11 +65,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'array_of_string' => null,
         'array_array_of_integer' => 'int64',
         'array_array_of_model' => null
@@ -78,7 +76,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'array_of_string' => false,
@@ -89,16 +87,16 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -106,9 +104,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -116,7 +114,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -126,7 +124,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -136,7 +134,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -169,9 +167,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'array_of_string' => 'array_of_string',
         'array_array_of_integer' => 'array_array_of_integer',
         'array_array_of_model' => 'array_array_of_model'
@@ -180,9 +178,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'array_of_string' => 'setArrayOfString',
         'array_array_of_integer' => 'setArrayArrayOfInteger',
         'array_array_of_model' => 'setArrayArrayOfModel'
@@ -191,9 +189,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'array_of_string' => 'getArrayOfString',
         'array_array_of_integer' => 'getArrayArrayOfInteger',
         'array_array_of_model' => 'getArrayArrayOfModel'
@@ -203,9 +201,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -213,9 +211,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -223,9 +221,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -235,7 +233,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -244,9 +242,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -270,7 +268,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -282,9 +280,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -305,7 +303,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -316,7 +314,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string[]|null
      */
-    public function getArrayOfString()
+    public function getArrayOfString(): ?array
     {
         return $this->container['array_of_string'];
     }
@@ -326,9 +324,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string[]|null $array_of_string array_of_string
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayOfString($array_of_string)
+    public function setArrayOfString(?array $array_of_string): static
     {
         if (is_null($array_of_string)) {
             throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
@@ -350,7 +348,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int[][]|null
      */
-    public function getArrayArrayOfInteger()
+    public function getArrayArrayOfInteger(): ?array
     {
         return $this->container['array_array_of_integer'];
     }
@@ -360,9 +358,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int[][]|null $array_array_of_integer array_array_of_integer
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayArrayOfInteger($array_array_of_integer)
+    public function setArrayArrayOfInteger(?array $array_array_of_integer): static
     {
         if (is_null($array_array_of_integer)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
@@ -377,7 +375,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\ReadOnlyFirst[][]|null
      */
-    public function getArrayArrayOfModel()
+    public function getArrayArrayOfModel(): ?array
     {
         return $this->container['array_array_of_model'];
     }
@@ -387,9 +385,9 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\ReadOnlyFirst[][]|null $array_array_of_model array_array_of_model
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayArrayOfModel($array_array_of_model)
+    public function setArrayArrayOfModel(?array $array_array_of_model): static
     {
         if (is_null($array_array_of_model)) {
             throw new \InvalidArgumentException('non-nullable array_array_of_model cannot be null');
@@ -405,7 +403,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -418,7 +416,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -431,7 +429,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -447,7 +445,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -460,7 +458,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -470,7 +468,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -483,7 +481,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ArrayTest Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
+class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -249,8 +252,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -329,14 +331,14 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setArrayOfString(?array $array_of_string): static
     {
         if (is_null($array_of_string)) {
-            throw new \InvalidArgumentException('non-nullable array_of_string cannot be null');
+            throw new InvalidArgumentException('non-nullable array_of_string cannot be null');
         }
 
         if ((count($array_of_string) > 3)) {
-            throw new \InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
+            throw new InvalidArgumentException('invalid value for $array_of_string when calling ArrayTest., number of items must be less than or equal to 3.');
         }
         if ((count($array_of_string) < 0)) {
-            throw new \InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
+            throw new InvalidArgumentException('invalid length for $array_of_string when calling ArrayTest., number of items must be greater than or equal to 0.');
         }
         $this->container['array_of_string'] = $array_of_string;
 
@@ -363,7 +365,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setArrayArrayOfInteger(?array $array_array_of_integer): static
     {
         if (is_null($array_array_of_integer)) {
-            throw new \InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
+            throw new InvalidArgumentException('non-nullable array_array_of_integer cannot be null');
         }
         $this->container['array_array_of_integer'] = $array_array_of_integer;
 
@@ -390,7 +392,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setArrayArrayOfModel(?array $array_array_of_model): static
     {
         if (is_null($array_array_of_model)) {
-            throw new \InvalidArgumentException('non-nullable array_array_of_model cannot be null');
+            throw new InvalidArgumentException('non-nullable array_array_of_model cannot be null');
         }
         $this->container['array_array_of_model'] = $array_array_of_model;
 
@@ -415,7 +417,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -457,7 +459,7 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -49,14 +49,14 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Capitalization';
+    protected static string $openAPIModelName = 'Capitalization';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'small_camel' => 'string',
         'capital_camel' => 'string',
         'small_snake' => 'string',
@@ -68,11 +68,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'small_camel' => null,
         'capital_camel' => null,
         'small_snake' => null,
@@ -84,7 +82,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'small_camel' => false,
@@ -98,16 +96,16 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -115,9 +113,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -125,7 +123,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -135,7 +133,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -145,7 +143,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -178,9 +176,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'small_camel' => 'smallCamel',
         'capital_camel' => 'CapitalCamel',
         'small_snake' => 'small_Snake',
@@ -192,9 +190,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'small_camel' => 'setSmallCamel',
         'capital_camel' => 'setCapitalCamel',
         'small_snake' => 'setSmallSnake',
@@ -206,9 +204,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'small_camel' => 'getSmallCamel',
         'capital_camel' => 'getCapitalCamel',
         'small_snake' => 'getSmallSnake',
@@ -221,9 +219,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -231,9 +229,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -241,9 +239,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -253,7 +251,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -262,9 +260,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -291,7 +289,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -303,9 +301,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -318,7 +316,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -329,7 +327,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getSmallCamel()
+    public function getSmallCamel(): ?string
     {
         return $this->container['small_camel'];
     }
@@ -339,9 +337,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $small_camel small_camel
      *
-     * @return self
+     * @return $this
      */
-    public function setSmallCamel($small_camel)
+    public function setSmallCamel(?string $small_camel): static
     {
         if (is_null($small_camel)) {
             throw new \InvalidArgumentException('non-nullable small_camel cannot be null');
@@ -356,7 +354,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getCapitalCamel()
+    public function getCapitalCamel(): ?string
     {
         return $this->container['capital_camel'];
     }
@@ -366,9 +364,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $capital_camel capital_camel
      *
-     * @return self
+     * @return $this
      */
-    public function setCapitalCamel($capital_camel)
+    public function setCapitalCamel(?string $capital_camel): static
     {
         if (is_null($capital_camel)) {
             throw new \InvalidArgumentException('non-nullable capital_camel cannot be null');
@@ -383,7 +381,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getSmallSnake()
+    public function getSmallSnake(): ?string
     {
         return $this->container['small_snake'];
     }
@@ -393,9 +391,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $small_snake small_snake
      *
-     * @return self
+     * @return $this
      */
-    public function setSmallSnake($small_snake)
+    public function setSmallSnake(?string $small_snake): static
     {
         if (is_null($small_snake)) {
             throw new \InvalidArgumentException('non-nullable small_snake cannot be null');
@@ -410,7 +408,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getCapitalSnake()
+    public function getCapitalSnake(): ?string
     {
         return $this->container['capital_snake'];
     }
@@ -420,9 +418,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $capital_snake capital_snake
      *
-     * @return self
+     * @return $this
      */
-    public function setCapitalSnake($capital_snake)
+    public function setCapitalSnake(?string $capital_snake): static
     {
         if (is_null($capital_snake)) {
             throw new \InvalidArgumentException('non-nullable capital_snake cannot be null');
@@ -437,7 +435,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getScaEthFlowPoints()
+    public function getScaEthFlowPoints(): ?string
     {
         return $this->container['sca_eth_flow_points'];
     }
@@ -447,9 +445,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $sca_eth_flow_points sca_eth_flow_points
      *
-     * @return self
+     * @return $this
      */
-    public function setScaEthFlowPoints($sca_eth_flow_points)
+    public function setScaEthFlowPoints(?string $sca_eth_flow_points): static
     {
         if (is_null($sca_eth_flow_points)) {
             throw new \InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
@@ -464,7 +462,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getAttName()
+    public function getAttName(): ?string
     {
         return $this->container['att_name'];
     }
@@ -474,9 +472,9 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $att_name Name of the pet
      *
-     * @return self
+     * @return $this
      */
-    public function setAttName($att_name)
+    public function setAttName(?string $att_name): static
     {
         if (is_null($att_name)) {
             throw new \InvalidArgumentException('non-nullable att_name cannot be null');
@@ -492,7 +490,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -505,7 +503,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -518,7 +516,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -534,7 +532,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -547,7 +545,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -557,7 +555,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -570,7 +568,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Capitalization Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
+class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -267,8 +270,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -342,7 +344,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setSmallCamel(?string $small_camel): static
     {
         if (is_null($small_camel)) {
-            throw new \InvalidArgumentException('non-nullable small_camel cannot be null');
+            throw new InvalidArgumentException('non-nullable small_camel cannot be null');
         }
         $this->container['small_camel'] = $small_camel;
 
@@ -369,7 +371,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setCapitalCamel(?string $capital_camel): static
     {
         if (is_null($capital_camel)) {
-            throw new \InvalidArgumentException('non-nullable capital_camel cannot be null');
+            throw new InvalidArgumentException('non-nullable capital_camel cannot be null');
         }
         $this->container['capital_camel'] = $capital_camel;
 
@@ -396,7 +398,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setSmallSnake(?string $small_snake): static
     {
         if (is_null($small_snake)) {
-            throw new \InvalidArgumentException('non-nullable small_snake cannot be null');
+            throw new InvalidArgumentException('non-nullable small_snake cannot be null');
         }
         $this->container['small_snake'] = $small_snake;
 
@@ -423,7 +425,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setCapitalSnake(?string $capital_snake): static
     {
         if (is_null($capital_snake)) {
-            throw new \InvalidArgumentException('non-nullable capital_snake cannot be null');
+            throw new InvalidArgumentException('non-nullable capital_snake cannot be null');
         }
         $this->container['capital_snake'] = $capital_snake;
 
@@ -450,7 +452,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setScaEthFlowPoints(?string $sca_eth_flow_points): static
     {
         if (is_null($sca_eth_flow_points)) {
-            throw new \InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
+            throw new InvalidArgumentException('non-nullable sca_eth_flow_points cannot be null');
         }
         $this->container['sca_eth_flow_points'] = $sca_eth_flow_points;
 
@@ -477,7 +479,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setAttName(?string $att_name): static
     {
         if (is_null($att_name)) {
-            throw new \InvalidArgumentException('non-nullable att_name cannot be null');
+            throw new InvalidArgumentException('non-nullable att_name cannot be null');
         }
         $this->container['att_name'] = $att_name;
 
@@ -502,7 +504,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -544,7 +546,7 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -47,32 +47,30 @@ class Cat extends Animal
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Cat';
+    protected static string $openAPIModelName = 'Cat';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'declawed' => 'bool'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'declawed' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'declawed' => false
@@ -81,16 +79,16 @@ class Cat extends Animal
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes + parent::openAPITypes();
     }
@@ -98,9 +96,9 @@ class Cat extends Animal
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats + parent::openAPIFormats();
     }
@@ -108,7 +106,7 @@ class Cat extends Animal
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -118,7 +116,7 @@ class Cat extends Animal
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -128,7 +126,7 @@ class Cat extends Animal
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -161,27 +159,27 @@ class Cat extends Animal
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'declawed' => 'declawed'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'declawed' => 'setDeclawed'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'declawed' => 'getDeclawed'
     ];
 
@@ -189,9 +187,9 @@ class Cat extends Animal
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return parent::attributeMap() + self::$attributeMap;
     }
@@ -199,9 +197,9 @@ class Cat extends Animal
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return parent::setters() + self::$setters;
     }
@@ -209,9 +207,9 @@ class Cat extends Animal
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return parent::getters() + self::$getters;
     }
@@ -221,7 +219,7 @@ class Cat extends Animal
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -250,7 +248,7 @@ class Cat extends Animal
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -262,9 +260,9 @@ class Cat extends Animal
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = parent::listInvalidProperties();
 
@@ -277,7 +275,7 @@ class Cat extends Animal
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -288,7 +286,7 @@ class Cat extends Animal
      *
      * @return bool|null
      */
-    public function getDeclawed()
+    public function getDeclawed(): ?bool
     {
         return $this->container['declawed'];
     }
@@ -298,9 +296,9 @@ class Cat extends Animal
      *
      * @param bool|null $declawed declawed
      *
-     * @return self
+     * @return $this
      */
-    public function setDeclawed($declawed)
+    public function setDeclawed(?bool $declawed): static
     {
         if (is_null($declawed)) {
             throw new \InvalidArgumentException('non-nullable declawed cannot be null');
@@ -316,7 +314,7 @@ class Cat extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -329,7 +327,7 @@ class Cat extends Animal
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -342,7 +340,7 @@ class Cat extends Animal
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -358,7 +356,7 @@ class Cat extends Animal
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -371,7 +369,7 @@ class Cat extends Animal
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -381,7 +379,7 @@ class Cat extends Animal
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -394,7 +392,7 @@ class Cat extends Animal
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Cat.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * Cat Class Doc Comment
@@ -36,7 +35,7 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
 class Cat extends Animal
 {
@@ -229,8 +228,7 @@ class Cat extends Animal
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -301,7 +299,7 @@ class Cat extends Animal
     public function setDeclawed(?bool $declawed): static
     {
         if (is_null($declawed)) {
-            throw new \InvalidArgumentException('non-nullable declawed cannot be null');
+            throw new InvalidArgumentException('non-nullable declawed cannot be null');
         }
         $this->container['declawed'] = $declawed;
 
@@ -326,7 +324,7 @@ class Cat extends Animal
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -368,7 +366,7 @@ class Cat extends Animal
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -49,14 +49,14 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Category';
+    protected static string $openAPIModelName = 'Category';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'id' => 'int',
         'name' => 'string'
     ];
@@ -64,11 +64,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'id' => 'int64',
         'name' => null
     ];
@@ -76,7 +74,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'id' => false,
@@ -86,16 +84,16 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'id' => 'id',
         'name' => 'name'
     ];
@@ -176,9 +174,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'id' => 'setId',
         'name' => 'setName'
     ];
@@ -186,9 +184,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'id' => 'getId',
         'name' => 'getName'
     ];
@@ -197,9 +195,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -293,7 +291,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -304,7 +302,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->container['id'];
     }
@@ -314,9 +312,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $id id
      *
-     * @return self
+     * @return $this
      */
-    public function setId($id)
+    public function setId(?int $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -331,7 +329,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -341,9 +339,9 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -359,7 +357,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -372,7 +370,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -385,7 +383,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -401,7 +399,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -414,7 +412,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -424,7 +422,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -437,7 +435,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Category Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Category implements ModelInterface, ArrayAccess, \JsonSerializable
+class Category implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -317,7 +319,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setId(?int $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -344,7 +346,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(string $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -369,7 +371,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -411,7 +413,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ClassModel Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
+class ClassModel implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -238,8 +241,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -308,7 +310,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setClass(?string $_class): static
     {
         if (is_null($_class)) {
-            throw new \InvalidArgumentException('non-nullable _class cannot be null');
+            throw new InvalidArgumentException('non-nullable _class cannot be null');
         }
         $this->container['_class'] = $_class;
 
@@ -333,7 +335,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -375,7 +377,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ClassModel.php
@@ -50,32 +50,30 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ClassModel';
+    protected static string $openAPIModelName = 'ClassModel';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         '_class' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         '_class' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         '_class' => false
@@ -84,16 +82,16 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -101,9 +99,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -111,7 +109,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -121,7 +119,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -131,7 +129,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -164,27 +162,27 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         '_class' => '_class'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         '_class' => 'setClass'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         '_class' => 'getClass'
     ];
 
@@ -192,9 +190,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -202,9 +200,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -212,9 +210,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -224,7 +222,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -233,9 +231,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -257,7 +255,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -269,9 +267,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -284,7 +282,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -295,7 +293,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->container['_class'];
     }
@@ -305,9 +303,9 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $_class _class
      *
-     * @return self
+     * @return $this
      */
-    public function setClass($_class)
+    public function setClass(?string $_class): static
     {
         if (is_null($_class)) {
             throw new \InvalidArgumentException('non-nullable _class cannot be null');
@@ -323,7 +321,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -336,7 +334,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -349,7 +347,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -365,7 +363,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -378,7 +376,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -388,7 +386,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -401,7 +399,7 @@ class ClassModel implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Client Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Client implements ModelInterface, ArrayAccess, \JsonSerializable
+class Client implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setClient(?string $client): static
     {
         if (is_null($client)) {
-            throw new \InvalidArgumentException('non-nullable client cannot be null');
+            throw new InvalidArgumentException('non-nullable client cannot be null');
         }
         $this->container['client'] = $client;
 
@@ -332,7 +334,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Client.php
@@ -49,32 +49,30 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Client';
+    protected static string $openAPIModelName = 'Client';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'client' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'client' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'client' => false
@@ -83,16 +81,16 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'client' => 'client'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'client' => 'setClient'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'client' => 'getClient'
     ];
 
@@ -191,9 +189,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getClient()
+    public function getClient(): ?string
     {
         return $this->container['client'];
     }
@@ -304,9 +302,9 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $client client
      *
-     * @return self
+     * @return $this
      */
-    public function setClient($client)
+    public function setClient(?string $client): static
     {
         if (is_null($client)) {
             throw new \InvalidArgumentException('non-nullable client cannot be null');
@@ -322,7 +320,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class Client implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * DeprecatedObject Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
+class DeprecatedObject implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(?string $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -332,7 +334,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/DeprecatedObject.php
@@ -49,32 +49,30 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'DeprecatedObject';
+    protected static string $openAPIModelName = 'DeprecatedObject';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'name' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'name' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'name' => false
@@ -83,16 +81,16 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'name' => 'name'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'name' => 'setName'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'name' => 'getName'
     ];
 
@@ -191,9 +189,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->container['name'];
     }
@@ -304,9 +302,9 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(?string $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -322,7 +320,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class DeprecatedObject implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * Dog Class Doc Comment
@@ -36,7 +35,7 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
 class Dog extends Animal
 {
@@ -229,8 +228,7 @@ class Dog extends Animal
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -301,7 +299,7 @@ class Dog extends Animal
     public function setBreed(?string $breed): static
     {
         if (is_null($breed)) {
-            throw new \InvalidArgumentException('non-nullable breed cannot be null');
+            throw new InvalidArgumentException('non-nullable breed cannot be null');
         }
         $this->container['breed'] = $breed;
 
@@ -326,7 +324,7 @@ class Dog extends Animal
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -368,7 +366,7 @@ class Dog extends Animal
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Dog.php
@@ -47,32 +47,30 @@ class Dog extends Animal
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Dog';
+    protected static string $openAPIModelName = 'Dog';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'breed' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'breed' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'breed' => false
@@ -81,16 +79,16 @@ class Dog extends Animal
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes + parent::openAPITypes();
     }
@@ -98,9 +96,9 @@ class Dog extends Animal
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats + parent::openAPIFormats();
     }
@@ -108,7 +106,7 @@ class Dog extends Animal
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -118,7 +116,7 @@ class Dog extends Animal
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -128,7 +126,7 @@ class Dog extends Animal
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -161,27 +159,27 @@ class Dog extends Animal
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'breed' => 'breed'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'breed' => 'setBreed'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'breed' => 'getBreed'
     ];
 
@@ -189,9 +187,9 @@ class Dog extends Animal
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return parent::attributeMap() + self::$attributeMap;
     }
@@ -199,9 +197,9 @@ class Dog extends Animal
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return parent::setters() + self::$setters;
     }
@@ -209,9 +207,9 @@ class Dog extends Animal
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return parent::getters() + self::$getters;
     }
@@ -221,7 +219,7 @@ class Dog extends Animal
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -250,7 +248,7 @@ class Dog extends Animal
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -262,9 +260,9 @@ class Dog extends Animal
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = parent::listInvalidProperties();
 
@@ -277,7 +275,7 @@ class Dog extends Animal
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -288,7 +286,7 @@ class Dog extends Animal
      *
      * @return string|null
      */
-    public function getBreed()
+    public function getBreed(): ?string
     {
         return $this->container['breed'];
     }
@@ -298,9 +296,9 @@ class Dog extends Animal
      *
      * @param string|null $breed breed
      *
-     * @return self
+     * @return $this
      */
-    public function setBreed($breed)
+    public function setBreed(?string $breed): static
     {
         if (is_null($breed)) {
             throw new \InvalidArgumentException('non-nullable breed cannot be null');
@@ -316,7 +314,7 @@ class Dog extends Animal
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -329,7 +327,7 @@ class Dog extends Animal
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -342,7 +340,7 @@ class Dog extends Animal
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -358,7 +356,7 @@ class Dog extends Animal
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -371,7 +369,7 @@ class Dog extends Animal
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -381,7 +379,7 @@ class Dog extends Animal
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -394,7 +392,7 @@ class Dog extends Animal
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * EnumArrays Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
+class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -273,8 +276,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -353,11 +355,11 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setJustSymbol(?string $just_symbol): static
     {
         if (is_null($just_symbol)) {
-            throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
+            throw new InvalidArgumentException('non-nullable just_symbol cannot be null');
         }
         $allowedValues = $this->getJustSymbolAllowableValues();
         if (!in_array($just_symbol, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'just_symbol', must be one of '%s'",
                     $just_symbol,
@@ -390,11 +392,11 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setArrayEnum(?array $array_enum): static
     {
         if (is_null($array_enum)) {
-            throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
+            throw new InvalidArgumentException('non-nullable array_enum cannot be null');
         }
         $allowedValues = $this->getArrayEnumAllowableValues();
         if (array_diff($array_enum, $allowedValues)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value for 'array_enum', must be one of '%s'",
                     implode("', '", $allowedValues)
@@ -424,7 +426,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -466,7 +468,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -49,14 +49,14 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'EnumArrays';
+    protected static string $openAPIModelName = 'EnumArrays';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'just_symbol' => 'string',
         'array_enum' => 'string[]'
     ];
@@ -64,11 +64,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'just_symbol' => null,
         'array_enum' => null
     ];
@@ -76,7 +74,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'just_symbol' => false,
@@ -86,16 +84,16 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'just_symbol' => 'just_symbol',
         'array_enum' => 'array_enum'
     ];
@@ -176,9 +174,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'just_symbol' => 'setJustSymbol',
         'array_enum' => 'setArrayEnum'
     ];
@@ -186,9 +184,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'just_symbol' => 'getJustSymbol',
         'array_enum' => 'getArrayEnum'
     ];
@@ -197,9 +195,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -268,9 +266,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -293,7 +291,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -305,9 +303,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -329,7 +327,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -340,7 +338,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getJustSymbol()
+    public function getJustSymbol(): ?string
     {
         return $this->container['just_symbol'];
     }
@@ -350,9 +348,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $just_symbol just_symbol
      *
-     * @return self
+     * @return $this
      */
-    public function setJustSymbol($just_symbol)
+    public function setJustSymbol(?string $just_symbol): static
     {
         if (is_null($just_symbol)) {
             throw new \InvalidArgumentException('non-nullable just_symbol cannot be null');
@@ -377,7 +375,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string[]|null
      */
-    public function getArrayEnum()
+    public function getArrayEnum(): ?array
     {
         return $this->container['array_enum'];
     }
@@ -387,9 +385,9 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string[]|null $array_enum array_enum
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayEnum($array_enum)
+    public function setArrayEnum(?array $array_enum): static
     {
         if (is_null($array_enum)) {
             throw new \InvalidArgumentException('non-nullable array_enum cannot be null');
@@ -414,7 +412,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -427,7 +425,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -440,7 +438,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -456,7 +454,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -469,7 +467,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -479,7 +477,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -492,7 +490,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumClass.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * EnumClass Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -49,14 +49,14 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Enum_Test';
+    protected static string $openAPIModelName = 'Enum_Test';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'enum_string' => 'string',
         'enum_string_required' => 'string',
         'enum_integer' => 'int',
@@ -70,11 +70,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'enum_string' => null,
         'enum_string_required' => null,
         'enum_integer' => 'int32',
@@ -88,7 +86,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'enum_string' => false,
@@ -104,16 +102,16 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -121,9 +119,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -131,7 +129,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -141,7 +139,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -151,7 +149,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -184,9 +182,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'enum_string' => 'enum_string',
         'enum_string_required' => 'enum_string_required',
         'enum_integer' => 'enum_integer',
@@ -200,9 +198,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'enum_string' => 'setEnumString',
         'enum_string_required' => 'setEnumStringRequired',
         'enum_integer' => 'setEnumInteger',
@@ -216,9 +214,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'enum_string' => 'getEnumString',
         'enum_string_required' => 'getEnumStringRequired',
         'enum_integer' => 'getEnumInteger',
@@ -233,9 +231,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -243,9 +241,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -253,9 +251,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -265,7 +263,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -338,9 +336,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -369,7 +367,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -381,9 +379,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -435,7 +433,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -446,7 +444,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getEnumString()
+    public function getEnumString(): ?string
     {
         return $this->container['enum_string'];
     }
@@ -456,9 +454,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $enum_string enum_string
      *
-     * @return self
+     * @return $this
      */
-    public function setEnumString($enum_string)
+    public function setEnumString(?string $enum_string): static
     {
         if (is_null($enum_string)) {
             throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
@@ -483,7 +481,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getEnumStringRequired()
+    public function getEnumStringRequired(): string
     {
         return $this->container['enum_string_required'];
     }
@@ -493,9 +491,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $enum_string_required enum_string_required
      *
-     * @return self
+     * @return $this
      */
-    public function setEnumStringRequired($enum_string_required)
+    public function setEnumStringRequired(string $enum_string_required): static
     {
         if (is_null($enum_string_required)) {
             throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
@@ -520,7 +518,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getEnumInteger()
+    public function getEnumInteger(): ?int
     {
         return $this->container['enum_integer'];
     }
@@ -530,9 +528,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $enum_integer enum_integer
      *
-     * @return self
+     * @return $this
      */
-    public function setEnumInteger($enum_integer)
+    public function setEnumInteger(?int $enum_integer): static
     {
         if (is_null($enum_integer)) {
             throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
@@ -557,7 +555,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getEnumNumber()
+    public function getEnumNumber(): ?float
     {
         return $this->container['enum_number'];
     }
@@ -567,9 +565,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $enum_number enum_number
      *
-     * @return self
+     * @return $this
      */
-    public function setEnumNumber($enum_number)
+    public function setEnumNumber(?float $enum_number): static
     {
         if (is_null($enum_number)) {
             throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
@@ -594,7 +592,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\OuterEnum|null
      */
-    public function getOuterEnum()
+    public function getOuterEnum(): ?\OpenAPI\Client\Model\OuterEnum
     {
         return $this->container['outer_enum'];
     }
@@ -604,9 +602,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\OuterEnum|null $outer_enum outer_enum
      *
-     * @return self
+     * @return $this
      */
-    public function setOuterEnum($outer_enum)
+    public function setOuterEnum(?\OpenAPI\Client\Model\OuterEnum $outer_enum): static
     {
         if (is_null($outer_enum)) {
             array_push($this->openAPINullablesSetToNull, 'outer_enum');
@@ -628,7 +626,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\OuterEnumInteger|null
      */
-    public function getOuterEnumInteger()
+    public function getOuterEnumInteger(): ?\OpenAPI\Client\Model\OuterEnumInteger
     {
         return $this->container['outer_enum_integer'];
     }
@@ -638,9 +636,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\OuterEnumInteger|null $outer_enum_integer outer_enum_integer
      *
-     * @return self
+     * @return $this
      */
-    public function setOuterEnumInteger($outer_enum_integer)
+    public function setOuterEnumInteger(?\OpenAPI\Client\Model\OuterEnumInteger $outer_enum_integer): static
     {
         if (is_null($outer_enum_integer)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
@@ -655,7 +653,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\OuterEnumDefaultValue|null
      */
-    public function getOuterEnumDefaultValue()
+    public function getOuterEnumDefaultValue(): ?\OpenAPI\Client\Model\OuterEnumDefaultValue
     {
         return $this->container['outer_enum_default_value'];
     }
@@ -665,9 +663,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\OuterEnumDefaultValue|null $outer_enum_default_value outer_enum_default_value
      *
-     * @return self
+     * @return $this
      */
-    public function setOuterEnumDefaultValue($outer_enum_default_value)
+    public function setOuterEnumDefaultValue(?\OpenAPI\Client\Model\OuterEnumDefaultValue $outer_enum_default_value): static
     {
         if (is_null($outer_enum_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
@@ -682,7 +680,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\OuterEnumIntegerDefaultValue|null
      */
-    public function getOuterEnumIntegerDefaultValue()
+    public function getOuterEnumIntegerDefaultValue(): ?\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue
     {
         return $this->container['outer_enum_integer_default_value'];
     }
@@ -692,9 +690,9 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\OuterEnumIntegerDefaultValue|null $outer_enum_integer_default_value outer_enum_integer_default_value
      *
-     * @return self
+     * @return $this
      */
-    public function setOuterEnumIntegerDefaultValue($outer_enum_integer_default_value)
+    public function setOuterEnumIntegerDefaultValue(?\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue $outer_enum_integer_default_value): static
     {
         if (is_null($outer_enum_integer_default_value)) {
             throw new \InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
@@ -710,7 +708,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -723,7 +721,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -736,7 +734,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -752,7 +750,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -765,7 +763,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -775,7 +773,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -788,7 +786,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * EnumTest Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
+class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -343,8 +346,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -459,11 +461,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setEnumString(?string $enum_string): static
     {
         if (is_null($enum_string)) {
-            throw new \InvalidArgumentException('non-nullable enum_string cannot be null');
+            throw new InvalidArgumentException('non-nullable enum_string cannot be null');
         }
         $allowedValues = $this->getEnumStringAllowableValues();
         if (!in_array($enum_string, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_string', must be one of '%s'",
                     $enum_string,
@@ -496,11 +498,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setEnumStringRequired(string $enum_string_required): static
     {
         if (is_null($enum_string_required)) {
-            throw new \InvalidArgumentException('non-nullable enum_string_required cannot be null');
+            throw new InvalidArgumentException('non-nullable enum_string_required cannot be null');
         }
         $allowedValues = $this->getEnumStringRequiredAllowableValues();
         if (!in_array($enum_string_required, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_string_required', must be one of '%s'",
                     $enum_string_required,
@@ -533,11 +535,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setEnumInteger(?int $enum_integer): static
     {
         if (is_null($enum_integer)) {
-            throw new \InvalidArgumentException('non-nullable enum_integer cannot be null');
+            throw new InvalidArgumentException('non-nullable enum_integer cannot be null');
         }
         $allowedValues = $this->getEnumIntegerAllowableValues();
         if (!in_array($enum_integer, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_integer', must be one of '%s'",
                     $enum_integer,
@@ -570,11 +572,11 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setEnumNumber(?float $enum_number): static
     {
         if (is_null($enum_number)) {
-            throw new \InvalidArgumentException('non-nullable enum_number cannot be null');
+            throw new InvalidArgumentException('non-nullable enum_number cannot be null');
         }
         $allowedValues = $this->getEnumNumberAllowableValues();
         if (!in_array($enum_number, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'enum_number', must be one of '%s'",
                     $enum_number,
@@ -641,7 +643,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setOuterEnumInteger(?\OpenAPI\Client\Model\OuterEnumInteger $outer_enum_integer): static
     {
         if (is_null($outer_enum_integer)) {
-            throw new \InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
+            throw new InvalidArgumentException('non-nullable outer_enum_integer cannot be null');
         }
         $this->container['outer_enum_integer'] = $outer_enum_integer;
 
@@ -668,7 +670,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setOuterEnumDefaultValue(?\OpenAPI\Client\Model\OuterEnumDefaultValue $outer_enum_default_value): static
     {
         if (is_null($outer_enum_default_value)) {
-            throw new \InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
+            throw new InvalidArgumentException('non-nullable outer_enum_default_value cannot be null');
         }
         $this->container['outer_enum_default_value'] = $outer_enum_default_value;
 
@@ -695,7 +697,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setOuterEnumIntegerDefaultValue(?\OpenAPI\Client\Model\OuterEnumIntegerDefaultValue $outer_enum_integer_default_value): static
     {
         if (is_null($outer_enum_integer_default_value)) {
-            throw new \InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
+            throw new InvalidArgumentException('non-nullable outer_enum_integer_default_value cannot be null');
         }
         $this->container['outer_enum_integer_default_value'] = $outer_enum_integer_default_value;
 
@@ -720,7 +722,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -762,7 +764,7 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * FakeBigDecimalMap200Response Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \JsonSerializable
+class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     public function setSomeId(?float $some_id): static
     {
         if (is_null($some_id)) {
-            throw new \InvalidArgumentException('non-nullable some_id cannot be null');
+            throw new InvalidArgumentException('non-nullable some_id cannot be null');
         }
         $this->container['some_id'] = $some_id;
 
@@ -341,7 +343,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     public function setSomeMap(?array $some_map): static
     {
         if (is_null($some_map)) {
-            throw new \InvalidArgumentException('non-nullable some_map cannot be null');
+            throw new InvalidArgumentException('non-nullable some_map cannot be null');
         }
         $this->container['some_map'] = $some_map;
 
@@ -366,7 +368,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -49,14 +49,14 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
       *
       * @var string
       */
-    protected static $openAPIModelName = 'fakeBigDecimalMap_200_response';
+    protected static string $openAPIModelName = 'fakeBigDecimalMap_200_response';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'some_id' => 'float',
         'some_map' => 'array<string,float>'
     ];
@@ -64,11 +64,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'some_id' => null,
         'some_map' => null
     ];
@@ -76,7 +74,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'some_id' => false,
@@ -86,16 +84,16 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'some_id' => 'someId',
         'some_map' => 'someMap'
     ];
@@ -176,9 +174,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'some_id' => 'setSomeId',
         'some_map' => 'setSomeMap'
     ];
@@ -186,9 +184,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'some_id' => 'getSomeId',
         'some_map' => 'getSomeMap'
     ];
@@ -197,9 +195,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return float|null
      */
-    public function getSomeId()
+    public function getSomeId(): ?float
     {
         return $this->container['some_id'];
     }
@@ -311,9 +309,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @param float|null $some_id some_id
      *
-     * @return self
+     * @return $this
      */
-    public function setSomeId($some_id)
+    public function setSomeId(?float $some_id): static
     {
         if (is_null($some_id)) {
             throw new \InvalidArgumentException('non-nullable some_id cannot be null');
@@ -328,7 +326,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return array<string,float>|null
      */
-    public function getSomeMap()
+    public function getSomeMap(): ?array
     {
         return $this->container['some_map'];
     }
@@ -338,9 +336,9 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @param array<string,float>|null $some_map some_map
      *
-     * @return self
+     * @return $this
      */
-    public function setSomeMap($some_map)
+    public function setSomeMap(?array $some_map): static
     {
         if (is_null($some_map)) {
             throw new \InvalidArgumentException('non-nullable some_map cannot be null');
@@ -356,7 +354,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * File Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class File implements ModelInterface, ArrayAccess, \JsonSerializable
+class File implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -238,8 +241,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -308,7 +310,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setSourceUri(?string $source_uri): static
     {
         if (is_null($source_uri)) {
-            throw new \InvalidArgumentException('non-nullable source_uri cannot be null');
+            throw new InvalidArgumentException('non-nullable source_uri cannot be null');
         }
         $this->container['source_uri'] = $source_uri;
 
@@ -333,7 +335,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -375,7 +377,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/File.php
@@ -50,32 +50,30 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'File';
+    protected static string $openAPIModelName = 'File';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'source_uri' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'source_uri' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'source_uri' => false
@@ -84,16 +82,16 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -101,9 +99,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -111,7 +109,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -121,7 +119,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -131,7 +129,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -164,27 +162,27 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'source_uri' => 'sourceURI'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'source_uri' => 'setSourceUri'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'source_uri' => 'getSourceUri'
     ];
 
@@ -192,9 +190,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -202,9 +200,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -212,9 +210,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -224,7 +222,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -233,9 +231,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -257,7 +255,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -269,9 +267,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -284,7 +282,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -295,7 +293,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getSourceUri()
+    public function getSourceUri(): ?string
     {
         return $this->container['source_uri'];
     }
@@ -305,9 +303,9 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $source_uri Test capitalization
      *
-     * @return self
+     * @return $this
      */
-    public function setSourceUri($source_uri)
+    public function setSourceUri(?string $source_uri): static
     {
         if (is_null($source_uri)) {
             throw new \InvalidArgumentException('non-nullable source_uri cannot be null');
@@ -323,7 +321,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -336,7 +334,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -349,7 +347,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -365,7 +363,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -378,7 +376,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -388,7 +386,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -401,7 +399,7 @@ class File implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -49,14 +49,14 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
       *
       * @var string
       */
-    protected static $openAPIModelName = 'FileSchemaTestClass';
+    protected static string $openAPIModelName = 'FileSchemaTestClass';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'file' => '\OpenAPI\Client\Model\File',
         'files' => '\OpenAPI\Client\Model\File[]'
     ];
@@ -64,11 +64,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'file' => null,
         'files' => null
     ];
@@ -76,7 +74,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'file' => false,
@@ -86,16 +84,16 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'file' => 'file',
         'files' => 'files'
     ];
@@ -176,9 +174,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'file' => 'setFile',
         'files' => 'setFiles'
     ];
@@ -186,9 +184,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'file' => 'getFile',
         'files' => 'getFiles'
     ];
@@ -197,9 +195,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return \OpenAPI\Client\Model\File|null
      */
-    public function getFile()
+    public function getFile(): ?\OpenAPI\Client\Model\File
     {
         return $this->container['file'];
     }
@@ -311,9 +309,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @param \OpenAPI\Client\Model\File|null $file file
      *
-     * @return self
+     * @return $this
      */
-    public function setFile($file)
+    public function setFile(?\OpenAPI\Client\Model\File $file): static
     {
         if (is_null($file)) {
             throw new \InvalidArgumentException('non-nullable file cannot be null');
@@ -328,7 +326,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return \OpenAPI\Client\Model\File[]|null
      */
-    public function getFiles()
+    public function getFiles(): ?array
     {
         return $this->container['files'];
     }
@@ -338,9 +336,9 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @param \OpenAPI\Client\Model\File[]|null $files files
      *
-     * @return self
+     * @return $this
      */
-    public function setFiles($files)
+    public function setFiles(?array $files): static
     {
         if (is_null($files)) {
             throw new \InvalidArgumentException('non-nullable files cannot be null');
@@ -356,7 +354,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * FileSchemaTestClass Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializable
+class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     public function setFile(?\OpenAPI\Client\Model\File $file): static
     {
         if (is_null($file)) {
-            throw new \InvalidArgumentException('non-nullable file cannot be null');
+            throw new InvalidArgumentException('non-nullable file cannot be null');
         }
         $this->container['file'] = $file;
 
@@ -341,7 +343,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
     public function setFiles(?array $files): static
     {
         if (is_null($files)) {
-            throw new \InvalidArgumentException('non-nullable files cannot be null');
+            throw new InvalidArgumentException('non-nullable files cannot be null');
         }
         $this->container['files'] = $files;
 
@@ -366,7 +368,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -49,32 +49,30 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Foo';
+    protected static string $openAPIModelName = 'Foo';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'bar' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'bar' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'bar' => false
@@ -83,16 +81,16 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'bar' => 'bar'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'bar' => 'setBar'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'bar' => 'getBar'
     ];
 
@@ -191,9 +189,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getBar()
+    public function getBar(): ?string
     {
         return $this->container['bar'];
     }
@@ -304,9 +302,9 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $bar bar
      *
-     * @return self
+     * @return $this
      */
-    public function setBar($bar)
+    public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
@@ -322,7 +320,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Foo.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Foo Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
+class Foo implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
-            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+            throw new InvalidArgumentException('non-nullable bar cannot be null');
         }
         $this->container['bar'] = $bar;
 
@@ -332,7 +334,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class Foo implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -49,32 +49,30 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
       *
       * @var string
       */
-    protected static $openAPIModelName = '_foo_get_default_response';
+    protected static string $openAPIModelName = '_foo_get_default_response';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'string' => '\OpenAPI\Client\Model\Foo'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'string' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'string' => false
@@ -83,16 +81,16 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'string' => 'string'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'string' => 'setString'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'string' => 'getString'
     ];
 
@@ -191,9 +189,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return \OpenAPI\Client\Model\Foo|null
      */
-    public function getString()
+    public function getString(): ?\OpenAPI\Client\Model\Foo
     {
         return $this->container['string'];
     }
@@ -304,9 +302,9 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @param \OpenAPI\Client\Model\Foo|null $string string
      *
-     * @return self
+     * @return $this
      */
-    public function setString($string)
+    public function setString(?\OpenAPI\Client\Model\Foo $string): static
     {
         if (is_null($string)) {
             throw new \InvalidArgumentException('non-nullable string cannot be null');
@@ -322,7 +320,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FooGetDefaultResponse.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * FooGetDefaultResponse Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSerializable
+class FooGetDefaultResponse implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
     public function setString(?\OpenAPI\Client\Model\Foo $string): static
     {
         if (is_null($string)) {
-            throw new \InvalidArgumentException('non-nullable string cannot be null');
+            throw new InvalidArgumentException('non-nullable string cannot be null');
         }
         $this->container['string'] = $string;
 
@@ -332,7 +334,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class FooGetDefaultResponse implements ModelInterface, ArrayAccess, \JsonSeriali
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * FormatTest Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
+class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -327,8 +330,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -484,14 +486,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setInteger(?int $integer): static
     {
         if (is_null($integer)) {
-            throw new \InvalidArgumentException('non-nullable integer cannot be null');
+            throw new InvalidArgumentException('non-nullable integer cannot be null');
         }
 
         if (($integer > 100)) {
-            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
+            throw new InvalidArgumentException('invalid value for $integer when calling FormatTest., must be smaller than or equal to 100.');
         }
         if (($integer < 10)) {
-            throw new \InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
+            throw new InvalidArgumentException('invalid value for $integer when calling FormatTest., must be bigger than or equal to 10.');
         }
 
         $this->container['integer'] = $integer;
@@ -519,14 +521,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setInt32(?int $int32): static
     {
         if (is_null($int32)) {
-            throw new \InvalidArgumentException('non-nullable int32 cannot be null');
+            throw new InvalidArgumentException('non-nullable int32 cannot be null');
         }
 
         if (($int32 > 200)) {
-            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
+            throw new InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be smaller than or equal to 200.');
         }
         if (($int32 < 20)) {
-            throw new \InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
+            throw new InvalidArgumentException('invalid value for $int32 when calling FormatTest., must be bigger than or equal to 20.');
         }
 
         $this->container['int32'] = $int32;
@@ -554,7 +556,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setInt64(?int $int64): static
     {
         if (is_null($int64)) {
-            throw new \InvalidArgumentException('non-nullable int64 cannot be null');
+            throw new InvalidArgumentException('non-nullable int64 cannot be null');
         }
         $this->container['int64'] = $int64;
 
@@ -581,14 +583,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setNumber(float $number): static
     {
         if (is_null($number)) {
-            throw new \InvalidArgumentException('non-nullable number cannot be null');
+            throw new InvalidArgumentException('non-nullable number cannot be null');
         }
 
         if (($number > 543.2)) {
-            throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
+            throw new InvalidArgumentException('invalid value for $number when calling FormatTest., must be smaller than or equal to 543.2.');
         }
         if (($number < 32.1)) {
-            throw new \InvalidArgumentException('invalid value for $number when calling FormatTest., must be bigger than or equal to 32.1.');
+            throw new InvalidArgumentException('invalid value for $number when calling FormatTest., must be bigger than or equal to 32.1.');
         }
 
         $this->container['number'] = $number;
@@ -616,14 +618,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setFloat(?float $float): static
     {
         if (is_null($float)) {
-            throw new \InvalidArgumentException('non-nullable float cannot be null');
+            throw new InvalidArgumentException('non-nullable float cannot be null');
         }
 
         if (($float > 987.6)) {
-            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
+            throw new InvalidArgumentException('invalid value for $float when calling FormatTest., must be smaller than or equal to 987.6.');
         }
         if (($float < 54.3)) {
-            throw new \InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
+            throw new InvalidArgumentException('invalid value for $float when calling FormatTest., must be bigger than or equal to 54.3.');
         }
 
         $this->container['float'] = $float;
@@ -651,14 +653,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setDouble(?float $double): static
     {
         if (is_null($double)) {
-            throw new \InvalidArgumentException('non-nullable double cannot be null');
+            throw new InvalidArgumentException('non-nullable double cannot be null');
         }
 
         if (($double > 123.4)) {
-            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
+            throw new InvalidArgumentException('invalid value for $double when calling FormatTest., must be smaller than or equal to 123.4.');
         }
         if (($double < 67.8)) {
-            throw new \InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
+            throw new InvalidArgumentException('invalid value for $double when calling FormatTest., must be bigger than or equal to 67.8.');
         }
 
         $this->container['double'] = $double;
@@ -686,7 +688,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setDecimal(?float $decimal): static
     {
         if (is_null($decimal)) {
-            throw new \InvalidArgumentException('non-nullable decimal cannot be null');
+            throw new InvalidArgumentException('non-nullable decimal cannot be null');
         }
         $this->container['decimal'] = $decimal;
 
@@ -713,11 +715,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setString(?string $string): static
     {
         if (is_null($string)) {
-            throw new \InvalidArgumentException('non-nullable string cannot be null');
+            throw new InvalidArgumentException('non-nullable string cannot be null');
         }
 
         if ((!preg_match("/[a-z]/i", $string))) {
-            throw new \InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
+            throw new InvalidArgumentException("invalid value for \$string when calling FormatTest., must conform to the pattern /[a-z]/i.");
         }
 
         $this->container['string'] = $string;
@@ -745,7 +747,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setByte(string $byte): static
     {
         if (is_null($byte)) {
-            throw new \InvalidArgumentException('non-nullable byte cannot be null');
+            throw new InvalidArgumentException('non-nullable byte cannot be null');
         }
         $this->container['byte'] = $byte;
 
@@ -772,7 +774,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setBinary(?\SplFileObject $binary): static
     {
         if (is_null($binary)) {
-            throw new \InvalidArgumentException('non-nullable binary cannot be null');
+            throw new InvalidArgumentException('non-nullable binary cannot be null');
         }
         $this->container['binary'] = $binary;
 
@@ -799,7 +801,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setDate(\DateTime $date): static
     {
         if (is_null($date)) {
-            throw new \InvalidArgumentException('non-nullable date cannot be null');
+            throw new InvalidArgumentException('non-nullable date cannot be null');
         }
         $this->container['date'] = $date;
 
@@ -826,7 +828,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setDateTime(?\DateTime $date_time): static
     {
         if (is_null($date_time)) {
-            throw new \InvalidArgumentException('non-nullable date_time cannot be null');
+            throw new InvalidArgumentException('non-nullable date_time cannot be null');
         }
         $this->container['date_time'] = $date_time;
 
@@ -853,7 +855,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
-            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+            throw new InvalidArgumentException('non-nullable uuid cannot be null');
         }
         $this->container['uuid'] = $uuid;
 
@@ -880,13 +882,13 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPassword(string $password): static
     {
         if (is_null($password)) {
-            throw new \InvalidArgumentException('non-nullable password cannot be null');
+            throw new InvalidArgumentException('non-nullable password cannot be null');
         }
         if ((mb_strlen($password) > 64)) {
-            throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be smaller than or equal to 64.');
+            throw new InvalidArgumentException('invalid length for $password when calling FormatTest., must be smaller than or equal to 64.');
         }
         if ((mb_strlen($password) < 10)) {
-            throw new \InvalidArgumentException('invalid length for $password when calling FormatTest., must be bigger than or equal to 10.');
+            throw new InvalidArgumentException('invalid length for $password when calling FormatTest., must be bigger than or equal to 10.');
         }
 
         $this->container['password'] = $password;
@@ -914,11 +916,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPatternWithDigits(?string $pattern_with_digits): static
     {
         if (is_null($pattern_with_digits)) {
-            throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
+            throw new InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
         }
 
         if ((!preg_match("/^\\d{10}$/", $pattern_with_digits))) {
-            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
+            throw new InvalidArgumentException("invalid value for \$pattern_with_digits when calling FormatTest., must conform to the pattern /^\\d{10}$/.");
         }
 
         $this->container['pattern_with_digits'] = $pattern_with_digits;
@@ -946,11 +948,11 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPatternWithDigitsAndDelimiter(?string $pattern_with_digits_and_delimiter): static
     {
         if (is_null($pattern_with_digits_and_delimiter)) {
-            throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
+            throw new InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
         }
 
         if ((!preg_match("/^image_\\d{1,3}$/i", $pattern_with_digits_and_delimiter))) {
-            throw new \InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
+            throw new InvalidArgumentException("invalid value for \$pattern_with_digits_and_delimiter when calling FormatTest., must conform to the pattern /^image_\\d{1,3}$/i.");
         }
 
         $this->container['pattern_with_digits_and_delimiter'] = $pattern_with_digits_and_delimiter;
@@ -976,7 +978,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -1018,7 +1020,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -49,14 +49,14 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'format_test';
+    protected static string $openAPIModelName = 'format_test';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'integer' => 'int',
         'int32' => 'int',
         'int64' => 'int',
@@ -78,11 +78,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'integer' => null,
         'int32' => 'int32',
         'int64' => 'int64',
@@ -104,7 +102,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'integer' => false,
@@ -128,16 +126,16 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -145,9 +143,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -155,7 +153,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -165,7 +163,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -175,7 +173,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -208,9 +206,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'integer' => 'integer',
         'int32' => 'int32',
         'int64' => 'int64',
@@ -232,9 +230,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'integer' => 'setInteger',
         'int32' => 'setInt32',
         'int64' => 'setInt64',
@@ -256,9 +254,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'integer' => 'getInteger',
         'int32' => 'getInt32',
         'int64' => 'getInt64',
@@ -281,9 +279,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -291,9 +289,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -301,9 +299,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -313,7 +311,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -322,9 +320,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -361,7 +359,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -373,9 +371,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -460,7 +458,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -471,7 +469,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getInteger()
+    public function getInteger(): ?int
     {
         return $this->container['integer'];
     }
@@ -481,9 +479,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $integer integer
      *
-     * @return self
+     * @return $this
      */
-    public function setInteger($integer)
+    public function setInteger(?int $integer): static
     {
         if (is_null($integer)) {
             throw new \InvalidArgumentException('non-nullable integer cannot be null');
@@ -506,7 +504,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getInt32()
+    public function getInt32(): ?int
     {
         return $this->container['int32'];
     }
@@ -516,9 +514,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $int32 int32
      *
-     * @return self
+     * @return $this
      */
-    public function setInt32($int32)
+    public function setInt32(?int $int32): static
     {
         if (is_null($int32)) {
             throw new \InvalidArgumentException('non-nullable int32 cannot be null');
@@ -541,7 +539,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getInt64()
+    public function getInt64(): ?int
     {
         return $this->container['int64'];
     }
@@ -551,9 +549,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $int64 int64
      *
-     * @return self
+     * @return $this
      */
-    public function setInt64($int64)
+    public function setInt64(?int $int64): static
     {
         if (is_null($int64)) {
             throw new \InvalidArgumentException('non-nullable int64 cannot be null');
@@ -568,7 +566,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float
      */
-    public function getNumber()
+    public function getNumber(): float
     {
         return $this->container['number'];
     }
@@ -578,9 +576,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float $number number
      *
-     * @return self
+     * @return $this
      */
-    public function setNumber($number)
+    public function setNumber(float $number): static
     {
         if (is_null($number)) {
             throw new \InvalidArgumentException('non-nullable number cannot be null');
@@ -603,7 +601,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getFloat()
+    public function getFloat(): ?float
     {
         return $this->container['float'];
     }
@@ -613,9 +611,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $float float
      *
-     * @return self
+     * @return $this
      */
-    public function setFloat($float)
+    public function setFloat(?float $float): static
     {
         if (is_null($float)) {
             throw new \InvalidArgumentException('non-nullable float cannot be null');
@@ -638,7 +636,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getDouble()
+    public function getDouble(): ?float
     {
         return $this->container['double'];
     }
@@ -648,9 +646,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $double double
      *
-     * @return self
+     * @return $this
      */
-    public function setDouble($double)
+    public function setDouble(?float $double): static
     {
         if (is_null($double)) {
             throw new \InvalidArgumentException('non-nullable double cannot be null');
@@ -673,7 +671,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getDecimal()
+    public function getDecimal(): ?float
     {
         return $this->container['decimal'];
     }
@@ -683,9 +681,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $decimal decimal
      *
-     * @return self
+     * @return $this
      */
-    public function setDecimal($decimal)
+    public function setDecimal(?float $decimal): static
     {
         if (is_null($decimal)) {
             throw new \InvalidArgumentException('non-nullable decimal cannot be null');
@@ -700,7 +698,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getString()
+    public function getString(): ?string
     {
         return $this->container['string'];
     }
@@ -710,9 +708,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $string string
      *
-     * @return self
+     * @return $this
      */
-    public function setString($string)
+    public function setString(?string $string): static
     {
         if (is_null($string)) {
             throw new \InvalidArgumentException('non-nullable string cannot be null');
@@ -732,7 +730,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getByte()
+    public function getByte(): string
     {
         return $this->container['byte'];
     }
@@ -742,9 +740,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $byte byte
      *
-     * @return self
+     * @return $this
      */
-    public function setByte($byte)
+    public function setByte(string $byte): static
     {
         if (is_null($byte)) {
             throw new \InvalidArgumentException('non-nullable byte cannot be null');
@@ -759,7 +757,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \SplFileObject|null
      */
-    public function getBinary()
+    public function getBinary(): ?\SplFileObject
     {
         return $this->container['binary'];
     }
@@ -769,9 +767,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \SplFileObject|null $binary binary
      *
-     * @return self
+     * @return $this
      */
-    public function setBinary($binary)
+    public function setBinary(?\SplFileObject $binary): static
     {
         if (is_null($binary)) {
             throw new \InvalidArgumentException('non-nullable binary cannot be null');
@@ -786,7 +784,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \DateTime
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->container['date'];
     }
@@ -796,9 +794,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \DateTime $date date
      *
-     * @return self
+     * @return $this
      */
-    public function setDate($date)
+    public function setDate(\DateTime $date): static
     {
         if (is_null($date)) {
             throw new \InvalidArgumentException('non-nullable date cannot be null');
@@ -813,7 +811,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \DateTime|null
      */
-    public function getDateTime()
+    public function getDateTime(): ?\DateTime
     {
         return $this->container['date_time'];
     }
@@ -823,9 +821,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \DateTime|null $date_time date_time
      *
-     * @return self
+     * @return $this
      */
-    public function setDateTime($date_time)
+    public function setDateTime(?\DateTime $date_time): static
     {
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
@@ -840,7 +838,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getUuid()
+    public function getUuid(): ?string
     {
         return $this->container['uuid'];
     }
@@ -850,9 +848,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $uuid uuid
      *
-     * @return self
+     * @return $this
      */
-    public function setUuid($uuid)
+    public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
@@ -867,7 +865,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getPassword()
+    public function getPassword(): string
     {
         return $this->container['password'];
     }
@@ -877,9 +875,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $password password
      *
-     * @return self
+     * @return $this
      */
-    public function setPassword($password)
+    public function setPassword(string $password): static
     {
         if (is_null($password)) {
             throw new \InvalidArgumentException('non-nullable password cannot be null');
@@ -901,7 +899,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getPatternWithDigits()
+    public function getPatternWithDigits(): ?string
     {
         return $this->container['pattern_with_digits'];
     }
@@ -911,9 +909,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $pattern_with_digits A string that is a 10 digit number. Can have leading zeros.
      *
-     * @return self
+     * @return $this
      */
-    public function setPatternWithDigits($pattern_with_digits)
+    public function setPatternWithDigits(?string $pattern_with_digits): static
     {
         if (is_null($pattern_with_digits)) {
             throw new \InvalidArgumentException('non-nullable pattern_with_digits cannot be null');
@@ -933,7 +931,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getPatternWithDigitsAndDelimiter()
+    public function getPatternWithDigitsAndDelimiter(): ?string
     {
         return $this->container['pattern_with_digits_and_delimiter'];
     }
@@ -943,9 +941,9 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $pattern_with_digits_and_delimiter A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.
      *
-     * @return self
+     * @return $this
      */
-    public function setPatternWithDigitsAndDelimiter($pattern_with_digits_and_delimiter)
+    public function setPatternWithDigitsAndDelimiter(?string $pattern_with_digits_and_delimiter): static
     {
         if (is_null($pattern_with_digits_and_delimiter)) {
             throw new \InvalidArgumentException('non-nullable pattern_with_digits_and_delimiter cannot be null');
@@ -966,7 +964,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -979,7 +977,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -992,7 +990,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -1008,7 +1006,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -1021,7 +1019,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -1031,7 +1029,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -1044,7 +1042,7 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -49,14 +49,14 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'hasOnlyReadOnly';
+    protected static string $openAPIModelName = 'hasOnlyReadOnly';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'bar' => 'string',
         'foo' => 'string'
     ];
@@ -64,11 +64,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'bar' => null,
         'foo' => null
     ];
@@ -76,7 +74,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'bar' => false,
@@ -86,16 +84,16 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'bar' => 'bar',
         'foo' => 'foo'
     ];
@@ -176,9 +174,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'bar' => 'setBar',
         'foo' => 'setFoo'
     ];
@@ -186,9 +184,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'bar' => 'getBar',
         'foo' => 'getFoo'
     ];
@@ -197,9 +195,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getBar()
+    public function getBar(): ?string
     {
         return $this->container['bar'];
     }
@@ -311,9 +309,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $bar bar
      *
-     * @return self
+     * @return $this
      */
-    public function setBar($bar)
+    public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
@@ -328,7 +326,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getFoo()
+    public function getFoo(): ?string
     {
         return $this->container['foo'];
     }
@@ -338,9 +336,9 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $foo foo
      *
-     * @return self
+     * @return $this
      */
-    public function setFoo($foo)
+    public function setFoo(?string $foo): static
     {
         if (is_null($foo)) {
             throw new \InvalidArgumentException('non-nullable foo cannot be null');
@@ -356,7 +354,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * HasOnlyReadOnly Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
+class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
-            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+            throw new InvalidArgumentException('non-nullable bar cannot be null');
         }
         $this->container['bar'] = $bar;
 
@@ -341,7 +343,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setFoo(?string $foo): static
     {
         if (is_null($foo)) {
-            throw new \InvalidArgumentException('non-nullable foo cannot be null');
+            throw new InvalidArgumentException('non-nullable foo cannot be null');
         }
         $this->container['foo'] = $foo;
 
@@ -366,7 +368,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * HealthCheckResult Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializable
+class HealthCheckResult implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -238,8 +241,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -340,7 +342,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -382,7 +384,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HealthCheckResult.php
@@ -50,32 +50,30 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
       *
       * @var string
       */
-    protected static $openAPIModelName = 'HealthCheckResult';
+    protected static string $openAPIModelName = 'HealthCheckResult';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'nullable_message' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'nullable_message' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'nullable_message' => true
@@ -84,16 +82,16 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -101,9 +99,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -111,7 +109,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -121,7 +119,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -131,7 +129,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -164,27 +162,27 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'nullable_message' => 'NullableMessage'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'nullable_message' => 'setNullableMessage'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'nullable_message' => 'getNullableMessage'
     ];
 
@@ -192,9 +190,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -202,9 +200,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -212,9 +210,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -224,7 +222,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -233,9 +231,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -257,7 +255,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -269,9 +267,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -284,7 +282,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -295,7 +293,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string|null
      */
-    public function getNullableMessage()
+    public function getNullableMessage(): ?string
     {
         return $this->container['nullable_message'];
     }
@@ -305,9 +303,9 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @param string|null $nullable_message nullable_message
      *
-     * @return self
+     * @return $this
      */
-    public function setNullableMessage($nullable_message)
+    public function setNullableMessage(?string $nullable_message): static
     {
         if (is_null($nullable_message)) {
             array_push($this->openAPINullablesSetToNull, 'nullable_message');
@@ -330,7 +328,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -343,7 +341,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -356,7 +354,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -372,7 +370,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -385,7 +383,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -395,7 +393,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -408,7 +406,7 @@ class HealthCheckResult implements ModelInterface, ArrayAccess, \JsonSerializabl
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -49,14 +49,14 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'MapTest';
+    protected static string $openAPIModelName = 'MapTest';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'map_map_of_string' => 'array<string,array<string,string>>',
         'map_of_enum_string' => 'array<string,string>',
         'direct_map' => 'array<string,bool>',
@@ -66,11 +66,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'map_map_of_string' => null,
         'map_of_enum_string' => null,
         'direct_map' => null,
@@ -80,7 +78,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'map_map_of_string' => false,
@@ -92,16 +90,16 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -109,9 +107,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -119,7 +117,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -129,7 +127,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -139,7 +137,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -172,9 +170,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'map_map_of_string' => 'map_map_of_string',
         'map_of_enum_string' => 'map_of_enum_string',
         'direct_map' => 'direct_map',
@@ -184,9 +182,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'map_map_of_string' => 'setMapMapOfString',
         'map_of_enum_string' => 'setMapOfEnumString',
         'direct_map' => 'setDirectMap',
@@ -196,9 +194,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'map_map_of_string' => 'getMapMapOfString',
         'map_of_enum_string' => 'getMapOfEnumString',
         'direct_map' => 'getDirectMap',
@@ -209,9 +207,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -219,9 +217,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -229,9 +227,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -241,7 +239,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -265,9 +263,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -292,7 +290,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -304,9 +302,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -319,7 +317,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -330,7 +328,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,array<string,string>>|null
      */
-    public function getMapMapOfString()
+    public function getMapMapOfString(): ?array
     {
         return $this->container['map_map_of_string'];
     }
@@ -340,9 +338,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,array<string,string>>|null $map_map_of_string map_map_of_string
      *
-     * @return self
+     * @return $this
      */
-    public function setMapMapOfString($map_map_of_string)
+    public function setMapMapOfString(?array $map_map_of_string): static
     {
         if (is_null($map_map_of_string)) {
             throw new \InvalidArgumentException('non-nullable map_map_of_string cannot be null');
@@ -357,7 +355,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,string>|null
      */
-    public function getMapOfEnumString()
+    public function getMapOfEnumString(): ?array
     {
         return $this->container['map_of_enum_string'];
     }
@@ -367,9 +365,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,string>|null $map_of_enum_string map_of_enum_string
      *
-     * @return self
+     * @return $this
      */
-    public function setMapOfEnumString($map_of_enum_string)
+    public function setMapOfEnumString(?array $map_of_enum_string): static
     {
         if (is_null($map_of_enum_string)) {
             throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
@@ -393,7 +391,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,bool>|null
      */
-    public function getDirectMap()
+    public function getDirectMap(): ?array
     {
         return $this->container['direct_map'];
     }
@@ -403,9 +401,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,bool>|null $direct_map direct_map
      *
-     * @return self
+     * @return $this
      */
-    public function setDirectMap($direct_map)
+    public function setDirectMap(?array $direct_map): static
     {
         if (is_null($direct_map)) {
             throw new \InvalidArgumentException('non-nullable direct_map cannot be null');
@@ -420,7 +418,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,bool>|null
      */
-    public function getIndirectMap()
+    public function getIndirectMap(): ?array
     {
         return $this->container['indirect_map'];
     }
@@ -430,9 +428,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,bool>|null $indirect_map indirect_map
      *
-     * @return self
+     * @return $this
      */
-    public function setIndirectMap($indirect_map)
+    public function setIndirectMap(?array $indirect_map): static
     {
         if (is_null($indirect_map)) {
             throw new \InvalidArgumentException('non-nullable indirect_map cannot be null');
@@ -448,7 +446,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -461,7 +459,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -474,7 +472,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -490,7 +488,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -503,7 +501,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -513,7 +511,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -526,7 +524,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * MapTest Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
+class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -270,8 +273,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -343,7 +345,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMapMapOfString(?array $map_map_of_string): static
     {
         if (is_null($map_map_of_string)) {
-            throw new \InvalidArgumentException('non-nullable map_map_of_string cannot be null');
+            throw new InvalidArgumentException('non-nullable map_map_of_string cannot be null');
         }
         $this->container['map_map_of_string'] = $map_map_of_string;
 
@@ -370,11 +372,11 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMapOfEnumString(?array $map_of_enum_string): static
     {
         if (is_null($map_of_enum_string)) {
-            throw new \InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
+            throw new InvalidArgumentException('non-nullable map_of_enum_string cannot be null');
         }
         $allowedValues = $this->getMapOfEnumStringAllowableValues();
         if (array_diff($map_of_enum_string, $allowedValues)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value for 'map_of_enum_string', must be one of '%s'",
                     implode("', '", $allowedValues)
@@ -406,7 +408,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setDirectMap(?array $direct_map): static
     {
         if (is_null($direct_map)) {
-            throw new \InvalidArgumentException('non-nullable direct_map cannot be null');
+            throw new InvalidArgumentException('non-nullable direct_map cannot be null');
         }
         $this->container['direct_map'] = $direct_map;
 
@@ -433,7 +435,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setIndirectMap(?array $indirect_map): static
     {
         if (is_null($indirect_map)) {
-            throw new \InvalidArgumentException('non-nullable indirect_map cannot be null');
+            throw new InvalidArgumentException('non-nullable indirect_map cannot be null');
         }
         $this->container['indirect_map'] = $indirect_map;
 
@@ -458,7 +460,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -500,7 +502,7 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -49,14 +49,14 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
       *
       * @var string
       */
-    protected static $openAPIModelName = 'MixedPropertiesAndAdditionalPropertiesClass';
+    protected static string $openAPIModelName = 'MixedPropertiesAndAdditionalPropertiesClass';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'uuid' => 'string',
         'date_time' => '\DateTime',
         'map' => 'array<string,\OpenAPI\Client\Model\Animal>'
@@ -65,11 +65,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'uuid' => 'uuid',
         'date_time' => 'date-time',
         'map' => null
@@ -78,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'uuid' => false,
@@ -89,16 +87,16 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -106,9 +104,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -116,7 +114,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -126,7 +124,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -136,7 +134,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -169,9 +167,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'uuid' => 'uuid',
         'date_time' => 'dateTime',
         'map' => 'map'
@@ -180,9 +178,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'uuid' => 'setUuid',
         'date_time' => 'setDateTime',
         'map' => 'setMap'
@@ -191,9 +189,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'uuid' => 'getUuid',
         'date_time' => 'getDateTime',
         'map' => 'getMap'
@@ -203,9 +201,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -213,9 +211,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -223,9 +221,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -235,7 +233,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -244,9 +242,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -270,7 +268,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -282,9 +280,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -297,7 +295,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -308,7 +306,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return string|null
      */
-    public function getUuid()
+    public function getUuid(): ?string
     {
         return $this->container['uuid'];
     }
@@ -318,9 +316,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @param string|null $uuid uuid
      *
-     * @return self
+     * @return $this
      */
-    public function setUuid($uuid)
+    public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
@@ -335,7 +333,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return \DateTime|null
      */
-    public function getDateTime()
+    public function getDateTime(): ?\DateTime
     {
         return $this->container['date_time'];
     }
@@ -345,9 +343,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @param \DateTime|null $date_time date_time
      *
-     * @return self
+     * @return $this
      */
-    public function setDateTime($date_time)
+    public function setDateTime(?\DateTime $date_time): static
     {
         if (is_null($date_time)) {
             throw new \InvalidArgumentException('non-nullable date_time cannot be null');
@@ -362,7 +360,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return array<string,\OpenAPI\Client\Model\Animal>|null
      */
-    public function getMap()
+    public function getMap(): ?array
     {
         return $this->container['map'];
     }
@@ -372,9 +370,9 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @param array<string,\OpenAPI\Client\Model\Animal>|null $map map
      *
-     * @return self
+     * @return $this
      */
-    public function setMap($map)
+    public function setMap(?array $map): static
     {
         if (is_null($map)) {
             throw new \InvalidArgumentException('non-nullable map cannot be null');
@@ -390,7 +388,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -403,7 +401,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -416,7 +414,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -432,7 +430,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -445,7 +443,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -455,7 +453,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -468,7 +466,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * MixedPropertiesAndAdditionalPropertiesClass Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSerializable
+class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -249,8 +252,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -321,7 +323,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
-            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+            throw new InvalidArgumentException('non-nullable uuid cannot be null');
         }
         $this->container['uuid'] = $uuid;
 
@@ -348,7 +350,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     public function setDateTime(?\DateTime $date_time): static
     {
         if (is_null($date_time)) {
-            throw new \InvalidArgumentException('non-nullable date_time cannot be null');
+            throw new InvalidArgumentException('non-nullable date_time cannot be null');
         }
         $this->container['date_time'] = $date_time;
 
@@ -375,7 +377,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
     public function setMap(?array $map): static
     {
         if (is_null($map)) {
-            throw new \InvalidArgumentException('non-nullable map cannot be null');
+            throw new InvalidArgumentException('non-nullable map cannot be null');
         }
         $this->container['map'] = $map;
 
@@ -400,7 +402,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -442,7 +444,7 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -50,14 +50,14 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = '200_response';
+    protected static string $openAPIModelName = '200_response';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'name' => 'int',
         'class' => 'string'
     ];
@@ -65,11 +65,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'name' => 'int32',
         'class' => null
     ];
@@ -77,7 +75,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'name' => false,
@@ -87,16 +85,16 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -104,9 +102,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -114,7 +112,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -124,7 +122,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -134,7 +132,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -167,9 +165,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'name' => 'name',
         'class' => 'class'
     ];
@@ -177,9 +175,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'name' => 'setName',
         'class' => 'setClass'
     ];
@@ -187,9 +185,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'name' => 'getName',
         'class' => 'getClass'
     ];
@@ -198,9 +196,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -208,9 +206,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -218,9 +216,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -230,7 +228,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -239,9 +237,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -264,7 +262,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -276,9 +274,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -291,7 +289,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -302,7 +300,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getName()
+    public function getName(): ?int
     {
         return $this->container['name'];
     }
@@ -312,9 +310,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(?int $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -329,7 +327,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->container['class'];
     }
@@ -339,9 +337,9 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $class class
      *
-     * @return self
+     * @return $this
      */
-    public function setClass($class)
+    public function setClass(?string $class): static
     {
         if (is_null($class)) {
             throw new \InvalidArgumentException('non-nullable class cannot be null');
@@ -357,7 +355,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -370,7 +368,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -383,7 +381,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -399,7 +397,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -412,7 +410,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -422,7 +420,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -435,7 +433,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Model200Response Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
+class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -244,8 +247,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -315,7 +317,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(?int $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -342,7 +344,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setClass(?string $class): static
     {
         if (is_null($class)) {
-            throw new \InvalidArgumentException('non-nullable class cannot be null');
+            throw new InvalidArgumentException('non-nullable class cannot be null');
         }
         $this->container['class'] = $class;
 
@@ -367,7 +369,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -409,7 +411,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelInterface.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelInterface.php
@@ -41,49 +41,49 @@ interface ModelInterface
      *
      * @return string
      */
-    public function getModelName();
+    public function getModelName(): string;
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function openAPITypes();
+    public static function openAPITypes(): array;
 
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
      * @return array
      */
-    public static function openAPIFormats();
+    public static function openAPIFormats(): array;
 
     /**
      * Array of attributes where the key is the local name, and the value is the original name
      *
      * @return array
      */
-    public static function attributeMap();
+    public static function attributeMap(): array;
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
      * @return array
      */
-    public static function setters();
+    public static function setters(): array;
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
      * @return array
      */
-    public static function getters();
+    public static function getters(): array;
 
     /**
      * Show all the invalid properties with reasons.
      *
      * @return array
      */
-    public function listInvalidProperties();
+    public function listInvalidProperties(): array;
 
     /**
      * Validate all the properties in the model
@@ -91,7 +91,7 @@ interface ModelInterface
      *
      * @return bool
      */
-    public function valid();
+    public function valid(): bool;
 
     /**
      * Checks if a property is nullable

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -49,32 +49,30 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'List';
+    protected static string $openAPIModelName = 'List';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         '_123_list' => 'string'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         '_123_list' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         '_123_list' => false
@@ -83,16 +81,16 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         '_123_list' => '123-list'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         '_123_list' => 'set123List'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         '_123_list' => 'get123List'
     ];
 
@@ -191,9 +189,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function get123List()
+    public function get123List(): ?string
     {
         return $this->container['_123_list'];
     }
@@ -304,9 +302,9 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $_123_list _123_list
      *
-     * @return self
+     * @return $this
      */
-    public function set123List($_123_list)
+    public function set123List(?string $_123_list): static
     {
         if (is_null($_123_list)) {
             throw new \InvalidArgumentException('non-nullable _123_list cannot be null');
@@ -322,7 +320,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelList.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ModelList Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
+class ModelList implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
     public function set123List(?string $_123_list): static
     {
         if (is_null($_123_list)) {
-            throw new \InvalidArgumentException('non-nullable _123_list cannot be null');
+            throw new InvalidArgumentException('non-nullable _123_list cannot be null');
         }
         $this->container['_123_list'] = $_123_list;
 
@@ -332,7 +334,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class ModelList implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -50,32 +50,30 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Return';
+    protected static string $openAPIModelName = 'Return';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'return' => 'int'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'return' => 'int32'
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'return' => false
@@ -84,16 +82,16 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -101,9 +99,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -111,7 +109,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -121,7 +119,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -131,7 +129,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -164,27 +162,27 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'return' => 'return'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'return' => 'setReturn'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'return' => 'getReturn'
     ];
 
@@ -192,9 +190,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -202,9 +200,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -212,9 +210,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -224,7 +222,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -233,9 +231,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -257,7 +255,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -269,9 +267,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -284,7 +282,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -295,7 +293,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getReturn()
+    public function getReturn(): ?int
     {
         return $this->container['return'];
     }
@@ -305,9 +303,9 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $return return
      *
-     * @return self
+     * @return $this
      */
-    public function setReturn($return)
+    public function setReturn(?int $return): static
     {
         if (is_null($return)) {
             throw new \InvalidArgumentException('non-nullable return cannot be null');
@@ -323,7 +321,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -336,7 +334,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -349,7 +347,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -365,7 +363,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -378,7 +376,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -388,7 +386,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -401,7 +399,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ModelReturn.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ModelReturn Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
+class ModelReturn implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -238,8 +241,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -308,7 +310,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setReturn(?int $return): static
     {
         if (is_null($return)) {
-            throw new \InvalidArgumentException('non-nullable return cannot be null');
+            throw new InvalidArgumentException('non-nullable return cannot be null');
         }
         $this->container['return'] = $return;
 
@@ -333,7 +335,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -375,7 +377,7 @@ class ModelReturn implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Name Class Doc Comment
@@ -39,9 +42,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Name implements ModelInterface, ArrayAccess, \JsonSerializable
+class Name implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -256,8 +259,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -332,7 +334,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(int $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -359,7 +361,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setSnakeCase(?int $snake_case): static
     {
         if (is_null($snake_case)) {
-            throw new \InvalidArgumentException('non-nullable snake_case cannot be null');
+            throw new InvalidArgumentException('non-nullable snake_case cannot be null');
         }
         $this->container['snake_case'] = $snake_case;
 
@@ -386,7 +388,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setProperty(?string $property): static
     {
         if (is_null($property)) {
-            throw new \InvalidArgumentException('non-nullable property cannot be null');
+            throw new InvalidArgumentException('non-nullable property cannot be null');
         }
         $this->container['property'] = $property;
 
@@ -413,7 +415,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     public function set123Number(?int $_123_number): static
     {
         if (is_null($_123_number)) {
-            throw new \InvalidArgumentException('non-nullable _123_number cannot be null');
+            throw new InvalidArgumentException('non-nullable _123_number cannot be null');
         }
         $this->container['_123_number'] = $_123_number;
 
@@ -438,7 +440,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -480,7 +482,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -50,14 +50,14 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Name';
+    protected static string $openAPIModelName = 'Name';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'name' => 'int',
         'snake_case' => 'int',
         'property' => 'string',
@@ -67,11 +67,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'name' => 'int32',
         'snake_case' => 'int32',
         'property' => null,
@@ -81,7 +79,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'name' => false,
@@ -93,16 +91,16 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -110,9 +108,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -120,7 +118,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -130,7 +128,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -140,7 +138,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -173,9 +171,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'name' => 'name',
         'snake_case' => 'snake_case',
         'property' => 'property',
@@ -185,9 +183,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'name' => 'setName',
         'snake_case' => 'setSnakeCase',
         'property' => 'setProperty',
@@ -197,9 +195,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'name' => 'getName',
         'snake_case' => 'getSnakeCase',
         'property' => 'getProperty',
@@ -210,9 +208,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -220,9 +218,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -230,9 +228,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -242,7 +240,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -251,9 +249,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -278,7 +276,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -290,9 +288,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -308,7 +306,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -319,7 +317,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int
      */
-    public function getName()
+    public function getName(): int
     {
         return $this->container['name'];
     }
@@ -329,9 +327,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(int $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -346,7 +344,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getSnakeCase()
+    public function getSnakeCase(): ?int
     {
         return $this->container['snake_case'];
     }
@@ -356,9 +354,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $snake_case snake_case
      *
-     * @return self
+     * @return $this
      */
-    public function setSnakeCase($snake_case)
+    public function setSnakeCase(?int $snake_case): static
     {
         if (is_null($snake_case)) {
             throw new \InvalidArgumentException('non-nullable snake_case cannot be null');
@@ -373,7 +371,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getProperty()
+    public function getProperty(): ?string
     {
         return $this->container['property'];
     }
@@ -383,9 +381,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $property property
      *
-     * @return self
+     * @return $this
      */
-    public function setProperty($property)
+    public function setProperty(?string $property): static
     {
         if (is_null($property)) {
             throw new \InvalidArgumentException('non-nullable property cannot be null');
@@ -400,7 +398,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function get123Number()
+    public function get123Number(): ?int
     {
         return $this->container['_123_number'];
     }
@@ -410,9 +408,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $_123_number _123_number
      *
-     * @return self
+     * @return $this
      */
-    public function set123Number($_123_number)
+    public function set123Number(?int $_123_number): static
     {
         if (is_null($_123_number)) {
             throw new \InvalidArgumentException('non-nullable _123_number cannot be null');
@@ -428,7 +426,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -441,7 +439,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -454,7 +452,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -470,7 +468,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -483,7 +481,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -493,7 +491,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -506,7 +504,7 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * NullableClass Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
+class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -303,8 +306,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -656,7 +658,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setArrayItemsNullable(?array $array_items_nullable): static
     {
         if (is_null($array_items_nullable)) {
-            throw new \InvalidArgumentException('non-nullable array_items_nullable cannot be null');
+            throw new InvalidArgumentException('non-nullable array_items_nullable cannot be null');
         }
         $this->container['array_items_nullable'] = $array_items_nullable;
 
@@ -751,7 +753,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setObjectItemsNullable(?array $object_items_nullable): static
     {
         if (is_null($object_items_nullable)) {
-            throw new \InvalidArgumentException('non-nullable object_items_nullable cannot be null');
+            throw new InvalidArgumentException('non-nullable object_items_nullable cannot be null');
         }
         $this->container['object_items_nullable'] = $object_items_nullable;
 
@@ -776,7 +778,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -818,7 +820,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -49,14 +49,14 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'NullableClass';
+    protected static string $openAPIModelName = 'NullableClass';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'integer_prop' => 'int',
         'number_prop' => 'float',
         'boolean_prop' => 'bool',
@@ -74,11 +74,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'integer_prop' => null,
         'number_prop' => null,
         'boolean_prop' => null,
@@ -96,7 +94,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'integer_prop' => true,
@@ -116,16 +114,16 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -133,9 +131,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -143,7 +141,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -153,7 +151,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -163,7 +161,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -196,9 +194,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'integer_prop' => 'integer_prop',
         'number_prop' => 'number_prop',
         'boolean_prop' => 'boolean_prop',
@@ -216,9 +214,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'integer_prop' => 'setIntegerProp',
         'number_prop' => 'setNumberProp',
         'boolean_prop' => 'setBooleanProp',
@@ -236,9 +234,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'integer_prop' => 'getIntegerProp',
         'number_prop' => 'getNumberProp',
         'boolean_prop' => 'getBooleanProp',
@@ -257,9 +255,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -267,9 +265,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -277,9 +275,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -289,7 +287,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -298,9 +296,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -333,7 +331,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -345,9 +343,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -360,7 +358,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -371,7 +369,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getIntegerProp()
+    public function getIntegerProp(): ?int
     {
         return $this->container['integer_prop'];
     }
@@ -381,9 +379,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $integer_prop integer_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setIntegerProp($integer_prop)
+    public function setIntegerProp(?int $integer_prop): static
     {
         if (is_null($integer_prop)) {
             array_push($this->openAPINullablesSetToNull, 'integer_prop');
@@ -405,7 +403,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getNumberProp()
+    public function getNumberProp(): ?float
     {
         return $this->container['number_prop'];
     }
@@ -415,9 +413,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $number_prop number_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setNumberProp($number_prop)
+    public function setNumberProp(?float $number_prop): static
     {
         if (is_null($number_prop)) {
             array_push($this->openAPINullablesSetToNull, 'number_prop');
@@ -439,7 +437,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool|null
      */
-    public function getBooleanProp()
+    public function getBooleanProp(): ?bool
     {
         return $this->container['boolean_prop'];
     }
@@ -449,9 +447,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param bool|null $boolean_prop boolean_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setBooleanProp($boolean_prop)
+    public function setBooleanProp(?bool $boolean_prop): static
     {
         if (is_null($boolean_prop)) {
             array_push($this->openAPINullablesSetToNull, 'boolean_prop');
@@ -473,7 +471,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getStringProp()
+    public function getStringProp(): ?string
     {
         return $this->container['string_prop'];
     }
@@ -483,9 +481,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $string_prop string_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setStringProp($string_prop)
+    public function setStringProp(?string $string_prop): static
     {
         if (is_null($string_prop)) {
             array_push($this->openAPINullablesSetToNull, 'string_prop');
@@ -507,7 +505,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \DateTime|null
      */
-    public function getDateProp()
+    public function getDateProp(): ?\DateTime
     {
         return $this->container['date_prop'];
     }
@@ -517,9 +515,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \DateTime|null $date_prop date_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setDateProp($date_prop)
+    public function setDateProp(?\DateTime $date_prop): static
     {
         if (is_null($date_prop)) {
             array_push($this->openAPINullablesSetToNull, 'date_prop');
@@ -541,7 +539,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \DateTime|null
      */
-    public function getDatetimeProp()
+    public function getDatetimeProp(): ?\DateTime
     {
         return $this->container['datetime_prop'];
     }
@@ -551,9 +549,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \DateTime|null $datetime_prop datetime_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setDatetimeProp($datetime_prop)
+    public function setDatetimeProp(?\DateTime $datetime_prop): static
     {
         if (is_null($datetime_prop)) {
             array_push($this->openAPINullablesSetToNull, 'datetime_prop');
@@ -575,7 +573,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return object[]|null
      */
-    public function getArrayNullableProp()
+    public function getArrayNullableProp(): ?array
     {
         return $this->container['array_nullable_prop'];
     }
@@ -585,9 +583,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param object[]|null $array_nullable_prop array_nullable_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayNullableProp($array_nullable_prop)
+    public function setArrayNullableProp(?array $array_nullable_prop): static
     {
         if (is_null($array_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'array_nullable_prop');
@@ -609,7 +607,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return object[]|null
      */
-    public function getArrayAndItemsNullableProp()
+    public function getArrayAndItemsNullableProp(): ?array
     {
         return $this->container['array_and_items_nullable_prop'];
     }
@@ -619,9 +617,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param object[]|null $array_and_items_nullable_prop array_and_items_nullable_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayAndItemsNullableProp($array_and_items_nullable_prop)
+    public function setArrayAndItemsNullableProp(?array $array_and_items_nullable_prop): static
     {
         if (is_null($array_and_items_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'array_and_items_nullable_prop');
@@ -643,7 +641,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return object[]|null
      */
-    public function getArrayItemsNullable()
+    public function getArrayItemsNullable(): ?array
     {
         return $this->container['array_items_nullable'];
     }
@@ -653,9 +651,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param object[]|null $array_items_nullable array_items_nullable
      *
-     * @return self
+     * @return $this
      */
-    public function setArrayItemsNullable($array_items_nullable)
+    public function setArrayItemsNullable(?array $array_items_nullable): static
     {
         if (is_null($array_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable array_items_nullable cannot be null');
@@ -670,7 +668,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,object>|null
      */
-    public function getObjectNullableProp()
+    public function getObjectNullableProp(): ?array
     {
         return $this->container['object_nullable_prop'];
     }
@@ -680,9 +678,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,object>|null $object_nullable_prop object_nullable_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setObjectNullableProp($object_nullable_prop)
+    public function setObjectNullableProp(?array $object_nullable_prop): static
     {
         if (is_null($object_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'object_nullable_prop');
@@ -704,7 +702,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,object>|null
      */
-    public function getObjectAndItemsNullableProp()
+    public function getObjectAndItemsNullableProp(): ?array
     {
         return $this->container['object_and_items_nullable_prop'];
     }
@@ -714,9 +712,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,object>|null $object_and_items_nullable_prop object_and_items_nullable_prop
      *
-     * @return self
+     * @return $this
      */
-    public function setObjectAndItemsNullableProp($object_and_items_nullable_prop)
+    public function setObjectAndItemsNullableProp(?array $object_and_items_nullable_prop): static
     {
         if (is_null($object_and_items_nullable_prop)) {
             array_push($this->openAPINullablesSetToNull, 'object_and_items_nullable_prop');
@@ -738,7 +736,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return array<string,object>|null
      */
-    public function getObjectItemsNullable()
+    public function getObjectItemsNullable(): ?array
     {
         return $this->container['object_items_nullable'];
     }
@@ -748,9 +746,9 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param array<string,object>|null $object_items_nullable object_items_nullable
      *
-     * @return self
+     * @return $this
      */
-    public function setObjectItemsNullable($object_items_nullable)
+    public function setObjectItemsNullable(?array $object_items_nullable): static
     {
         if (is_null($object_items_nullable)) {
             throw new \InvalidArgumentException('non-nullable object_items_nullable cannot be null');
@@ -766,7 +764,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -779,7 +777,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -792,7 +790,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -808,7 +806,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -821,7 +819,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -831,7 +829,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -844,7 +842,7 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * NumberOnly Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
+class NumberOnly implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setJustNumber(?float $just_number): static
     {
         if (is_null($just_number)) {
-            throw new \InvalidArgumentException('non-nullable just_number cannot be null');
+            throw new InvalidArgumentException('non-nullable just_number cannot be null');
         }
         $this->container['just_number'] = $just_number;
 
@@ -332,7 +334,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NumberOnly.php
@@ -49,32 +49,30 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'NumberOnly';
+    protected static string $openAPIModelName = 'NumberOnly';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'just_number' => 'float'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'just_number' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'just_number' => false
@@ -83,16 +81,16 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'just_number' => 'JustNumber'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'just_number' => 'setJustNumber'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'just_number' => 'getJustNumber'
     ];
 
@@ -191,9 +189,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getJustNumber()
+    public function getJustNumber(): ?float
     {
         return $this->container['just_number'];
     }
@@ -304,9 +302,9 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $just_number just_number
      *
-     * @return self
+     * @return $this
      */
-    public function setJustNumber($just_number)
+    public function setJustNumber(?float $just_number): static
     {
         if (is_null($just_number)) {
             throw new \InvalidArgumentException('non-nullable just_number cannot be null');
@@ -322,7 +320,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class NumberOnly implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ObjectWithDeprecatedFields Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSerializable
+class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -255,8 +258,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -328,7 +330,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
-            throw new \InvalidArgumentException('non-nullable uuid cannot be null');
+            throw new InvalidArgumentException('non-nullable uuid cannot be null');
         }
         $this->container['uuid'] = $uuid;
 
@@ -357,7 +359,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     public function setId(?float $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -386,7 +388,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     public function setDeprecatedRef(?\OpenAPI\Client\Model\DeprecatedObject $deprecated_ref): static
     {
         if (is_null($deprecated_ref)) {
-            throw new \InvalidArgumentException('non-nullable deprecated_ref cannot be null');
+            throw new InvalidArgumentException('non-nullable deprecated_ref cannot be null');
         }
         $this->container['deprecated_ref'] = $deprecated_ref;
 
@@ -415,7 +417,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     public function setBars(?array $bars): static
     {
         if (is_null($bars)) {
-            throw new \InvalidArgumentException('non-nullable bars cannot be null');
+            throw new InvalidArgumentException('non-nullable bars cannot be null');
         }
         $this->container['bars'] = $bars;
 
@@ -440,7 +442,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -482,7 +484,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -49,14 +49,14 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ObjectWithDeprecatedFields';
+    protected static string $openAPIModelName = 'ObjectWithDeprecatedFields';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'uuid' => 'string',
         'id' => 'float',
         'deprecated_ref' => '\OpenAPI\Client\Model\DeprecatedObject',
@@ -66,11 +66,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'uuid' => null,
         'id' => null,
         'deprecated_ref' => null,
@@ -80,7 +78,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'uuid' => false,
@@ -92,16 +90,16 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -109,9 +107,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -119,7 +117,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -129,7 +127,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -139,7 +137,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -172,9 +170,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'uuid' => 'uuid',
         'id' => 'id',
         'deprecated_ref' => 'deprecatedRef',
@@ -184,9 +182,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'uuid' => 'setUuid',
         'id' => 'setId',
         'deprecated_ref' => 'setDeprecatedRef',
@@ -196,9 +194,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'uuid' => 'getUuid',
         'id' => 'getId',
         'deprecated_ref' => 'getDeprecatedRef',
@@ -209,9 +207,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -219,9 +217,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -229,9 +227,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -241,7 +239,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -250,9 +248,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -277,7 +275,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -289,9 +287,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -304,7 +302,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -315,7 +313,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string|null
      */
-    public function getUuid()
+    public function getUuid(): ?string
     {
         return $this->container['uuid'];
     }
@@ -325,9 +323,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @param string|null $uuid uuid
      *
-     * @return self
+     * @return $this
      */
-    public function setUuid($uuid)
+    public function setUuid(?string $uuid): static
     {
         if (is_null($uuid)) {
             throw new \InvalidArgumentException('non-nullable uuid cannot be null');
@@ -343,7 +341,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return float|null
      * @deprecated
      */
-    public function getId()
+    public function getId(): ?float
     {
         return $this->container['id'];
     }
@@ -353,10 +351,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @param float|null $id id
      *
-     * @return self
+     * @return $this
      * @deprecated
      */
-    public function setId($id)
+    public function setId(?float $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -372,7 +370,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return \OpenAPI\Client\Model\DeprecatedObject|null
      * @deprecated
      */
-    public function getDeprecatedRef()
+    public function getDeprecatedRef(): ?\OpenAPI\Client\Model\DeprecatedObject
     {
         return $this->container['deprecated_ref'];
     }
@@ -382,10 +380,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @param \OpenAPI\Client\Model\DeprecatedObject|null $deprecated_ref deprecated_ref
      *
-     * @return self
+     * @return $this
      * @deprecated
      */
-    public function setDeprecatedRef($deprecated_ref)
+    public function setDeprecatedRef(?\OpenAPI\Client\Model\DeprecatedObject $deprecated_ref): static
     {
         if (is_null($deprecated_ref)) {
             throw new \InvalidArgumentException('non-nullable deprecated_ref cannot be null');
@@ -401,7 +399,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return string[]|null
      * @deprecated
      */
-    public function getBars()
+    public function getBars(): ?array
     {
         return $this->container['bars'];
     }
@@ -411,10 +409,10 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @param string[]|null $bars bars
      *
-     * @return self
+     * @return $this
      * @deprecated
      */
-    public function setBars($bars)
+    public function setBars(?array $bars): static
     {
         if (is_null($bars)) {
             throw new \InvalidArgumentException('non-nullable bars cannot be null');
@@ -430,7 +428,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -443,7 +441,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -456,7 +454,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -472,7 +470,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -485,7 +483,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -495,7 +493,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -508,7 +506,7 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Order Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Order implements ModelInterface, ArrayAccess, \JsonSerializable
+class Order implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -284,8 +287,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -368,7 +370,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setId(?int $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -395,7 +397,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPetId(?int $pet_id): static
     {
         if (is_null($pet_id)) {
-            throw new \InvalidArgumentException('non-nullable pet_id cannot be null');
+            throw new InvalidArgumentException('non-nullable pet_id cannot be null');
         }
         $this->container['pet_id'] = $pet_id;
 
@@ -422,7 +424,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setQuantity(?int $quantity): static
     {
         if (is_null($quantity)) {
-            throw new \InvalidArgumentException('non-nullable quantity cannot be null');
+            throw new InvalidArgumentException('non-nullable quantity cannot be null');
         }
         $this->container['quantity'] = $quantity;
 
@@ -449,7 +451,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setShipDate(?\DateTime $ship_date): static
     {
         if (is_null($ship_date)) {
-            throw new \InvalidArgumentException('non-nullable ship_date cannot be null');
+            throw new InvalidArgumentException('non-nullable ship_date cannot be null');
         }
         $this->container['ship_date'] = $ship_date;
 
@@ -476,11 +478,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setStatus(?string $status): static
     {
         if (is_null($status)) {
-            throw new \InvalidArgumentException('non-nullable status cannot be null');
+            throw new InvalidArgumentException('non-nullable status cannot be null');
         }
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'status', must be one of '%s'",
                     $status,
@@ -513,7 +515,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setComplete(?bool $complete): static
     {
         if (is_null($complete)) {
-            throw new \InvalidArgumentException('non-nullable complete cannot be null');
+            throw new InvalidArgumentException('non-nullable complete cannot be null');
         }
         $this->container['complete'] = $complete;
 
@@ -538,7 +540,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -580,7 +582,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -49,14 +49,14 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Order';
+    protected static string $openAPIModelName = 'Order';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'id' => 'int',
         'pet_id' => 'int',
         'quantity' => 'int',
@@ -68,11 +68,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'id' => 'int64',
         'pet_id' => 'int64',
         'quantity' => 'int32',
@@ -84,7 +82,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'id' => false,
@@ -98,16 +96,16 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -115,9 +113,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -125,7 +123,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -135,7 +133,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -145,7 +143,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -178,9 +176,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'id' => 'id',
         'pet_id' => 'petId',
         'quantity' => 'quantity',
@@ -192,9 +190,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'id' => 'setId',
         'pet_id' => 'setPetId',
         'quantity' => 'setQuantity',
@@ -206,9 +204,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'id' => 'getId',
         'pet_id' => 'getPetId',
         'quantity' => 'getQuantity',
@@ -221,9 +219,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -231,9 +229,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -241,9 +239,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -253,7 +251,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -279,9 +277,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -308,7 +306,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -320,9 +318,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -344,7 +342,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -355,7 +353,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->container['id'];
     }
@@ -365,9 +363,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $id id
      *
-     * @return self
+     * @return $this
      */
-    public function setId($id)
+    public function setId(?int $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -382,7 +380,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getPetId()
+    public function getPetId(): ?int
     {
         return $this->container['pet_id'];
     }
@@ -392,9 +390,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $pet_id pet_id
      *
-     * @return self
+     * @return $this
      */
-    public function setPetId($pet_id)
+    public function setPetId(?int $pet_id): static
     {
         if (is_null($pet_id)) {
             throw new \InvalidArgumentException('non-nullable pet_id cannot be null');
@@ -409,7 +407,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getQuantity()
+    public function getQuantity(): ?int
     {
         return $this->container['quantity'];
     }
@@ -419,9 +417,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $quantity quantity
      *
-     * @return self
+     * @return $this
      */
-    public function setQuantity($quantity)
+    public function setQuantity(?int $quantity): static
     {
         if (is_null($quantity)) {
             throw new \InvalidArgumentException('non-nullable quantity cannot be null');
@@ -436,7 +434,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \DateTime|null
      */
-    public function getShipDate()
+    public function getShipDate(): ?\DateTime
     {
         return $this->container['ship_date'];
     }
@@ -446,9 +444,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \DateTime|null $ship_date ship_date
      *
-     * @return self
+     * @return $this
      */
-    public function setShipDate($ship_date)
+    public function setShipDate(?\DateTime $ship_date): static
     {
         if (is_null($ship_date)) {
             throw new \InvalidArgumentException('non-nullable ship_date cannot be null');
@@ -463,7 +461,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getStatus()
+    public function getStatus(): ?string
     {
         return $this->container['status'];
     }
@@ -473,9 +471,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $status Order Status
      *
-     * @return self
+     * @return $this
      */
-    public function setStatus($status)
+    public function setStatus(?string $status): static
     {
         if (is_null($status)) {
             throw new \InvalidArgumentException('non-nullable status cannot be null');
@@ -500,7 +498,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool|null
      */
-    public function getComplete()
+    public function getComplete(): ?bool
     {
         return $this->container['complete'];
     }
@@ -510,9 +508,9 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param bool|null $complete complete
      *
-     * @return self
+     * @return $this
      */
-    public function setComplete($complete)
+    public function setComplete(?bool $complete): static
     {
         if (is_null($complete)) {
             throw new \InvalidArgumentException('non-nullable complete cannot be null');
@@ -528,7 +526,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -541,7 +539,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -554,7 +552,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -570,7 +568,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -583,7 +581,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -593,7 +591,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -606,7 +604,7 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterComposite Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
+class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -249,8 +252,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -321,7 +323,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMyNumber(?float $my_number): static
     {
         if (is_null($my_number)) {
-            throw new \InvalidArgumentException('non-nullable my_number cannot be null');
+            throw new InvalidArgumentException('non-nullable my_number cannot be null');
         }
         $this->container['my_number'] = $my_number;
 
@@ -348,7 +350,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMyString(?string $my_string): static
     {
         if (is_null($my_string)) {
-            throw new \InvalidArgumentException('non-nullable my_string cannot be null');
+            throw new InvalidArgumentException('non-nullable my_string cannot be null');
         }
         $this->container['my_string'] = $my_string;
 
@@ -375,7 +377,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setMyBoolean(?bool $my_boolean): static
     {
         if (is_null($my_boolean)) {
-            throw new \InvalidArgumentException('non-nullable my_boolean cannot be null');
+            throw new InvalidArgumentException('non-nullable my_boolean cannot be null');
         }
         $this->container['my_boolean'] = $my_boolean;
 
@@ -400,7 +402,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -442,7 +444,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -49,14 +49,14 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'OuterComposite';
+    protected static string $openAPIModelName = 'OuterComposite';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'my_number' => 'float',
         'my_string' => 'string',
         'my_boolean' => 'bool'
@@ -65,11 +65,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'my_number' => null,
         'my_string' => null,
         'my_boolean' => null
@@ -78,7 +76,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'my_number' => false,
@@ -89,16 +87,16 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -106,9 +104,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -116,7 +114,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -126,7 +124,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -136,7 +134,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -169,9 +167,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'my_number' => 'my_number',
         'my_string' => 'my_string',
         'my_boolean' => 'my_boolean'
@@ -180,9 +178,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'my_number' => 'setMyNumber',
         'my_string' => 'setMyString',
         'my_boolean' => 'setMyBoolean'
@@ -191,9 +189,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'my_number' => 'getMyNumber',
         'my_string' => 'getMyString',
         'my_boolean' => 'getMyBoolean'
@@ -203,9 +201,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -213,9 +211,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -223,9 +221,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -235,7 +233,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -244,9 +242,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -270,7 +268,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -282,9 +280,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -297,7 +295,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -308,7 +306,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return float|null
      */
-    public function getMyNumber()
+    public function getMyNumber(): ?float
     {
         return $this->container['my_number'];
     }
@@ -318,9 +316,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param float|null $my_number my_number
      *
-     * @return self
+     * @return $this
      */
-    public function setMyNumber($my_number)
+    public function setMyNumber(?float $my_number): static
     {
         if (is_null($my_number)) {
             throw new \InvalidArgumentException('non-nullable my_number cannot be null');
@@ -335,7 +333,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getMyString()
+    public function getMyString(): ?string
     {
         return $this->container['my_string'];
     }
@@ -345,9 +343,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $my_string my_string
      *
-     * @return self
+     * @return $this
      */
-    public function setMyString($my_string)
+    public function setMyString(?string $my_string): static
     {
         if (is_null($my_string)) {
             throw new \InvalidArgumentException('non-nullable my_string cannot be null');
@@ -362,7 +360,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool|null
      */
-    public function getMyBoolean()
+    public function getMyBoolean(): ?bool
     {
         return $this->container['my_boolean'];
     }
@@ -372,9 +370,9 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param bool|null $my_boolean my_boolean
      *
-     * @return self
+     * @return $this
      */
-    public function setMyBoolean($my_boolean)
+    public function setMyBoolean(?bool $my_boolean): static
     {
         if (is_null($my_boolean)) {
             throw new \InvalidArgumentException('non-nullable my_boolean cannot be null');
@@ -390,7 +388,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -403,7 +401,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -416,7 +414,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -432,7 +430,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -445,7 +443,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -455,7 +453,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -468,7 +466,7 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterEnum Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterEnumDefaultValue Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumInteger.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterEnumInteger Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumIntegerDefaultValue.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterEnumIntegerDefaultValue Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -49,32 +49,30 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
       *
       * @var string
       */
-    protected static $openAPIModelName = 'OuterObjectWithEnumProperty';
+    protected static string $openAPIModelName = 'OuterObjectWithEnumProperty';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'value' => '\OpenAPI\Client\Model\OuterEnumInteger'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'value' => null
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'value' => false
@@ -83,16 +81,16 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'value' => 'value'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'value' => 'setValue'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'value' => 'getValue'
     ];
 
@@ -191,9 +189,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -286,7 +284,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -297,7 +295,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return \OpenAPI\Client\Model\OuterEnumInteger
      */
-    public function getValue()
+    public function getValue(): \OpenAPI\Client\Model\OuterEnumInteger
     {
         return $this->container['value'];
     }
@@ -307,9 +305,9 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @param \OpenAPI\Client\Model\OuterEnumInteger $value value
      *
-     * @return self
+     * @return $this
      */
-    public function setValue($value)
+    public function setValue(\OpenAPI\Client\Model\OuterEnumInteger $value): static
     {
         if (is_null($value)) {
             throw new \InvalidArgumentException('non-nullable value cannot be null');
@@ -325,7 +323,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -338,7 +336,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -351,7 +349,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -367,7 +365,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -380,7 +378,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -390,7 +388,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -403,7 +401,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterObjectWithEnumProperty.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * OuterObjectWithEnumProperty Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonSerializable
+class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -310,7 +312,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
     public function setValue(\OpenAPI\Client\Model\OuterEnumInteger $value): static
     {
         if (is_null($value)) {
-            throw new \InvalidArgumentException('non-nullable value cannot be null');
+            throw new InvalidArgumentException('non-nullable value cannot be null');
         }
         $this->container['value'] = $value;
 
@@ -335,7 +337,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -377,7 +379,7 @@ class OuterObjectWithEnumProperty implements ModelInterface, ArrayAccess, \JsonS
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Pet Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
+class Pet implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -284,8 +287,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -374,7 +376,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setId(?int $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -401,7 +403,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setCategory(?\OpenAPI\Client\Model\Category $category): static
     {
         if (is_null($category)) {
-            throw new \InvalidArgumentException('non-nullable category cannot be null');
+            throw new InvalidArgumentException('non-nullable category cannot be null');
         }
         $this->container['category'] = $category;
 
@@ -428,7 +430,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(string $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -455,7 +457,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPhotoUrls(array $photo_urls): static
     {
         if (is_null($photo_urls)) {
-            throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
+            throw new InvalidArgumentException('non-nullable photo_urls cannot be null');
         }
 
 
@@ -484,7 +486,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setTags(?array $tags): static
     {
         if (is_null($tags)) {
-            throw new \InvalidArgumentException('non-nullable tags cannot be null');
+            throw new InvalidArgumentException('non-nullable tags cannot be null');
         }
         $this->container['tags'] = $tags;
 
@@ -511,11 +513,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setStatus(?string $status): static
     {
         if (is_null($status)) {
-            throw new \InvalidArgumentException('non-nullable status cannot be null');
+            throw new InvalidArgumentException('non-nullable status cannot be null');
         }
         $allowedValues = $this->getStatusAllowableValues();
         if (!in_array($status, $allowedValues, true)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'status', must be one of '%s'",
                     $status,
@@ -546,7 +548,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -588,7 +590,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -49,14 +49,14 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Pet';
+    protected static string $openAPIModelName = 'Pet';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'id' => 'int',
         'category' => '\OpenAPI\Client\Model\Category',
         'name' => 'string',
@@ -68,11 +68,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'id' => 'int64',
         'category' => null,
         'name' => null,
@@ -84,7 +82,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'id' => false,
@@ -98,16 +96,16 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -115,9 +113,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -125,7 +123,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -135,7 +133,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -145,7 +143,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -178,9 +176,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'id' => 'id',
         'category' => 'category',
         'name' => 'name',
@@ -192,9 +190,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'id' => 'setId',
         'category' => 'setCategory',
         'name' => 'setName',
@@ -206,9 +204,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'id' => 'getId',
         'category' => 'getCategory',
         'name' => 'getName',
@@ -221,9 +219,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -231,9 +229,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -241,9 +239,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -253,7 +251,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -279,9 +277,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -308,7 +306,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -320,9 +318,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -350,7 +348,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -361,7 +359,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->container['id'];
     }
@@ -371,9 +369,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $id id
      *
-     * @return self
+     * @return $this
      */
-    public function setId($id)
+    public function setId(?int $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -388,7 +386,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\Category|null
      */
-    public function getCategory()
+    public function getCategory(): ?\OpenAPI\Client\Model\Category
     {
         return $this->container['category'];
     }
@@ -398,9 +396,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\Category|null $category category
      *
-     * @return self
+     * @return $this
      */
-    public function setCategory($category)
+    public function setCategory(?\OpenAPI\Client\Model\Category $category): static
     {
         if (is_null($category)) {
             throw new \InvalidArgumentException('non-nullable category cannot be null');
@@ -415,7 +413,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->container['name'];
     }
@@ -425,9 +423,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -442,7 +440,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string[]
      */
-    public function getPhotoUrls()
+    public function getPhotoUrls(): array
     {
         return $this->container['photo_urls'];
     }
@@ -452,9 +450,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string[] $photo_urls photo_urls
      *
-     * @return self
+     * @return $this
      */
-    public function setPhotoUrls($photo_urls)
+    public function setPhotoUrls(array $photo_urls): static
     {
         if (is_null($photo_urls)) {
             throw new \InvalidArgumentException('non-nullable photo_urls cannot be null');
@@ -471,7 +469,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return \OpenAPI\Client\Model\Tag[]|null
      */
-    public function getTags()
+    public function getTags(): ?array
     {
         return $this->container['tags'];
     }
@@ -481,9 +479,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param \OpenAPI\Client\Model\Tag[]|null $tags tags
      *
-     * @return self
+     * @return $this
      */
-    public function setTags($tags)
+    public function setTags(?array $tags): static
     {
         if (is_null($tags)) {
             throw new \InvalidArgumentException('non-nullable tags cannot be null');
@@ -498,7 +496,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getStatus()
+    public function getStatus(): ?string
     {
         return $this->container['status'];
     }
@@ -508,9 +506,9 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $status pet status in the store
      *
-     * @return self
+     * @return $this
      */
-    public function setStatus($status)
+    public function setStatus(?string $status): static
     {
         if (is_null($status)) {
             throw new \InvalidArgumentException('non-nullable status cannot be null');
@@ -536,7 +534,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -549,7 +547,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -562,7 +560,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -578,7 +576,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -591,7 +589,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -601,7 +599,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -614,7 +612,7 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * ReadOnlyFirst Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
+class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
-            throw new \InvalidArgumentException('non-nullable bar cannot be null');
+            throw new InvalidArgumentException('non-nullable bar cannot be null');
         }
         $this->container['bar'] = $bar;
 
@@ -341,7 +343,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setBaz(?string $baz): static
     {
         if (is_null($baz)) {
-            throw new \InvalidArgumentException('non-nullable baz cannot be null');
+            throw new InvalidArgumentException('non-nullable baz cannot be null');
         }
         $this->container['baz'] = $baz;
 
@@ -366,7 +368,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -49,14 +49,14 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'ReadOnlyFirst';
+    protected static string $openAPIModelName = 'ReadOnlyFirst';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'bar' => 'string',
         'baz' => 'string'
     ];
@@ -64,11 +64,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'bar' => null,
         'baz' => null
     ];
@@ -76,7 +74,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'bar' => false,
@@ -86,16 +84,16 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'bar' => 'bar',
         'baz' => 'baz'
     ];
@@ -176,9 +174,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'bar' => 'setBar',
         'baz' => 'setBaz'
     ];
@@ -186,9 +184,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'bar' => 'getBar',
         'baz' => 'getBaz'
     ];
@@ -197,9 +195,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getBar()
+    public function getBar(): ?string
     {
         return $this->container['bar'];
     }
@@ -311,9 +309,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $bar bar
      *
-     * @return self
+     * @return $this
      */
-    public function setBar($bar)
+    public function setBar(?string $bar): static
     {
         if (is_null($bar)) {
             throw new \InvalidArgumentException('non-nullable bar cannot be null');
@@ -328,7 +326,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getBaz()
+    public function getBaz(): ?string
     {
         return $this->container['baz'];
     }
@@ -338,9 +336,9 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $baz baz
      *
-     * @return self
+     * @return $this
      */
-    public function setBaz($baz)
+    public function setBaz(?string $baz): static
     {
         if (is_null($baz)) {
             throw new \InvalidArgumentException('non-nullable baz cannot be null');
@@ -356,7 +354,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SingleRefType.php
@@ -27,7 +27,6 @@
  */
 
 namespace OpenAPI\Client\Model;
-use \OpenAPI\Client\ObjectSerializer;
 
 /**
  * SingleRefType Class Doc Comment

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * SpecialModelName Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
+class SpecialModelName implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -237,8 +240,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -307,7 +309,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setSpecialPropertyName(?int $special_property_name): static
     {
         if (is_null($special_property_name)) {
-            throw new \InvalidArgumentException('non-nullable special_property_name cannot be null');
+            throw new InvalidArgumentException('non-nullable special_property_name cannot be null');
         }
         $this->container['special_property_name'] = $special_property_name;
 
@@ -332,7 +334,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -374,7 +376,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/SpecialModelName.php
@@ -49,32 +49,30 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = '_special_model.name_';
+    protected static string $openAPIModelName = '_special_model.name_';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'special_property_name' => 'int'
     ];
 
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'special_property_name' => 'int64'
     ];
 
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'special_property_name' => false
@@ -83,16 +81,16 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -100,9 +98,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -110,7 +108,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -120,7 +118,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -130,7 +128,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -163,27 +161,27 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'special_property_name' => '$special[property.name]'
     ];
 
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'special_property_name' => 'setSpecialPropertyName'
     ];
 
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'special_property_name' => 'getSpecialPropertyName'
     ];
 
@@ -191,9 +189,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -201,9 +199,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -211,9 +209,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -223,7 +221,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -232,9 +230,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -256,7 +254,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -268,9 +266,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -283,7 +281,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -294,7 +292,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getSpecialPropertyName()
+    public function getSpecialPropertyName(): ?int
     {
         return $this->container['special_property_name'];
     }
@@ -304,9 +302,9 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $special_property_name special_property_name
      *
-     * @return self
+     * @return $this
      */
-    public function setSpecialPropertyName($special_property_name)
+    public function setSpecialPropertyName(?int $special_property_name): static
     {
         if (is_null($special_property_name)) {
             throw new \InvalidArgumentException('non-nullable special_property_name cannot be null');
@@ -322,7 +320,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -335,7 +333,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -348,7 +346,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -364,7 +362,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -377,7 +375,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -387,7 +385,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -400,7 +398,7 @@ class SpecialModelName implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -49,14 +49,14 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'Tag';
+    protected static string $openAPIModelName = 'Tag';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'id' => 'int',
         'name' => 'string'
     ];
@@ -64,11 +64,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'id' => 'int64',
         'name' => null
     ];
@@ -76,7 +74,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'id' => false,
@@ -86,16 +84,16 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -103,9 +101,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -113,7 +111,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -123,7 +121,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -133,7 +131,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -166,9 +164,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'id' => 'id',
         'name' => 'name'
     ];
@@ -176,9 +174,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'id' => 'setId',
         'name' => 'setName'
     ];
@@ -186,9 +184,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'id' => 'getId',
         'name' => 'getName'
     ];
@@ -197,9 +195,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -207,9 +205,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -217,9 +215,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -229,7 +227,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -238,9 +236,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -263,7 +261,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -275,9 +273,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -290,7 +288,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -301,7 +299,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->container['id'];
     }
@@ -311,9 +309,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $id id
      *
-     * @return self
+     * @return $this
      */
-    public function setId($id)
+    public function setId(?int $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -328,7 +326,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->container['name'];
     }
@@ -338,9 +336,9 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $name name
      *
-     * @return self
+     * @return $this
      */
-    public function setName($name)
+    public function setName(?string $name): static
     {
         if (is_null($name)) {
             throw new \InvalidArgumentException('non-nullable name cannot be null');
@@ -356,7 +354,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -369,7 +367,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -382,7 +380,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -398,7 +396,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -411,7 +409,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -421,7 +419,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -434,7 +432,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * Tag Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
+class Tag implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -243,8 +246,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -314,7 +316,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setId(?int $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -341,7 +343,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setName(?string $name): static
     {
         if (is_null($name)) {
-            throw new \InvalidArgumentException('non-nullable name cannot be null');
+            throw new InvalidArgumentException('non-nullable name cannot be null');
         }
         $this->container['name'] = $name;
 
@@ -366,7 +368,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -408,7 +410,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -28,8 +28,11 @@
 
 namespace OpenAPI\Client\Model;
 
-use \ArrayAccess;
-use \OpenAPI\Client\ObjectSerializer;
+use ArrayAccess;
+use JsonSerializable;
+use InvalidArgumentException;
+use ReturnTypeWillChange;
+use OpenAPI\Client\ObjectSerializer;
 
 /**
  * User Class Doc Comment
@@ -38,9 +41,9 @@ use \OpenAPI\Client\ObjectSerializer;
  * @package  OpenAPI\Client
  * @author   OpenAPI Generator team
  * @link     https://openapi-generator.tech
- * @implements \ArrayAccess<string, mixed>
+ * @implements ArrayAccess<string, mixed>
  */
-class User implements ModelInterface, ArrayAccess, \JsonSerializable
+class User implements ModelInterface, ArrayAccess, JsonSerializable
 {
     public const DISCRIMINATOR = null;
 
@@ -279,8 +282,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
-     *                      initializing the model
+     * @param array $data Associated array of property values initializing the model
      */
     public function __construct(array $data = null)
     {
@@ -356,7 +358,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setId(?int $id): static
     {
         if (is_null($id)) {
-            throw new \InvalidArgumentException('non-nullable id cannot be null');
+            throw new InvalidArgumentException('non-nullable id cannot be null');
         }
         $this->container['id'] = $id;
 
@@ -383,7 +385,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setUsername(?string $username): static
     {
         if (is_null($username)) {
-            throw new \InvalidArgumentException('non-nullable username cannot be null');
+            throw new InvalidArgumentException('non-nullable username cannot be null');
         }
         $this->container['username'] = $username;
 
@@ -410,7 +412,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setFirstName(?string $first_name): static
     {
         if (is_null($first_name)) {
-            throw new \InvalidArgumentException('non-nullable first_name cannot be null');
+            throw new InvalidArgumentException('non-nullable first_name cannot be null');
         }
         $this->container['first_name'] = $first_name;
 
@@ -437,7 +439,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setLastName(?string $last_name): static
     {
         if (is_null($last_name)) {
-            throw new \InvalidArgumentException('non-nullable last_name cannot be null');
+            throw new InvalidArgumentException('non-nullable last_name cannot be null');
         }
         $this->container['last_name'] = $last_name;
 
@@ -464,7 +466,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setEmail(?string $email): static
     {
         if (is_null($email)) {
-            throw new \InvalidArgumentException('non-nullable email cannot be null');
+            throw new InvalidArgumentException('non-nullable email cannot be null');
         }
         $this->container['email'] = $email;
 
@@ -491,7 +493,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPassword(?string $password): static
     {
         if (is_null($password)) {
-            throw new \InvalidArgumentException('non-nullable password cannot be null');
+            throw new InvalidArgumentException('non-nullable password cannot be null');
         }
         $this->container['password'] = $password;
 
@@ -518,7 +520,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setPhone(?string $phone): static
     {
         if (is_null($phone)) {
-            throw new \InvalidArgumentException('non-nullable phone cannot be null');
+            throw new InvalidArgumentException('non-nullable phone cannot be null');
         }
         $this->container['phone'] = $phone;
 
@@ -545,7 +547,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     public function setUserStatus(?int $user_status): static
     {
         if (is_null($user_status)) {
-            throw new \InvalidArgumentException('non-nullable user_status cannot be null');
+            throw new InvalidArgumentException('non-nullable user_status cannot be null');
         }
         $this->container['user_status'] = $user_status;
 
@@ -570,7 +572,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
@@ -612,7 +614,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed Returns data which can be serialized by json_encode(), which is a value
      * of any type other than a resource.
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -49,14 +49,14 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
       *
       * @var string
       */
-    protected static $openAPIModelName = 'User';
+    protected static string $openAPIModelName = 'User';
 
     /**
       * Array of property to type mappings. Used for (de)serialization
       *
-      * @var string[]
+      * @var array<string, string>
       */
-    protected static $openAPITypes = [
+    protected static array $openAPITypes = [
         'id' => 'int',
         'username' => 'string',
         'first_name' => 'string',
@@ -70,11 +70,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of property to format mappings. Used for (de)serialization
       *
-      * @var string[]
-      * @phpstan-var array<string, string|null>
-      * @psalm-var array<string, string|null>
+      * @var array<string, string|null>
       */
-    protected static $openAPIFormats = [
+    protected static array $openAPIFormats = [
         'id' => 'int64',
         'username' => null,
         'first_name' => null,
@@ -88,7 +86,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * Array of nullable properties. Used for (de)serialization
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected static array $openAPINullables = [
         'id' => false,
@@ -104,16 +102,16 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
       * If a nullable field gets set to null, insert it here
       *
-      * @var boolean[]
+      * @var array<string, bool>
       */
     protected array $openAPINullablesSetToNull = [];
 
     /**
      * Array of property to type mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPITypes()
+    public static function openAPITypes(): array
     {
         return self::$openAPITypes;
     }
@@ -121,9 +119,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of property to format mappings. Used for (de)serialization
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function openAPIFormats()
+    public static function openAPIFormats(): array
     {
         return self::$openAPIFormats;
     }
@@ -131,7 +129,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable properties
      *
-     * @return array
+     * @return array<string, bool>
      */
     protected static function openAPINullables(): array
     {
@@ -141,7 +139,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of nullable field names deliberately set to null
      *
-     * @return boolean[]
+     * @return array<string, bool>
      */
     private function getOpenAPINullablesSetToNull(): array
     {
@@ -151,7 +149,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Setter - Array of nullable field names deliberately set to null
      *
-     * @param boolean[] $openAPINullablesSetToNull
+     * @param array<string, bool> $openAPINullablesSetToNull
      */
     private function setOpenAPINullablesSetToNull(array $openAPINullablesSetToNull): void
     {
@@ -184,9 +182,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $attributeMap = [
+    protected static array $attributeMap = [
         'id' => 'id',
         'username' => 'username',
         'first_name' => 'firstName',
@@ -200,9 +198,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $setters = [
+    protected static array $setters = [
         'id' => 'setId',
         'username' => 'setUsername',
         'first_name' => 'setFirstName',
@@ -216,9 +214,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @var string[]
+     * @var array<string, string>
      */
-    protected static $getters = [
+    protected static array $getters = [
         'id' => 'getId',
         'username' => 'getUsername',
         'first_name' => 'getFirstName',
@@ -233,9 +231,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * Array of attributes where the key is the local name,
      * and the value is the original name
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function attributeMap()
+    public static function attributeMap(): array
     {
         return self::$attributeMap;
     }
@@ -243,9 +241,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to setter functions (for deserialization of responses)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function setters()
+    public static function setters(): array
     {
         return self::$setters;
     }
@@ -253,9 +251,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Array of attributes to getter functions (for serialization of requests)
      *
-     * @return array
+     * @return array<string, string>
      */
-    public static function getters()
+    public static function getters(): array
     {
         return self::$getters;
     }
@@ -265,7 +263,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return self::$openAPIModelName;
     }
@@ -274,9 +272,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Associative array for storing property values
      *
-     * @var mixed[]
+     * @var array
      */
-    protected $container = [];
+    protected array $container = [];
 
     /**
      * Constructor
@@ -305,7 +303,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     * @param array  $fields
     * @param mixed  $defaultValue
     */
-    private function setIfExists(string $variableName, array $fields, $defaultValue): void
+    private function setIfExists(string $variableName, array $fields, mixed $defaultValue): void
     {
         if (self::isNullable($variableName) && array_key_exists($variableName, $fields) && is_null($fields[$variableName])) {
             $this->openAPINullablesSetToNull[] = $variableName;
@@ -317,9 +315,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Show all the invalid properties with reasons.
      *
-     * @return array invalid properties with reasons
+     * @return string[] invalid properties with reasons
      */
-    public function listInvalidProperties()
+    public function listInvalidProperties(): array
     {
         $invalidProperties = [];
 
@@ -332,7 +330,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return bool True if all properties are valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return count($this->listInvalidProperties()) === 0;
     }
@@ -343,7 +341,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->container['id'];
     }
@@ -353,9 +351,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $id id
      *
-     * @return self
+     * @return $this
      */
-    public function setId($id)
+    public function setId(?int $id): static
     {
         if (is_null($id)) {
             throw new \InvalidArgumentException('non-nullable id cannot be null');
@@ -370,7 +368,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->container['username'];
     }
@@ -380,9 +378,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $username username
      *
-     * @return self
+     * @return $this
      */
-    public function setUsername($username)
+    public function setUsername(?string $username): static
     {
         if (is_null($username)) {
             throw new \InvalidArgumentException('non-nullable username cannot be null');
@@ -397,7 +395,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         return $this->container['first_name'];
     }
@@ -407,9 +405,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $first_name first_name
      *
-     * @return self
+     * @return $this
      */
-    public function setFirstName($first_name)
+    public function setFirstName(?string $first_name): static
     {
         if (is_null($first_name)) {
             throw new \InvalidArgumentException('non-nullable first_name cannot be null');
@@ -424,7 +422,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getLastName()
+    public function getLastName(): ?string
     {
         return $this->container['last_name'];
     }
@@ -434,9 +432,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $last_name last_name
      *
-     * @return self
+     * @return $this
      */
-    public function setLastName($last_name)
+    public function setLastName(?string $last_name): static
     {
         if (is_null($last_name)) {
             throw new \InvalidArgumentException('non-nullable last_name cannot be null');
@@ -451,7 +449,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getEmail()
+    public function getEmail(): ?string
     {
         return $this->container['email'];
     }
@@ -461,9 +459,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $email email
      *
-     * @return self
+     * @return $this
      */
-    public function setEmail($email)
+    public function setEmail(?string $email): static
     {
         if (is_null($email)) {
             throw new \InvalidArgumentException('non-nullable email cannot be null');
@@ -478,7 +476,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->container['password'];
     }
@@ -488,9 +486,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $password password
      *
-     * @return self
+     * @return $this
      */
-    public function setPassword($password)
+    public function setPassword(?string $password): static
     {
         if (is_null($password)) {
             throw new \InvalidArgumentException('non-nullable password cannot be null');
@@ -505,7 +503,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string|null
      */
-    public function getPhone()
+    public function getPhone(): ?string
     {
         return $this->container['phone'];
     }
@@ -515,9 +513,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param string|null $phone phone
      *
-     * @return self
+     * @return $this
      */
-    public function setPhone($phone)
+    public function setPhone(?string $phone): static
     {
         if (is_null($phone)) {
             throw new \InvalidArgumentException('non-nullable phone cannot be null');
@@ -532,7 +530,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return int|null
      */
-    public function getUserStatus()
+    public function getUserStatus(): ?int
     {
         return $this->container['user_status'];
     }
@@ -542,9 +540,9 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @param int|null $user_status User Status
      *
-     * @return self
+     * @return $this
      */
-    public function setUserStatus($user_status)
+    public function setUserStatus(?int $user_status): static
     {
         if (is_null($user_status)) {
             throw new \InvalidArgumentException('non-nullable user_status cannot be null');
@@ -560,7 +558,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return boolean
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->container[$offset]);
     }
@@ -573,7 +571,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->container[$offset] ?? null;
     }
@@ -586,7 +584,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if (is_null($offset)) {
             $this->container[] = $value;
@@ -602,7 +600,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return void
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->container[$offset]);
     }
@@ -615,7 +613,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      * of any type other than a resource.
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
        return ObjectSerializer::sanitizeForSerialization($this);
     }
@@ -625,7 +623,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode(
             ObjectSerializer::sanitizeForSerialization($this),
@@ -638,7 +636,7 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function toHeaderValue()
+    public function toHeaderValue(): string
     {
         return json_encode(ObjectSerializer::sanitizeForSerialization($this));
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -42,14 +42,14 @@ use OpenAPI\Client\Model\ModelInterface;
 class ObjectSerializer
 {
     /** @var string */
-    private static $dateTimeFormat = \DateTime::ATOM;
+    private static string $dateTimeFormat = \DateTime::ATOM;
 
     /**
      * Change the date format
      *
      * @param string $format   the new date format to use
      */
-    public static function setDateTimeFormat($format)
+    public static function setDateTimeFormat(string $format)
     {
         self::$dateTimeFormat = $format;
     }
@@ -63,7 +63,7 @@ class ObjectSerializer
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization($data, $type = null, $format = null)
+    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null)
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -119,7 +119,7 @@ class ObjectSerializer
      *
      * @return string the sanitized filename
      */
-    public static function sanitizeFilename($filename)
+    public static function sanitizeFilename(string $filename): string
     {
         if (preg_match("/.*[\/\\\\](.*)$/", $filename, $match)) {
             return $match[1];
@@ -135,7 +135,7 @@ class ObjectSerializer
      *
      * @return string the shorten timestamp
      */
-    public static function sanitizeTimestamp($timestamp)
+    public static function sanitizeTimestamp(string $timestamp): string
     {
         if (!is_string($timestamp)) return $timestamp;
 
@@ -150,7 +150,7 @@ class ObjectSerializer
      *
      * @return string the serialized object
      */
-    public static function toPathValue($value)
+    public static function toPathValue(string $value): string
     {
         return rawurlencode(self::toString($value));
     }
@@ -163,7 +163,7 @@ class ObjectSerializer
      *
      * @return bool true if $value is empty
      */
-    private static function isEmptyValue($value, string $openApiType): bool
+    private static function isEmptyValue(mixed $value, string $openApiType): bool
     {
         # If empty() returns false, it is not empty regardless of its type.
         if (!empty($value)) {
@@ -212,7 +212,7 @@ class ObjectSerializer
      * @return array
      */
     public static function toQueryValue(
-        $value,
+        mixed $value,
         string $paramName,
         string $openApiType = 'string',
         string $style = 'form',
@@ -284,7 +284,7 @@ class ObjectSerializer
      *
      * @return int|string Boolean value in format
      */
-    public static function convertBoolToQueryStringFormat(bool $value)
+    public static function convertBoolToQueryStringFormat(bool $value): int|string
     {
         if (Configuration::BOOLEAN_FORMAT_STRING == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()) {
             return $value ? 'true' : 'false';
@@ -302,7 +302,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toHeaderValue($value)
+    public static function toHeaderValue(string $value): string
     {
         $callable = [$value, 'toHeaderValue'];
         if (is_callable($callable)) {
@@ -321,7 +321,7 @@ class ObjectSerializer
      *
      * @return string the form string
      */
-    public static function toFormValue($value)
+    public static function toFormValue(string|\SplFileObject $value): string
     {
         if ($value instanceof \SplFileObject) {
             return $value->getRealPath();
@@ -340,7 +340,7 @@ class ObjectSerializer
      *
      * @return string the header string
      */
-    public static function toString($value)
+    public static function toString(string|bool|\DateTime $value): string
     {
         if ($value instanceof \DateTime) { // datetime in ISO8601 format
             return $value->format(self::$dateTimeFormat);
@@ -361,7 +361,7 @@ class ObjectSerializer
      *
      * @return string
      */
-    public static function serializeCollection(array $collection, $style, $allowCollectionFormatMulti = false)
+    public static function serializeCollection(array $collection, string $style, bool $allowCollectionFormatMulti = false): string
     {
         if ($allowCollectionFormatMulti && ('multi' === $style)) {
             // http_build_query() almost does the job for us. We just
@@ -398,7 +398,7 @@ class ObjectSerializer
      *
      * @return object|array|null a single or an array of $class instances
      */
-    public static function deserialize($data, $class, $httpHeaders = null)
+    public static function deserialize(mixed $data, string $class, string $httpHeaders = null): object|array|null
     {
         if (null === $data) {
             return null;

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -28,6 +28,8 @@
 
 namespace OpenAPI\Client;
 
+use DateTimeInterface;
+use DateTime;
 use GuzzleHttp\Psr7\Utils;
 use OpenAPI\Client\Model\ModelInterface;
 
@@ -42,14 +44,16 @@ use OpenAPI\Client\Model\ModelInterface;
 class ObjectSerializer
 {
     /** @var string */
-    private static string $dateTimeFormat = \DateTime::ATOM;
+    private static string $dateTimeFormat = DateTimeInterface::ATOM;
 
     /**
      * Change the date format
      *
      * @param string $format   the new date format to use
+     *
+     * @return void
      */
-    public static function setDateTimeFormat(string $format)
+    public static function setDateTimeFormat(string $format): void
     {
         self::$dateTimeFormat = $format;
     }
@@ -57,19 +61,19 @@ class ObjectSerializer
     /**
      * Serialize data
      *
-     * @param mixed  $data   the data to serialize
-     * @param string $type   the OpenAPIToolsType of the data
-     * @param string $format the format of the OpenAPITools type of the data
+     * @param mixed       $data   the data to serialize
+     * @param string|null $type   the OpenAPIToolsType of the data
+     * @param string|null $format the format of the OpenAPITools type of the data
      *
      * @return scalar|object|array|null serialized form of $data
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null)
+    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
         }
 
-        if ($data instanceof \DateTime) {
+        if ($data instanceof DateTime) {
             return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
         }
 
@@ -137,8 +141,6 @@ class ObjectSerializer
      */
     public static function sanitizeTimestamp(string $timestamp): string
     {
-        if (!is_string($timestamp)) return $timestamp;
-
         return preg_replace('/(:\d{2}.\d{6})\d*/', '$1', $timestamp);
     }
 
@@ -175,27 +177,19 @@ class ObjectSerializer
             return true;
         }
 
-        switch ($openApiType) {
+        return match ($openApiType) {
             # For numeric values, false and '' are considered empty.
             # This comparison is safe for floating point values, since the previous call to empty() will
             # filter out values that don't match 0.
-            case 'int':
-            case 'integer':
-                return $value !== 0;
-
-            case 'number':
-            case 'float':
-                return $value !== 0 && $value !== 0.0;
+            'int','integer' => $value !== 0,
+            'number'|'float' => $value !== 0 && $value !== 0.0,
 
             # For boolean values, '' is considered empty
-            case 'bool':
-            case 'boolean':
-                return !in_array($value, [false, 0], true);
+            'bool','boolean' => !in_array($value, [false, 0], true),
 
             # For all the other types, any value at this point can be considered empty.
-            default:
-                return true;
-        }
+            default => true
+        };
     }
 
     /**
@@ -204,7 +198,7 @@ class ObjectSerializer
      *
      * @param mixed  $value       Parameter value
      * @param string $paramName   Parameter name
-     * @param string $openApiType OpenAPIType eg. array or object
+     * @param string $openApiType OpenAPIType e.g. array or object
      * @param string $style       Parameter serialization style
      * @param bool   $explode     Parameter explode option
      * @param bool   $required    Whether query param is required or not
@@ -233,7 +227,7 @@ class ObjectSerializer
         }
 
         # Handle DateTime objects in query
-        if($openApiType === "\\DateTime" && $value instanceof \DateTime) {
+        if($openApiType === "\DateTime" && $value instanceof DateTime) {
             return ["{$paramName}" => $value->format(self::$dateTimeFormat)];
         }
 
@@ -246,7 +240,7 @@ class ObjectSerializer
             if (!is_array($arr)) return $arr;
 
             foreach ($arr as $k => $v) {
-                $prop = ($style === 'deepObject') ? $prop = "{$name}[{$k}]" : $k;
+                $prop = ($style === 'deepObject') ? "{$name}[{$k}]" : $k;
 
                 if (is_array($v)) {
                     $flattenArray($v, $prop, $result);
@@ -336,13 +330,13 @@ class ObjectSerializer
      * If it's a datetime object, format it in ISO8601
      * If it's a boolean, convert it to "true" or "false".
      *
-     * @param string|bool|\DateTime $value the value of the parameter
+     * @param string|bool|DateTime $value the value of the parameter
      *
      * @return string the header string
      */
-    public static function toString(string|bool|\DateTime $value): string
+    public static function toString(string|bool|DateTime $value): string
     {
-        if ($value instanceof \DateTime) { // datetime in ISO8601 format
+        if ($value instanceof DateTime) { // datetime in ISO8601 format
             return $value->format(self::$dateTimeFormat);
         } elseif (is_bool($value)) {
             return $value ? 'true' : 'false';
@@ -368,33 +362,21 @@ class ObjectSerializer
             // need to fix the result of multidimensional arrays.
             return preg_replace('/%5B[0-9]+%5D=/', '=', http_build_query($collection, '', '&'));
         }
-        switch ($style) {
-            case 'pipeDelimited':
-            case 'pipes':
-                return implode('|', $collection);
-
-            case 'tsv':
-                return implode("\t", $collection);
-
-            case 'spaceDelimited':
-            case 'ssv':
-                return implode(' ', $collection);
-
-            case 'simple':
-            case 'csv':
-                // Deliberate fall through. CSV is default format.
-            default:
-                return implode(',', $collection);
-        }
+        return match ($style) {
+            'pipeDelimited', 'pipes' => implode('|', $collection),
+            'tsv' => implode("\t", $collection),
+            'spaceDelimited', 'ssv' => implode(' ', $collection),
+            default => implode(',', $collection),
+        };
     }
 
     /**
      * Deserialize a JSON string into an object
      *
-     * @param mixed    $data          object or primitive to be deserialized
-     * @param string   $class         class name is passed as a string
-     * @param string[] $httpHeaders   HTTP headers
-     * @param string   $discriminator discriminator if polymorphism is used
+     * @param mixed         $data          object or primitive to be deserialized
+     * @param string        $class         class name is passed as a string
+     * @param string[]|null $httpHeaders   HTTP headers
+     * @param string|null   $discriminator discriminator if polymorphism is used
      *
      * @return object|array|null a single or an array of $class instances
      */
@@ -442,7 +424,7 @@ class ObjectSerializer
             return $data;
         }
 
-        if ($class === '\DateTime') {
+        if ($class === 'DateTime') {
             // Some APIs return an invalid, empty string as a
             // date-time property. DateTime::__construct() will return
             // the current time for empty input which is probably not
@@ -451,12 +433,12 @@ class ObjectSerializer
             // this graceful.
             if (!empty($data)) {
                 try {
-                    return new \DateTime($data);
+                    return new DateTime($data);
                 } catch (\Exception $exception) {
                     // Some APIs return a date-time with too high nanosecond
                     // precision for php's DateTime to handle.
                     // With provided regexp 6 digits of microseconds saved
-                    return new \DateTime(self::sanitizeTimestamp($data));
+                    return new DateTime(self::sanitizeTimestamp($data));
                 }
             } else {
                 return null;
@@ -556,10 +538,10 @@ class ObjectSerializer
      * @return string
      */
     public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
+        array|object $data,
+        string       $numeric_prefix = '',
+        ?string      $arg_separator = null,
+        int          $encoding_type = \PHP_QUERY_RFC3986
     ): string {
         return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
     }


### PR DESCRIPTION
This PR adds PHP type declarations in many places, including:
- Generated API classes
- Generated Models
- ApiException, Configuration and other included classes



### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier @dkarlovi @mandrean @jfastnacht  @ybelenko @renepardon