### PR TITLE
python: remove aenum in favor of stdlib's enum

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
+++ b/modules/openapi-generator/src/main/resources/python/README_onlypackage.mustache
@@ -34,7 +34,6 @@ To be able to use it, you will need these dependencies in your own package that 
 * tornado>=4.2,<5
 {{/tornado}}
 * pydantic
-* aenum
 
 ## Getting Started
 

--- a/modules/openapi-generator/src/main/resources/python/model_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_enum.mustache
@@ -1,7 +1,8 @@
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}
 {{#vendorExtensions.x-py-pydantic-imports}}{{#-first}}from pydantic import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-pydantic-imports}}

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -25,7 +25,6 @@ pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
 {{/hasHttpSignatureMethods}}
 pydantic = ">=2"
-aenum = ">=3.1.11"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]

--- a/modules/openapi-generator/src/main/resources/python/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/requirements.mustache
@@ -2,7 +2,6 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
-aenum >= 3.1.11
 typing-extensions >= 4.7.1
 {{#asyncio}}
 aiohttp >= 3.0.0

--- a/modules/openapi-generator/src/main/resources/python/setup.mustache
+++ b/modules/openapi-generator/src/main/resources/python/setup.mustache
@@ -30,7 +30,6 @@ REQUIRES = [
     "pycryptodome>=3.9.0",
 {{/hasHttpSignatureMethods}}
     "pydantic >= 2",
-    "aenum",
     "typing-extensions >= 4.7.1",
 ]
 

--- a/samples/client/echo_api/python/openapi_client/models/string_enum_ref.py
+++ b/samples/client/echo_api/python/openapi_client/models/string_enum_ref.py
@@ -13,10 +13,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -15,7 +15,6 @@ python = "^3.7"
 urllib3 = ">= 1.25.3"
 python-dateutil = ">=2.8.2"
 pydantic = ">=2"
-aenum = ">=3.1.11"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]

--- a/samples/client/echo_api/python/requirements.txt
+++ b/samples/client/echo_api/python/requirements.txt
@@ -2,5 +2,4 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
-aenum >= 3.1.11
 typing-extensions >= 4.7.1

--- a/samples/client/echo_api/python/setup.py
+++ b/samples/client/echo_api/python/setup.py
@@ -28,7 +28,6 @@ REQUIRES = [
     "urllib3 >= 1.25.3, < 2.1.0",
     "python-dateutil",
     "pydantic >= 2",
-    "aenum",
     "typing-extensions >= 4.7.1",
 ]
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string1.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string1.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string2.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_string2.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/single_ref_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/single_ref_type.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_character_enum.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_character_enum.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -18,7 +18,6 @@ aiohttp = ">= 3.8.4"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
 pydantic = ">=2"
-aenum = ">=3.1.11"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]

--- a/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/requirements.txt
@@ -2,7 +2,6 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
-aenum >= 3.1.11
 typing-extensions >= 4.7.1
 aiohttp >= 3.0.0
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python-aiohttp/setup.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/setup.py
@@ -30,7 +30,6 @@ REQUIRES = [
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",
     "pydantic >= 2",
-    "aenum",
     "typing-extensions >= 4.7.1",
 ]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_string1.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_string1.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_string2.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_string2.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/single_ref_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/single_ref_type.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_character_enum.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_character_enum.py
@@ -12,10 +12,11 @@
 """  # noqa: E501
 
 
+from __future__ import annotations
 import json
 import pprint
 import re  # noqa: F401
-from aenum import Enum, no_arg
+from enum import Enum
 
 
 

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -17,7 +17,6 @@ python-dateutil = ">=2.8.2"
 pem = ">= 19.3.0"
 pycryptodome = ">= 3.9.0"
 pydantic = ">=2"
-aenum = ">=3.1.11"
 typing-extensions = ">=4.7.1"
 
 [tool.poetry.dev-dependencies]

--- a/samples/openapi3/client/petstore/python/requirements.txt
+++ b/samples/openapi3/client/petstore/python/requirements.txt
@@ -2,6 +2,5 @@ python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.25.3, < 2.1.0
 pydantic >= 2
-aenum >= 3.1.11
 typing-extensions >= 4.7.1
 pycryptodome >= 3.9.0

--- a/samples/openapi3/client/petstore/python/setup.py
+++ b/samples/openapi3/client/petstore/python/setup.py
@@ -29,7 +29,6 @@ REQUIRES = [
     "pem>=19.3.0",
     "pycryptodome>=3.9.0",
     "pydantic >= 2",
-    "aenum",
     "typing-extensions >= 4.7.1",
 ]
 


### PR DESCRIPTION
The aenum dependency didn't provide any specific improvements over the stdlib's enum module.
[aenum also doesn't provide typing information](https://github.com/ethanfurman/aenum/issues/10) at the moment.

This removes one dependency and will help for completing the typing of the generated client.

Fix: #16677

@wing328 
@krjakbrjak
@fa0311 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
