### PR TITLE
kotlin-server: fix mainClassName

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/ktor/build.gradle.mustache
@@ -27,7 +27,7 @@ apply plugin: "java"
 apply plugin: "kotlin"
 apply plugin: "application"
 
-mainClassName = "io.ktor.server.netty.DevelopmentEngine"
+mainClassName = "io.ktor.server.netty.EngineMain"
 
 // Initialization order with shadow 2.0.1 and Gradle 6.9 is weird.
 // See https://github.com/johnrengelman/shadow/issues/336#issuecomment-355402508

--- a/samples/server/petstore/kotlin-server/ktor/build.gradle
+++ b/samples/server/petstore/kotlin-server/ktor/build.gradle
@@ -25,7 +25,7 @@ apply plugin: "java"
 apply plugin: "kotlin"
 apply plugin: "application"
 
-mainClassName = "io.ktor.server.netty.DevelopmentEngine"
+mainClassName = "io.ktor.server.netty.EngineMain"
 
 // Initialization order with shadow 2.0.1 and Gradle 6.9 is weird.
 // See https://github.com/johnrengelman/shadow/issues/336#issuecomment-355402508


### PR DESCRIPTION
The mainClassName in build.gradle is the wrong one for the provided ktor server version.

https://github.com/ktorio/ktor/issues/386

This causes the generated petstore sample server to not run properly with the following command:

$ java -jar build/libs/kotlin-server.jar

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
