### PR TITLE
python: Remove usage of six

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/controllers/controller.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/controllers/controller.mustache
@@ -1,5 +1,4 @@
 import connexion
-import six
 
 {{#imports}}{{import}}  # noqa: E501
 {{/imports}}
@@ -94,15 +93,15 @@ def {{operationId}}({{#allParams}}{{paramName}}{{^required}}=None{{/required}}{{
             {{#items}}
                 {{#isDate}}
     if connexion.request.is_json:
-        {{paramName}} = {k: util.deserialize_date(v) for k, v in six.iteritems(connexion.request.get_json())}  # noqa: E501
+        {{paramName}} = {k: util.deserialize_date(v) for k, v in connexion.request.get_json().items()}  # noqa: E501
                 {{/isDate}}
                 {{#isDateTime}}
     if connexion.request.is_json:
-        {{paramName}} = {k: util.deserialize_datetime(v) for k, v in six.iteritems(connexion.request.get_json())}  # noqa: E501
+        {{paramName}} = {k: util.deserialize_datetime(v) for k, v in connexion.request.get_json().items()}  # noqa: E501
                 {{/isDateTime}}
                 {{#complexType}}
     if connexion.request.is_json:
-        {{paramName}} = {k: {{baseType}}.from_dict(v) for k, v in six.iteritems(connexion.request.get_json())}  # noqa: E501
+        {{paramName}} = {k: {{baseType}}.from_dict(v) for k, v in connexion.request.get_json().items()}  # noqa: E501
                 {{/complexType}}
             {{/items}}
         {{/isMap}}

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/encoder.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/encoder.mustache
@@ -1,5 +1,4 @@
 from connexion.apps.flask_app import FlaskJSONEncoder
-import six
 
 from {{modelPackage}}.base_model import Model
 
@@ -10,7 +9,7 @@ class JSONEncoder(FlaskJSONEncoder):
     def default(self, o):
         if isinstance(o, Model):
             dikt = {}
-            for attr, _ in six.iteritems(o.swagger_types):
+            for attr in o.swagger_types:
                 value = getattr(o, attr)
                 if value is None and not self.include_nulls:
                     continue

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/models/base_model.mustache
@@ -1,6 +1,5 @@
 import pprint
 
-import six
 import typing
 
 from {{packageName}} import util
@@ -29,7 +28,7 @@ class Model(object):
         """
         result = {}
 
-        for attr, _ in six.iteritems(self.swagger_types):
+        for attr in self.swagger_types:
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/test/controller_test.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/test/controller_test.mustache
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 {{#imports}}{{import}}  # noqa: E501
 {{/imports}}

--- a/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
+++ b/modules/openapi-generator/src/main/resources/python-blueplanet/app/{{packageName}}/util.mustache
@@ -1,6 +1,5 @@
 import datetime
 
-import six
 import typing
 from {{packageName}} import typing_utils
 
@@ -16,7 +15,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass == int or klass in (float, str, bool):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)
@@ -45,7 +44,7 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = six.u(data)
+        value = str(data)
     except TypeError:
         value = data
     return value
@@ -104,7 +103,7 @@ def deserialize_model(data, klass):
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.swagger_types):
+    for attr, attr_type in instance.swagger_types.items():
         if data is not None \
                 and instance.attribute_map[attr] in data \
                 and isinstance(data, (list, dict)):
@@ -139,4 +138,4 @@ def _deserialize_dict(data, boxed_type):
     :rtype: dict
     """
     return {k: _deserialize(v, boxed_type)
-            for k, v in six.iteritems(data)}
+            for k, v in data.items()}

--- a/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-fastapi/requirements.mustache
@@ -26,7 +26,6 @@ python-multipart==0.0.5
 PyYAML==5.4.1
 requests==2.25.1
 Rx==1.6.1
-six==1.16.0
 starlette==0.27.0
 typing-extensions==3.10.0.0
 ujson==4.0.2

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api/fake_classname_tags_123_api.py
@@ -14,9 +14,6 @@ from __future__ import absolute_import
 
 import re  # noqa: F401
 
-# python 2 and python 3 compatibility library
-import six
-
 from petstore_api.api_client import ApiClient
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
@@ -119,7 +116,7 @@ class FakeClassnameTags123Api(object):
             ]
         )
 
-        for key, val in six.iteritems(local_var_params['kwargs']):
+        for key, val in local_var_params['kwargs'].items():
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_exception.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_exception.py
@@ -10,7 +10,6 @@ $ pytest
 """
 
 import os
-import six
 import sys
 import unittest
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_validation.py
@@ -10,7 +10,6 @@ $ pytest
 """
 
 import os
-import six
 import sys
 import unittest
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags_123_api.py
@@ -14,9 +14,6 @@ from __future__ import absolute_import
 
 import re  # noqa: F401
 
-# python 2 and python 3 compatibility library
-import six
-
 from petstore_api.api_client import ApiClient
 from petstore_api.exceptions import (  # noqa: F401
     ApiTypeError,
@@ -119,7 +116,7 @@ class FakeClassnameTags123Api(object):
             ]
         )
 
-        for key, val in six.iteritems(local_var_params['kwargs']):
+        for key, val in local_var_params['kwargs'].items():
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"

--- a/samples/openapi3/client/petstore/python/tests/test_api_exception.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_exception.py
@@ -10,7 +10,6 @@ $ pytest
 """
 
 import os
-import six
 import sys
 import unittest
 

--- a/samples/openapi3/client/petstore/python/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_validation.py
@@ -10,7 +10,6 @@ $ pytest
 """
 
 import os
-import six
 import sys
 import unittest
 

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/pet_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 from typing import Dict
 from typing import Tuple
 from typing import Union

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/store_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/store_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 from typing import Dict
 from typing import Tuple
 from typing import Union

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/user_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/controllers/user_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 from typing import Dict
 from typing import Tuple
 from typing import Union

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/encoder.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/encoder.py
@@ -1,5 +1,4 @@
 from connexion.apps.flask_app import FlaskJSONEncoder
-import six
 
 from openapi_server.models.base_model import Model
 
@@ -10,7 +9,7 @@ class JSONEncoder(FlaskJSONEncoder):
     def default(self, o):
         if isinstance(o, Model):
             dikt = {}
-            for attr, _ in six.iteritems(o.openapi_types):
+            for attr in o.openapi_types:
                 value = getattr(o, attr)
                 if value is None and not self.include_nulls:
                     continue

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/models/base_model.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/models/base_model.py
@@ -1,6 +1,5 @@
 import pprint
 
-import six
 import typing
 
 from openapi_server import util
@@ -29,7 +28,7 @@ class Model(object):
         """
         result = {}
 
-        for attr, _ in six.iteritems(self.openapi_types):
+        for attr in self.openapi_types:
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_pet_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_pet_controller.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import unittest
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from openapi_server.models.api_response import ApiResponse  # noqa: E501
 from openapi_server.models.pet import Pet  # noqa: E501

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_store_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_store_controller.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import unittest
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from openapi_server.models.order import Order  # noqa: E501
 from openapi_server.test import BaseTestCase

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_user_controller.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/test/test_user_controller.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import unittest
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from openapi_server.models.user import User  # noqa: E501
 from openapi_server.test import BaseTestCase

--- a/samples/openapi3/server/petstore/python-flask/openapi_server/util.py
+++ b/samples/openapi3/server/petstore/python-flask/openapi_server/util.py
@@ -1,6 +1,5 @@
 import datetime
 
-import six
 import typing
 from openapi_server import typing_utils
 
@@ -16,7 +15,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool, bytearray):
+    if klass == int or klass in (float, str, bool, bytearray):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)
@@ -45,7 +44,7 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = six.u(data)
+        value = str(data)
     except TypeError:
         value = data
     return value
@@ -110,7 +109,7 @@ def deserialize_model(data, klass):
     if not instance.openapi_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.openapi_types):
+    for attr, attr_type in instance.openapi_types.items():
         if data is not None \
                 and instance.attribute_map[attr] in data \
                 and isinstance(data, (list, dict)):
@@ -145,4 +144,4 @@ def _deserialize_dict(data, boxed_type):
     :rtype: dict
     """
     return {k: _deserialize(v, boxed_type)
-            for k, v in six.iteritems(data)}
+            for k, v in data.items()}

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/pet_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/pet_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 
 from app.openapi_server.models.api_response import ApiResponse  # noqa: E501
 from app.openapi_server.models.pet import Pet  # noqa: E501

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/store_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/store_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 
 from app.openapi_server.models.order import Order  # noqa: E501
 from openapi_server import util

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/user_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/controllers/user_controller.py
@@ -1,5 +1,4 @@
 import connexion
-import six
 
 from app.openapi_server.models.user import User  # noqa: E501
 from openapi_server import util

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/encoder.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/encoder.py
@@ -1,5 +1,4 @@
 from connexion.apps.flask_app import FlaskJSONEncoder
-import six
 
 from app.openapi_server.models.base_model import Model
 
@@ -10,7 +9,7 @@ class JSONEncoder(FlaskJSONEncoder):
     def default(self, o):
         if isinstance(o, Model):
             dikt = {}
-            for attr, _ in six.iteritems(o.swagger_types):
+            for attr in o.swagger_types:
                 value = getattr(o, attr)
                 if value is None and not self.include_nulls:
                     continue

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/models/base_model.py
@@ -1,6 +1,5 @@
 import pprint
 
-import six
 import typing
 
 from openapi_server import util
@@ -29,7 +28,7 @@ class Model(object):
         """
         result = {}
 
-        for attr, _ in six.iteritems(self.swagger_types):
+        for attr in self.swagger_types:
             value = getattr(self, attr)
             if isinstance(value, list):
                 result[attr] = list(map(

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_pet_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_pet_controller.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from app.openapi_server.models.api_response import ApiResponse  # noqa: E501
 from app.openapi_server.models.pet import Pet  # noqa: E501

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_store_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_store_controller.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from app.openapi_server.models.order import Order  # noqa: E501
 from openapi_server.test import BaseTestCase

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_user_controller.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/test/test_user_controller.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from flask import json
-from six import BytesIO
+from io import BytesIO
 
 from app.openapi_server.models.user import User  # noqa: E501
 from openapi_server.test import BaseTestCase

--- a/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
+++ b/samples/server/petstore/python-blueplanet/app/openapi_server/util.py
@@ -1,6 +1,5 @@
 import datetime
 
-import six
 import typing
 from openapi_server import typing_utils
 
@@ -16,7 +15,7 @@ def _deserialize(data, klass):
     if data is None:
         return None
 
-    if klass in six.integer_types or klass in (float, str, bool):
+    if klass == int or klass in (float, str, bool):
         return _deserialize_primitive(data, klass)
     elif klass == object:
         return _deserialize_object(data)
@@ -45,7 +44,7 @@ def _deserialize_primitive(data, klass):
     try:
         value = klass(data)
     except UnicodeEncodeError:
-        value = six.u(data)
+        value = str(data)
     except TypeError:
         value = data
     return value
@@ -104,7 +103,7 @@ def deserialize_model(data, klass):
     if not instance.swagger_types:
         return data
 
-    for attr, attr_type in six.iteritems(instance.swagger_types):
+    for attr, attr_type in instance.swagger_types.items():
         if data is not None \
                 and instance.attribute_map[attr] in data \
                 and isinstance(data, (list, dict)):
@@ -139,4 +138,4 @@ def _deserialize_dict(data, boxed_type):
     :rtype: dict
     """
     return {k: _deserialize(v, boxed_type)
-            for k, v in six.iteritems(data)}
+            for k, v in data.items()}

--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -26,7 +26,6 @@ python-multipart==0.0.5
 PyYAML==5.4.1
 requests==2.25.1
 Rx==1.6.1
-six==1.16.0
 starlette==0.27.0
 typing-extensions==3.10.0.0
 ujson==4.0.2


### PR DESCRIPTION
This PR removes remaining traces of the `six` Python 2/Python 3 compatibility library; the Python generator targets Python 3.7+ only, so it isn't needed for anything.

The idea is to eventually drop the `six` dep from https://github.com/kubernetes-client/python too.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples (...)
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
  - This should not break anything, since the generators are targeting Python 3.7 anyway. 
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - 👋 @krjakbrjak