### PR TITLE
[php-nextgen] Fix default value for array of items

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -50,6 +50,7 @@ import org.openapitools.codegen.CodegenDiscriminator.MappedModel;
 import org.openapitools.codegen.api.TemplatingEngineAdapter;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.examples.ExampleGenerator;
+import org.openapitools.codegen.languages.PhpNextgenClientCodegen;
 import org.openapitools.codegen.languages.RustServerCodegen;
 import org.openapitools.codegen.meta.FeatureSet;
 import org.openapitools.codegen.meta.GeneratorMetadata;
@@ -7083,8 +7084,12 @@ public class DefaultCodegen implements CodegenConfig {
             // hoist items data into the array property
             // TODO this hoisting code is generator specific and should be isolated into updateFormPropertyForArray
             codegenParameter.baseType = arrayInnerProperty.dataType;
-            // no need to set default value here as it was set earlier
-            //codegenParameter.defaultValue = arrayInnerProperty.getDefaultValue();
+            // TODO we need to fix array of item (with default value) generator by generator
+            // https://github.com/OpenAPITools/openapi-generator/pull/16654/ is a good reference
+            if (!(this instanceof PhpNextgenClientCodegen)) {
+                // no need to set default value here as it was set earlier
+                codegenParameter.defaultValue = arrayInnerProperty.getDefaultValue();
+            }
             if (codegenParameter.items.isFile) {
                 codegenParameter.isFile = true;
                 codegenParameter.dataFormat = codegenParameter.items.dataFormat;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -7083,7 +7083,8 @@ public class DefaultCodegen implements CodegenConfig {
             // hoist items data into the array property
             // TODO this hoisting code is generator specific and should be isolated into updateFormPropertyForArray
             codegenParameter.baseType = arrayInnerProperty.dataType;
-            codegenParameter.defaultValue = arrayInnerProperty.getDefaultValue();
+            // no need to set default value here as it was set earlier
+            //codegenParameter.defaultValue = arrayInnerProperty.getDefaultValue();
             if (codegenParameter.items.isFile) {
                 codegenParameter.isFile = true;
                 codegenParameter.dataFormat = codegenParameter.items.dataFormat;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpNextgenClientCodegen.java
@@ -144,8 +144,7 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
             for (CodegenProperty prop : model.vars) {
                 if (prop.isArray || prop.isMap) {
                     prop.vendorExtensions.putIfAbsent("x-php-prop-type", "array");
-                }
-                else {
+                } else {
                     prop.vendorExtensions.putIfAbsent("x-php-prop-type", prop.dataType);
                 }
             }
@@ -170,16 +169,14 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
         for (CodegenOperation operation : operations.getOperation()) {
             if (operation.returnType == null) {
                 operation.vendorExtensions.putIfAbsent("x-php-return-type", "void");
-            }
-            else {
+            } else {
                 operation.vendorExtensions.putIfAbsent("x-php-return-type", operation.returnType);
             }
 
             for (CodegenParameter param : operation.allParams) {
                 if (param.isArray || param.isMap) {
                     param.vendorExtensions.putIfAbsent("x-php-param-type", "array");
-                }
-                else {
+                } else {
                     param.vendorExtensions.putIfAbsent("x-php-param-type", param.dataType);
                 }
             }
@@ -191,12 +188,28 @@ public class PhpNextgenClientCodegen extends AbstractPhpCodegen {
     @Override
     public String toDefaultValue(CodegenProperty codegenProperty, Schema schema) {
         if (codegenProperty.isArray) {
-            if (schema.getDefault() != null) {
+            if (schema.getDefault() != null) { // array schema has default value
                 return "[" + schema.getDefault().toString() + "]";
+            } else if (schema.getItems().getDefault() != null) { // array item schema has default value
+                return "[" + toDefaultValue(schema.getItems()) + "]";
             } else {
                 return null;
             }
         }
         return super.toDefaultValue(codegenProperty, schema);
+    }
+
+    @Override
+    public String toDefaultParameterValue(CodegenProperty codegenProperty, Schema<?> schema) {
+        return toDefaultValue(codegenProperty, schema);
+    }
+
+    @Override
+    public void setParameterExampleValue(CodegenParameter p) {
+        if (p.isArray && p.items.defaultValue != null) {
+            p.example = p.defaultValue;
+        } else {
+            super.setParameterExampleValue(p);
+        }
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/FakeApi.md
@@ -800,14 +800,14 @@ $apiInstance = new OpenAPI\Client\Api\FakeApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
-$enum_header_string_array = array('enum_header_string_array_example'); // string[] | Header parameter enum test (string array)
+$enum_header_string_array = ['$']; // string[] | Header parameter enum test (string array)
 $enum_header_string = '-efg'; // string | Header parameter enum test (string)
-$enum_query_string_array = array('enum_query_string_array_example'); // string[] | Query parameter enum test (string array)
+$enum_query_string_array = ['$']; // string[] | Query parameter enum test (string array)
 $enum_query_string = '-efg'; // string | Query parameter enum test (string)
 $enum_query_integer = 56; // int | Query parameter enum test (double)
 $enum_query_double = 3.4; // float | Query parameter enum test (double)
 $enum_query_model_array = array(new \OpenAPI\Client\Model\\OpenAPI\Client\Model\EnumClass()); // \OpenAPI\Client\Model\EnumClass[]
-$enum_form_string_array = array('$'); // string[] | Form parameter enum test (string array)
+$enum_form_string_array = ['$']; // string[] | Form parameter enum test (string array)
 $enum_form_string = '-efg'; // string | Form parameter enum test (string)
 
 try {
@@ -821,14 +821,14 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **enum_header_string_array** | [**string[]**](../Model/string.md)| Header parameter enum test (string array) | [optional] |
+| **enum_header_string_array** | [**string[]**](../Model/string.md)| Header parameter enum test (string array) | [optional] [default to [&#39;$&#39;]] |
 | **enum_header_string** | **string**| Header parameter enum test (string) | [optional] [default to &#39;-efg&#39;] |
-| **enum_query_string_array** | [**string[]**](../Model/string.md)| Query parameter enum test (string array) | [optional] |
+| **enum_query_string_array** | [**string[]**](../Model/string.md)| Query parameter enum test (string array) | [optional] [default to [&#39;$&#39;]] |
 | **enum_query_string** | **string**| Query parameter enum test (string) | [optional] [default to &#39;-efg&#39;] |
 | **enum_query_integer** | **int**| Query parameter enum test (double) | [optional] |
 | **enum_query_double** | **float**| Query parameter enum test (double) | [optional] |
 | **enum_query_model_array** | [**\OpenAPI\Client\Model\EnumClass[]**](../Model/\OpenAPI\Client\Model\EnumClass.md)|  | [optional] |
-| **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional] [default to &#39;$&#39;] |
+| **enum_form_string_array** | [**string[]**](../Model/string.md)| Form parameter enum test (string array) | [optional] [default to [&#39;$&#39;]] |
 | **enum_form_string** | **string**| Form parameter enum test (string) | [optional] [default to &#39;-efg&#39;] |
 
 ### Return type

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/PetApi.md
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/docs/Api/PetApi.md
@@ -185,7 +185,7 @@ $apiInstance = new OpenAPI\Client\Api\PetApi(
     new GuzzleHttp\Client(),
     $config
 );
-$status = array('status_example'); // string[] | Status values that need to be considered for filter
+$status = ['available']; // string[] | Status values that need to be considered for filter
 
 try {
     $result = $apiInstance->findPetsByStatus($status);
@@ -199,7 +199,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
-| **status** | [**string[]**](../Model/string.md)| Status values that need to be considered for filter | |
+| **status** | [**string[]**](../Model/string.md)| Status values that need to be considered for filter | [default to [&#39;available&#39;]] |
 
 ### Return type
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -3956,14 +3956,14 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
      * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array enum_query_model_array (optional)
-     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
@@ -3972,14 +3972,14 @@ class FakeApi
      * @return void
      */
     public function testEnumParameters(
-        ?array $enum_header_string_array = null,
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = null,
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
         ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = '$',
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): void
@@ -3992,14 +3992,14 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
      * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
-     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
@@ -4008,14 +4008,14 @@ class FakeApi
      * @return array of null, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEnumParametersWithHttpInfo(
-        ?array $enum_header_string_array = null,
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = null,
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
         ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = '$',
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): array
@@ -4071,14 +4071,14 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
      * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
-     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
@@ -4086,14 +4086,14 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsync(
-        ?array $enum_header_string_array = null,
+        ?array $enum_header_string_array = ['$'],
         ?string $enum_header_string = '-efg',
-        ?array $enum_query_string_array = null,
+        ?array $enum_query_string_array = ['$'],
         ?string $enum_query_string = '-efg',
         ?int $enum_query_integer = null,
         ?float $enum_query_double = null,
         ?array $enum_query_model_array = null,
-        ?array $enum_form_string_array = '$',
+        ?array $enum_form_string_array = ['$'],
         ?string $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
@@ -4111,14 +4111,14 @@ class FakeApi
      *
      * To test enum parameters
      *
-     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
      * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
-     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
@@ -4126,14 +4126,14 @@ class FakeApi
      * @return PromiseInterface
      */
     public function testEnumParametersAsyncWithHttpInfo(
-        $enum_header_string_array = null,
+        $enum_header_string_array = ['$'],
         $enum_header_string = '-efg',
-        $enum_query_string_array = null,
+        $enum_query_string_array = ['$'],
         $enum_query_string = '-efg',
         $enum_query_integer = null,
         $enum_query_double = null,
         $enum_query_model_array = null,
-        $enum_form_string_array = '$',
+        $enum_form_string_array = ['$'],
         $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): PromiseInterface
@@ -4167,14 +4167,14 @@ class FakeApi
     /**
      * Create request for operation 'testEnumParameters'
      *
-     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_header_string_array Header parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_header_string Header parameter enum test (string) (optional, default to '-efg')
-     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional)
+     * @param  string[]|null $enum_query_string_array Query parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_query_string Query parameter enum test (string) (optional, default to '-efg')
      * @param  int|null $enum_query_integer Query parameter enum test (double) (optional)
      * @param  float|null $enum_query_double Query parameter enum test (double) (optional)
      * @param  \OpenAPI\Client\Model\EnumClass[]|null $enum_query_model_array (optional)
-     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to '$')
+     * @param  string[]|null $enum_form_string_array Form parameter enum test (string array) (optional, default to ['$'])
      * @param  string|null $enum_form_string Form parameter enum test (string) (optional, default to '-efg')
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumParameters'] to see the possible values for this operation
      *
@@ -4182,14 +4182,14 @@ class FakeApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumParametersRequest(
-        $enum_header_string_array = null,
+        $enum_header_string_array = ['$'],
         $enum_header_string = '-efg',
-        $enum_query_string_array = null,
+        $enum_query_string_array = ['$'],
         $enum_query_string = '-efg',
         $enum_query_integer = null,
         $enum_query_double = null,
         $enum_query_model_array = null,
-        $enum_form_string_array = '$',
+        $enum_form_string_array = ['$'],
         $enum_form_string = '-efg',
         string $contentType = self::contentTypes['testEnumParameters'][0]
     ): Request


### PR DESCRIPTION
- Fix form parameter default value
- A follow-up PR to fix php-nextgen parameter default value (array): https://github.com/OpenAPITools/openapi-generator/pull/16572

A follow-up PR to https://github.com/OpenAPITools/openapi-generator/pull/16572

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
