### PR TITLE
[C] map set to list, add tests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CLibcurlClientCodegen.java
@@ -289,6 +289,7 @@ public class CLibcurlClientCodegen extends DefaultCodegen implements CodegenConf
         typeMapping.put("UUID", "char");
         typeMapping.put("URI", "char");
         typeMapping.put("array", "list");
+        typeMapping.put("set", "list");
         typeMapping.put("map", "list_t*");
         typeMapping.put("date-time", "char");
 

--- a/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/2_0/c/petstore.yaml
@@ -726,3 +726,17 @@ definitions:
         type: string
         format: uuid
         default: 1111-2222-3333-4444
+  model_with_set_propertes:
+    description: to test set properties
+    type: object
+    properties:
+      tag_set:
+        type: array
+        uniqueItems: true
+        items:
+          $ref: '#/definitions/Tag'
+      string_set:
+        type: array
+        uniqueItems: true
+        items:
+          type: string

--- a/samples/client/petstore/c/.openapi-generator/FILES
+++ b/samples/client/petstore/c/.openapi-generator/FILES
@@ -12,6 +12,7 @@ docs/StoreAPI.md
 docs/UserAPI.md
 docs/api_response.md
 docs/category.md
+docs/model_with_set_propertes.md
 docs/order.md
 docs/pet.md
 docs/tag.md
@@ -30,6 +31,8 @@ model/category.c
 model/category.h
 model/mapped_model.c
 model/mapped_model.h
+model/model_with_set_propertes.c
+model/model_with_set_propertes.h
 model/object.c
 model/object.h
 model/order.c

--- a/samples/client/petstore/c/README.md
+++ b/samples/client/petstore/c/README.md
@@ -92,6 +92,7 @@ Category | Method | HTTP request | Description
  - [MappedModel_t](docs/MappedModel.md)
  - [api_response_t](docs/api_response.md)
  - [category_t](docs/category.md)
+ - [model_with_set_propertes_t](docs/model_with_set_propertes.md)
  - [order_t](docs/order.md)
  - [pet_t](docs/pet.md)
  - [tag_t](docs/tag.md)

--- a/samples/client/petstore/c/docs/model_with_set_propertes.md
+++ b/samples/client/petstore/c/docs/model_with_set_propertes.md
@@ -1,0 +1,11 @@
+# model_with_set_propertes_t
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**tag_set** | [**list_t**](tag.md) \* |  | [optional] 
+**string_set** | **list_t \*** |  | [optional] 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/samples/client/petstore/c/model/model_with_set_propertes.c
+++ b/samples/client/petstore/c/model/model_with_set_propertes.c
@@ -1,0 +1,170 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "model_with_set_propertes.h"
+
+
+
+model_with_set_propertes_t *model_with_set_propertes_create(
+    list_t *tag_set,
+    list_t *string_set
+    ) {
+    model_with_set_propertes_t *model_with_set_propertes_local_var = malloc(sizeof(model_with_set_propertes_t));
+    if (!model_with_set_propertes_local_var) {
+        return NULL;
+    }
+    model_with_set_propertes_local_var->tag_set = tag_set;
+    model_with_set_propertes_local_var->string_set = string_set;
+
+    return model_with_set_propertes_local_var;
+}
+
+
+void model_with_set_propertes_free(model_with_set_propertes_t *model_with_set_propertes) {
+    if(NULL == model_with_set_propertes){
+        return ;
+    }
+    listEntry_t *listEntry;
+    if (model_with_set_propertes->tag_set) {
+        list_ForEach(listEntry, model_with_set_propertes->tag_set) {
+            tag_free(listEntry->data);
+        }
+        list_freeList(model_with_set_propertes->tag_set);
+        model_with_set_propertes->tag_set = NULL;
+    }
+    if (model_with_set_propertes->string_set) {
+        list_ForEach(listEntry, model_with_set_propertes->string_set) {
+            free(listEntry->data);
+        }
+        list_freeList(model_with_set_propertes->string_set);
+        model_with_set_propertes->string_set = NULL;
+    }
+    free(model_with_set_propertes);
+}
+
+cJSON *model_with_set_propertes_convertToJSON(model_with_set_propertes_t *model_with_set_propertes) {
+    cJSON *item = cJSON_CreateObject();
+
+    // model_with_set_propertes->tag_set
+    if(model_with_set_propertes->tag_set) {
+    cJSON *tag_set = cJSON_AddArrayToObject(item, "tag_set");
+    if(tag_set == NULL) {
+    goto fail; //nonprimitive container
+    }
+
+    listEntry_t *tag_setListEntry;
+    if (model_with_set_propertes->tag_set) {
+    list_ForEach(tag_setListEntry, model_with_set_propertes->tag_set) {
+    cJSON *itemLocal = tag_convertToJSON(tag_setListEntry->data);
+    if(itemLocal == NULL) {
+    goto fail;
+    }
+    cJSON_AddItemToArray(tag_set, itemLocal);
+    }
+    }
+    }
+
+
+    // model_with_set_propertes->string_set
+    if(model_with_set_propertes->string_set) {
+    cJSON *string_set = cJSON_AddArrayToObject(item, "string_set");
+    if(string_set == NULL) {
+        goto fail; //primitive container
+    }
+
+    listEntry_t *string_setListEntry;
+    list_ForEach(string_setListEntry, model_with_set_propertes->string_set) {
+    if(cJSON_AddStringToObject(string_set, "", (char*)string_setListEntry->data) == NULL)
+    {
+        goto fail;
+    }
+    }
+    }
+
+    return item;
+fail:
+    if (item) {
+        cJSON_Delete(item);
+    }
+    return NULL;
+}
+
+model_with_set_propertes_t *model_with_set_propertes_parseFromJSON(cJSON *model_with_set_propertesJSON){
+
+    model_with_set_propertes_t *model_with_set_propertes_local_var = NULL;
+
+    // define the local list for model_with_set_propertes->tag_set
+    list_t *tag_setList = NULL;
+
+    // define the local list for model_with_set_propertes->string_set
+    list_t *string_setList = NULL;
+
+    // model_with_set_propertes->tag_set
+    cJSON *tag_set = cJSON_GetObjectItemCaseSensitive(model_with_set_propertesJSON, "tag_set");
+    if (tag_set) { 
+    cJSON *tag_set_local_nonprimitive = NULL;
+    if(!cJSON_IsArray(tag_set)){
+        goto end; //nonprimitive container
+    }
+
+    tag_setList = list_createList();
+
+    cJSON_ArrayForEach(tag_set_local_nonprimitive,tag_set )
+    {
+        if(!cJSON_IsObject(tag_set_local_nonprimitive)){
+            goto end;
+        }
+        tag_t *tag_setItem = tag_parseFromJSON(tag_set_local_nonprimitive);
+
+        list_addElement(tag_setList, tag_setItem);
+    }
+    }
+
+    // model_with_set_propertes->string_set
+    cJSON *string_set = cJSON_GetObjectItemCaseSensitive(model_with_set_propertesJSON, "string_set");
+    if (string_set) { 
+    cJSON *string_set_local = NULL;
+    if(!cJSON_IsArray(string_set)) {
+        goto end;//primitive container
+    }
+    string_setList = list_createList();
+
+    cJSON_ArrayForEach(string_set_local, string_set)
+    {
+        if(!cJSON_IsString(string_set_local))
+        {
+            goto end;
+        }
+        list_addElement(string_setList , strdup(string_set_local->valuestring));
+    }
+    }
+
+
+    model_with_set_propertes_local_var = model_with_set_propertes_create (
+        tag_set ? tag_setList : NULL,
+        string_set ? string_setList : NULL
+        );
+
+    return model_with_set_propertes_local_var;
+end:
+    if (tag_setList) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, tag_setList) {
+            tag_free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        list_freeList(tag_setList);
+        tag_setList = NULL;
+    }
+    if (string_setList) {
+        listEntry_t *listEntry = NULL;
+        list_ForEach(listEntry, string_setList) {
+            free(listEntry->data);
+            listEntry->data = NULL;
+        }
+        list_freeList(string_setList);
+        string_setList = NULL;
+    }
+    return NULL;
+
+}

--- a/samples/client/petstore/c/model/model_with_set_propertes.h
+++ b/samples/client/petstore/c/model/model_with_set_propertes.h
@@ -1,0 +1,40 @@
+/*
+ * model_with_set_propertes.h
+ *
+ * to test set properties
+ */
+
+#ifndef _model_with_set_propertes_H_
+#define _model_with_set_propertes_H_
+
+#include <string.h>
+#include "../external/cJSON.h"
+#include "../include/list.h"
+#include "../include/keyValuePair.h"
+#include "../include/binary.h"
+
+typedef struct model_with_set_propertes_t model_with_set_propertes_t;
+
+#include "tag.h"
+
+
+
+typedef struct model_with_set_propertes_t {
+    list_t *tag_set; //nonprimitive container
+    list_t *string_set; //primitive container
+
+} model_with_set_propertes_t;
+
+model_with_set_propertes_t *model_with_set_propertes_create(
+    list_t *tag_set,
+    list_t *string_set
+);
+
+void model_with_set_propertes_free(model_with_set_propertes_t *model_with_set_propertes);
+
+model_with_set_propertes_t *model_with_set_propertes_parseFromJSON(cJSON *model_with_set_propertesJSON);
+
+cJSON *model_with_set_propertes_convertToJSON(model_with_set_propertes_t *model_with_set_propertes);
+
+#endif /* _model_with_set_propertes_H_ */
+

--- a/samples/client/petstore/c/unit-test/test_model_with_set_propertes.c
+++ b/samples/client/petstore/c/unit-test/test_model_with_set_propertes.c
@@ -1,0 +1,60 @@
+#ifndef model_with_set_propertes_TEST
+#define model_with_set_propertes_TEST
+
+// the following is to include only the main from the first c file
+#ifndef TEST_MAIN
+#define TEST_MAIN
+#define model_with_set_propertes_MAIN
+#endif // TEST_MAIN
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include "../external/cJSON.h"
+
+#include "../model/model_with_set_propertes.h"
+model_with_set_propertes_t* instantiate_model_with_set_propertes(int include_optional);
+
+
+
+model_with_set_propertes_t* instantiate_model_with_set_propertes(int include_optional) {
+  model_with_set_propertes_t* model_with_set_propertes = NULL;
+  if (include_optional) {
+    model_with_set_propertes = model_with_set_propertes_create(
+      list_createList(),
+      list_createList()
+    );
+  } else {
+    model_with_set_propertes = model_with_set_propertes_create(
+      list_createList(),
+      list_createList()
+    );
+  }
+
+  return model_with_set_propertes;
+}
+
+
+#ifdef model_with_set_propertes_MAIN
+
+void test_model_with_set_propertes(int include_optional) {
+    model_with_set_propertes_t* model_with_set_propertes_1 = instantiate_model_with_set_propertes(include_optional);
+
+	cJSON* jsonmodel_with_set_propertes_1 = model_with_set_propertes_convertToJSON(model_with_set_propertes_1);
+	printf("model_with_set_propertes :\n%s\n", cJSON_Print(jsonmodel_with_set_propertes_1));
+	model_with_set_propertes_t* model_with_set_propertes_2 = model_with_set_propertes_parseFromJSON(jsonmodel_with_set_propertes_1);
+	cJSON* jsonmodel_with_set_propertes_2 = model_with_set_propertes_convertToJSON(model_with_set_propertes_2);
+	printf("repeating model_with_set_propertes:\n%s\n", cJSON_Print(jsonmodel_with_set_propertes_2));
+}
+
+int main() {
+  test_model_with_set_propertes(1);
+  test_model_with_set_propertes(0);
+
+  printf("Hello world \n");
+  return 0;
+}
+
+#endif // model_with_set_propertes_MAIN
+#endif // model_with_set_propertes_TEST


### PR DESCRIPTION
map set to list so that the output compiles before someone has time to map `set` to a proper set data structure in C.

to close https://github.com/OpenAPITools/openapi-generator/issues/16611

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@zhemant (2018/11) @ityuhui (2019/12) @michelealbano (2020/03)
