### PR TITLE
Replace deprecated Gradle properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/google-api-client/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/build.gradle.mustache
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/build.gradle.mustache
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/build.gradle.mustache
@@ -66,9 +66,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resteasy/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/build.gradle.mustache
@@ -63,9 +63,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/retrofit2/build.gradle.mustache
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/webclient/build.gradle.mustache
@@ -63,9 +63,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/modules/openapi-generator/src/main/resources/android/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/build.mustache
@@ -101,9 +101,9 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
-        task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-        task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+        task.from variant.javaCompile.destinationDirectory
+        task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+        task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);
     }
 }

--- a/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/android/libraries/volley/build.mustache
@@ -87,9 +87,9 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
-        task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-        task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+        task.from variant.javaCompile.destinationDirectory
+        task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+        task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);
     }
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-volley/build.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-volley/build.mustache
@@ -92,7 +92,7 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
+        task.from variant.javaCompile.destinationDirectory
         task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
         task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/build.gradle.mustache
@@ -63,9 +63,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/echo_api/java/apache-httpclient/build.gradle
+++ b/samples/client/echo_api/java/apache-httpclient/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/echo_api/java/feign-gson/build.gradle
+++ b/samples/client/echo_api/java/feign-gson/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/echo_api/java/okhttp-gson/build.gradle
+++ b/samples/client/echo_api/java/okhttp-gson/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/others/java/okhttp-gson-streaming/build.gradle
+++ b/samples/client/others/java/okhttp-gson-streaming/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
+++ b/samples/client/others/java/webclient-useAbstractionForFiles/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/apache-httpclient/build.gradle
+++ b/samples/client/petstore/java/apache-httpclient/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/feign-no-nullable/build.gradle
+++ b/samples/client/petstore/java/feign-no-nullable/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/feign/build.gradle
+++ b/samples/client/petstore/java/feign/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/google-api-client/build.gradle
+++ b/samples/client/petstore/java/google-api-client/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/client/petstore/java/jersey2-java8/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/jersey3/build.gradle
+++ b/samples/client/petstore/java/jersey3/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-3.1/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/okhttp-gson/build.gradle
+++ b/samples/client/petstore/java/okhttp-gson/build.gradle
@@ -62,9 +62,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task)
         }
     }

--- a/samples/client/petstore/java/rest-assured-jackson/build.gradle
+++ b/samples/client/petstore/java/rest-assured-jackson/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resteasy/build.gradle
+++ b/samples/client/petstore/java/resteasy/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resttemplate-jakarta/build.gradle
+++ b/samples/client/petstore/java/resttemplate-jakarta/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resttemplate-swagger1/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger1/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resttemplate-swagger2/build.gradle
+++ b/samples/client/petstore/java/resttemplate-swagger2/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resttemplate-withXml/build.gradle
+++ b/samples/client/petstore/java/resttemplate-withXml/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/resttemplate/build.gradle
+++ b/samples/client/petstore/java/resttemplate/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/retrofit2-play26/build.gradle
+++ b/samples/client/petstore/java/retrofit2-play26/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/retrofit2/build.gradle
+++ b/samples/client/petstore/java/retrofit2/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/retrofit2rx2/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx2/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/retrofit2rx3/build.gradle
+++ b/samples/client/petstore/java/retrofit2rx3/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/webclient-jakarta/build.gradle
+++ b/samples/client/petstore/java/webclient-jakarta/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
+++ b/samples/client/petstore/java/webclient-nullable-arrays/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/webclient-swagger2/build.gradle
+++ b/samples/client/petstore/java/webclient-swagger2/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/java/webclient/build.gradle
+++ b/samples/client/petstore/java/webclient/build.gradle
@@ -57,9 +57,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-volley/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-volley/build.gradle
@@ -78,7 +78,7 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
+        task.from variant.javaCompile.destinationDirectory
         task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
         task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);

--- a/samples/client/petstore/kotlin-default-values-jvm-volley/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-volley/build.gradle
@@ -80,7 +80,7 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
+        task.from variant.javaCompile.destinationDirectory
         task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
         task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);

--- a/samples/client/petstore/kotlin-jvm-volley/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-volley/build.gradle
@@ -80,7 +80,7 @@ afterEvaluate {
         def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
         task.description = "Create jar artifact for ${variant.name}"
         task.dependsOn variant.javaCompile
-        task.from variant.javaCompile.destinationDir
+        task.from variant.javaCompile.destinationDirectory
         task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
         task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
         artifacts.add('archives', task);

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }

--- a/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/build.gradle
@@ -58,9 +58,9 @@ if(hasProperty('target') && target == 'android') {
             def task = project.tasks.create "jar${variant.name.capitalize()}", Jar
             task.description = "Create jar artifact for ${variant.name}"
             task.dependsOn variant.javaCompile
-            task.from variant.javaCompile.destinationDir
-            task.destinationDir = project.file("${project.buildDir}/outputs/jar")
-            task.archiveName = "${project.name}-${variant.baseName}-${version}.jar"
+            task.from variant.javaCompile.destinationDirectory
+            task.destinationDirectory = project.file("${project.buildDir}/outputs/jar")
+            task.archiveFileName = "${project.name}-${variant.baseName}-${version}.jar"
             artifacts.add('archives', task);
         }
     }


### PR DESCRIPTION
We noticed two properties in the Gradle build files that were reported as deprecated. This PR replaces them with the new names.

* destinationDir -> destinationDirectory (scheduled to be removed in Gradle 9.0)
* archiveName -> archiveFileName (removed in Gradle 8.0)

Cp. https://docs.gradle.org/current/userguide/upgrading_version_7.html

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
