### PR TITLE
python: remove non-async code path from the aiohttp generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -37,35 +37,34 @@ class {{classname}}:
         self.api_client = api_client
 {{#operation}}
 
-{{#asyncio}}
-    @overload
-    async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
-        ...
-
-    @overload
-    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}async_req: Optional[bool]=True, **kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
-        ...
-
-{{/asyncio}}
     @validate_arguments
+{{#asyncio}}
+    async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
+{{/asyncio}}
+{{^asyncio}}
     def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}{{#asyncio}}async_req: Optional[bool]=None, {{/asyncio}}**kwargs) -> {{#asyncio}}Union[{{{returnType}}}{{^returnType}}None{{/returnType}}, Awaitable[{{{returnType}}}{{^returnType}}None{{/returnType}}]]{{/asyncio}}{{^asyncio}}{{{returnType}}}{{^returnType}}None{{/returnType}}{{/asyncio}}:  # noqa: E501
+{{/asyncio}}
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
 {{#notes}}
         {{{.}}}  # noqa: E501
 {{/notes}}
+{{^asyncio}}
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
         >>> thread = api.{{operationId}}({{#allParams}}{{paramName}}, {{/allParams}}async_req=True)
         >>> result = thread.get()
+{{/asyncio}}
 
 {{#allParams}}
         :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
         :type {{paramName}}: {{dataType}}{{#optional}}, optional{{/optional}}
 {{/allParams}}
+{{^asyncio}}
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
+{{/asyncio}}
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -79,31 +78,36 @@ class {{classname}}:
         if '_preload_content' in kwargs:
             message = "Error! Please call the {{operationId}}_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-{{#asyncio}}
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-{{/asyncio}}
-        return self.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}**kwargs)  # noqa: E501
+        return {{#asyncio}}await {{/asyncio}}self.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}**kwargs)  # noqa: E501
 
     @validate_arguments
+{{#asyncio}}
+    async def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> ApiResponse:  # noqa: E501
+{{/asyncio}}
+{{^asyncio}}
     def {{operationId}}_with_http_info(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> ApiResponse:  # noqa: E501
+{{/asyncio}}
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 
 {{#notes}}
         {{{.}}}  # noqa: E501
 {{/notes}}
+{{^asyncio}}
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
         >>> thread = api.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}async_req=True)
         >>> result = thread.get()
+{{/asyncio}}
 
 {{#allParams}}
         :param {{paramName}}:{{#description}} {{{.}}}{{/description}}{{#required}} (required){{/required}}{{#optional}}(optional){{/optional}}
         :type {{paramName}}: {{dataType}}{{#optional}}, optional{{/optional}}
 {{/allParams}}
+{{^asyncio}}
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
+{{/asyncio}}
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -156,7 +160,9 @@ class {{classname}}:
         ]
         _all_params.extend(
             [
+{{^asyncio}}
                 'async_req',
+{{/asyncio}}
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -290,7 +296,7 @@ class {{classname}}:
         _response_types_map = {}
         {{/returnType}}
 
-        return self.api_client.call_api(
+        return {{#asyncio}}await {{/asyncio}}self.api_client.call_api(
             '{{{path}}}', '{{httpMethod}}',
             _path_params,
             _query_params,
@@ -300,7 +306,9 @@ class {{classname}}:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
+{{^asyncio}}
             async_req=_params.get('async_req'),
+{{/asyncio}}
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -42,7 +42,7 @@ class {{classname}}:
     async def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
 {{/asyncio}}
 {{^asyncio}}
-    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}{{#asyncio}}async_req: Optional[bool]=None, {{/asyncio}}**kwargs) -> {{#asyncio}}Union[{{{returnType}}}{{^returnType}}None{{/returnType}}, Awaitable[{{{returnType}}}{{^returnType}}None{{/returnType}}]]{{/asyncio}}{{^asyncio}}{{{returnType}}}{{^returnType}}None{{/returnType}}{{/asyncio}}:  # noqa: E501
+    def {{operationId}}(self, {{#allParams}}{{paramName}} : {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}}, {{/allParams}}**kwargs) -> {{{returnType}}}{{^returnType}}None{{/returnType}}:  # noqa: E501
 {{/asyncio}}
         """{{#isDeprecated}}(Deprecated) {{/isDeprecated}}{{{summary}}}{{^summary}}{{operationId}}{{/summary}}  # noqa: E501
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -58,6 +58,7 @@ class ApiClient:
         'object': object,
     }
     _pool = None
+
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None{{^asyncio}}, pool_threads=1{{/asyncio}}) -> None:
         # use default configuration if none is provided

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -7,7 +7,9 @@ import datetime
 from dateutil.parser import parse
 import json
 import mimetypes
+{{^asyncio}}
 from multiprocessing.pool import ThreadPool
+{{/asyncio}}
 import os
 import re
 import tempfile
@@ -38,8 +40,10 @@ class ApiClient:
         the API.
     :param cookie: a cookie to include in the header when making calls
         to the API
+{{^asyncio}}
     :param pool_threads: The number of threads to use for async requests
         to the API. More threads means more concurrent API requests.
+{{/asyncio}}
     """
 
     PRIMITIVE_TYPES = (float, bool, bytes, str, int)
@@ -54,14 +58,15 @@ class ApiClient:
         'object': object,
     }
     _pool = None
-
     def __init__(self, configuration=None, header_name=None, header_value=None,
-                 cookie=None, pool_threads=1) -> None:
+                 cookie=None{{^asyncio}}, pool_threads=1{{/asyncio}}) -> None:
         # use default configuration if none is provided
         if configuration is None:
             configuration = Configuration.get_default()
         self.configuration = configuration
+{{^asyncio}}
         self.pool_threads = pool_threads
+{{/asyncio}}
 
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
@@ -72,25 +77,24 @@ class ApiClient:
         self.user_agent = '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{packageVersion}}}/python{{/httpUserAgent}}'
         self.client_side_validation = configuration.client_side_validation
 
-    {{#asyncio}}
+{{#asyncio}}
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close()
-    {{/asyncio}}
-    {{^asyncio}}
+
+    async def close(self):
+        await self.rest_client.close()
+{{/asyncio}}
+{{^asyncio}}
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
-    {{/asyncio}}
 
-    {{#asyncio}}async {{/asyncio}}def close(self):
-        {{#asyncio}}
-        await self.rest_client.close()
-        {{/asyncio}}
+    def close(self):
         if self._pool:
             self._pool.close()
             self._pool.join()
@@ -107,6 +111,7 @@ class ApiClient:
             atexit.register(self.close)
             self._pool = ThreadPool(self.pool_threads)
         return self._pool
+{{/asyncio}}
 
     @property
     def user_agent(self):
@@ -230,7 +235,7 @@ class ApiClient:
 
         self.last_response = response_data
 
-        return_data = None # assuming derialization is not needed
+        return_data = None # assuming deserialization is not needed
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
@@ -376,17 +381,19 @@ class ApiClient:
         else:
             return self.__deserialize_model(data, klass)
 
-    def call_api(self, resource_path, method,
+    {{#asyncio}}async {{/asyncio}}def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
                  response_types_map=None, auth_settings=None,
-                 async_req=None, _return_http_data_only=None,
+                 {{^asyncio}}async_req=None, {{/asyncio}}_return_http_data_only=None,
                  collection_formats=None, _preload_content=True,
                  _request_timeout=None, _host=None, _request_auth=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
+{{^asyncio}}
         To make an async_req request, set the async_req parameter.
 
+{{/asyncio}}
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
         :param path_params: Path parameters in the url.
@@ -400,7 +407,9 @@ class ApiClient:
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
+{{^asyncio}}
         :param async_req bool: execute request asynchronously
+{{/asyncio}}
         :param _return_http_data_only: response data instead of ApiResponse
                                        object with status code, headers, etc
         :param _preload_content: if False, the ApiResponse.data will
@@ -418,58 +427,69 @@ class ApiClient:
                               in the spec for a single request.
         :type _request_token: dict, optional
         :return:
+{{#asyncio}}
+            The response.
+{{/asyncio}}
+{{^asyncio}}
             If async_req parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
             If parameter async_req is False or missing,
             then the method will return the response directly.
+{{/asyncio}}
         """
+        args = (
+            resource_path,
+            method,
+            path_params,
+            query_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            response_types_map,
+            auth_settings,
+            _return_http_data_only,
+            collection_formats,
+            _preload_content,
+            _request_timeout,
+            _host,
+            _request_auth,
+        )
+{{#asyncio}}
+        return await self.__call_api(*args)
+{{/asyncio}}
+{{^asyncio}}
         if not async_req:
-            return self.__call_api(resource_path, method,
-                                   path_params, query_params, header_params,
-                                   body, post_params, files,
-                                   response_types_map, auth_settings,
-                                   _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host,
-                                   _request_auth)
+            return self.__call_api(*args)
 
-        return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params,
-                                                       query_params,
-                                                       header_params, body,
-                                                       post_params, files,
-                                                       response_types_map,
-                                                       auth_settings,
-                                                       _return_http_data_only,
-                                                       collection_formats,
-                                                       _preload_content,
-                                                       _request_timeout,
-                                                       _host, _request_auth))
+        return self.pool.apply_async(self.__call_api, args)
+{{/asyncio}}
 
-    def request(self, method, url, query_params=None, headers=None,
+    {{#asyncio}}async {{/asyncio}}def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
                 _request_timeout=None):
         """Makes the HTTP request using RESTClient."""
         if method == "GET":
-            return self.rest_client.get_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.get_request(url,
                                         query_params=query_params,
                                         _preload_content=_preload_content,
                                         _request_timeout=_request_timeout,
                                         headers=headers)
         elif method == "HEAD":
-            return self.rest_client.head_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.head_request(url,
                                          query_params=query_params,
                                          _preload_content=_preload_content,
                                          _request_timeout=_request_timeout,
                                          headers=headers)
         elif method == "OPTIONS":
-            return self.rest_client.options_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.options_request(url,
                                             query_params=query_params,
                                             headers=headers,
                                             _preload_content=_preload_content,
                                             _request_timeout=_request_timeout)
         elif method == "POST":
-            return self.rest_client.post_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.post_request(url,
                                          query_params=query_params,
                                          headers=headers,
                                          post_params=post_params,
@@ -477,7 +497,7 @@ class ApiClient:
                                          _request_timeout=_request_timeout,
                                          body=body)
         elif method == "PUT":
-            return self.rest_client.put_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.put_request(url,
                                         query_params=query_params,
                                         headers=headers,
                                         post_params=post_params,
@@ -485,7 +505,7 @@ class ApiClient:
                                         _request_timeout=_request_timeout,
                                         body=body)
         elif method == "PATCH":
-            return self.rest_client.patch_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.patch_request(url,
                                           query_params=query_params,
                                           headers=headers,
                                           post_params=post_params,
@@ -493,7 +513,7 @@ class ApiClient:
                                           _request_timeout=_request_timeout,
                                           body=body)
         elif method == "DELETE":
-            return self.rest_client.delete_request(url,
+            return {{#asyncio}}await {{/asyncio}}self.rest_client.delete_request(url,
                                            query_params=query_params,
                                            headers=headers,
                                            _preload_content=_preload_content,

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -62,7 +62,6 @@ class ApiClient:
         'object': object,
     }
     _pool = None
-
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1) -> None:
         # use default configuration if none is provided
@@ -223,7 +222,7 @@ class ApiClient:
 
         self.last_response = response_data
 
-        return_data = None # assuming derialization is not needed
+        return_data = None # assuming deserialization is not needed
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
@@ -406,27 +405,28 @@ class ApiClient:
             If parameter async_req is False or missing,
             then the method will return the response directly.
         """
+        args = (
+            resource_path,
+            method,
+            path_params,
+            query_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            response_types_map,
+            auth_settings,
+            _return_http_data_only,
+            collection_formats,
+            _preload_content,
+            _request_timeout,
+            _host,
+            _request_auth,
+        )
         if not async_req:
-            return self.__call_api(resource_path, method,
-                                   path_params, query_params, header_params,
-                                   body, post_params, files,
-                                   response_types_map, auth_settings,
-                                   _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host,
-                                   _request_auth)
+            return self.__call_api(*args)
 
-        return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params,
-                                                       query_params,
-                                                       header_params, body,
-                                                       post_params, files,
-                                                       response_types_map,
-                                                       auth_settings,
-                                                       _return_http_data_only,
-                                                       collection_formats,
-                                                       _preload_content,
-                                                       _request_timeout,
-                                                       _host, _request_auth))
+        return self.pool.apply_async(self.__call_api, args)
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -62,6 +62,7 @@ class ApiClient:
         'object': object,
     }
     _pool = None
+
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1) -> None:
         # use default configuration if none is provided

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -44,29 +44,14 @@ class AnotherFakeApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
-        ...
-
-    @overload
-    def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
-        ...
-
     @validate_arguments
-    def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
+    async def call_123_test_special_tags(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test special tags  # noqa: E501
 
         To test special tags and operation ID starting with number  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.call_123_test_special_tags(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -80,25 +65,16 @@ class AnotherFakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
+        return await self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def call_123_test_special_tags_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test special tags  # noqa: E501
 
         To test special tags and operation ID starting with number  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.call_123_test_special_tags_with_http_info(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -129,7 +105,6 @@ class AnotherFakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -184,7 +159,7 @@ class AnotherFakeApi:
             '200': "Client",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/another-fake/dummy', 'PATCH',
             _path_params,
             _query_params,
@@ -194,7 +169,6 @@ class AnotherFakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -41,26 +41,11 @@ class DefaultApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def foo_get(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
-        ...
-
-    @overload
-    def foo_get(self, async_req: Optional[bool]=True, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
-        ...
-
     @validate_arguments
-    def foo_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[FooGetDefaultResponse, Awaitable[FooGetDefaultResponse]]:  # noqa: E501
+    async def foo_get(self, **kwargs) -> FooGetDefaultResponse:  # noqa: E501
         """foo_get  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.foo_get(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -74,22 +59,13 @@ class DefaultApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.foo_get_with_http_info(**kwargs)  # noqa: E501
+        return await self.foo_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def foo_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """foo_get  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.foo_get_with_http_info(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -119,7 +95,6 @@ class DefaultApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -163,7 +138,7 @@ class DefaultApi:
         _response_types_map = {
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/foo', 'GET',
             _path_params,
             _query_params,
@@ -173,7 +148,6 @@ class DefaultApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -56,28 +56,13 @@ class FakeApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def fake_any_type_request_body(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> None:  # noqa: E501
         """test any type request body  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_any_type_request_body(body, async_req=True)
-        >>> result = thread.get()
 
         :param body:
         :type body: object
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -91,24 +76,15 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
+        return await self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_any_type_request_body_with_http_info(self, body : Optional[Dict[str, Any]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test any type request body  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_any_type_request_body_with_http_info(body, async_req=True)
-        >>> result = thread.get()
 
         :param body:
         :type body: object
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -139,7 +115,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -188,7 +163,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/any_type_body', 'POST',
             _path_params,
             _query_params,
@@ -198,35 +173,19 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def fake_enum_ref_query_parameter(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> None:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_enum_ref_query_parameter(enum_ref, async_req=True)
-        >>> result = thread.get()
 
         :param enum_ref: enum reference
         :type enum_ref: EnumClass
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -240,24 +199,15 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
+        return await self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_enum_ref_query_parameter_with_http_info(self, enum_ref : Annotated[Optional[EnumClass], Field(description="enum reference")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test enum reference query parameter  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_enum_ref_query_parameter_with_http_info(enum_ref, async_req=True)
-        >>> result = thread.get()
 
         :param enum_ref: enum reference
         :type enum_ref: EnumClass
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -288,7 +238,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -330,7 +279,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/enum_ref_query_parameter', 'GET',
             _path_params,
             _query_params,
@@ -340,33 +289,17 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_health_get(self, **kwargs) -> HealthCheckResult:  # noqa: E501
-        ...
-
-    @overload
-    def fake_health_get(self, async_req: Optional[bool]=True, **kwargs) -> HealthCheckResult:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_health_get(self, async_req: Optional[bool]=None, **kwargs) -> Union[HealthCheckResult, Awaitable[HealthCheckResult]]:  # noqa: E501
+    async def fake_health_get(self, **kwargs) -> HealthCheckResult:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.fake_health_get(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -380,22 +313,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
+        return await self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_health_get_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Health check endpoint  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.fake_health_get_with_http_info(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -425,7 +349,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -470,7 +393,7 @@ class FakeApi:
             '200': "HealthCheckResult",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/health', 'GET',
             _path_params,
             _query_params,
@@ -480,30 +403,16 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def fake_http_signature_test(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> None:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_http_signature_test(pet, query_1, header_1, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
@@ -511,8 +420,6 @@ class FakeApi:
         :type query_1: str
         :param header_1: header parameter
         :type header_1: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -526,19 +433,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
+        return await self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_http_signature_test_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], query_1 : Annotated[Optional[StrictStr], Field(description="query parameter")] = None, header_1 : Annotated[Optional[StrictStr], Field(description="header parameter")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test http signature authentication  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_http_signature_test_with_http_info(pet, query_1, header_1, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
@@ -546,8 +446,6 @@ class FakeApi:
         :type query_1: str
         :param header_1: header parameter
         :type header_1: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -580,7 +478,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -635,7 +532,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/http-signature-test', 'GET',
             _path_params,
             _query_params,
@@ -645,36 +542,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
-        ...
-
-    @overload
-    def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> bool:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[bool, Awaitable[bool]]:  # noqa: E501
+    async def fake_outer_boolean_serialize(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> bool:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
         Test serialization of outer boolean types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_boolean_serialize(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input boolean as post body
         :type body: bool
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -688,25 +569,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
+        return await self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_boolean_serialize_with_http_info(self, body : Annotated[Optional[StrictBool], Field(description="Input boolean as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_boolean_serialize  # noqa: E501
 
         Test serialization of outer boolean types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_boolean_serialize_with_http_info(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input boolean as post body
         :type body: bool
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -737,7 +609,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -792,7 +663,7 @@ class FakeApi:
             '200': "bool",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/outer/boolean', 'POST',
             _path_params,
             _query_params,
@@ -802,36 +673,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
-        ...
-
-    @overload
-    def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> OuterComposite:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[OuterComposite, Awaitable[OuterComposite]]:  # noqa: E501
+    async def fake_outer_composite_serialize(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> OuterComposite:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
         Test serialization of object with outer number type  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_composite_serialize(outer_composite, async_req=True)
-        >>> result = thread.get()
 
         :param outer_composite: Input composite as post body
         :type outer_composite: OuterComposite
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -845,25 +700,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
+        return await self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_composite_serialize_with_http_info(self, outer_composite : Annotated[Optional[OuterComposite], Field(description="Input composite as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_composite_serialize  # noqa: E501
 
         Test serialization of object with outer number type  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_composite_serialize_with_http_info(outer_composite, async_req=True)
-        >>> result = thread.get()
 
         :param outer_composite: Input composite as post body
         :type outer_composite: OuterComposite
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -894,7 +740,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -949,7 +794,7 @@ class FakeApi:
             '200': "OuterComposite",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/outer/composite', 'POST',
             _path_params,
             _query_params,
@@ -959,36 +804,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
-        ...
-
-    @overload
-    def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> float:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[float, Awaitable[float]]:  # noqa: E501
+    async def fake_outer_number_serialize(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> float:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
         Test serialization of outer number types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_number_serialize(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input number as post body
         :type body: float
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1002,25 +831,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
+        return await self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_number_serialize_with_http_info(self, body : Annotated[Optional[float], Field(description="Input number as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_number_serialize  # noqa: E501
 
         Test serialization of outer number types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_number_serialize_with_http_info(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input number as post body
         :type body: float
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1051,7 +871,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1106,7 +925,7 @@ class FakeApi:
             '200': "float",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/outer/number', 'POST',
             _path_params,
             _query_params,
@@ -1116,36 +935,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
-        ...
-
-    @overload
-    def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
+    async def fake_outer_string_serialize(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> str:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
         Test serialization of outer string types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_string_serialize(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input string as post body
         :type body: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1159,25 +962,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
+        return await self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_outer_string_serialize_with_http_info(self, body : Annotated[Optional[StrictStr], Field(description="Input string as post body")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """fake_outer_string_serialize  # noqa: E501
 
         Test serialization of outer string types  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_outer_string_serialize_with_http_info(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: Input string as post body
         :type body: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1208,7 +1002,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1263,7 +1056,7 @@ class FakeApi:
             '200': "str",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/outer/string', 'POST',
             _path_params,
             _query_params,
@@ -1273,36 +1066,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
-        ...
-
-    @overload
-    def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=True, **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], async_req: Optional[bool]=None, **kwargs) -> Union[OuterObjectWithEnumProperty, Awaitable[OuterObjectWithEnumProperty]]:  # noqa: E501
+    async def fake_property_enum_integer_serialize(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> OuterObjectWithEnumProperty:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
         Test serialization of enum (int) properties with examples  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_property_enum_integer_serialize(outer_object_with_enum_property, async_req=True)
-        >>> result = thread.get()
 
         :param outer_object_with_enum_property: Input enum (int) as post body (required)
         :type outer_object_with_enum_property: OuterObjectWithEnumProperty
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1316,25 +1093,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
+        return await self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_property_enum_integer_serialize_with_http_info(self, outer_object_with_enum_property : Annotated[OuterObjectWithEnumProperty, Field(..., description="Input enum (int) as post body")], **kwargs) -> ApiResponse:  # noqa: E501
         """fake_property_enum_integer_serialize  # noqa: E501
 
         Test serialization of enum (int) properties with examples  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, async_req=True)
-        >>> result = thread.get()
 
         :param outer_object_with_enum_property: Input enum (int) as post body (required)
         :type outer_object_with_enum_property: OuterObjectWithEnumProperty
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1365,7 +1133,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1420,7 +1187,7 @@ class FakeApi:
             '200': "OuterObjectWithEnumProperty",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/property/enum-int', 'POST',
             _path_params,
             _query_params,
@@ -1430,33 +1197,17 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_return_list_of_objects(self, **kwargs) -> List[List[Tag]]:  # noqa: E501
-        ...
-
-    @overload
-    def fake_return_list_of_objects(self, async_req: Optional[bool]=True, **kwargs) -> List[List[Tag]]:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_return_list_of_objects(self, async_req: Optional[bool]=None, **kwargs) -> Union[List[List[Tag]], Awaitable[List[List[Tag]]]]:  # noqa: E501
+    async def fake_return_list_of_objects(self, **kwargs) -> List[List[Tag]]:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.fake_return_list_of_objects(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1470,22 +1221,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
+        return await self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_return_list_of_objects_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """test returning list of objects  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.fake_return_list_of_objects_with_http_info(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1515,7 +1257,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1560,7 +1301,7 @@ class FakeApi:
             '200': "List[List[Tag]]",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/return_list_of_object', 'GET',
             _path_params,
             _query_params,
@@ -1570,35 +1311,19 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def fake_uuid_example(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> None:  # noqa: E501
         """test uuid example  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_uuid_example(uuid_example, async_req=True)
-        >>> result = thread.get()
 
         :param uuid_example: uuid example (required)
         :type uuid_example: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1612,24 +1337,15 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
+        return await self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def fake_uuid_example_with_http_info(self, uuid_example : Annotated[StrictStr, Field(..., description="uuid example")], **kwargs) -> ApiResponse:  # noqa: E501
         """test uuid example  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.fake_uuid_example_with_http_info(uuid_example, async_req=True)
-        >>> result = thread.get()
 
         :param uuid_example: uuid example (required)
         :type uuid_example: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1660,7 +1376,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1702,7 +1417,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/uuid_example', 'GET',
             _path_params,
             _query_params,
@@ -1712,36 +1427,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_body_with_binary(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> None:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
         For this test, the body has to be a binary file.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_binary(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: image to upload (required)
         :type body: bytearray
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1755,25 +1454,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
+        return await self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_binary_with_http_info(self, body : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(..., description="image to upload")], **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_binary  # noqa: E501
 
         For this test, the body has to be a binary file.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_binary_with_http_info(body, async_req=True)
-        >>> result = thread.get()
 
         :param body: image to upload (required)
         :type body: bytearray
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1804,7 +1494,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1858,7 +1547,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/body-with-binary', 'PUT',
             _path_params,
             _query_params,
@@ -1868,36 +1557,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_body_with_file_schema(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> None:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
         For this test, the body for this request must reference a schema named `File`.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_file_schema(file_schema_test_class, async_req=True)
-        >>> result = thread.get()
 
         :param file_schema_test_class: (required)
         :type file_schema_test_class: FileSchemaTestClass
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1911,25 +1584,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
+        return await self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_file_schema_with_http_info(self, file_schema_test_class : FileSchemaTestClass, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_file_schema  # noqa: E501
 
         For this test, the body for this request must reference a schema named `File`.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_file_schema_with_http_info(file_schema_test_class, async_req=True)
-        >>> result = thread.get()
 
         :param file_schema_test_class: (required)
         :type file_schema_test_class: FileSchemaTestClass
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1960,7 +1624,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2009,7 +1672,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/body-with-file-schema', 'PUT',
             _path_params,
             _query_params,
@@ -2019,37 +1682,21 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_body_with_query_params(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_body_with_query_params(self, query : StrictStr, user : User, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_body_with_query_params(self, query : StrictStr, user : User, **kwargs) -> None:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_query_params(query, user, async_req=True)
-        >>> result = thread.get()
 
         :param query: (required)
         :type query: str
         :param user: (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2063,26 +1710,17 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
+        return await self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_body_with_query_params_with_http_info(self, query : StrictStr, user : User, **kwargs) -> ApiResponse:  # noqa: E501
         """test_body_with_query_params  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_body_with_query_params_with_http_info(query, user, async_req=True)
-        >>> result = thread.get()
 
         :param query: (required)
         :type query: str
         :param user: (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -2114,7 +1752,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2166,7 +1803,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/body-with-query-params', 'PUT',
             _path_params,
             _query_params,
@@ -2176,36 +1813,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
-        ...
-
-    @overload
-    def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
+    async def test_client_model(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
         To test \"client\" model  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_client_model(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2219,25 +1840,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
+        return await self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_client_model_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_client_model_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test \"client\" model  # noqa: E501
 
         To test \"client\" model  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_client_model_with_http_info(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -2268,7 +1880,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2323,7 +1934,7 @@ class FakeApi:
             '200': "Client",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake', 'PATCH',
             _path_params,
             _query_params,
@@ -2333,37 +1944,21 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_date_time_query_parameter(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> None:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_date_time_query_parameter(date_time_query, str_query, async_req=True)
-        >>> result = thread.get()
 
         :param date_time_query: (required)
         :type date_time_query: datetime
         :param str_query: (required)
         :type str_query: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2377,26 +1972,17 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
+        return await self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_date_time_query_parameter_with_http_info(self, date_time_query : datetime, str_query : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
         """test_date_time_query_parameter  # noqa: E501
 
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_date_time_query_parameter_with_http_info(date_time_query, str_query, async_req=True)
-        >>> result = thread.get()
 
         :param date_time_query: (required)
         :type date_time_query: datetime
         :param str_query: (required)
         :type str_query: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -2428,7 +2014,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2476,7 +2061,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/date-time-query-params', 'PUT',
             _path_params,
             _query_params,
@@ -2486,31 +2071,17 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_endpoint_parameters(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_endpoint_parameters(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, async_req=True)
-        >>> result = thread.get()
 
         :param number: None (required)
         :type number: float
@@ -2542,8 +2113,6 @@ class FakeApi:
         :type password: str
         :param param_callback: None
         :type param_callback: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2557,20 +2126,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
+        return await self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_endpoint_parameters_with_http_info(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_endpoint_parameters_with_http_info(self, number : Annotated[confloat(le=543.2, ge=32.1), Field(..., description="None")], double : Annotated[confloat(le=123.4, ge=67.8), Field(..., description="None")], pattern_without_delimiter : Annotated[constr(strict=True), Field(..., description="None")], byte : Annotated[Union[StrictBytes, StrictStr], Field(..., description="None")], integer : Annotated[Optional[conint(strict=True, le=100, ge=10)], Field(description="None")] = None, int32 : Annotated[Optional[conint(strict=True, le=200, ge=20)], Field(description="None")] = None, int64 : Annotated[Optional[StrictInt], Field(description="None")] = None, float : Annotated[Optional[confloat(le=987.6)], Field(description="None")] = None, string : Annotated[Optional[constr(strict=True)], Field(description="None")] = None, binary : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="None")] = None, byte_with_max_length : Annotated[Optional[Union[conbytes(strict=True, max_length=64), constr(strict=True, max_length=64)]], Field(description="None")] = None, var_date : Annotated[Optional[date], Field(description="None")] = None, date_time : Annotated[Optional[datetime], Field(description="None")] = None, password : Annotated[Optional[constr(strict=True, max_length=64, min_length=10)], Field(description="None")] = None, param_callback : Annotated[Optional[StrictStr], Field(description="None")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
 
         Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트   # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, async_req=True)
-        >>> result = thread.get()
 
         :param number: None (required)
         :type number: float
@@ -2602,8 +2164,6 @@ class FakeApi:
         :type password: str
         :param param_callback: None
         :type param_callback: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -2648,7 +2208,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2739,7 +2298,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake', 'POST',
             _path_params,
             _query_params,
@@ -2749,31 +2308,17 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_group_parameters(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> None:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
         Fake endpoint to test group parameters (optional)  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_group_parameters(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, async_req=True)
-        >>> result = thread.get()
 
         :param required_string_group: Required String in group parameters (required)
         :type required_string_group: int
@@ -2787,8 +2332,6 @@ class FakeApi:
         :type boolean_group: bool
         :param int64_group: Integer in group parameters
         :type int64_group: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2802,20 +2345,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
+        return await self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_group_parameters_with_http_info(self, required_string_group : Annotated[StrictInt, Field(..., description="Required String in group parameters")], required_boolean_group : Annotated[StrictBool, Field(..., description="Required Boolean in group parameters")], required_int64_group : Annotated[StrictInt, Field(..., description="Required Integer in group parameters")], string_group : Annotated[Optional[StrictInt], Field(description="String in group parameters")] = None, boolean_group : Annotated[Optional[StrictBool], Field(description="Boolean in group parameters")] = None, int64_group : Annotated[Optional[StrictInt], Field(description="Integer in group parameters")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Fake endpoint to test group parameters (optional)  # noqa: E501
 
         Fake endpoint to test group parameters (optional)  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, async_req=True)
-        >>> result = thread.get()
 
         :param required_string_group: Required String in group parameters (required)
         :type required_string_group: int
@@ -2829,8 +2365,6 @@ class FakeApi:
         :type boolean_group: bool
         :param int64_group: Integer in group parameters
         :type int64_group: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -2866,7 +2400,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -2923,7 +2456,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake', 'DELETE',
             _path_params,
             _query_params,
@@ -2933,36 +2466,20 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_inline_additional_properties(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> None:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_inline_additional_properties(request_body, async_req=True)
-        >>> result = thread.get()
 
         :param request_body: request body (required)
         :type request_body: Dict[str, str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -2976,25 +2493,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
+        return await self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_inline_additional_properties_with_http_info(self, request_body : Annotated[Dict[str, StrictStr], Field(..., description="request body")], **kwargs) -> ApiResponse:  # noqa: E501
         """test inline additionalProperties  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_inline_additional_properties_with_http_info(request_body, async_req=True)
-        >>> result = thread.get()
 
         :param request_body: request body (required)
         :type request_body: Dict[str, str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -3025,7 +2533,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -3074,7 +2581,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/inline-additionalProperties', 'POST',
             _path_params,
             _query_params,
@@ -3084,38 +2591,22 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_json_form_data(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> None:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_json_form_data(param, param2, async_req=True)
-        >>> result = thread.get()
 
         :param param: field1 (required)
         :type param: str
         :param param2: field2 (required)
         :type param2: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -3129,27 +2620,18 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
+        return await self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_json_form_data_with_http_info(self, param : Annotated[StrictStr, Field(..., description="field1")], param2 : Annotated[StrictStr, Field(..., description="field2")], **kwargs) -> ApiResponse:  # noqa: E501
         """test json serialization of form data  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_json_form_data_with_http_info(param, param2, async_req=True)
-        >>> result = thread.get()
 
         :param param: field1 (required)
         :type param: str
         :param param2: field2 (required)
         :type param2: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -3181,7 +2663,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -3233,7 +2714,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/jsonFormData', 'GET',
             _path_params,
             _query_params,
@@ -3243,31 +2724,17 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def test_query_parameter_collection_format(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> None:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_query_parameter_collection_format(pipe, ioutil, http, url, context, allow_empty, language, async_req=True)
-        >>> result = thread.get()
 
         :param pipe: (required)
         :type pipe: List[str]
@@ -3283,8 +2750,6 @@ class FakeApi:
         :type allow_empty: str
         :param language:
         :type language: Dict[str, str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -3298,20 +2763,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
+        return await self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_query_parameter_collection_format_with_http_info(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_query_parameter_collection_format_with_http_info(self, pipe : conlist(StrictStr), ioutil : conlist(StrictStr), http : conlist(StrictStr), url : conlist(StrictStr), context : conlist(StrictStr), allow_empty : StrictStr, language : Optional[Dict[str, StrictStr]] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """test_query_parameter_collection_format  # noqa: E501
 
         To test the collection format in query parameters  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, async_req=True)
-        >>> result = thread.get()
 
         :param pipe: (required)
         :type pipe: List[str]
@@ -3327,8 +2785,6 @@ class FakeApi:
         :type allow_empty: str
         :param language:
         :type language: Dict[str, str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -3365,7 +2821,6 @@ class FakeApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -3430,7 +2885,7 @@ class FakeApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/test-query-parameters', 'PUT',
             _path_params,
             _query_params,
@@ -3440,7 +2895,6 @@ class FakeApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -44,29 +44,14 @@ class FakeClassnameTags123Api:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def test_classname(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
-        ...
-
-    @overload
-    def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=True, **kwargs) -> Client:  # noqa: E501
-        ...
-
     @validate_arguments
-    def test_classname(self, client : Annotated[Client, Field(..., description="client model")], async_req: Optional[bool]=None, **kwargs) -> Union[Client, Awaitable[Client]]:  # noqa: E501
+    async def test_classname(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> Client:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
         To test class name in snake case  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_classname(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -80,25 +65,16 @@ class FakeClassnameTags123Api:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
+        return await self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_classname_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def test_classname_with_http_info(self, client : Annotated[Client, Field(..., description="client model")], **kwargs) -> ApiResponse:  # noqa: E501
         """To test class name in snake case  # noqa: E501
 
         To test class name in snake case  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.test_classname_with_http_info(client, async_req=True)
-        >>> result = thread.get()
 
         :param client: client model (required)
         :type client: Client
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -129,7 +105,6 @@ class FakeClassnameTags123Api:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -184,7 +159,7 @@ class FakeClassnameTags123Api:
             '200': "Client",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake_classname_test', 'PATCH',
             _path_params,
             _query_params,
@@ -194,7 +169,6 @@ class FakeClassnameTags123Api:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -47,29 +47,14 @@ class PetApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def add_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.add_pet(pet, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -83,25 +68,16 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
+        return await self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def add_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def add_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Add a new pet to the store  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.add_pet_with_http_info(pet, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -132,7 +108,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -181,7 +156,7 @@ class PetApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet', 'POST',
             _path_params,
             _query_params,
@@ -191,38 +166,22 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def delete_pet(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> None:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_pet(pet_id, api_key, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: Pet id to delete (required)
         :type pet_id: int
         :param api_key:
         :type api_key: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -236,27 +195,18 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
+        return await self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_pet_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="Pet id to delete")], api_key : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Deletes a pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_pet_with_http_info(pet_id, api_key, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: Pet id to delete (required)
         :type pet_id: int
         :param api_key:
         :type api_key: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -288,7 +238,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -333,7 +282,7 @@ class PetApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/{petId}', 'DELETE',
             _path_params,
             _query_params,
@@ -343,36 +292,20 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
-        ...
-
-    @overload
-    def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
-        ...
-
     @validate_arguments
-    def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
+    async def find_pets_by_status(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> List[Pet]:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
         Multiple status values can be provided with comma separated strings  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.find_pets_by_status(status, async_req=True)
-        >>> result = thread.get()
 
         :param status: Status values that need to be considered for filter (required)
         :type status: List[str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -386,25 +319,16 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
+        return await self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def find_pets_by_status_with_http_info(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def find_pets_by_status_with_http_info(self, status : Annotated[conlist(StrictStr), Field(..., description="Status values that need to be considered for filter")], **kwargs) -> ApiResponse:  # noqa: E501
         """Finds Pets by status  # noqa: E501
 
         Multiple status values can be provided with comma separated strings  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.find_pets_by_status_with_http_info(status, async_req=True)
-        >>> result = thread.get()
 
         :param status: Status values that need to be considered for filter (required)
         :type status: List[str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -435,7 +359,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -485,7 +408,7 @@ class PetApi:
             '400': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/findByStatus', 'GET',
             _path_params,
             _query_params,
@@ -495,36 +418,20 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
-        ...
-
-    @overload
-    def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=True, **kwargs) -> List[Pet]:  # noqa: E501
-        ...
-
     @validate_arguments
-    def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], async_req: Optional[bool]=None, **kwargs) -> Union[List[Pet], Awaitable[List[Pet]]]:  # noqa: E501
+    async def find_pets_by_tags(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> List[Pet]:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.find_pets_by_tags(tags, async_req=True)
-        >>> result = thread.get()
 
         :param tags: Tags to filter by (required)
         :type tags: List[str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -538,25 +445,16 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
+        return await self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def find_pets_by_tags_with_http_info(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def find_pets_by_tags_with_http_info(self, tags : Annotated[conlist(StrictStr, unique_items=True), Field(..., description="Tags to filter by")], **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) Finds Pets by tags  # noqa: E501
 
         Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.find_pets_by_tags_with_http_info(tags, async_req=True)
-        >>> result = thread.get()
 
         :param tags: Tags to filter by (required)
         :type tags: List[str]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -589,7 +487,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -639,7 +536,7 @@ class PetApi:
             '400': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/findByTags', 'GET',
             _path_params,
             _query_params,
@@ -649,36 +546,20 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
-        ...
-
-    @overload
-    def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=True, **kwargs) -> Pet:  # noqa: E501
-        ...
-
     @validate_arguments
-    def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], async_req: Optional[bool]=None, **kwargs) -> Union[Pet, Awaitable[Pet]]:  # noqa: E501
+    async def get_pet_by_id(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> Pet:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
         Returns a single pet  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_pet_by_id(pet_id, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to return (required)
         :type pet_id: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -692,25 +573,16 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
+        return await self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_pet_by_id_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to return")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find pet by ID  # noqa: E501
 
         Returns a single pet  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_pet_by_id_with_http_info(pet_id, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to return (required)
         :type pet_id: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -741,7 +613,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -791,7 +662,7 @@ class PetApi:
             '404': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/{petId}', 'GET',
             _path_params,
             _query_params,
@@ -801,36 +672,20 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def update_pet(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> None:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_pet(pet, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -844,25 +699,16 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
+        return await self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def update_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_pet_with_http_info(self, pet : Annotated[Pet, Field(..., description="Pet object that needs to be added to the store")], **kwargs) -> ApiResponse:  # noqa: E501
         """Update an existing pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_pet_with_http_info(pet, async_req=True)
-        >>> result = thread.get()
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -893,7 +739,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -942,7 +787,7 @@ class PetApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet', 'PUT',
             _path_params,
             _query_params,
@@ -952,31 +797,17 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def update_pet_with_form(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> None:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_pet_with_form(pet_id, name, status, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet that needs to be updated (required)
         :type pet_id: int
@@ -984,8 +815,6 @@ class PetApi:
         :type name: str
         :param status: Updated status of the pet
         :type status: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -999,20 +828,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
+        return await self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_pet_with_form_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet that needs to be updated")], name : Annotated[Optional[StrictStr], Field(description="Updated name of the pet")] = None, status : Annotated[Optional[StrictStr], Field(description="Updated status of the pet")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Updates a pet in the store with form data  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_pet_with_form_with_http_info(pet_id, name, status, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet that needs to be updated (required)
         :type pet_id: int
@@ -1020,8 +842,6 @@ class PetApi:
         :type name: str
         :param status: Updated status of the pet
         :type status: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1054,7 +874,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1109,7 +928,7 @@ class PetApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/{petId}', 'POST',
             _path_params,
             _query_params,
@@ -1119,31 +938,17 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
-        ...
-
-    @overload
-    def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
-        ...
-
     @validate_arguments
-    def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
+    async def upload_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.upload_file(pet_id, additional_metadata, file, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
@@ -1151,8 +956,6 @@ class PetApi:
         :type additional_metadata: str
         :param file: file to upload
         :type file: bytearray
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1166,20 +969,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
+        return await self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def upload_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def upload_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, file : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="file to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.upload_file_with_http_info(pet_id, additional_metadata, file, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
@@ -1187,8 +983,6 @@ class PetApi:
         :type additional_metadata: str
         :param file: file to upload
         :type file: bytearray
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1221,7 +1015,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1282,7 +1075,7 @@ class PetApi:
             '200': "ApiResponse",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/pet/{petId}/uploadImage', 'POST',
             _path_params,
             _query_params,
@@ -1292,31 +1085,17 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
-        ...
-
-    @overload
-    def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=True, **kwargs) -> ApiResponse:  # noqa: E501
-        ...
-
     @validate_arguments
-    def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, async_req: Optional[bool]=None, **kwargs) -> Union[ApiResponse, Awaitable[ApiResponse]]:  # noqa: E501
+    async def upload_file_with_required_file(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.upload_file_with_required_file(pet_id, required_file, additional_metadata, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
@@ -1324,8 +1103,6 @@ class PetApi:
         :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1339,20 +1116,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
+        return await self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def upload_file_with_required_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    async def upload_file_with_required_file_with_http_info(self, pet_id : Annotated[StrictInt, Field(..., description="ID of pet to update")], required_file : Annotated[Union[StrictBytes, StrictStr], Field(..., description="file to upload")], additional_metadata : Annotated[Optional[StrictStr], Field(description="Additional data to pass to server")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """uploads an image (required)  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, async_req=True)
-        >>> result = thread.get()
 
         :param pet_id: ID of pet to update (required)
         :type pet_id: int
@@ -1360,8 +1130,6 @@ class PetApi:
         :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1394,7 +1162,6 @@ class PetApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1455,7 +1222,7 @@ class PetApi:
             '200': "ApiResponse",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/fake/{petId}/uploadImageWithRequiredFile', 'POST',
             _path_params,
             _query_params,
@@ -1465,7 +1232,6 @@ class PetApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -46,29 +46,14 @@ class StoreApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def delete_order(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_order(order_id, async_req=True)
-        >>> result = thread.get()
 
         :param order_id: ID of the order that needs to be deleted (required)
         :type order_id: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -82,25 +67,16 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
+        return await self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_order_with_http_info(self, order_id : Annotated[StrictStr, Field(..., description="ID of the order that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_order_with_http_info(order_id, async_req=True)
-        >>> result = thread.get()
 
         :param order_id: ID of the order that needs to be deleted (required)
         :type order_id: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -131,7 +107,6 @@ class StoreApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -173,7 +148,7 @@ class StoreApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/store/order/{order_id}', 'DELETE',
             _path_params,
             _query_params,
@@ -183,34 +158,18 @@ class StoreApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def get_inventory(self, **kwargs) -> Dict[str, int]:  # noqa: E501
-        ...
-
-    @overload
-    def get_inventory(self, async_req: Optional[bool]=True, **kwargs) -> Dict[str, int]:  # noqa: E501
-        ...
-
     @validate_arguments
-    def get_inventory(self, async_req: Optional[bool]=None, **kwargs) -> Union[Dict[str, int], Awaitable[Dict[str, int]]]:  # noqa: E501
+    async def get_inventory(self, **kwargs) -> Dict[str, int]:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
         Returns a map of status codes to quantities  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_inventory(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -224,23 +183,14 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
+        return await self.get_inventory_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_inventory_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Returns pet inventories by status  # noqa: E501
 
         Returns a map of status codes to quantities  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.get_inventory_with_http_info(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -270,7 +220,6 @@ class StoreApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -315,7 +264,7 @@ class StoreApi:
             '200': "Dict[str, int]",
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/store/inventory', 'GET',
             _path_params,
             _query_params,
@@ -325,36 +274,20 @@ class StoreApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
-        ...
-
-    @overload
-    def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
-        ...
-
     @validate_arguments
-    def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
+    async def get_order_by_id(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> Order:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_order_by_id(order_id, async_req=True)
-        >>> result = thread.get()
 
         :param order_id: ID of pet that needs to be fetched (required)
         :type order_id: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -368,25 +301,16 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
+        return await self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_order_by_id_with_http_info(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_order_by_id_with_http_info(self, order_id : Annotated[conint(strict=True, le=5, ge=1), Field(..., description="ID of pet that needs to be fetched")], **kwargs) -> ApiResponse:  # noqa: E501
         """Find purchase order by ID  # noqa: E501
 
         For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_order_by_id_with_http_info(order_id, async_req=True)
-        >>> result = thread.get()
 
         :param order_id: ID of pet that needs to be fetched (required)
         :type order_id: int
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -417,7 +341,6 @@ class StoreApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -467,7 +390,7 @@ class StoreApi:
             '404': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/store/order/{order_id}', 'GET',
             _path_params,
             _query_params,
@@ -477,36 +400,20 @@ class StoreApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
-        ...
-
-    @overload
-    def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=True, **kwargs) -> Order:  # noqa: E501
-        ...
-
     @validate_arguments
-    def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], async_req: Optional[bool]=None, **kwargs) -> Union[Order, Awaitable[Order]]:  # noqa: E501
+    async def place_order(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> Order:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.place_order(order, async_req=True)
-        >>> result = thread.get()
 
         :param order: order placed for purchasing the pet (required)
         :type order: Order
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -520,25 +427,16 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
+        return await self.place_order_with_http_info(order, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def place_order_with_http_info(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def place_order_with_http_info(self, order : Annotated[Order, Field(..., description="order placed for purchasing the pet")], **kwargs) -> ApiResponse:  # noqa: E501
         """Place an order for a pet  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.place_order_with_http_info(order, async_req=True)
-        >>> result = thread.get()
 
         :param order: order placed for purchasing the pet (required)
         :type order: Order
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -569,7 +467,6 @@ class StoreApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -625,7 +522,7 @@ class StoreApi:
             '400': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/store/order', 'POST',
             _path_params,
             _query_params,
@@ -635,7 +532,6 @@ class StoreApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -44,29 +44,14 @@ class UserApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
-    @overload
-    async def create_user(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def create_user(self, user : Annotated[User, Field(..., description="Created user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def create_user(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> None:  # noqa: E501
         """Create user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_user(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: Created user object (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -80,25 +65,16 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
+        return await self.create_user_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def create_user_with_http_info(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_user_with_http_info(self, user : Annotated[User, Field(..., description="Created user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Create user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_user_with_http_info(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: Created user object (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -143,7 +119,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -192,7 +167,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user', 'POST',
             _path_params,
             _query_params,
@@ -202,7 +177,6 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
@@ -210,29 +184,14 @@ class UserApi:
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def create_users_with_array_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_users_with_array_input(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -246,25 +205,16 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
+        return await self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def create_users_with_array_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_users_with_array_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_users_with_array_input_with_http_info(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -295,7 +245,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -344,7 +293,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/createWithArray', 'POST',
             _path_params,
             _query_params,
@@ -354,36 +303,20 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def create_users_with_list_input(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> None:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_users_with_list_input(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -397,25 +330,16 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
+        return await self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def create_users_with_list_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def create_users_with_list_input_with_http_info(self, user : Annotated[conlist(User), Field(..., description="List of user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Creates list of users with given input array  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.create_users_with_list_input_with_http_info(user, async_req=True)
-        >>> result = thread.get()
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -446,7 +370,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -495,7 +418,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/createWithList', 'POST',
             _path_params,
             _query_params,
@@ -505,36 +428,20 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def delete_user(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> None:  # noqa: E501
         """Delete user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_user(username, async_req=True)
-        >>> result = thread.get()
 
         :param username: The name that needs to be deleted (required)
         :type username: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -548,25 +455,16 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
+        return await self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def delete_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be deleted")], **kwargs) -> ApiResponse:  # noqa: E501
         """Delete user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.delete_user_with_http_info(username, async_req=True)
-        >>> result = thread.get()
 
         :param username: The name that needs to be deleted (required)
         :type username: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -597,7 +495,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -639,7 +536,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/{username}', 'DELETE',
             _path_params,
             _query_params,
@@ -649,36 +546,20 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
-        ...
-
-    @overload
-    def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=True, **kwargs) -> User:  # noqa: E501
-        ...
-
     @validate_arguments
-    def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], async_req: Optional[bool]=None, **kwargs) -> Union[User, Awaitable[User]]:  # noqa: E501
+    async def get_user_by_name(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> User:  # noqa: E501
         """Get user by user name  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_user_by_name(username, async_req=True)
-        >>> result = thread.get()
 
         :param username: The name that needs to be fetched. Use user1 for testing. (required)
         :type username: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -692,25 +573,16 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
+        return await self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def get_user_by_name_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The name that needs to be fetched. Use user1 for testing.")], **kwargs) -> ApiResponse:  # noqa: E501
         """Get user by user name  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.get_user_by_name_with_http_info(username, async_req=True)
-        >>> result = thread.get()
 
         :param username: The name that needs to be fetched. Use user1 for testing. (required)
         :type username: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -741,7 +613,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -791,7 +662,7 @@ class UserApi:
             '404': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/{username}', 'GET',
             _path_params,
             _query_params,
@@ -801,38 +672,22 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
-        ...
-
-    @overload
-    def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=True, **kwargs) -> str:  # noqa: E501
-        ...
-
     @validate_arguments
-    def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], async_req: Optional[bool]=None, **kwargs) -> Union[str, Awaitable[str]]:  # noqa: E501
+    async def login_user(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> str:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.login_user(username, password, async_req=True)
-        >>> result = thread.get()
 
         :param username: The user name for login (required)
         :type username: str
         :param password: The password for login in clear text (required)
         :type password: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -846,27 +701,18 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
+        return await self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def login_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def login_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="The user name for login")], password : Annotated[StrictStr, Field(..., description="The password for login in clear text")], **kwargs) -> ApiResponse:  # noqa: E501
         """Logs user into the system  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.login_user_with_http_info(username, password, async_req=True)
-        >>> result = thread.get()
 
         :param username: The user name for login (required)
         :type username: str
         :param password: The password for login in clear text (required)
         :type password: str
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -898,7 +744,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -950,7 +795,7 @@ class UserApi:
             '400': None,
         }
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/login', 'GET',
             _path_params,
             _query_params,
@@ -960,34 +805,18 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def logout_user(self, **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def logout_user(self, async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def logout_user(self, async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def logout_user(self, **kwargs) -> None:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.logout_user(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1001,23 +830,14 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.logout_user_with_http_info(**kwargs)  # noqa: E501
+        return await self.logout_user_with_http_info(**kwargs)  # noqa: E501
 
     @validate_arguments
-    def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
+    async def logout_user_with_http_info(self, **kwargs) -> ApiResponse:  # noqa: E501
         """Logs out current logged in user session  # noqa: E501
 
           # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.logout_user_with_http_info(async_req=True)
-        >>> result = thread.get()
-
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1047,7 +867,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1086,7 +905,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/logout', 'GET',
             _path_params,
             _query_params,
@@ -1096,38 +915,22 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),
             collection_formats=_collection_formats,
             _request_auth=_params.get('_request_auth'))
 
-    @overload
-    async def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> None:  # noqa: E501
-        ...
-
-    @overload
-    def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=True, **kwargs) -> None:  # noqa: E501
-        ...
-
     @validate_arguments
-    def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], async_req: Optional[bool]=None, **kwargs) -> Union[None, Awaitable[None]]:  # noqa: E501
+    async def update_user(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> None:  # noqa: E501
         """Updated user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_user(username, user, async_req=True)
-        >>> result = thread.get()
 
         :param username: name that need to be deleted (required)
         :type username: str
         :param user: Updated user object (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
                If one number provided, it will be total request
                timeout. It can also be a pair (tuple) of
@@ -1141,27 +944,18 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        if async_req is not None:
-            kwargs['async_req'] = async_req
-        return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
+        return await self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def update_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
+    async def update_user_with_http_info(self, username : Annotated[StrictStr, Field(..., description="name that need to be deleted")], user : Annotated[User, Field(..., description="Updated user object")], **kwargs) -> ApiResponse:  # noqa: E501
         """Updated user  # noqa: E501
 
         This can only be done by the logged in user.  # noqa: E501
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please pass async_req=True
-
-        >>> thread = api.update_user_with_http_info(username, user, async_req=True)
-        >>> result = thread.get()
 
         :param username: name that need to be deleted (required)
         :type username: str
         :param user: Updated user object (required)
         :type user: User
-        :param async_req: Whether to execute the request asynchronously.
-        :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
                                  be set to none and raw_data will store the
                                  HTTP response body without reading/decoding.
@@ -1193,7 +987,6 @@ class UserApi:
         ]
         _all_params.extend(
             [
-                'async_req',
                 '_return_http_data_only',
                 '_preload_content',
                 '_request_timeout',
@@ -1245,7 +1038,7 @@ class UserApi:
 
         _response_types_map = {}
 
-        return self.api_client.call_api(
+        return await self.api_client.call_api(
             '/user/{username}', 'PUT',
             _path_params,
             _query_params,
@@ -1255,7 +1048,6 @@ class UserApi:
             files=_files,
             response_types_map=_response_types_map,
             auth_settings=_auth_settings,
-            async_req=_params.get('async_req'),
             _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
             _preload_content=_params.get('_preload_content', True),
             _request_timeout=_params.get('_request_timeout'),

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -58,6 +58,7 @@ class ApiClient:
         'object': object,
     }
     _pool = None
+
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None) -> None:
         # use default configuration if none is provided

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -17,7 +17,6 @@ import datetime
 from dateutil.parser import parse
 import json
 import mimetypes
-from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
@@ -45,8 +44,6 @@ class ApiClient:
         the API.
     :param cookie: a cookie to include in the header when making calls
         to the API
-    :param pool_threads: The number of threads to use for async requests
-        to the API. More threads means more concurrent API requests.
     """
 
     PRIMITIVE_TYPES = (float, bool, bytes, str, int)
@@ -61,14 +58,12 @@ class ApiClient:
         'object': object,
     }
     _pool = None
-
     def __init__(self, configuration=None, header_name=None, header_value=None,
-                 cookie=None, pool_threads=1) -> None:
+                 cookie=None) -> None:
         # use default configuration if none is provided
         if configuration is None:
             configuration = Configuration.get_default()
         self.configuration = configuration
-        self.pool_threads = pool_threads
 
         self.rest_client = rest.RESTClientObject(configuration)
         self.default_headers = {}
@@ -87,22 +82,6 @@ class ApiClient:
 
     async def close(self):
         await self.rest_client.close()
-        if self._pool:
-            self._pool.close()
-            self._pool.join()
-            self._pool = None
-            if hasattr(atexit, 'unregister'):
-                atexit.unregister(self.close)
-
-    @property
-    def pool(self):
-        """Create thread pool on first request
-         avoids instantiating unused threadpool for blocking clients.
-        """
-        if self._pool is None:
-            atexit.register(self.close)
-            self._pool = ThreadPool(self.pool_threads)
-        return self._pool
 
     @property
     def user_agent(self):
@@ -223,7 +202,7 @@ class ApiClient:
 
         self.last_response = response_data
 
-        return_data = None # assuming derialization is not needed
+        return_data = None # assuming deserialization is not needed
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
@@ -358,16 +337,14 @@ class ApiClient:
         else:
             return self.__deserialize_model(data, klass)
 
-    def call_api(self, resource_path, method,
+    async def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
                  response_types_map=None, auth_settings=None,
-                 async_req=None, _return_http_data_only=None,
+                 _return_http_data_only=None,
                  collection_formats=None, _preload_content=True,
                  _request_timeout=None, _host=None, _request_auth=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
-
-        To make an async_req request, set the async_req parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -382,7 +359,6 @@ class ApiClient:
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async_req bool: execute request asynchronously
         :param _return_http_data_only: response data instead of ApiResponse
                                        object with status code, headers, etc
         :param _preload_content: if False, the ApiResponse.data will
@@ -400,58 +376,52 @@ class ApiClient:
                               in the spec for a single request.
         :type _request_token: dict, optional
         :return:
-            If async_req parameter is True,
-            the request will be called asynchronously.
-            The method will return the request thread.
-            If parameter async_req is False or missing,
-            then the method will return the response directly.
+            The response.
         """
-        if not async_req:
-            return self.__call_api(resource_path, method,
-                                   path_params, query_params, header_params,
-                                   body, post_params, files,
-                                   response_types_map, auth_settings,
-                                   _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host,
-                                   _request_auth)
+        args = (
+            resource_path,
+            method,
+            path_params,
+            query_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            response_types_map,
+            auth_settings,
+            _return_http_data_only,
+            collection_formats,
+            _preload_content,
+            _request_timeout,
+            _host,
+            _request_auth,
+        )
+        return await self.__call_api(*args)
 
-        return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params,
-                                                       query_params,
-                                                       header_params, body,
-                                                       post_params, files,
-                                                       response_types_map,
-                                                       auth_settings,
-                                                       _return_http_data_only,
-                                                       collection_formats,
-                                                       _preload_content,
-                                                       _request_timeout,
-                                                       _host, _request_auth))
-
-    def request(self, method, url, query_params=None, headers=None,
+    async def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
                 _request_timeout=None):
         """Makes the HTTP request using RESTClient."""
         if method == "GET":
-            return self.rest_client.get_request(url,
+            return await self.rest_client.get_request(url,
                                         query_params=query_params,
                                         _preload_content=_preload_content,
                                         _request_timeout=_request_timeout,
                                         headers=headers)
         elif method == "HEAD":
-            return self.rest_client.head_request(url,
+            return await self.rest_client.head_request(url,
                                          query_params=query_params,
                                          _preload_content=_preload_content,
                                          _request_timeout=_request_timeout,
                                          headers=headers)
         elif method == "OPTIONS":
-            return self.rest_client.options_request(url,
+            return await self.rest_client.options_request(url,
                                             query_params=query_params,
                                             headers=headers,
                                             _preload_content=_preload_content,
                                             _request_timeout=_request_timeout)
         elif method == "POST":
-            return self.rest_client.post_request(url,
+            return await self.rest_client.post_request(url,
                                          query_params=query_params,
                                          headers=headers,
                                          post_params=post_params,
@@ -459,7 +429,7 @@ class ApiClient:
                                          _request_timeout=_request_timeout,
                                          body=body)
         elif method == "PUT":
-            return self.rest_client.put_request(url,
+            return await self.rest_client.put_request(url,
                                         query_params=query_params,
                                         headers=headers,
                                         post_params=post_params,
@@ -467,7 +437,7 @@ class ApiClient:
                                         _request_timeout=_request_timeout,
                                         body=body)
         elif method == "PATCH":
-            return self.rest_client.patch_request(url,
+            return await self.rest_client.patch_request(url,
                                           query_params=query_params,
                                           headers=headers,
                                           post_params=post_params,
@@ -475,7 +445,7 @@ class ApiClient:
                                           _request_timeout=_request_timeout,
                                           body=body)
         elif method == "DELETE":
-            return self.rest_client.delete_request(url,
+            return await self.rest_client.delete_request(url,
                                            query_params=query_params,
                                            headers=headers,
                                            _preload_content=_preload_content,

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/test_api_client.py
@@ -15,13 +15,8 @@ class TestApiClient(unittest.TestCase):
     async def test_context_manager_closes_client(self):
 
         async with petstore_api.ApiClient() as client:
-            # thread pool
-            self.assertIsNotNone(client.pool)
-            pool_ref = weakref.ref(client._pool)
-            self.assertIsNotNone(pool_ref())
             # pool_manager
             self.assertFalse(client.rest_client.pool_manager.closed)
             rest_pool_ref = client.rest_client.pool_manager
 
-        self.assertIsNone(pool_ref())
         self.assertTrue(rest_pool_ref.closed)

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/util.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/util.py
@@ -11,7 +11,8 @@ def id_gen(bits=32):
 
 def async_test(f):
     def wrapper(*args, **kwargs):
-        coro = asyncio.coroutine(f)
+        # coro = asyncio.coroutine(f)
+        coro = f
         future = coro(*args, **kwargs)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(future)

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -61,7 +61,6 @@ class ApiClient:
         'object': object,
     }
     _pool = None
-
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1) -> None:
         # use default configuration if none is provided
@@ -222,7 +221,7 @@ class ApiClient:
 
         self.last_response = response_data
 
-        return_data = None # assuming derialization is not needed
+        return_data = None # assuming deserialization is not needed
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content or _return_http_data_only:
           response_type = response_types_map.get(str(response_data.status), None)
@@ -405,27 +404,28 @@ class ApiClient:
             If parameter async_req is False or missing,
             then the method will return the response directly.
         """
+        args = (
+            resource_path,
+            method,
+            path_params,
+            query_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            response_types_map,
+            auth_settings,
+            _return_http_data_only,
+            collection_formats,
+            _preload_content,
+            _request_timeout,
+            _host,
+            _request_auth,
+        )
         if not async_req:
-            return self.__call_api(resource_path, method,
-                                   path_params, query_params, header_params,
-                                   body, post_params, files,
-                                   response_types_map, auth_settings,
-                                   _return_http_data_only, collection_formats,
-                                   _preload_content, _request_timeout, _host,
-                                   _request_auth)
+            return self.__call_api(*args)
 
-        return self.pool.apply_async(self.__call_api, (resource_path,
-                                                       method, path_params,
-                                                       query_params,
-                                                       header_params, body,
-                                                       post_params, files,
-                                                       response_types_map,
-                                                       auth_settings,
-                                                       _return_http_data_only,
-                                                       collection_formats,
-                                                       _preload_content,
-                                                       _request_timeout,
-                                                       _host, _request_auth))
+        return self.pool.apply_async(self.__call_api, args)
 
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -61,6 +61,7 @@ class ApiClient:
         'object': object,
     }
     _pool = None
+
     def __init__(self, configuration=None, header_name=None, header_value=None,
                  cookie=None, pool_threads=1) -> None:
         # use default configuration if none is provided


### PR DESCRIPTION
This removes all the non-async code from the aiohttp generator:

* all the methods that should be asynchronous are marked as `async`
* the `async_req` parameter is gone; calls are directly awaitables now
* the async calls into a thread pool are gone and the thread pool is gone too (now useless)

Closes: #15824
Closes: #5539
Related: #763
Related: #3696

The code is extracted from https://github.com/OpenAPITools/openapi-generator/pull/15878, readjusted to remove the typing changes and fixed for the aiohttp client tests to pass.

@krjakbrjak @wing328 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
