### PR TITLE
fix[csharp]: The Deserialize should use the ClientUtils to handle the headers

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
@@ -91,7 +91,18 @@ namespace {{packageName}}.Client
         /// <returns>Object representation of the JSON string.</returns>
         internal async Task<object> Deserialize(HttpResponseMessage response, Type type)
         {
-            IList<string> headers = response.Headers.Select(x => x.Key + "=" + x.Value).ToList();
+            IList<string> headers = new List<string>();
+            // process response headers, e.g. Access-Control-Allow-Methods
+            foreach (var responseHeader in response.Headers)
+            {
+                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+            }
+
+            // process response content headers, e.g. Content-Type
+            foreach (var responseHeader in response.Content.Headers)
+            {
+                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+            }
 
             if (type == typeof(byte[])) // return byte array
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -94,7 +94,18 @@ namespace Org.OpenAPITools.Client
         /// <returns>Object representation of the JSON string.</returns>
         internal async Task<object> Deserialize(HttpResponseMessage response, Type type)
         {
-            IList<string> headers = response.Headers.Select(x => x.Key + "=" + x.Value).ToList();
+            IList<string> headers = new List<string>();
+            // process response headers, e.g. Access-Control-Allow-Methods
+            foreach (var responseHeader in response.Headers)
+            {
+                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+            }
+
+            // process response content headers, e.g. Content-Type
+            foreach (var responseHeader in response.Content.Headers)
+            {
+                headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
+            }
 
             if (type == typeof(byte[])) // return byte array
             {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (7.0.1 - patch release), `7.1.x` (minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

## Summary

The C Sharp Client will not handle the headers in the `Deserialize` function.

Should use the `ClientUtils.ParameterToString` to handle the header value.

Reference: [httpclient/ApiClient.mustache#L417](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache#L417)

## OpenAPI Example
```yaml
openapi: 3.0.0
info:
  title: Swagger Petstore - OpenAPI 3.1
  description: |-
  version: 1.0.11
servers:
  - url: http://localhost:8080
tags:
  - name: file
    description: A Restful API to manage files
paths:
  /files/${fileId}:
    get:
      tags:
        - file
      description: Download an existing file by Id
      operationId: downloadFile
      parameters:  
        - in: path
          name: fileId
          schema:
            type: string
            format: uuid
          required: true
      responses:
        '200':
          description: Successful operation
          content:
            application/octet-stream:
              schema:
                type: string
                format: binary
```

### OpenAPI CLI Command
```shell
openapi-generator-cli generate -g csharp --additional-properties=library=httpclient --additional-properties=targetFramework=net6.0 -i file.yaml 
```

## Expect
The headers are in a String List with the format: `${header key}=${header value}`, like:  `content-type=application/json`

## Actual
![Screenshot from 2023-09-17 21-35-18](https://github.com/OpenAPITools/openapi-generator/assets/7081582/ec1f0bf8-5248-41cc-a95f-9025e5de759d)
The header value has been handled to `System.String[]`

## Server
If you want to have a quick test, you can use this Golang code:
```Golang
package main

import (
	"github.com/gin-gonic/gin"
	"log"
	"path/filepath"
)

func main() {
	r := gin.Default()
	r.GET("/files/:fileId", func(c *gin.Context) {
		fileId := c.Param("fileId")
		log.Println(fileId)
		filePath := filepath.Join("./", "example.txt")
		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT")
		c.Header("Content-Disposition", "attachment; filename=example.txt")
		c.Header("Content-Type", "application/octet-stream")
		c.File(filePath)
	})
	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
}
```
