### PR TITLE
Fix ruby httpx test

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_httpx_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_httpx_partial.mustache
@@ -19,7 +19,7 @@
                 Net::HTTP::STATUS_CODES.fetch(response.status, "HTTP Error (#{response.status})")
       rescue HTTPX::TimeoutError
         fail ApiError.new('Connection timed out')
-      rescue HTTPX::ConnectionError
+      rescue HTTPX::ConnectionError, HTTPX::ResolveError
         fail ApiError.new('Connection failed')
       end
 
@@ -73,14 +73,11 @@
       # http form
       if header_params['Content-Type'] == 'application/x-www-form-urlencoded' ||
          header_params['Content-Type'] == 'multipart/form-data'
-        data = { form: form_params }
+        header_params.delete('Content-Type') # httpx takes care of this
+        { form: form_params }
       elsif body
-
-        data = body.is_a?(String) ? { body: body } : { json: body }
-      else
-        data = nil
+        body.is_a?(String) ? { body: body } : { json: body }
       end
-      data
     end
 
     def session

--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_httpx_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_httpx_partial.mustache
@@ -54,13 +54,11 @@
         if config.debugging
           config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
-      else
-        body_params = {}
       end
       req_opts = {
-        :headers => HTTPX::Headers.new(header_params),
-        **body_params
+        :headers => HTTPX::Headers.new(header_params)
       }
+      req_opts.merge!(body_params) if body_params
       req_opts[:params] = query_params if query_params && !query_params.empty?
       session.request(http_method, url, **req_opts)
     end

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api_client.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api_client.rb
@@ -65,7 +65,7 @@ module OpenapiClient
                 Net::HTTP::STATUS_CODES.fetch(response.status, "HTTP Error (#{response.status})")
       rescue HTTPX::TimeoutError
         fail ApiError.new('Connection timed out')
-      rescue HTTPX::ConnectionError
+      rescue HTTPX::ConnectionError, HTTPX::ResolveError
         fail ApiError.new('Connection failed')
       end
 
@@ -100,13 +100,11 @@ module OpenapiClient
         if config.debugging
           config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
-      else
-        body_params = {}
       end
       req_opts = {
-        :headers => HTTPX::Headers.new(header_params),
-        **body_params
+        :headers => HTTPX::Headers.new(header_params)
       }
+      req_opts.merge!(body_params) if body_params
       req_opts[:params] = query_params if query_params && !query_params.empty?
       session.request(http_method, url, **req_opts)
     end
@@ -121,14 +119,11 @@ module OpenapiClient
       # http form
       if header_params['Content-Type'] == 'application/x-www-form-urlencoded' ||
          header_params['Content-Type'] == 'multipart/form-data'
-        data = { form: form_params }
+        header_params.delete('Content-Type') # httpx takes care of this
+        { form: form_params }
       elsif body
-
-        data = body.is_a?(String) ? { body: body } : { json: body }
-      else
-        data = nil
+        body.is_a?(String) ? { body: body } : { json: body }
       end
-      data
     end
 
     def session

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api_client.rb
@@ -100,13 +100,11 @@ module Petstore
         if config.debugging
           config.logger.debug "HTTP request body param ~BEGIN~\n#{req_body}\n~END~\n"
         end
-      else
-        body_params = {}
       end
       req_opts = {
-        :headers => HTTPX::Headers.new(header_params),
-        **body_params
+        :headers => HTTPX::Headers.new(header_params)
       }
+      req_opts.merge!(body_params) if body_params
       req_opts[:params] = query_params if query_params && !query_params.empty?
       session.request(http_method, url, **req_opts)
     end

--- a/samples/client/petstore/ruby-httpx/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/api_client.rb
@@ -65,7 +65,7 @@ module Petstore
                 Net::HTTP::STATUS_CODES.fetch(response.status, "HTTP Error (#{response.status})")
       rescue HTTPX::TimeoutError
         fail ApiError.new('Connection timed out')
-      rescue HTTPX::ConnectionError
+      rescue HTTPX::ConnectionError, HTTPX::ResolveError
         fail ApiError.new('Connection failed')
       end
 
@@ -119,14 +119,11 @@ module Petstore
       # http form
       if header_params['Content-Type'] == 'application/x-www-form-urlencoded' ||
          header_params['Content-Type'] == 'multipart/form-data'
-        data = { form: form_params }
+        header_params.delete('Content-Type') # httpx takes care of this
+        { form: form_params }
       elsif body
-
-        data = body.is_a?(String) ? { body: body } : { json: body }
-      else
-        data = nil
+        body.is_a?(String) ? { body: body } : { json: body }
       end
-      data
     end
 
     def session

--- a/samples/client/petstore/ruby-httpx/spec/custom/pet_spec.rb
+++ b/samples/client/petstore/ruby-httpx/spec/custom/pet_spec.rb
@@ -106,7 +106,7 @@ describe "Pet" do
     it "should fetch a pet object with http info" do
       pet, status_code, headers = @pet_api.get_pet_by_id_with_http_info(@pet_id)
       expect(status_code).to eq(200)
-      expect(headers['Content-Type']).to eq('application/json')
+      expect(headers['content-type']).to eq('application/json')
       expect(pet).to be_a(Petstore::Pet)
       expect(pet.id).to eq(@pet_id)
       expect(pet.name).to eq("RUBY UNIT TESTING")
@@ -123,8 +123,8 @@ describe "Pet" do
         # skip the check as the response contains a timestamp that changes on every response
         # expect(e.message).to eq("Error message: the server returns an error\nHTTP status code: 404\nResponse headers: {\"Date\"=>\"Tue, 26 Feb 2019 04:35:40 GMT\", \"Access-Control-Allow-Origin\"=>\"*\", \"Access-Control-Allow-Methods\"=>\"GET, POST, DELETE, PUT\", \"Access-Control-Allow-Headers\"=>\"Content-Type, api_key, Authorization\", \"Content-Type\"=>\"application/json\", \"Connection\"=>\"close\", \"Server\"=>\"Jetty(9.2.9.v20150224)\"}\nResponse body: {\"code\":1,\"type\":\"error\",\"message\":\"Pet not found\"}")
         expect(e.response_body).to eq('{"code":1,"type":"error","message":"Pet not found"}')
-        expect(e.response_headers).to include('Content-Type')
-        expect(e.response_headers['Content-Type']).to eq('application/json')
+        expect(e.response_headers).to include('content-type')
+        expect(e.response_headers['content-type']).to eq('application/json')
       end
     end
 


### PR DESCRIPTION
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
