### PR TITLE
[php-symfony] Support for default scalar value of properties in model

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -466,25 +466,12 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             if (var.dataType != null) {
                 // Determine if the parameter type is supported as a type hint and make it available
                 // to the templating engine
-
-                String parameterType = getTypeHintNullable(var.dataType);
-                String commentType = getTypeHintNullableForComments(var.dataType);
-                String parameterTypeForGetter = null;
-                String commentTypeForGetter = null;
-
+                var.vendorExtensions.put("x-parameter-type", getTypeHintNullable(var.dataType));
+                var.vendorExtensions.put("x-comment-type", getTypeHintNullableForComments(var.dataType));
                 if (var.isContainer) {
-                    parameterType = getTypeHintNullable(var.dataType + "[]");
-                    commentType = getTypeHintNullableForComments(var.dataType + "[]");
-                } else if (var.defaultValue != null) {
-                    // Make type hint without nullable for var with scalar type
-                    parameterTypeForGetter = getTypeHint(var.dataType);
-                    commentTypeForGetter = getTypeHint(var.dataType);
+                    var.vendorExtensions.put("x-parameter-type", getTypeHintNullable(var.dataType + "[]"));
+                    var.vendorExtensions.put("x-comment-type", getTypeHintNullableForComments(var.dataType + "[]"));
                 }
-
-                var.vendorExtensions.put("x-parameter-type", parameterType);
-                var.vendorExtensions.put("x-parameter-type-for-getter", parameterTypeForGetter != null ? parameterTypeForGetter : parameterType);
-                var.vendorExtensions.put("x-comment-type", commentType);
-                var.vendorExtensions.put("x-comment-type-for-getter", commentTypeForGetter != null ? commentTypeForGetter : commentType);
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -466,12 +466,25 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             if (var.dataType != null) {
                 // Determine if the parameter type is supported as a type hint and make it available
                 // to the templating engine
-                var.vendorExtensions.put("x-parameter-type", getTypeHintNullable(var.dataType));
-                var.vendorExtensions.put("x-comment-type", getTypeHintNullableForComments(var.dataType));
+
+                String parameterType = getTypeHintNullable(var.dataType);
+                String commentType = getTypeHintNullableForComments(var.dataType);
+                String parameterTypeForGetter = null;
+                String commentTypeForGetter = null;
+
                 if (var.isContainer) {
-                    var.vendorExtensions.put("x-parameter-type", getTypeHintNullable(var.dataType + "[]"));
-                    var.vendorExtensions.put("x-comment-type", getTypeHintNullableForComments(var.dataType + "[]"));
+                    parameterType = getTypeHintNullable(var.dataType + "[]");
+                    commentType = getTypeHintNullableForComments(var.dataType + "[]");
+                } else if (var.defaultValue != null) {
+                    // Make type hint without nullable for var with scalar type
+                    parameterTypeForGetter = getTypeHint(var.dataType);
+                    commentTypeForGetter = getTypeHint(var.dataType);
                 }
+
+                var.vendorExtensions.put("x-parameter-type", parameterType);
+                var.vendorExtensions.put("x-parameter-type-for-getter", parameterTypeForGetter != null ? parameterTypeForGetter : parameterType);
+                var.vendorExtensions.put("x-comment-type", commentType);
+                var.vendorExtensions.put("x-comment-type-for-getter", commentTypeForGetter != null ? commentTypeForGetter : commentType);
             }
         }
 
@@ -483,7 +496,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             return dataType;
         }
 
-        return  "\\" + dataType;
+        return "\\" + dataType;
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
@@ -12,20 +12,22 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
         parent::__construct($data);
 
         {{/parentSchema}}
-        {{#vars}}
-        $this->{{name}} = $data['{{name}}'] ?? null;
-        {{/vars}}
+        if (is_array($data)) {
+            {{#vars}}
+            $this->{{name}} = array_key_exists('{{name}}', $data) ? $data['{{name}}'] : $this->{{name}};
+            {{/vars}}
+        }
     }
     {{#vars}}
 
     /**
      * Gets {{name}}.
      *
-     * @return {{{vendorExtensions.x-comment-type-for-getter}}}
+     * @return {{{vendorExtensions.x-comment-type}}}
      */
-    public function {{getter}}(){{#vendorExtensions.x-parameter-type-for-getter}}: {{vendorExtensions.x-parameter-type-for-getter}}{{/vendorExtensions.x-parameter-type-for-getter}}
+    public function {{getter}}(){{#vendorExtensions.x-parameter-type}}: {{vendorExtensions.x-parameter-type}}{{/vendorExtensions.x-parameter-type}}
     {
-        return {{#defaultValue}}$this->{{name}} ?? {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}$this->{{name}}{{/defaultValue}};
+        return $this->{{name}};
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_generic.mustache
@@ -21,11 +21,11 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}} {{/parentSchema}}
     /**
      * Gets {{name}}.
      *
-     * @return {{{vendorExtensions.x-comment-type}}}
+     * @return {{{vendorExtensions.x-comment-type-for-getter}}}
      */
-    public function {{getter}}(){{#vendorExtensions.x-parameter-type}}: {{vendorExtensions.x-parameter-type}}{{/vendorExtensions.x-parameter-type}}
+    public function {{getter}}(){{#vendorExtensions.x-parameter-type-for-getter}}: {{vendorExtensions.x-parameter-type-for-getter}}{{/vendorExtensions.x-parameter-type-for-getter}}
     {
-        return $this->{{name}};
+        return {{#defaultValue}}$this->{{name}} ?? {{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}$this->{{name}}{{/defaultValue}};
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
@@ -98,4 +98,4 @@
     {{/minItems}}
 {{/hasValidation}}
      */
-    protected {{{vendorExtensions.x-parameter-type}}} ${{name}} = null;
+    protected {{{vendorExtensions.x-parameter-type}}} ${{name}} = {{#defaultValue}}{{{defaultValue}}}{{/defaultValue}}{{^defaultValue}}null{{/defaultValue}};

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/ApiResponse.php
@@ -74,9 +74,11 @@ class ApiResponse
      */
     public function __construct(array $data = null)
     {
-        $this->code = $data['code'] ?? null;
-        $this->type = $data['type'] ?? null;
-        $this->message = $data['message'] ?? null;
+        if (is_array($data)) {
+            $this->code = array_key_exists('code', $data) ? $data['code'] : $this->code;
+            $this->type = array_key_exists('type', $data) ? $data['type'] : $this->type;
+            $this->message = array_key_exists('message', $data) ? $data['message'] : $this->message;
+        }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Category.php
@@ -67,8 +67,10 @@ class Category
      */
     public function __construct(array $data = null)
     {
-        $this->id = $data['id'] ?? null;
-        $this->name = $data['name'] ?? null;
+        if (is_array($data)) {
+            $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;
+            $this->name = array_key_exists('name', $data) ? $data['name'] : $this->name;
+        }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -93,7 +93,7 @@ class Order
      * @Assert\Type("bool")
      * @Type("bool")
      */
-    protected ?bool $complete = null;
+    protected ?bool $complete = false;
 
     /**
      * Constructor
@@ -101,12 +101,14 @@ class Order
      */
     public function __construct(array $data = null)
     {
-        $this->id = $data['id'] ?? null;
-        $this->petId = $data['petId'] ?? null;
-        $this->quantity = $data['quantity'] ?? null;
-        $this->shipDate = $data['shipDate'] ?? null;
-        $this->status = $data['status'] ?? null;
-        $this->complete = $data['complete'] ?? null;
+        if (is_array($data)) {
+            $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;
+            $this->petId = array_key_exists('petId', $data) ? $data['petId'] : $this->petId;
+            $this->quantity = array_key_exists('quantity', $data) ? $data['quantity'] : $this->quantity;
+            $this->shipDate = array_key_exists('shipDate', $data) ? $data['shipDate'] : $this->shipDate;
+            $this->status = array_key_exists('status', $data) ? $data['status'] : $this->status;
+            $this->complete = array_key_exists('complete', $data) ? $data['complete'] : $this->complete;
+        }
     }
 
     /**
@@ -232,11 +234,11 @@ class Order
     /**
      * Gets complete.
      *
-     * @return bool
+     * @return bool|null
      */
-    public function isComplete(): bool
+    public function isComplete(): ?bool
     {
-        return $this->complete ?? false;
+        return $this->complete;
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -232,11 +232,11 @@ class Order
     /**
      * Gets complete.
      *
-     * @return bool|null
+     * @return bool
      */
-    public function isComplete(): ?bool
+    public function isComplete(): bool
     {
-        return $this->complete;
+        return $this->complete ?? false;
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -107,12 +107,14 @@ class Pet
      */
     public function __construct(array $data = null)
     {
-        $this->id = $data['id'] ?? null;
-        $this->category = $data['category'] ?? null;
-        $this->name = $data['name'] ?? null;
-        $this->photoUrls = $data['photoUrls'] ?? null;
-        $this->tags = $data['tags'] ?? null;
-        $this->status = $data['status'] ?? null;
+        if (is_array($data)) {
+            $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;
+            $this->category = array_key_exists('category', $data) ? $data['category'] : $this->category;
+            $this->name = array_key_exists('name', $data) ? $data['name'] : $this->name;
+            $this->photoUrls = array_key_exists('photoUrls', $data) ? $data['photoUrls'] : $this->photoUrls;
+            $this->tags = array_key_exists('tags', $data) ? $data['tags'] : $this->tags;
+            $this->status = array_key_exists('status', $data) ? $data['status'] : $this->status;
+        }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Tag.php
@@ -66,8 +66,10 @@ class Tag
      */
     public function __construct(array $data = null)
     {
-        $this->id = $data['id'] ?? null;
-        $this->name = $data['name'] ?? null;
+        if (is_array($data)) {
+            $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;
+            $this->name = array_key_exists('name', $data) ? $data['name'] : $this->name;
+        }
     }
 
     /**

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/User.php
@@ -116,14 +116,16 @@ class User
      */
     public function __construct(array $data = null)
     {
-        $this->id = $data['id'] ?? null;
-        $this->username = $data['username'] ?? null;
-        $this->firstName = $data['firstName'] ?? null;
-        $this->lastName = $data['lastName'] ?? null;
-        $this->email = $data['email'] ?? null;
-        $this->password = $data['password'] ?? null;
-        $this->phone = $data['phone'] ?? null;
-        $this->userStatus = $data['userStatus'] ?? null;
+        if (is_array($data)) {
+            $this->id = array_key_exists('id', $data) ? $data['id'] : $this->id;
+            $this->username = array_key_exists('username', $data) ? $data['username'] : $this->username;
+            $this->firstName = array_key_exists('firstName', $data) ? $data['firstName'] : $this->firstName;
+            $this->lastName = array_key_exists('lastName', $data) ? $data['lastName'] : $this->lastName;
+            $this->email = array_key_exists('email', $data) ? $data['email'] : $this->email;
+            $this->password = array_key_exists('password', $data) ? $data['password'] : $this->password;
+            $this->phone = array_key_exists('phone', $data) ? $data['phone'] : $this->phone;
+            $this->userStatus = array_key_exists('userStatus', $data) ? $data['userStatus'] : $this->userStatus;
+        }
     }
 
     /**


### PR DESCRIPTION
After PR https://github.com/OpenAPITools/openapi-generator/pull/12532 in php-symfony model does not exist default values from OpenApi specification. This commit add support for default scalar value of properties in php-symfony model. Default values now returns in getter-functions, and return type in getter function changed to not nullable/

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)