### PR TITLE
[Go] Adding response middleware

### DIFF
--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -22,15 +22,14 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |enumClassPrefix|Prefix enum with class name| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
-|isGoSubmodule|Whether the generated Go module is a submodule| |false|
+|isGoSubmodule|whether the generated Go module is a submodule| |false|
 |packageName|Go package name (convention: lowercase).| |openapi|
 |packageVersion|Go package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|structPrefix|Whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
+|structPrefix|whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.| |false|
-|withAWSV4Signature|Whether to include AWS v4 signature support| |false|
-|withCustomMiddlewareFunction|Whether to include hooks for custom middlewares before the request is sent and after the response is received.| |false|
-|withXml|Whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
+|withAWSV4Signature|whether to include AWS v4 signature support| |false|
+|withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING
 

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -22,14 +22,15 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |enumClassPrefix|Prefix enum with class name| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
-|isGoSubmodule|whether the generated Go module is a submodule| |false|
+|isGoSubmodule|Whether the generated Go module is a submodule| |false|
 |packageName|Go package name (convention: lowercase).| |openapi|
 |packageVersion|Go package version.| |1.0.0|
 |prependFormOrBodyParameters|Add form or body parameters to the beginning of the parameter list.| |false|
-|structPrefix|whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
+|structPrefix|Whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.| |false|
-|withAWSV4Signature|whether to include AWS v4 signature support| |false|
-|withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
+|withAWSV4Signature|Whether to include AWS v4 signature support| |false|
+|withCustomMiddlewareFunction|Whether to include hooks for custom middlewares before the request is sent and after the response is received.| |false|
+|withXml|Whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -351,8 +351,8 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
-{{#withCustomMiddlewareFunction}}
 
+{{#withCustomMiddlewareFunction}}
 	if a.client.cfg.ResponseMiddleware != nil {
 		err = a.client.cfg.ResponseMiddleware(localVarHTTPResponse, localVarBody)
 		if err != nil {

--- a/modules/openapi-generator/src/main/resources/go/api.mustache
+++ b/modules/openapi-generator/src/main/resources/go/api.mustache
@@ -351,7 +351,16 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
+{{#withCustomMiddlewareFunction}}
 
+	if a.client.cfg.ResponseMiddleware != nil {
+		err = a.client.cfg.ResponseMiddleware(localVarHTTPResponse, localVarBody)
+		if err != nil {
+			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+		}
+	}
+
+{{/withCustomMiddlewareFunction}}
 	if localVarHTTPResponse.StatusCode >= 300 {
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,

--- a/modules/openapi-generator/src/main/resources/go/client.mustache
+++ b/modules/openapi-generator/src/main/resources/go/client.mustache
@@ -487,6 +487,13 @@ func (c *APIClient) prepareRequest(
 		c.cfg.Middleware(localVarRequest)
 	}
 
+	if c.cfg.MiddlewareWithError != nil {
+		err = c.cfg.MiddlewareWithError(localVarRequest)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 {{/withCustomMiddlewareFunction}}
 {{#hasHttpSignatureMethods}}
 	if ctx != nil {

--- a/modules/openapi-generator/src/main/resources/go/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/go/configuration.mustache
@@ -104,8 +104,14 @@ type ServerConfiguration struct {
 type ServerConfigurations []ServerConfiguration
 
 {{#withCustomMiddlewareFunction}}
-// MiddlewareFunction provides way to implement custom middleware
+// MiddlewareFunction provides way to implement custom middleware in the prepareRequest
 type MiddlewareFunction func(*http.Request)
+
+// MiddlewareFunctionWithError provides way to implement custom middleware with errors in the prepareRequest
+type MiddlewareFunctionWithError func(*http.Request) error
+
+// ResponseMiddlewareFunction provides way to implement custom middleware with errors after the response is received
+type ResponseMiddlewareFunction func(*http.Response, []byte) error
 
 {{/withCustomMiddlewareFunction}}
 // Configuration stores the configuration of the API client
@@ -119,7 +125,9 @@ type Configuration struct {
 	OperationServers map[string]ServerConfigurations
 	HTTPClient       *http.Client
 	{{#withCustomMiddlewareFunction}}
-	Middleware       MiddlewareFunction
+	Middleware          MiddlewareFunction
+	MiddlewareWithError MiddlewareFunctionWithError
+	ResponseMiddleware  ResponseMiddlewareFunction
 	{{/withCustomMiddlewareFunction}}
 }
 


### PR DESCRIPTION
Add optional response middleware to go template.
Adds a second request middleware which can return an error (did not modify the existing request middleware to avoid any breaking changes).

Fixes #16471 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @lwj5 @ph4r5h4d @jirikuncar @kemokemo @grokify @antihax 
