### PR TITLE
issue #16304: add restTemplateLoggingLevel option

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaClientCodegen.java
@@ -103,6 +103,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
 
     public static final String GENERATE_CLIENT_AS_BEAN = "generateClientAsBean";
 
+    public static final String REST_TEMPLATE_LOGGING_LEVEL = "restTemplateLoggingLevel";
+
     protected String gradleWrapperPackage = "gradle.wrapper";
     protected boolean useRxJava = false;
     protected boolean useRxJava2 = false;
@@ -138,6 +140,8 @@ public class JavaClientCodegen extends AbstractJavaCodegen
     protected boolean webclientBlockingOperations = false;
     protected boolean generateClientAsBean = false;
     protected boolean useEnumCaseInsensitive = false;
+    protected String restTemplateLoggingLevel = "debug";
+    protected Set<String> allowedLoggingLevels;
 
     private static class MpRestClientVersion {
         public final String rootPackage;
@@ -257,6 +261,11 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         serializationOptions.put(SERIALIZATION_LIBRARY_JSONB, "Use JSON-B as serialization library");
         serializationLibrary.setEnum(serializationOptions);
         cliOptions.add(serializationLibrary);
+        allowedLoggingLevels = new HashSet<>() {{
+            add("debug");
+            add("info");
+            add("trace");
+        }};
 
         // Ensure the OAS 3.x discriminator mappings include any descendent schemas that allOf
         // inherit from self, any oneOf schemas, any anyOf schemas, any x-discriminator-values,
@@ -447,6 +456,11 @@ public class JavaClientCodegen extends AbstractJavaCodegen
         if (additionalProperties.containsKey(WEBCLIENT_BLOCKING_OPERATIONS)) {
             this.webclientBlockingOperations = Boolean.parseBoolean(additionalProperties.get(WEBCLIENT_BLOCKING_OPERATIONS).toString());
         }
+
+        if (additionalProperties.containsKey(REST_TEMPLATE_LOGGING_LEVEL)) {
+            this.setRestTemplateLoggingLevel(additionalProperties.get(REST_TEMPLATE_LOGGING_LEVEL).toString());
+        }
+        additionalProperties.put(REST_TEMPLATE_LOGGING_LEVEL, restTemplateLoggingLevel);
 
         // add URL query deepObject support to native, apache-httpclient by default
         if (!additionalProperties.containsKey(SUPPORT_URL_QUERY)) {
@@ -1258,6 +1272,15 @@ public class JavaClientCodegen extends AbstractJavaCodegen
             this.serializationLibrary = SERIALIZATION_LIBRARY_JSONB;
         } else {
             throw new IllegalArgumentException("Unexpected serializationLibrary value: " + serializationLibrary);
+        }
+    }
+
+    public void setRestTemplateLoggingLevel(String restTemplateLoggingLevel) {
+        String loggingLevel = restTemplateLoggingLevel.toLowerCase();
+        if (allowedLoggingLevels.contains(loggingLevel)) {
+            this.restTemplateLoggingLevel = restTemplateLoggingLevel;
+        } else {
+            throw new IllegalArgumentException("Unexpected restTemplateLoggingLevel value: " + loggingLevel);
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -832,17 +832,17 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.{{restTemplateLoggingLevel}}("URI: " + request.getURI());
+            log.{{restTemplateLoggingLevel}}("HTTP Method: " + request.getMethod());
+            log.{{restTemplateLoggingLevel}}("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.{{restTemplateLoggingLevel}}("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.{{restTemplateLoggingLevel}}("HTTP Status Code: " + response.getRawStatusCode());
+            log.{{restTemplateLoggingLevel}}("Status Text: " + response.getStatusText());
+            log.{{restTemplateLoggingLevel}}("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.{{restTemplateLoggingLevel}}("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.openapitools.codegen.TestUtils.assertFileContains;
 import static org.openapitools.codegen.TestUtils.assertFileNotContains;
 import static org.openapitools.codegen.TestUtils.validateJavaSourceFiles;
+import static org.openapitools.codegen.languages.JavaClientCodegen.REST_TEMPLATE_LOGGING_LEVEL;
 import static org.openapitools.codegen.languages.JavaClientCodegen.USE_ENUM_CASE_INSENSITIVE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -1887,6 +1888,32 @@ public class JavaClientCodegenTest {
         "ResponseEntity<org.springframework.core.io.Resource> resourceInResponseWithHttpInfo()",
         "ParameterizedTypeReference<org.springframework.core.io.Resource> localReturnType = new"
             + " ParameterizedTypeReference<org.springframework.core.io.Resource>()");
+    }
+
+    @Test
+    public void testRestTemplateNotDefaultLoggingLevel() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.USE_ABSTRACTION_FOR_FILES, true);
+        properties.put(JavaClientCodegen.REST_TEMPLATE_LOGGING_LEVEL, "info");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/issue13146_file_abstraction_response.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
     }
 
     public void testExtraAnnotations(String library) throws IOException {

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -681,17 +681,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -730,17 +730,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -730,17 +730,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -730,17 +730,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -801,17 +801,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -788,17 +788,17 @@ public class ApiClient extends JavaTimeFormatter {
         }
 
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
-            log.info("URI: " + request.getURI());
-            log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
-            log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
+            log.debug("URI: " + request.getURI());
+            log.debug("HTTP Method: " + request.getMethod());
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 
         private void logResponse(ClientHttpResponse response) throws IOException {
-            log.info("HTTP Status Code: " + response.getRawStatusCode());
-            log.info("Status Text: " + response.getStatusText());
-            log.info("HTTP Headers: " + headersToString(response.getHeaders()));
-            log.info("Response Body: " + bodyToString(response.getBody()));
+            log.debug("HTTP Status Code: " + response.getRawStatusCode());
+            log.debug("Status Text: " + response.getStatusText());
+            log.debug("HTTP Headers: " + headersToString(response.getHeaders()));
+            log.debug("Response Body: " + bodyToString(response.getBody()));
         }
 
         private String headersToString(HttpHeaders headers) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@martin-mfg Hi! I added a 'restTemplateLoggingLevel' additional option so that logging level is configurable as per the issue #16304 request. Added only 'debug', 'info', 'trace' as options for now as well as validation for the input string.