### PR TITLE
python: runs GitHub Actions with Python 3.11

### DIFF
--- a/.github/workflows/samples-python-nextgen-client-echo-api.yaml
+++ b/.github/workflows/samples-python-nextgen-client-echo-api.yaml
@@ -21,7 +21,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          #- "3.11"
+          - "3.11"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -19,7 +19,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          #- "3.11"
+          - "3.11"
         sample:
           - samples/openapi3/client/petstore/python-aiohttp
           - samples/openapi3/client/petstore/python

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_api.py
@@ -70,12 +70,17 @@ class TestPetApiTests(unittest.TestCase):
     async def test_async_with_result(self):
         await self.pet_api.add_pet(self.pet)
 
-        calls = [self.pet_api.get_pet_by_id(self.pet.id),
-                 self.pet_api.get_pet_by_id(self.pet.id)]
+        tasks = [
+            asyncio.create_task(coro)
+            for coro in [
+                self.pet_api.get_pet_by_id(self.pet.id),
+                self.pet_api.get_pet_by_id(self.pet.id),
+            ]
+        ]
 
-        responses, _ = await asyncio.wait(calls)
+        responses = await asyncio.gather(*tasks)
         for response in responses:
-            self.assertEqual(response.result().id, self.pet.id)
+            self.assertEqual(response.id, self.pet.id)
         self.assertEqual(len(responses), 2)
 
     @async_test


### PR DESCRIPTION
Follow-up to https://github.com/OpenAPITools/openapi-generator/pull/16643, but with Python 3.11 enabled.

In Python 3.11, [`asyncio.wait()` can't be used on coroutines alone](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait):

![image](https://github.com/OpenAPITools/openapi-generator/assets/65311/fcd7fe1b-73ac-4203-8478-1a586c574631)

@krjakbrjak as Python tech-comittee
@wing328 as the merger for the parent PR #16643

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
