### PR TITLE
Added support to skip creation of go.mod and go.sum in the Go client generator

### DIFF
--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -29,6 +29,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |structPrefix|whether to prefix struct with the class name. e.g. DeletePetOpts =&gt; PetApiDeletePetOpts| |false|
 |useOneOfDiscriminatorLookup|Use the discriminator's mapping in oneOf to speed up the model lookup. IMPORTANT: Validation (e.g. one and only one match in oneOf's schemas) will be skipped.| |false|
 |withAWSV4Signature|whether to include AWS v4 signature support| |false|
+|withGoMod|Generate go.mod and go.sum| |true|
 |withXml|whether to include support for application/xml content type and include XML annotations in the model (works with libraries that provide support for JSON and XML)| |false|
 
 ## IMPORT MAPPING

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -429,4 +429,6 @@ public class CodegenConstants {
                     "<li>setting additionalProperties: false in your schemas</li></ul>";
 
     public static final String FASTAPI_IMPLEMENTATION_PACKAGE = "fastapiImplementationPackage";
+
+    public static final String WITH_GO_MOD = "withGoMod";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -49,6 +49,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected boolean enumClassPrefix = false;
     protected boolean structPrefix = false;
     protected boolean generateInterfaces = false;
+    protected boolean withGoMod = false;
 
     protected String packageName = "openapi";
     protected Set<String> numberTypes;
@@ -802,6 +803,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     public void setGenerateInterfaces(boolean generateInterfaces) {
         this.generateInterfaces = generateInterfaces;
+    }
+
+    public void setWithGoMod(boolean withGoMod) {
+        this.withGoMod = withGoMod;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -56,6 +56,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
     public static final String WITH_AWSV4_SIGNATURE = "withAWSV4Signature";
     public static final String GENERATE_INTERFACES = "generateInterfaces";
     public static final String MODEL_FILE_FOLDER = "modelFileFolder";
+    public static final String WITH_GO_MOD = "withGoMod";
     protected String goImportAlias = "openapiclient";
     protected boolean isGoSubmodule = false;
     protected boolean useOneOfDiscriminatorLookup = false; // use oneOf discriminator's mapping for model lookup
@@ -137,6 +138,8 @@ public class GoClientCodegen extends AbstractGoCodegen {
         disallowAdditionalPropertiesIfNotPresentOpt.setEnum(disallowAdditionalPropertiesIfNotPresentOpts);
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
+        cliOptions.add(CliOption.newBoolean(WITH_GO_MOD, "Generate go.mod and go.sum", true));
+        this.setWithGoMod(true);
     }
 
     /**
@@ -262,6 +265,13 @@ public class GoClientCodegen extends AbstractGoCodegen {
             modelFileFolder = additionalProperties.get(MODEL_FILE_FOLDER).toString();
         }
 
+        if (additionalProperties.containsKey(WITH_GO_MOD)) {
+            setWithGoMod(Boolean.parseBoolean(additionalProperties.get(WITH_GO_MOD).toString()));
+            additionalProperties.put(WITH_GO_MOD, withGoMod);
+        } else {
+            additionalProperties.put(WITH_GO_MOD, true);
+        }
+
         // add lambda for mustache templates to handle oneOf/anyOf naming
         // e.g. []string => ArrayOfString
         additionalProperties.put("lambda.type-to-name", (Mustache.Lambda) (fragment, writer) -> writer.write(typeToName(fragment.execute())));
@@ -273,8 +283,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
         supportingFiles.add(new SupportingFile("configuration.mustache", "", "configuration.go"));
         supportingFiles.add(new SupportingFile("client.mustache", "", "client.go"));
         supportingFiles.add(new SupportingFile("response.mustache", "", "response.go"));
-        supportingFiles.add(new SupportingFile("go.mod.mustache", "", "go.mod"));
-        supportingFiles.add(new SupportingFile("go.sum.mustache", "", "go.sum"));
+        if ((boolean)additionalProperties.get(WITH_GO_MOD)) {
+            supportingFiles.add(new SupportingFile("go.mod.mustache", "", "go.mod"));
+            supportingFiles.add(new SupportingFile("go.sum.mustache", "", "go.sum"));
+        }
         supportingFiles.add(new SupportingFile(".travis.yml", "", ".travis.yml"));
         supportingFiles.add(new SupportingFile("utils.mustache", "", "utils.go"));
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -291,4 +291,46 @@ public class GoClientCodegenTest {
                 "httpRes, err := apiClient.PetAPI.PetDelete(context.Background()).Execute()");
     }
 
+    @Test
+    public void testAdditionalPropertiesWithGoMod() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_0/petstore_oas3_test.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        System.out.println(files);
+        files.forEach(File::deleteOnExit);
+
+        Path goModFile = Paths.get(output + "/go.mod");
+        TestUtils.assertFileExists(goModFile);
+        Path goSumFile = Paths.get(output + "/go.sum");
+        TestUtils.assertFileExists(goSumFile);
+    }
+
+    @Test
+    public void testAdditionalPropertiesWithoutGoMod() throws Exception {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setInputSpec("src/test/resources/3_0/petstore_oas3_test.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"))
+                .addAdditionalProperty(GoClientCodegen.WITH_GO_MOD, false);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        System.out.println(files);
+        files.forEach(File::deleteOnExit);
+
+        Path goModFile = Paths.get(output + "/go.mod");
+        TestUtils.assertFileNotExists(goModFile);
+        Path goSumFile = Paths.get(output + "/go.sum");
+        TestUtils.assertFileNotExists(goSumFile);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -51,5 +51,6 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setStructPrefix(GoClientOptionsProvider.STRUCT_PREFIX_VALUE);
         verify(clientCodegen).setWithAWSV4Signature(GoClientOptionsProvider.WITH_AWSV4_SIGNATURE);
         verify(clientCodegen).setUseOneOfDiscriminatorLookup(GoClientOptionsProvider.USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE);
+        verify(clientCodegen).setWithGoMod(GoClientOptionsProvider.WITH_GO_MOD_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
@@ -36,6 +36,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
     public static final boolean GENERATE_INTERFACES_VALUE = true;
     public static final boolean DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT_VALUE = true;
     public static final boolean USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE = true;
+    public static final boolean WITH_GO_MOD_VALUE = true;
 
     @Override
     public String getLanguage() {
@@ -56,6 +57,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.WITH_AWSV4_SIGNATURE_COMMENT, "true")
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, "true")
+                .put(CodegenConstants.WITH_GO_MOD, "true")
                 .put("generateInterfaces", "true")
                 .put("structPrefix", "true")
                 .build();


### PR DESCRIPTION
This PR adds support to avoid generating go.mod and go.sum for Go client.

By default it is set to true to keep compatibility with previous version of the tool.

It can be set to false using --additional-properties=withGoMod=false

Tests have been written to make sure the option is working correctly.

This will probably close https://github.com/OpenAPITools/openapi-generator/issues/4773

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
