### PR TITLE
[typescript-fetch] Generate @deprecated comments for all deprecated APIs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -65,6 +65,9 @@ export interface {{classname}}Interface {
      {{#summary}}
      * {{&summary}}
      {{/summary}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
      */
     {{^useSingleRequestParameter}}
     {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{^returnType}}void{{/returnType}}>;
@@ -97,6 +100,9 @@ export class {{classname}} extends runtime.BaseAPI {
      {{#summary}}
      * {{&summary}}
      {{/summary}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
      */
     async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         {{#allParams}}
@@ -340,6 +346,9 @@ export class {{classname}} extends runtime.BaseAPI {
      {{#summary}}
      * {{&summary}}
      {{/summary}}
+     {{#isDeprecated}}
+     * @deprecated
+     {{/isDeprecated}}
      */
     {{^useSingleRequestParameter}}
     async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -196,6 +196,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Set<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -228,6 +229,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Set<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -186,6 +186,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -218,6 +219,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -186,6 +186,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -218,6 +219,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -186,6 +186,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -218,6 +219,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(tags: Array<string>, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw({ tags: tags }, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -186,6 +186,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -218,6 +219,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: PetApiFindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -174,6 +174,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by ids
+     * @deprecated
      */
     async findPetsByIdsRaw(requestParameters: FindPetsByIdsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.ids === null || requestParameters.ids === undefined) {
@@ -206,6 +207,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by ids
+     * @deprecated
      */
     async findPetsByIds(ids: Array<number>, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByIdsRaw({ ids: ids }, initOverrides);
@@ -256,6 +258,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -288,6 +291,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(tags: Array<string>, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw({ tags: tags }, initOverrides);
@@ -297,6 +301,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by user ids
+     * @deprecated
      */
     async findPetsByUserIdsRaw(requestParameters: FindPetsByUserIdsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FindPetsByUserResponse>> {
         if (requestParameters.ids === null || requestParameters.ids === undefined) {
@@ -329,6 +334,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple ids can be provided with comma separated strings.
      * Finds Pets by user ids
+     * @deprecated
      */
     async findPetsByUserIds(ids: Array<number>, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<FindPetsByUserResponse> {
         const response = await this.findPetsByUserIdsRaw({ ids: ids }, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
@@ -196,6 +196,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Set<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -228,6 +229,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Set<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -130,6 +130,7 @@ export interface PetApiInterface {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>>;
 
@@ -324,6 +325,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -356,6 +358,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -186,6 +186,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -218,6 +219,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -180,6 +180,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
         if (requestParameters.tags === null || requestParameters.tags === undefined) {
@@ -212,6 +213,7 @@ export class PetApi extends runtime.BaseAPI {
     /**
      * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
      * Finds Pets by tags
+     * @deprecated
      */
     async findPetsByTags(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Pet>> {
         const response = await this.findPetsByTagsRaw(requestParameters, initOverrides);


### PR DESCRIPTION
PR https://github.com/OpenAPITools/openapi-generator/pull/11523 changed the typescript-fetch generator so that marking an API or property as deprecated would result in a @deprecated comment being added above the relevant generated API or property. However, this was only enabled for interfaces and only raw methods.

This PR adds @deprecated comments for all deprecated APIs and properties, in classes and interfaces. This is important so that developers can easily tell when they're using a deprecated API, and so that other tooling (linters, etc) can be used to forbid using deprecated APIs.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
