### PR TITLE
python: provide full typing for the REST client(s)

### DIFF
--- a/.github/workflows/samples-python-petstore.yaml
+++ b/.github/workflows/samples-python-petstore.yaml
@@ -57,3 +57,16 @@ jobs:
       - name: Test
         working-directory: ${{ matrix.sample }}
         run: poetry run pytest -v
+
+      # These modules should pass mypy without errors
+      - name: mypy (WIP)
+        working-directory: ${{ matrix.sample }}
+        run: |
+          poetry run mypy */rest.py
+
+      # This runs mypy on all the modules, but full typing is not yet fully implemented, this can fail.
+      - name: mypy
+        working-directory: ${{ matrix.sample }}
+        continue-on-error: true
+        run: |
+          poetry run mypy

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -2,41 +2,60 @@
 
 {{>partial_header}}
 
-import io
 import json
 import logging
 import re
 import ssl
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import aiohttp
-from urllib.parse import urlencode, quote_plus
+from aiohttp import ClientResponse
+from urllib.parse import urlencode
 
+from {{packageName}}.configuration import Configuration
 from {{packageName}}.exceptions import ApiException, ApiValueError
 
 logger = logging.getLogger(__name__)
 
 
-class RESTResponse(io.IOBase):
+class RESTResponse:
+    """An HTTP response."""
+    # This provides a generic object to store HTTP responses.
+    # It proxies the original HTTP response from the underlying HTTP library
+    # (aiohttp, urllib3, etc.) so that clients of RESTClientObject can work
+    # without knowing too much about each library specifics.
 
-    def __init__(self, resp, data) -> None:
-        self.aiohttp_response = resp
+    def __init__(self, resp: ClientResponse, data: bytes) -> None:
+        self._aiohttp_response = resp
         self.status = resp.status
         self.reason = resp.reason
         self.data = data
 
-    def getheaders(self):
-        """Returns a CIMultiDictProxy of the response headers."""
-        return self.aiohttp_response.headers
+    def getheaders(self) -> Dict[str, str]:
+        """Returns a dictionary of the response headers."""
+        # Note: this can lose the CIMultiDictProxy duplicated headers.
+        return dict(self._aiohttp_response.headers)
 
-    def getheader(self, name, default=None):
+    def getheader(self, name: str, default: Optional[str]=None) -> Optional[str]:
         """Returns a given response header."""
-        return self.aiohttp_response.headers.get(name, default)
+        return self._aiohttp_response.headers.get(name, default)
+
+
+PostParam = Tuple[
+    str, # The key of the parameter
+    Union[
+        str, # The value of the parameter
+        Tuple[ # or a file: (inspired by https://urllib3.readthedocs.io/en/v2.0.5/user-guide.html#files-binary-data)
+            str, # filename
+            bytes, # file data
+            str, # mime-type
+        ],
+    ]
+]
 
 
 class RESTClientObject:
-
-    def __init__(self, configuration, pools_size=4, maxsize=None) -> None:
-
+    def __init__(self, configuration: Configuration, pools_size: int=4, maxsize: Optional[int]=None) -> None:
         # maxsize is number of requests to host that are allowed in parallel
         if maxsize is None:
             maxsize = configuration.connection_pool_maxsize
@@ -65,12 +84,19 @@ class RESTClientObject:
             trust_env=True
         )
 
-    async def close(self):
+    async def close(self) -> None:
         await self.pool_manager.close()
 
-    async def request(self, method, url, query_params=None, headers=None,
-                      body=None, post_params=None, _preload_content=True,
-                      _request_timeout=None):
+    async def request(self,
+        method: str,
+        url: str,
+        query_params: Optional[Dict[str, str]]=None,
+        headers: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        post_params: Optional[List[PostParam]]=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         """Execute request
 
         :param method: http request method
@@ -97,7 +123,7 @@ class RESTClientObject:
                 "body parameter cannot be used with post_params parameter."
             )
 
-        post_params = post_params or {}
+        post_params = post_params or []
         headers = headers or {}
         # url already contains the URL query string
         # so reset query_params to empty dict
@@ -108,8 +134,6 @@ class RESTClientObject:
             headers['Content-Type'] = 'application/json'
 
         args = {
-            "method": method,
-            "url": url,
             "timeout": timeout,
             "headers": headers
         }
@@ -120,7 +144,8 @@ class RESTClientObject:
             args["proxy_headers"] = self.proxy_headers
 
         if query_params:
-            args["url"] += '?' + urlencode(query_params)
+            url += '?' + urlencode(query_params)
+
 
         # For `POST`, `PUT`, `PATCH`, `OPTIONS`, `DELETE`
         if method in ['POST', 'PUT', 'PATCH', 'OPTIONS', 'DELETE']:
@@ -158,12 +183,12 @@ class RESTClientObject:
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
-        r = await self.pool_manager.request(**args)
+        _r = await self.pool_manager.request(method, url, **args)
+
+        response_data = await _r.read()
+        r = RESTResponse(_r, response_data)
+
         if _preload_content:
-
-            data = await r.read()
-            r = RESTResponse(r, data)
-
             # log response body
             logger.debug("response body: %s", r.data)
 
@@ -172,25 +197,44 @@ class RESTClientObject:
 
         return r
 
-    async def get_request(self, url, headers=None, query_params=None,
-                  _preload_content=True, _request_timeout=None):
+    async def get_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("GET", url,
                                    headers=headers,
                                    _preload_content=_preload_content,
                                    _request_timeout=_request_timeout,
                                    query_params=query_params))
 
-    async def head_request(self, url, headers=None, query_params=None,
-                   _preload_content=True, _request_timeout=None):
+    async def head_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("HEAD", url,
                                    headers=headers,
                                    _preload_content=_preload_content,
                                    _request_timeout=_request_timeout,
                                    query_params=query_params))
 
-    async def options_request(self, url, headers=None, query_params=None,
-                      post_params=None, body=None, _preload_content=True,
-                      _request_timeout=None):
+    async def options_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("OPTIONS", url,
                                    headers=headers,
                                    query_params=query_params,
@@ -199,8 +243,15 @@ class RESTClientObject:
                                    _request_timeout=_request_timeout,
                                    body=body))
 
-    async def delete_request(self, url, headers=None, query_params=None, body=None,
-                     _preload_content=True, _request_timeout=None):
+    async def delete_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("DELETE", url,
                                    headers=headers,
                                    query_params=query_params,
@@ -208,9 +259,16 @@ class RESTClientObject:
                                    _request_timeout=_request_timeout,
                                    body=body))
 
-    async def post_request(self, url, headers=None, query_params=None,
-                   post_params=None, body=None, _preload_content=True,
-                   _request_timeout=None):
+    async def post_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("POST", url,
                                    headers=headers,
                                    query_params=query_params,
@@ -219,8 +277,16 @@ class RESTClientObject:
                                    _request_timeout=_request_timeout,
                                    body=body))
 
-    async def put_request(self, url, headers=None, query_params=None, post_params=None,
-                  body=None, _preload_content=True, _request_timeout=None):
+    async def put_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("PUT", url,
                                    headers=headers,
                                    query_params=query_params,
@@ -229,9 +295,16 @@ class RESTClientObject:
                                    _request_timeout=_request_timeout,
                                    body=body))
 
-    async def patch_request(self, url, headers=None, query_params=None,
-                    post_params=None, body=None, _preload_content=True,
-                    _request_timeout=None):
+    async def patch_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: Optional[int]=None,
+    ) -> RESTResponse:
         return (await self.request("PATCH", url,
                                    headers=headers,
                                    query_params=query_params,

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -31,6 +31,7 @@ typing-extensions = ">=4.7.1"
 pytest = ">=7.2.1"
 tox = ">=3.9.0"
 flake8 = ">=4.0.0"
+mypy = "<1.5.0" # 1.5.0 supports Python 3.8+
 
 [build-system]
 requires = ["setuptools"]
@@ -38,3 +39,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.mypy]
+packages = ["{{packageName}}"]
+warn_unused_configs = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "{{packageName}}.rest"
+#strict = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -2,41 +2,67 @@
 
 {{>partial_header}}
 
-import io
 import json
 import logging
 import re
 import ssl
+from typing import Any, Dict, List, Optional, Union, Tuple
 
-from urllib.parse import urlencode, quote_plus
 import urllib3
+from urllib3 import BaseHTTPResponse
+from urllib3.util.timeout import _TYPE_TIMEOUT
 
-from {{packageName}}.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
+from {{packageName}}.configuration import Configuration
+from {{packageName}}.exceptions import ApiException
+from {{packageName}}.exceptions import ApiValueError
+from {{packageName}}.exceptions import BadRequestException
+from {{packageName}}.exceptions import ForbiddenException
+from {{packageName}}.exceptions import NotFoundException
+from {{packageName}}.exceptions import ServiceException
+from {{packageName}}.exceptions import UnauthorizedException
 
 
 logger = logging.getLogger(__name__)
 
 
-class RESTResponse(io.IOBase):
+class RESTResponse:
+    """An HTTP response."""
+    # This provides a generic object to store HTTP responses.
+    # It proxies the original HTTP response from the underlying HTTP library
+    # (aiohttp, urllib3, etc.) so that clients of RESTClientObject can work
+    # without knowing too much about each library specifics.
 
-    def __init__(self, resp) -> None:
-        self.urllib3_response = resp
+    def __init__(self, resp: BaseHTTPResponse) -> None:
+        self._urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
         self.data = resp.data
 
-    def getheaders(self):
+    def getheaders(self) -> Dict[str, str]:
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.headers
+        # Note: this can lose the urllib3.HTTPHeaderDict duplicated headers.
+        return dict(self._urllib3_response.headers)
 
-    def getheader(self, name, default=None):
+    def getheader(self, name: str, default: Optional[str]=None) -> Optional[str]:
         """Returns a given response header."""
-        return self.urllib3_response.headers.get(name, default)
+        return self._urllib3_response.headers.get(name, default)
+
+
+PostParam = Tuple[
+    str, # The key of the parameter
+    Union[
+        str, # The value of the parameter
+        Tuple[ # or a file: (inspired by https://urllib3.readthedocs.io/en/v2.0.5/user-guide.html#files-binary-data)
+            str, # filename
+            bytes, # file data  
+            str, # mime-type
+        ],
+    ]
+]
 
 
 class RESTClientObject:
-
-    def __init__(self, configuration, pools_size=4, maxsize=None) -> None:
+    def __init__(self, configuration: Configuration, pools_size: int=4, maxsize: Optional[int]=None) -> None:
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
@@ -49,7 +75,7 @@ class RESTClientObject:
         else:
             cert_reqs = ssl.CERT_NONE
 
-        addition_pool_args = {}
+        addition_pool_args: Dict[str, Any] = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
 
@@ -68,6 +94,8 @@ class RESTClientObject:
                 maxsize = configuration.connection_pool_maxsize
             else:
                 maxsize = 4
+
+        self.pool_manager: urllib3.PoolManager
 
         # https pool manager
         if configuration.proxy:
@@ -93,9 +121,16 @@ class RESTClientObject:
                 **addition_pool_args
             )
 
-    def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None, _preload_content=True,
-                _request_timeout=None):
+    def request(self,
+        method: str,
+        url: str,
+        query_params: Optional[Dict[str, str]]=None,
+        headers: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        post_params: Optional[List[PostParam]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         """Perform requests.
 
         :param method: http request method
@@ -123,7 +158,7 @@ class RESTClientObject:
                 "body parameter cannot be used with post_params parameter."
             )
 
-        post_params = post_params or {}
+        post_params = post_params or []
         headers = headers or {}
         # url already contains the URL query string
         # so reset query_params to empty dict
@@ -147,14 +182,14 @@ class RESTClientObject:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         body=request_body,
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         fields=post_params,
                         encode_multipart=False,
@@ -166,7 +201,7 @@ class RESTClientObject:
                     # Content-Type which generated by urllib3 will be
                     # overwritten.
                     del headers['Content-Type']
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         fields=post_params,
                         encode_multipart=True,
@@ -177,10 +212,9 @@ class RESTClientObject:
                 # other content types than Json when `body` argument is
                 # provided in serialized form
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
-                        body=request_body,
+                        body=body,
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
@@ -192,7 +226,7 @@ class RESTClientObject:
                     raise ApiException(status=0, reason=msg)
             # For `GET`, `HEAD`
             else:
-                r = self.pool_manager.request(method, url,
+                _r = self.pool_manager.request(method, url,
                                               fields={},
                                               preload_content=_preload_content,
                                               timeout=timeout,
@@ -201,11 +235,12 @@ class RESTClientObject:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
             raise ApiException(status=0, reason=msg)
 
-        if _preload_content:
-            r = RESTResponse(r)
+        r = RESTResponse(_r)
 
+        if _preload_content:
             # log response body
             logger.debug("response body: %s", r.data)
+
 
         if not 200 <= r.status <= 299:
             if r.status == 400:
@@ -227,24 +262,44 @@ class RESTClientObject:
 
         return r
 
-    def get_request(self, url, headers=None, query_params=None, _preload_content=True,
-            _request_timeout=None):
+    def get_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("GET", url,
                             headers=headers,
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def head_request(self, url, headers=None, query_params=None, _preload_content=True,
-             _request_timeout=None):
+    def head_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("HEAD", url,
                             headers=headers,
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def options_request(self, url, headers=None, query_params=None, post_params=None,
-                body=None, _preload_content=True, _request_timeout=None):
+    def options_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
@@ -253,8 +308,15 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def delete_request(self, url, headers=None, query_params=None, body=None,
-               _preload_content=True, _request_timeout=None):
+    def delete_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
@@ -262,8 +324,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def post_request(self, url, headers=None, query_params=None, post_params=None,
-             body=None, _preload_content=True, _request_timeout=None):
+    def post_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
@@ -272,8 +342,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def put_request(self, url, headers=None, query_params=None, post_params=None,
-            body=None, _preload_content=True, _request_timeout=None):
+    def put_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
@@ -282,8 +360,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def patch_request(self, url, headers=None, query_params=None, post_params=None,
-              body=None, _preload_content=True, _request_timeout=None):
+    def patch_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,

--- a/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python/test-requirements.mustache
@@ -1,3 +1,4 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
+mypy<1.5.0

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -21,6 +21,7 @@ typing-extensions = ">=4.7.1"
 pytest = ">=7.2.1"
 tox = ">=3.9.0"
 flake8 = ">=4.0.0"
+mypy = "<1.5.0" # 1.5.0 supports Python 3.8+
 
 [build-system]
 requires = ["setuptools"]
@@ -28,3 +29,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.mypy]
+packages = ["openapi_client"]
+warn_unused_configs = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "openapi_client.rest"
+#strict = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/test-requirements.txt
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
+mypy<1.5.0

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -21,6 +21,7 @@ typing-extensions = ">=4.7.1"
 pytest = ">=7.2.1"
 tox = ">=3.9.0"
 flake8 = ">=4.0.0"
+mypy = "<1.5.0" # 1.5.0 supports Python 3.8+
 
 [build-system]
 requires = ["setuptools"]
@@ -28,3 +29,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.mypy]
+packages = ["openapi_client"]
+warn_unused_configs = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "openapi_client.rest"
+#strict = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true

--- a/samples/client/echo_api/python/test-requirements.txt
+++ b/samples/client/echo_api/python/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
+mypy<1.5.0

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -24,6 +24,7 @@ typing-extensions = ">=4.7.1"
 pytest = ">=7.2.1"
 tox = ">=3.9.0"
 flake8 = ">=4.0.0"
+mypy = "<1.5.0" # 1.5.0 supports Python 3.8+
 
 [build-system]
 requires = ["setuptools"]
@@ -31,3 +32,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.mypy]
+packages = ["petstore_api"]
+warn_unused_configs = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "petstore_api.rest"
+#strict = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true

--- a/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python-aiohttp/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
+mypy<1.5.0

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -12,41 +12,67 @@
 """  # noqa: E501
 
 
-import io
 import json
 import logging
 import re
 import ssl
+from typing import Any, Dict, List, Optional, Union, Tuple
 
-from urllib.parse import urlencode, quote_plus
 import urllib3
+from urllib3 import BaseHTTPResponse
+from urllib3.util.timeout import _TYPE_TIMEOUT
 
-from petstore_api.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError, BadRequestException
+from petstore_api.configuration import Configuration
+from petstore_api.exceptions import ApiException
+from petstore_api.exceptions import ApiValueError
+from petstore_api.exceptions import BadRequestException
+from petstore_api.exceptions import ForbiddenException
+from petstore_api.exceptions import NotFoundException
+from petstore_api.exceptions import ServiceException
+from petstore_api.exceptions import UnauthorizedException
 
 
 logger = logging.getLogger(__name__)
 
 
-class RESTResponse(io.IOBase):
+class RESTResponse:
+    """An HTTP response."""
+    # This provides a generic object to store HTTP responses.
+    # It proxies the original HTTP response from the underlying HTTP library
+    # (aiohttp, urllib3, etc.) so that clients of RESTClientObject can work
+    # without knowing too much about each library specifics.
 
-    def __init__(self, resp) -> None:
-        self.urllib3_response = resp
+    def __init__(self, resp: BaseHTTPResponse) -> None:
+        self._urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
         self.data = resp.data
 
-    def getheaders(self):
+    def getheaders(self) -> Dict[str, str]:
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.headers
+        # Note: this can lose the urllib3.HTTPHeaderDict duplicated headers.
+        return dict(self._urllib3_response.headers)
 
-    def getheader(self, name, default=None):
+    def getheader(self, name: str, default: Optional[str]=None) -> Optional[str]:
         """Returns a given response header."""
-        return self.urllib3_response.headers.get(name, default)
+        return self._urllib3_response.headers.get(name, default)
+
+
+PostParam = Tuple[
+    str, # The key of the parameter
+    Union[
+        str, # The value of the parameter
+        Tuple[ # or a file: (inspired by https://urllib3.readthedocs.io/en/v2.0.5/user-guide.html#files-binary-data)
+            str, # filename
+            bytes, # file data  
+            str, # mime-type
+        ],
+    ]
+]
 
 
 class RESTClientObject:
-
-    def __init__(self, configuration, pools_size=4, maxsize=None) -> None:
+    def __init__(self, configuration: Configuration, pools_size: int=4, maxsize: Optional[int]=None) -> None:
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501
@@ -59,7 +85,7 @@ class RESTClientObject:
         else:
             cert_reqs = ssl.CERT_NONE
 
-        addition_pool_args = {}
+        addition_pool_args: Dict[str, Any] = {}
         if configuration.assert_hostname is not None:
             addition_pool_args['assert_hostname'] = configuration.assert_hostname  # noqa: E501
 
@@ -78,6 +104,8 @@ class RESTClientObject:
                 maxsize = configuration.connection_pool_maxsize
             else:
                 maxsize = 4
+
+        self.pool_manager: urllib3.PoolManager
 
         # https pool manager
         if configuration.proxy:
@@ -103,9 +131,16 @@ class RESTClientObject:
                 **addition_pool_args
             )
 
-    def request(self, method, url, query_params=None, headers=None,
-                body=None, post_params=None, _preload_content=True,
-                _request_timeout=None):
+    def request(self,
+        method: str,
+        url: str,
+        query_params: Optional[Dict[str, str]]=None,
+        headers: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        post_params: Optional[List[PostParam]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         """Perform requests.
 
         :param method: http request method
@@ -133,7 +168,7 @@ class RESTClientObject:
                 "body parameter cannot be used with post_params parameter."
             )
 
-        post_params = post_params or {}
+        post_params = post_params or []
         headers = headers or {}
         # url already contains the URL query string
         # so reset query_params to empty dict
@@ -157,14 +192,14 @@ class RESTClientObject:
                     request_body = None
                     if body is not None:
                         request_body = json.dumps(body)
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         body=request_body,
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
                 elif headers['Content-Type'] == 'application/x-www-form-urlencoded':  # noqa: E501
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         fields=post_params,
                         encode_multipart=False,
@@ -176,7 +211,7 @@ class RESTClientObject:
                     # Content-Type which generated by urllib3 will be
                     # overwritten.
                     del headers['Content-Type']
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
                         fields=post_params,
                         encode_multipart=True,
@@ -187,10 +222,9 @@ class RESTClientObject:
                 # other content types than Json when `body` argument is
                 # provided in serialized form
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
-                    r = self.pool_manager.request(
+                    _r = self.pool_manager.request(
                         method, url,
-                        body=request_body,
+                        body=body,
                         preload_content=_preload_content,
                         timeout=timeout,
                         headers=headers)
@@ -202,7 +236,7 @@ class RESTClientObject:
                     raise ApiException(status=0, reason=msg)
             # For `GET`, `HEAD`
             else:
-                r = self.pool_manager.request(method, url,
+                _r = self.pool_manager.request(method, url,
                                               fields={},
                                               preload_content=_preload_content,
                                               timeout=timeout,
@@ -211,11 +245,12 @@ class RESTClientObject:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
             raise ApiException(status=0, reason=msg)
 
-        if _preload_content:
-            r = RESTResponse(r)
+        r = RESTResponse(_r)
 
+        if _preload_content:
             # log response body
             logger.debug("response body: %s", r.data)
+
 
         if not 200 <= r.status <= 299:
             if r.status == 400:
@@ -237,24 +272,44 @@ class RESTClientObject:
 
         return r
 
-    def get_request(self, url, headers=None, query_params=None, _preload_content=True,
-            _request_timeout=None):
+    def get_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("GET", url,
                             headers=headers,
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def head_request(self, url, headers=None, query_params=None, _preload_content=True,
-             _request_timeout=None):
+    def head_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("HEAD", url,
                             headers=headers,
                             _preload_content=_preload_content,
                             _request_timeout=_request_timeout,
                             query_params=query_params)
 
-    def options_request(self, url, headers=None, query_params=None, post_params=None,
-                body=None, _preload_content=True, _request_timeout=None):
+    def options_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("OPTIONS", url,
                             headers=headers,
                             query_params=query_params,
@@ -263,8 +318,15 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def delete_request(self, url, headers=None, query_params=None, body=None,
-               _preload_content=True, _request_timeout=None):
+    def delete_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("DELETE", url,
                             headers=headers,
                             query_params=query_params,
@@ -272,8 +334,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def post_request(self, url, headers=None, query_params=None, post_params=None,
-             body=None, _preload_content=True, _request_timeout=None):
+    def post_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("POST", url,
                             headers=headers,
                             query_params=query_params,
@@ -282,8 +352,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def put_request(self, url, headers=None, query_params=None, post_params=None,
-            body=None, _preload_content=True, _request_timeout=None):
+    def put_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("PUT", url,
                             headers=headers,
                             query_params=query_params,
@@ -292,8 +370,16 @@ class RESTClientObject:
                             _request_timeout=_request_timeout,
                             body=body)
 
-    def patch_request(self, url, headers=None, query_params=None, post_params=None,
-              body=None, _preload_content=True, _request_timeout=None):
+    def patch_request(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]]=None,
+        query_params: Optional[Dict[str, str]]=None,
+        post_params: Optional[List[PostParam]]=None,
+        body: Any=None,
+        _preload_content: bool=True,
+        _request_timeout: _TYPE_TIMEOUT=None,
+    ) -> RESTResponse:
         return self.request("PATCH", url,
                             headers=headers,
                             query_params=query_params,

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -23,6 +23,7 @@ typing-extensions = ">=4.7.1"
 pytest = ">=7.2.1"
 tox = ">=3.9.0"
 flake8 = ">=4.0.0"
+mypy = "<1.5.0" # 1.5.0 supports Python 3.8+
 
 [build-system]
 requires = ["setuptools"]
@@ -30,3 +31,24 @@ build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']
 extension-pkg-whitelist = "pydantic"
+
+[tool.mypy]
+packages = ["petstore_api"]
+warn_unused_configs = true
+warn_redundant_casts = true
+
+[[tool.mypy.overrides]]
+module = "petstore_api.rest"
+#strict = true
+warn_unused_ignores = true
+strict_equality = true
+strict_concatenate = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+no_implicit_reexport = true
+warn_return_any = true

--- a/samples/openapi3/client/petstore/python/test-requirements.txt
+++ b/samples/openapi3/client/petstore/python/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest~=7.1.3
 pytest-cov>=2.8.1
 pytest-randomly>=3.12.0
+mypy<1.5.0


### PR DESCRIPTION
This is a prototype to showcase the typing on the lower generated module, `rest.py`.

The goal with fully typing this module would be to then help build correct typing information on top of it.
This may also help in case we want to refactor the content of this module, and/or replacing it by another HTTP library.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
