### PR TITLE
[csharp] Fix Issue #16660 System.NotImplementedException in ApiClient.cs with OAuth2

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/ApiClient.mustache
@@ -454,25 +454,25 @@ namespace {{packageName}}.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            {{#hasOAuthMethods}}
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
+            {{/hasOAuthMethods}}
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                {{#hasOAuthMethods}}
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
-                {{/hasOAuthMethods}}
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -567,25 +567,25 @@ namespace {{packageName}}.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            {{#hasOAuthMethods}}
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
+            {{/hasOAuthMethods}}
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                {{#hasOAuthMethods}}
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
-                {{/hasOAuthMethods}}
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -454,23 +454,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -564,23 +564,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,23 +455,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -565,23 +565,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,23 +455,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -565,23 +565,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,23 +455,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -565,23 +565,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -454,23 +454,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -564,23 +564,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -455,23 +455,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -565,23 +565,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ApiClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Client/ApiClient.cs
@@ -454,23 +454,23 @@ namespace Org.OpenAPITools.Client
                 RemoteCertificateValidationCallback = configuration.RemoteCertificateValidationCallback
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;
@@ -564,23 +564,23 @@ namespace Org.OpenAPITools.Client
                 UseDefaultCredentials = configuration.UseDefaultCredentials
             };
 
+            if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientId) &&
+                !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
+                configuration.OAuthFlow != null)
+            {
+                clientOptions.Authenticator = new OAuthAuthenticator(
+                    configuration.OAuthTokenUrl,
+                    configuration.OAuthClientId,
+                    configuration.OAuthClientSecret,
+                    configuration.OAuthFlow,
+                    SerializerSettings,
+                    configuration);
+            }
+
             using (RestClient client = new RestClient(clientOptions,
                 configureSerialization: serializerConfig => serializerConfig.UseSerializer(() => new CustomJsonCodec(SerializerSettings, configuration))))
             {
-                if (!string.IsNullOrEmpty(configuration.OAuthTokenUrl) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientId) &&
-                    !string.IsNullOrEmpty(configuration.OAuthClientSecret) &&
-                    configuration.OAuthFlow != null)
-                {
-                    client.UseAuthenticator(new OAuthAuthenticator(
-                        configuration.OAuthTokenUrl,
-                        configuration.OAuthClientId,
-                        configuration.OAuthClientSecret,
-                        configuration.OAuthFlow,
-                        SerializerSettings,
-                        configuration));
-                }
-
                 InterceptRequest(request);
 
                 RestResponse<T> response;


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Given a csharp client is generated for an API that is secured using OAuth2 
When the client is used to call any secured operation 
Then an exception occurs as follows;

```
Unhandled Exception: System.NotImplementedException: Set the RestClientOptions.Authenticator property instead
   at RestSharp.RestClientExtensions.UseAuthenticator(RestClient client, IAuthenticator authenticator)
   at MyProj.OAuthService.Client.ApiClient.Exec[T](RestRequest request, RequestOptions options, IReadableConfiguration configuration) in C:\Source\OAuthSolution\src\MyProj.OAuthService\Client\ApiClient.cs:line 466
   at MyProj.OAuthService.Client.ApiClient.Get[T](String path, RequestOptions options, IReadableConfiguration configuration) in C:\Source\OAuthSolution\src\MyProj.OAuthService\Client\ApiClient.cs:line 773
   at MyProj.OAuthService.Api.UsersApi.ListUsersWithHttpInfo(String organizationRef, String search, String userName, String email, String firstName, String lastName, Nullable`1 enabled, Nullable`1 requireEmailVerification, Nullable`1 requireMFA, Nullable`1 requirePasswordReset, Nullable`1 limit, String cursor, Int32 operationIndex) in C:\Source\OAuthSolution\src\MyProj.OAuthService\Api\UsersApi.cs:line 2681
   at MyProj.OAuthService.Api.UsersApi.ListUsers(String organizationRef, String search, String userName, String email, String firstName, String lastName, Nullable`1 enabled, Nullable`1 requireEmailVerification, Nullable`1 requireMFA, Nullable`1 requirePasswordReset, Nullable`1 limit, String cursor, Int32 operationIndex) in C:\Source\OAuthSolution\src\MyProj.OAuthService\Api\UsersApi.cs:line 2560
   at IdentityService.Console.NETFW.DisableUser.Main(String[] args) in C:\Source\OAuthSolution\src\MyProj.OAuthConsole\DisableUser.cs:line 28
``` 

This is happening due to a change in the RestSharp API between v108 and v110 whereby the authenticator must be set as a property of the RestClientOptions class rather than the RestClient class.

This change moves the block of code used to instantiate the OAuthAuthenticator outside the scope of the RestClient and instead sets it as the Authenticator property of the RestClientOptions object.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)
