### PR TITLE
[php-next-gen] fix handling with enums in object serializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -68,6 +68,10 @@ class ObjectSerializer
             return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
         }
 
+        if ($data instanceof \BackedEnum) {
+            return $data->value;
+        }
+
         if (is_array($data)) {
             foreach ($data as $property => $value) {
                 $data[$property] = self::sanitizeForSerialization($value);
@@ -84,10 +88,18 @@ class ObjectSerializer
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, [{{&primitives}}], true)) {
                         if (is_subclass_of($openAPIType, '\BackedEnum')) {
-                            $data = $openAPIType::tryFrom($data);
-                            if ($data === null) {
-                                $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
-                                throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+                            if (is_scalar($value)) {
+                                $value = $openAPIType::tryFrom($value);
+                                if ($value === null) {
+                                    $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
+                                    throw new \InvalidArgumentException(
+                                        sprintf(
+                                            "Invalid value for enum '%s', must be one of: '%s'",
+                                            $openAPIType::class,
+                                            $imploded
+                                        )
+                                    );
+                                }
                             }
                         }
                     }
@@ -444,7 +456,7 @@ class ObjectSerializer
             // determine file name
             if (
                 is_array($httpHeaders)
-                && array_key_exists('Content-Disposition', $httpHeaders) 
+                && array_key_exists('Content-Disposition', $httpHeaders)
                 && preg_match('/inline; filename=[\'"]?([^\'"\s]+)[\'"]?$/i', $httpHeaders['Content-Disposition'], $match)
             ) {
                 $filename = Configuration::getDefaultConfiguration()->getTempFolderPath() . DIRECTORY_SEPARATOR . self::sanitizeFilename($match[1]);

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -78,6 +78,10 @@ class ObjectSerializer
             return ($format === 'date') ? $data->format('Y-m-d') : $data->format(self::$dateTimeFormat);
         }
 
+        if ($data instanceof \BackedEnum) {
+            return $data->value;
+        }
+
         if (is_array($data)) {
             foreach ($data as $property => $value) {
                 $data[$property] = self::sanitizeForSerialization($value);
@@ -94,10 +98,18 @@ class ObjectSerializer
                     $value = $data->$getter();
                     if ($value !== null && !in_array($openAPIType, ['\DateTime', '\SplFileObject', 'array', 'bool', 'boolean', 'byte', 'float', 'int', 'integer', 'mixed', 'number', 'object', 'string', 'void'], true)) {
                         if (is_subclass_of($openAPIType, '\BackedEnum')) {
-                            $data = $openAPIType::tryFrom($data);
-                            if ($data === null) {
-                                $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
-                                throw new \InvalidArgumentException("Invalid value for enum '$openAPIType', must be one of: '$imploded'");
+                            if (is_scalar($value)) {
+                                $value = $openAPIType::tryFrom($value);
+                                if ($value === null) {
+                                    $imploded = implode("', '", array_map(fn($case) => $case->value, $openAPIType::cases()));
+                                    throw new \InvalidArgumentException(
+                                        sprintf(
+                                            "Invalid value for enum '%s', must be one of: '%s'",
+                                            $openAPIType::class,
+                                            $imploded
+                                        )
+                                    );
+                                }
                             }
                         }
                     }
@@ -454,7 +466,7 @@ class ObjectSerializer
             // determine file name
             if (
                 is_array($httpHeaders)
-                && array_key_exists('Content-Disposition', $httpHeaders) 
+                && array_key_exists('Content-Disposition', $httpHeaders)
                 && preg_match('/inline; filename=[\'"]?([^\'"\s]+)[\'"]?$/i', $httpHeaders['Content-Disposition'], $match)
             ) {
                 $filename = Configuration::getDefaultConfiguration()->getTempFolderPath() . DIRECTORY_SEPARATOR . self::sanitizeFilename($match[1]);


### PR DESCRIPTION
I am unsure if the whole check could be removed because in the setter method of the model there is a phpdoc typehint which states that only an enum is allowed. But as long as there are no native type hints it could not be ensured that the value is always an enum. 

`$data` in this case should never be overwritten because it contains the OpenApi information. 

In my opinion serialization of the value should always be a scalar value because otherwise receiving clients must understand PHP enums serialization. 

Offtopic: there are some more issues with enums, i.e. in query parameters. But I will fix them with separate pull requests so they are clean and simple. 


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
