### PR TITLE
python: run the Python samples tests with GitHub Actions

### DIFF
--- a/.github/workflows/samples-python-nextgen-client-echo-api.yaml
+++ b/.github/workflows/samples-python-nextgen-client-echo-api.yaml
@@ -1,12 +1,11 @@
 name: Python Client (Echo API)
 
 on:
-  push:
-    paths:
-      - samples/client/echo_api/python/**
   pull_request:
     paths:
       - samples/client/echo_api/python/**
+      - .github/workflows/samples-python-nextgen-client-echo-api.yaml
+
 jobs:
   build:
     name: Test Python client
@@ -17,11 +16,17 @@ jobs:
         sample:
           # clients
           - samples/client/echo_api/python
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          #- "3.11"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: ${{ matrix.python-version }}
       - name: Setup node.js
         uses: actions/setup-node@v3
       - name: Run echo server
@@ -33,6 +38,7 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r test-requirements.txt
+
       - name: Test
         working-directory: ${{ matrix.sample }}
         run: python -m pytest

--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -1,0 +1,59 @@
+name: "Python Client: Petstore"
+
+on:
+  pull_request:
+    paths:
+      - samples/openapi3/client/petstore/python-aiohttp/**
+      - samples/openapi3/client/petstore/python/**
+      - .github/workflows/samples-python-petstore.yaml
+
+jobs:
+  build:
+    name: Test Python client
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          #- "3.11"
+        sample:
+          - samples/openapi3/client/petstore/python-aiohttp
+          - samples/openapi3/client/petstore/python
+    services:
+      petstore-api:
+        image: swaggerapi/petstore
+        ports:
+          - 80:8080
+        env:
+          SWAGGER_HOST: http://petstore.swagger.io
+          SWAGGER_BASE_PATH: /v2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        id: py
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-python-${{ steps.py.outputs.python-version }}-
+          path: |
+            ~/.cache/pypoetry/virtualenvs/
+            ~/.local/pipx/venvs/poetry/
+            .mypy_cache/
+
+      - name: Install poetry
+        run: pipx install --python '${{ steps.py.outputs.python-path }}' poetry
+
+      - name: Install
+        working-directory: ${{ matrix.sample }}
+        run: poetry install
+
+      - name: Test
+        working-directory: ${{ matrix.sample }}
+        run: poetry run pytest -v

--- a/samples/openapi3/client/petstore/python/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_client.py
@@ -19,7 +19,7 @@ from dateutil.parser import parse
 import petstore_api
 import petstore_api.configuration
 
-HOST = 'http://petstore.swagger.io/v2'
+HOST = 'http://localhost/v2'
 
 
 class ApiClientTests(unittest.TestCase):

--- a/samples/openapi3/client/petstore/python/tests/test_pet_api.py
+++ b/samples/openapi3/client/petstore/python/tests/test_pet_api.py
@@ -24,7 +24,7 @@ import json
 
 import urllib3
 
-HOST = 'http://petstore.swagger.io/v2'
+HOST = 'http://localhost/v2'
 
 
 class TimeoutWithEqual(urllib3.Timeout):


### PR DESCRIPTION
This runs more Python tests through GitHub Actions, with multiple code base and multiple Python versions.

I used this a lot to test my change in https://github.com/OpenAPITools/openapi-generator/pull/16624, which is difficult to fully assess if nothing exercises the generated Python code.

@krjakbrjak as Python tech-comittee
@wing328 as the previous editor on the `echo_client` sample + GitHub Action workflow

See: https://github.com/OpenAPITools/openapi-generator/pull/16643

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
