### PR TITLE
[python] Add tests and fix enum path parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -186,7 +186,7 @@ class {{classname}}:
         _path_params: Dict[str, str] = {}
 {{#pathParams}}
         if _params['{{paramName}}'] is not None:
-            _path_params['{{baseName}}'] = _params['{{paramName}}']
+            _path_params['{{baseName}}'] = _params['{{paramName}}']{{#isEnumRef}}.value{{/isEnumRef}}
             {{#isArray}}
             _collection_formats['{{baseName}}'] = '{{collectionFormat}}'
             {{/isArray}}

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -31,13 +31,13 @@ paths:
   # will response with the same body in the HTTP request.
   #
   # path parameter tests
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       tags:
         - path 
       summary: Test path parameter(s)
       description: Test path parameter(s)
-      operationId: tests/path/string/{path_string}/integer/{path_integer}
+      operationId: tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}
       parameters:
       - in: path 
         name: path_string
@@ -49,6 +49,20 @@ paths:
         required: true
         schema:
           type: integer 
+      - in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
+      - in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
       responses:
         '200':
           description: Successful operation
@@ -118,13 +132,13 @@ paths:
               schema:
                 type: string
   # header parameter tests
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       tags:
         - header
       summary: Test header parameter(s)
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - in: header
         name: integer_header
@@ -144,6 +158,22 @@ paths:
         explode: true #default
         schema:
           type: string
+      - in: header
+        name: enum_nonref_string_header
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
+      - in: header
+        name: enum_ref_string_header
+        style: form #default
+        explode: true #default
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
       responses:
         '200':
           description: Successful operation
@@ -160,6 +190,16 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - in: query
+        name: enum_nonref_string_query
+        style: form #default
+        explode: true #default
+        schema:
+          type: string
+          enum:
+          - success
+          - failure
+          - unclassified
       - in: query
         name: enum_ref_string_query
         style: form #default

--- a/samples/client/echo_api/csharp-restsharp/README.md
+++ b/samples/client/echo_api/csharp-restsharp/README.md
@@ -126,8 +126,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**TestEchoBodyTagResponseString**](docs/BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**TestFormIntegerBooleanString**](docs/FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**TestFormOneof**](docs/FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**TestHeaderIntegerBooleanString**](docs/HeaderApi.md#testheaderintegerbooleanstring) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**TestsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testspathstringpathstringintegerpathinteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**TestHeaderIntegerBooleanStringEnums**](docs/HeaderApi.md#testheaderintegerbooleanstringenums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/PathApi.md#testspathstringpathstringintegerpathintegerenumnonrefstringpathenumrefstringpath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**TestEnumRefString**](docs/QueryApi.md#testenumrefstring) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**TestQueryDatetimeDateString**](docs/QueryApi.md#testquerydatetimedatestring) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**TestQueryIntegerBooleanString**](docs/QueryApi.md#testqueryintegerbooleanstring) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
+++ b/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -78,10 +96,10 @@ paths:
       summary: Test form parameter(s) for oneOf schema
       tags:
       - form
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -104,6 +122,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -119,6 +155,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/csharp-restsharp/docs/HeaderApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/HeaderApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |--------|--------------|-------------|
-| [**TestHeaderIntegerBooleanString**](HeaderApi.md#testheaderintegerbooleanstring) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**TestHeaderIntegerBooleanStringEnums**](HeaderApi.md#testheaderintegerbooleanstringenums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
-<a id="testheaderintegerbooleanstring"></a>
-# **TestHeaderIntegerBooleanString**
-> string TestHeaderIntegerBooleanString (int? integerHeader = null, bool? booleanHeader = null, string? stringHeader = null)
+<a id="testheaderintegerbooleanstringenums"></a>
+# **TestHeaderIntegerBooleanStringEnums**
+> string TestHeaderIntegerBooleanStringEnums (int? integerHeader = null, bool? booleanHeader = null, string? stringHeader = null, string? enumNonrefStringHeader = null, StringEnumRef? enumRefStringHeader = null)
 
 Test header parameter(s)
 
@@ -24,7 +24,7 @@ using Org.OpenAPITools.Model;
 
 namespace Example
 {
-    public class TestHeaderIntegerBooleanStringExample
+    public class TestHeaderIntegerBooleanStringEnumsExample
     {
         public static void Main()
         {
@@ -34,16 +34,18 @@ namespace Example
             var integerHeader = 56;  // int? |  (optional) 
             var booleanHeader = true;  // bool? |  (optional) 
             var stringHeader = "stringHeader_example";  // string? |  (optional) 
+            var enumNonrefStringHeader = "success";  // string? |  (optional) 
+            var enumRefStringHeader = new StringEnumRef?(); // StringEnumRef? |  (optional) 
 
             try
             {
                 // Test header parameter(s)
-                string result = apiInstance.TestHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+                string result = apiInstance.TestHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
             {
-                Debug.Print("Exception when calling HeaderApi.TestHeaderIntegerBooleanString: " + e.Message);
+                Debug.Print("Exception when calling HeaderApi.TestHeaderIntegerBooleanStringEnums: " + e.Message);
                 Debug.Print("Status Code: " + e.ErrorCode);
                 Debug.Print(e.StackTrace);
             }
@@ -52,21 +54,21 @@ namespace Example
 }
 ```
 
-#### Using the TestHeaderIntegerBooleanStringWithHttpInfo variant
+#### Using the TestHeaderIntegerBooleanStringEnumsWithHttpInfo variant
 This returns an ApiResponse object which contains the response data, status code and headers.
 
 ```csharp
 try
 {
     // Test header parameter(s)
-    ApiResponse<string> response = apiInstance.TestHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader);
+    ApiResponse<string> response = apiInstance.TestHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
 }
 catch (ApiException e)
 {
-    Debug.Print("Exception when calling HeaderApi.TestHeaderIntegerBooleanStringWithHttpInfo: " + e.Message);
+    Debug.Print("Exception when calling HeaderApi.TestHeaderIntegerBooleanStringEnumsWithHttpInfo: " + e.Message);
     Debug.Print("Status Code: " + e.ErrorCode);
     Debug.Print(e.StackTrace);
 }
@@ -79,6 +81,8 @@ catch (ApiException e)
 | **integerHeader** | **int?** |  | [optional]  |
 | **booleanHeader** | **bool?** |  | [optional]  |
 | **stringHeader** | **string?** |  | [optional]  |
+| **enumNonrefStringHeader** | **string?** |  | [optional]  |
+| **enumRefStringHeader** | [**StringEnumRef?**](StringEnumRef?.md) |  | [optional]  |
 
 ### Return type
 

--- a/samples/client/echo_api/csharp-restsharp/docs/PathApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/PathApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |--------|--------------|-------------|
-| [**TestsPathStringPathStringIntegerPathInteger**](PathApi.md#testspathstringpathstringintegerpathinteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](PathApi.md#testspathstringpathstringintegerpathintegerenumnonrefstringpathenumrefstringpath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
-<a id="testspathstringpathstringintegerpathinteger"></a>
-# **TestsPathStringPathStringIntegerPathInteger**
-> string TestsPathStringPathStringIntegerPathInteger (string pathString, int pathInteger)
+<a id="testspathstringpathstringintegerpathintegerenumnonrefstringpathenumrefstringpath"></a>
+# **TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**
+> string TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath (string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath)
 
 Test path parameter(s)
 
@@ -24,7 +24,7 @@ using Org.OpenAPITools.Model;
 
 namespace Example
 {
-    public class TestsPathStringPathStringIntegerPathIntegerExample
+    public class TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathExample
     {
         public static void Main()
         {
@@ -33,16 +33,18 @@ namespace Example
             var apiInstance = new PathApi(config);
             var pathString = "pathString_example";  // string | 
             var pathInteger = 56;  // int | 
+            var enumNonrefStringPath = "success";  // string | 
+            var enumRefStringPath = new StringEnumRef(); // StringEnumRef | 
 
             try
             {
                 // Test path parameter(s)
-                string result = apiInstance.TestsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+                string result = apiInstance.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
             {
-                Debug.Print("Exception when calling PathApi.TestsPathStringPathStringIntegerPathInteger: " + e.Message);
+                Debug.Print("Exception when calling PathApi.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath: " + e.Message);
                 Debug.Print("Status Code: " + e.ErrorCode);
                 Debug.Print(e.StackTrace);
             }
@@ -51,21 +53,21 @@ namespace Example
 }
 ```
 
-#### Using the TestsPathStringPathStringIntegerPathIntegerWithHttpInfo variant
+#### Using the TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo variant
 This returns an ApiResponse object which contains the response data, status code and headers.
 
 ```csharp
 try
 {
     // Test path parameter(s)
-    ApiResponse<string> response = apiInstance.TestsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger);
+    ApiResponse<string> response = apiInstance.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
 }
 catch (ApiException e)
 {
-    Debug.Print("Exception when calling PathApi.TestsPathStringPathStringIntegerPathIntegerWithHttpInfo: " + e.Message);
+    Debug.Print("Exception when calling PathApi.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo: " + e.Message);
     Debug.Print("Status Code: " + e.ErrorCode);
     Debug.Print(e.StackTrace);
 }
@@ -77,6 +79,8 @@ catch (ApiException e)
 |------|------|-------------|-------|
 | **pathString** | **string** |  |  |
 | **pathInteger** | **int** |  |  |
+| **enumNonrefStringPath** | **string** |  |  |
+| **enumRefStringPath** | [**StringEnumRef**](StringEnumRef.md) |  |  |
 
 ### Return type
 

--- a/samples/client/echo_api/csharp-restsharp/docs/QueryApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/QueryApi.md
@@ -15,7 +15,7 @@ All URIs are relative to *http://localhost:3000*
 
 <a id="testenumrefstring"></a>
 # **TestEnumRefString**
-> string TestEnumRefString (StringEnumRef? enumRefStringQuery = null)
+> string TestEnumRefString (string? enumNonrefStringQuery = null, StringEnumRef? enumRefStringQuery = null)
 
 Test query parameter(s)
 
@@ -38,12 +38,13 @@ namespace Example
             Configuration config = new Configuration();
             config.BasePath = "http://localhost:3000";
             var apiInstance = new QueryApi(config);
+            var enumNonrefStringQuery = "success";  // string? |  (optional) 
             var enumRefStringQuery = new StringEnumRef?(); // StringEnumRef? |  (optional) 
 
             try
             {
                 // Test query parameter(s)
-                string result = apiInstance.TestEnumRefString(enumRefStringQuery);
+                string result = apiInstance.TestEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -64,7 +65,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Test query parameter(s)
-    ApiResponse<string> response = apiInstance.TestEnumRefStringWithHttpInfo(enumRefStringQuery);
+    ApiResponse<string> response = apiInstance.TestEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -81,6 +82,7 @@ catch (ApiException e)
 
 | Name | Type | Description | Notes |
 |------|------|-------------|-------|
+| **enumNonrefStringQuery** | **string?** |  | [optional]  |
 | **enumRefStringQuery** | [**StringEnumRef?**](StringEnumRef?.md) |  | [optional]  |
 
 ### Return type

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/HeaderApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/HeaderApi.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Mime;
 using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Api
 {
@@ -36,9 +37,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        string TestHeaderIntegerBooleanString(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0);
+        string TestHeaderIntegerBooleanStringEnums(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0);
 
         /// <summary>
         /// Test header parameter(s)
@@ -50,9 +53,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        ApiResponse<string> TestHeaderIntegerBooleanStringWithHttpInfo(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0);
+        ApiResponse<string> TestHeaderIntegerBooleanStringEnumsWithHttpInfo(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -72,10 +77,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        System.Threading.Tasks.Task<string> TestHeaderIntegerBooleanStringAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<string> TestHeaderIntegerBooleanStringEnumsAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Test header parameter(s)
@@ -87,10 +94,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        System.Threading.Tasks.Task<ApiResponse<string>> TestHeaderIntegerBooleanStringWithHttpInfoAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<string>> TestHeaderIntegerBooleanStringEnumsWithHttpInfoAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -218,11 +227,13 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        public string TestHeaderIntegerBooleanString(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0)
+        public string TestHeaderIntegerBooleanStringEnums(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
             return localVarResponse.Data;
         }
 
@@ -233,9 +244,11 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        public Org.OpenAPITools.Client.ApiResponse<string> TestHeaderIntegerBooleanStringWithHttpInfo(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0)
+        public Org.OpenAPITools.Client.ApiResponse<string> TestHeaderIntegerBooleanStringEnumsWithHttpInfo(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -271,16 +284,24 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.HeaderParameters.Add("string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(stringHeader)); // header parameter
             }
+            if (enumNonrefStringHeader != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("enum_nonref_string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumNonrefStringHeader)); // header parameter
+            }
+            if (enumRefStringHeader != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("enum_ref_string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumRefStringHeader)); // header parameter
+            }
 
-            localVarRequestOptions.Operation = "HeaderApi.TestHeaderIntegerBooleanString";
+            localVarRequestOptions.Operation = "HeaderApi.TestHeaderIntegerBooleanStringEnums";
             localVarRequestOptions.OperationIndex = operationIndex;
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<string>("/header/integer/boolean/string", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<string>("/header/integer/boolean/string/enums", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
-                Exception _exception = this.ExceptionFactory("TestHeaderIntegerBooleanString", localVarResponse);
+                Exception _exception = this.ExceptionFactory("TestHeaderIntegerBooleanStringEnums", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;
@@ -297,12 +318,14 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        public async System.Threading.Tasks.Task<string> TestHeaderIntegerBooleanStringAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<string> TestHeaderIntegerBooleanStringEnumsAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestHeaderIntegerBooleanStringWithHttpInfoAsync(integerHeader, booleanHeader, stringHeader, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestHeaderIntegerBooleanStringEnumsWithHttpInfoAsync(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -313,10 +336,12 @@ namespace Org.OpenAPITools.Api
         /// <param name="integerHeader"> (optional)</param>
         /// <param name="booleanHeader"> (optional)</param>
         /// <param name="stringHeader"> (optional)</param>
+        /// <param name="enumNonrefStringHeader"> (optional)</param>
+        /// <param name="enumRefStringHeader"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestHeaderIntegerBooleanStringWithHttpInfoAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestHeaderIntegerBooleanStringEnumsWithHttpInfoAsync(int? integerHeader = default(int?), bool? booleanHeader = default(bool?), string? stringHeader = default(string?), string? enumNonrefStringHeader = default(string?), StringEnumRef? enumRefStringHeader = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -353,17 +378,25 @@ namespace Org.OpenAPITools.Api
             {
                 localVarRequestOptions.HeaderParameters.Add("string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(stringHeader)); // header parameter
             }
+            if (enumNonrefStringHeader != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("enum_nonref_string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumNonrefStringHeader)); // header parameter
+            }
+            if (enumRefStringHeader != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("enum_ref_string_header", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumRefStringHeader)); // header parameter
+            }
 
-            localVarRequestOptions.Operation = "HeaderApi.TestHeaderIntegerBooleanString";
+            localVarRequestOptions.Operation = "HeaderApi.TestHeaderIntegerBooleanStringEnums";
             localVarRequestOptions.OperationIndex = operationIndex;
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/header/integer/boolean/string", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/header/integer/boolean/string/enums", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
-                Exception _exception = this.ExceptionFactory("TestHeaderIntegerBooleanString", localVarResponse);
+                Exception _exception = this.ExceptionFactory("TestHeaderIntegerBooleanStringEnums", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/PathApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/PathApi.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Mime;
 using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
 
 namespace Org.OpenAPITools.Api
 {
@@ -35,9 +36,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        string TestsPathStringPathStringIntegerPathInteger(string pathString, int pathInteger, int operationIndex = 0);
+        string TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0);
 
         /// <summary>
         /// Test path parameter(s)
@@ -48,9 +51,11 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        ApiResponse<string> TestsPathStringPathStringIntegerPathIntegerWithHttpInfo(string pathString, int pathInteger, int operationIndex = 0);
+        ApiResponse<string> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,10 +74,12 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        System.Threading.Tasks.Task<string> TestsPathStringPathStringIntegerPathIntegerAsync(string pathString, int pathInteger, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<string> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsync(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Test path parameter(s)
@@ -83,10 +90,12 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        System.Threading.Tasks.Task<ApiResponse<string>> TestsPathStringPathStringIntegerPathIntegerWithHttpInfoAsync(string pathString, int pathInteger, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<string>> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfoAsync(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -213,11 +222,13 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        public string TestsPathStringPathStringIntegerPathInteger(string pathString, int pathInteger, int operationIndex = 0)
+        public string TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
             return localVarResponse.Data;
         }
 
@@ -227,14 +238,28 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        public Org.OpenAPITools.Client.ApiResponse<string> TestsPathStringPathStringIntegerPathIntegerWithHttpInfo(string pathString, int pathInteger, int operationIndex = 0)
+        public Org.OpenAPITools.Client.ApiResponse<string> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0)
         {
             // verify the required parameter 'pathString' is set
             if (pathString == null)
             {
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pathString' when calling PathApi->TestsPathStringPathStringIntegerPathInteger");
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pathString' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+            }
+
+            // verify the required parameter 'enumNonrefStringPath' is set
+            if (enumNonrefStringPath == null)
+            {
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'enumNonrefStringPath' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+            }
+
+            // verify the required parameter 'enumRefStringPath' is set
+            if (enumRefStringPath == null)
+            {
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'enumRefStringPath' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
             }
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -261,16 +286,18 @@ namespace Org.OpenAPITools.Api
 
             localVarRequestOptions.PathParameters.Add("path_string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(pathString)); // path parameter
             localVarRequestOptions.PathParameters.Add("path_integer", Org.OpenAPITools.Client.ClientUtils.ParameterToString(pathInteger)); // path parameter
+            localVarRequestOptions.PathParameters.Add("enum_nonref_string_path", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumNonrefStringPath)); // path parameter
+            localVarRequestOptions.PathParameters.Add("enum_ref_string_path", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumRefStringPath)); // path parameter
 
-            localVarRequestOptions.Operation = "PathApi.TestsPathStringPathStringIntegerPathInteger";
+            localVarRequestOptions.Operation = "PathApi.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath";
             localVarRequestOptions.OperationIndex = operationIndex;
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<string>("/path/string/{path_string}/integer/{path_integer}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<string>("/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
-                Exception _exception = this.ExceptionFactory("TestsPathStringPathStringIntegerPathInteger", localVarResponse);
+                Exception _exception = this.ExceptionFactory("TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;
@@ -286,12 +313,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        public async System.Threading.Tasks.Task<string> TestsPathStringPathStringIntegerPathIntegerAsync(string pathString, int pathInteger, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<string> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsync(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestsPathStringPathStringIntegerPathIntegerWithHttpInfoAsync(pathString, pathInteger, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfoAsync(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,15 +330,29 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pathString"></param>
         /// <param name="pathInteger"></param>
+        /// <param name="enumNonrefStringPath"></param>
+        /// <param name="enumRefStringPath"></param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestsPathStringPathStringIntegerPathIntegerWithHttpInfoAsync(string pathString, int pathInteger, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfoAsync(string pathString, int pathInteger, string enumNonrefStringPath, StringEnumRef enumRefStringPath, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'pathString' is set
             if (pathString == null)
             {
-                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pathString' when calling PathApi->TestsPathStringPathStringIntegerPathInteger");
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'pathString' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+            }
+
+            // verify the required parameter 'enumNonrefStringPath' is set
+            if (enumNonrefStringPath == null)
+            {
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'enumNonrefStringPath' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+            }
+
+            // verify the required parameter 'enumRefStringPath' is set
+            if (enumRefStringPath == null)
+            {
+                throw new Org.OpenAPITools.Client.ApiException(400, "Missing required parameter 'enumRefStringPath' when calling PathApi->TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
             }
 
 
@@ -337,17 +380,19 @@ namespace Org.OpenAPITools.Api
 
             localVarRequestOptions.PathParameters.Add("path_string", Org.OpenAPITools.Client.ClientUtils.ParameterToString(pathString)); // path parameter
             localVarRequestOptions.PathParameters.Add("path_integer", Org.OpenAPITools.Client.ClientUtils.ParameterToString(pathInteger)); // path parameter
+            localVarRequestOptions.PathParameters.Add("enum_nonref_string_path", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumNonrefStringPath)); // path parameter
+            localVarRequestOptions.PathParameters.Add("enum_ref_string_path", Org.OpenAPITools.Client.ClientUtils.ParameterToString(enumRefStringPath)); // path parameter
 
-            localVarRequestOptions.Operation = "PathApi.TestsPathStringPathStringIntegerPathInteger";
+            localVarRequestOptions.Operation = "PathApi.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath";
             localVarRequestOptions.OperationIndex = operationIndex;
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/path/string/{path_string}/integer/{path_integer}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<string>("/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
-                Exception _exception = this.ExceptionFactory("TestsPathStringPathStringIntegerPathInteger", localVarResponse);
+                Exception _exception = this.ExceptionFactory("TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/QueryApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/QueryApi.cs
@@ -34,10 +34,11 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s)
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        string TestEnumRefString(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0);
+        string TestEnumRefString(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0);
 
         /// <summary>
         /// Test query parameter(s)
@@ -46,10 +47,11 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s)
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        ApiResponse<string> TestEnumRefStringWithHttpInfo(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0);
+        ApiResponse<string> TestEnumRefStringWithHttpInfo(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0);
         /// <summary>
         /// Test query parameter(s)
         /// </summary>
@@ -235,11 +237,12 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s)
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        System.Threading.Tasks.Task<string> TestEnumRefStringAsync(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<string> TestEnumRefStringAsync(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Test query parameter(s)
@@ -248,11 +251,12 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s)
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        System.Threading.Tasks.Task<ApiResponse<string>> TestEnumRefStringWithHttpInfoAsync(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<string>> TestEnumRefStringWithHttpInfoAsync(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test query parameter(s)
         /// </summary>
@@ -560,12 +564,13 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s) Test query parameter(s)
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>string</returns>
-        public string TestEnumRefString(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0)
+        public string TestEnumRefString(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestEnumRefStringWithHttpInfo(enumRefStringQuery);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = TestEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery);
             return localVarResponse.Data;
         }
 
@@ -573,10 +578,11 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s) Test query parameter(s)
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of string</returns>
-        public Org.OpenAPITools.Client.ApiResponse<string> TestEnumRefStringWithHttpInfo(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0)
+        public Org.OpenAPITools.Client.ApiResponse<string> TestEnumRefStringWithHttpInfo(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -600,6 +606,10 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
+            if (enumNonrefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "enum_nonref_string_query", enumNonrefStringQuery));
+            }
             if (enumRefStringQuery != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "enum_ref_string_query", enumRefStringQuery));
@@ -627,13 +637,14 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s) Test query parameter(s)
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of string</returns>
-        public async System.Threading.Tasks.Task<string> TestEnumRefStringAsync(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<string> TestEnumRefStringAsync(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestEnumRefStringWithHttpInfoAsync(enumRefStringQuery, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<string> localVarResponse = await TestEnumRefStringWithHttpInfoAsync(enumNonrefStringQuery, enumRefStringQuery, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -641,11 +652,12 @@ namespace Org.OpenAPITools.Api
         /// Test query parameter(s) Test query parameter(s)
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="enumNonrefStringQuery"> (optional)</param>
         /// <param name="enumRefStringQuery"> (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestEnumRefStringWithHttpInfoAsync(StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<string>> TestEnumRefStringWithHttpInfoAsync(string? enumNonrefStringQuery = default(string?), StringEnumRef? enumRefStringQuery = default(StringEnumRef?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -670,6 +682,10 @@ namespace Org.OpenAPITools.Api
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
+            if (enumNonrefStringQuery != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "enum_nonref_string_query", enumNonrefStringQuery));
+            }
             if (enumRefStringQuery != null)
             {
                 localVarRequestOptions.QueryParameters.Add(Org.OpenAPITools.Client.ClientUtils.ParameterToMultiMap("", "enum_ref_string_query", enumRefStringQuery));

--- a/samples/client/echo_api/go/README.md
+++ b/samples/client/echo_api/go/README.md
@@ -87,8 +87,8 @@ Class | Method | HTTP request | Description
 *BodyAPI* | [**TestEchoBodyTagResponseString**](docs/BodyAPI.md#testechobodytagresponsestring) | **Post** /echo/body/Tag/response_string | Test empty json (request body)
 *FormAPI* | [**TestFormIntegerBooleanString**](docs/FormAPI.md#testformintegerbooleanstring) | **Post** /form/integer/boolean/string | Test form parameter(s)
 *FormAPI* | [**TestFormOneof**](docs/FormAPI.md#testformoneof) | **Post** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderAPI* | [**TestHeaderIntegerBooleanString**](docs/HeaderAPI.md#testheaderintegerbooleanstring) | **Get** /header/integer/boolean/string | Test header parameter(s)
-*PathAPI* | [**TestsPathStringPathStringIntegerPathInteger**](docs/PathAPI.md#testspathstringpathstringintegerpathinteger) | **Get** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderAPI* | [**TestHeaderIntegerBooleanStringEnums**](docs/HeaderAPI.md#testheaderintegerbooleanstringenums) | **Get** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathAPI* | [**TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/PathAPI.md#testspathstringpathstringintegerpathintegerenumnonrefstringpathenumrefstringpath) | **Get** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryAPI* | [**TestEnumRefString**](docs/QueryAPI.md#testenumrefstring) | **Get** /query/enum_ref_string | Test query parameter(s)
 *QueryAPI* | [**TestQueryDatetimeDateString**](docs/QueryAPI.md#testquerydatetimedatestring) | **Get** /query/datetime/date/string | Test query parameter(s)
 *QueryAPI* | [**TestQueryIntegerBooleanString**](docs/QueryAPI.md#testqueryintegerbooleanstring) | **Get** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/go/api/openapi.yaml
+++ b/samples/client/echo_api/go/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -78,10 +96,10 @@ paths:
       summary: Test form parameter(s) for oneOf schema
       tags:
       - form
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -104,6 +122,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -119,6 +155,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/go/api_header.go
+++ b/samples/client/echo_api/go/api_header.go
@@ -23,43 +23,55 @@ import (
 // HeaderAPIService HeaderAPI service
 type HeaderAPIService service
 
-type ApiTestHeaderIntegerBooleanStringRequest struct {
+type ApiTestHeaderIntegerBooleanStringEnumsRequest struct {
 	ctx context.Context
 	ApiService *HeaderAPIService
 	integerHeader *int32
 	booleanHeader *bool
 	stringHeader *string
+	enumNonrefStringHeader *string
+	enumRefStringHeader *StringEnumRef
 }
 
-func (r ApiTestHeaderIntegerBooleanStringRequest) IntegerHeader(integerHeader int32) ApiTestHeaderIntegerBooleanStringRequest {
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) IntegerHeader(integerHeader int32) ApiTestHeaderIntegerBooleanStringEnumsRequest {
 	r.integerHeader = &integerHeader
 	return r
 }
 
-func (r ApiTestHeaderIntegerBooleanStringRequest) BooleanHeader(booleanHeader bool) ApiTestHeaderIntegerBooleanStringRequest {
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) BooleanHeader(booleanHeader bool) ApiTestHeaderIntegerBooleanStringEnumsRequest {
 	r.booleanHeader = &booleanHeader
 	return r
 }
 
-func (r ApiTestHeaderIntegerBooleanStringRequest) StringHeader(stringHeader string) ApiTestHeaderIntegerBooleanStringRequest {
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) StringHeader(stringHeader string) ApiTestHeaderIntegerBooleanStringEnumsRequest {
 	r.stringHeader = &stringHeader
 	return r
 }
 
-func (r ApiTestHeaderIntegerBooleanStringRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.TestHeaderIntegerBooleanStringExecute(r)
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) EnumNonrefStringHeader(enumNonrefStringHeader string) ApiTestHeaderIntegerBooleanStringEnumsRequest {
+	r.enumNonrefStringHeader = &enumNonrefStringHeader
+	return r
+}
+
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) EnumRefStringHeader(enumRefStringHeader StringEnumRef) ApiTestHeaderIntegerBooleanStringEnumsRequest {
+	r.enumRefStringHeader = &enumRefStringHeader
+	return r
+}
+
+func (r ApiTestHeaderIntegerBooleanStringEnumsRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.TestHeaderIntegerBooleanStringEnumsExecute(r)
 }
 
 /*
-TestHeaderIntegerBooleanString Test header parameter(s)
+TestHeaderIntegerBooleanStringEnums Test header parameter(s)
 
 Test header parameter(s)
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiTestHeaderIntegerBooleanStringRequest
+ @return ApiTestHeaderIntegerBooleanStringEnumsRequest
 */
-func (a *HeaderAPIService) TestHeaderIntegerBooleanString(ctx context.Context) ApiTestHeaderIntegerBooleanStringRequest {
-	return ApiTestHeaderIntegerBooleanStringRequest{
+func (a *HeaderAPIService) TestHeaderIntegerBooleanStringEnums(ctx context.Context) ApiTestHeaderIntegerBooleanStringEnumsRequest {
+	return ApiTestHeaderIntegerBooleanStringEnumsRequest{
 		ApiService: a,
 		ctx: ctx,
 	}
@@ -67,7 +79,7 @@ func (a *HeaderAPIService) TestHeaderIntegerBooleanString(ctx context.Context) A
 
 // Execute executes the request
 //  @return string
-func (a *HeaderAPIService) TestHeaderIntegerBooleanStringExecute(r ApiTestHeaderIntegerBooleanStringRequest) (string, *http.Response, error) {
+func (a *HeaderAPIService) TestHeaderIntegerBooleanStringEnumsExecute(r ApiTestHeaderIntegerBooleanStringEnumsRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -75,12 +87,12 @@ func (a *HeaderAPIService) TestHeaderIntegerBooleanStringExecute(r ApiTestHeader
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "HeaderAPIService.TestHeaderIntegerBooleanString")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "HeaderAPIService.TestHeaderIntegerBooleanStringEnums")
 	if err != nil {
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/header/integer/boolean/string"
+	localVarPath := localBasePath + "/header/integer/boolean/string/enums"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -111,6 +123,12 @@ func (a *HeaderAPIService) TestHeaderIntegerBooleanStringExecute(r ApiTestHeader
 	}
 	if r.stringHeader != nil {
 		parameterAddToHeaderOrQuery(localVarHeaderParams, "string_header", r.stringHeader, "")
+	}
+	if r.enumNonrefStringHeader != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "enum_nonref_string_header", r.enumNonrefStringHeader, "")
+	}
+	if r.enumRefStringHeader != nil {
+		parameterAddToHeaderOrQuery(localVarHeaderParams, "enum_ref_string_header", r.enumRefStringHeader, "")
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
 	if err != nil {

--- a/samples/client/echo_api/go/api_path.go
+++ b/samples/client/echo_api/go/api_path.go
@@ -24,39 +24,45 @@ import (
 // PathAPIService PathAPI service
 type PathAPIService service
 
-type ApiTestsPathStringPathStringIntegerPathIntegerRequest struct {
+type ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest struct {
 	ctx context.Context
 	ApiService *PathAPIService
 	pathString string
 	pathInteger int32
+	enumNonrefStringPath string
+	enumRefStringPath StringEnumRef
 }
 
-func (r ApiTestsPathStringPathStringIntegerPathIntegerRequest) Execute() (string, *http.Response, error) {
-	return r.ApiService.TestsPathStringPathStringIntegerPathIntegerExecute(r)
+func (r ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest) Execute() (string, *http.Response, error) {
+	return r.ApiService.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathExecute(r)
 }
 
 /*
-TestsPathStringPathStringIntegerPathInteger Test path parameter(s)
+TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath Test path parameter(s)
 
 Test path parameter(s)
 
  @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  @param pathString
  @param pathInteger
- @return ApiTestsPathStringPathStringIntegerPathIntegerRequest
+ @param enumNonrefStringPath
+ @param enumRefStringPath
+ @return ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest
 */
-func (a *PathAPIService) TestsPathStringPathStringIntegerPathInteger(ctx context.Context, pathString string, pathInteger int32) ApiTestsPathStringPathStringIntegerPathIntegerRequest {
-	return ApiTestsPathStringPathStringIntegerPathIntegerRequest{
+func (a *PathAPIService) TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(ctx context.Context, pathString string, pathInteger int32, enumNonrefStringPath string, enumRefStringPath StringEnumRef) ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest {
+	return ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest{
 		ApiService: a,
 		ctx: ctx,
 		pathString: pathString,
 		pathInteger: pathInteger,
+		enumNonrefStringPath: enumNonrefStringPath,
+		enumRefStringPath: enumRefStringPath,
 	}
 }
 
 // Execute executes the request
 //  @return string
-func (a *PathAPIService) TestsPathStringPathStringIntegerPathIntegerExecute(r ApiTestsPathStringPathStringIntegerPathIntegerRequest) (string, *http.Response, error) {
+func (a *PathAPIService) TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathExecute(r ApiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod   = http.MethodGet
 		localVarPostBody     interface{}
@@ -64,14 +70,16 @@ func (a *PathAPIService) TestsPathStringPathStringIntegerPathIntegerExecute(r Ap
 		localVarReturnValue  string
 	)
 
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PathAPIService.TestsPathStringPathStringIntegerPathInteger")
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "PathAPIService.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath")
 	if err != nil {
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/path/string/{path_string}/integer/{path_integer}"
+	localVarPath := localBasePath + "/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
 	localVarPath = strings.Replace(localVarPath, "{"+"path_string"+"}", url.PathEscape(parameterValueToString(r.pathString, "pathString")), -1)
 	localVarPath = strings.Replace(localVarPath, "{"+"path_integer"+"}", url.PathEscape(parameterValueToString(r.pathInteger, "pathInteger")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"enum_nonref_string_path"+"}", url.PathEscape(parameterValueToString(r.enumNonrefStringPath, "enumNonrefStringPath")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"enum_ref_string_path"+"}", url.PathEscape(parameterValueToString(r.enumRefStringPath, "enumRefStringPath")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}

--- a/samples/client/echo_api/go/api_query.go
+++ b/samples/client/echo_api/go/api_query.go
@@ -27,7 +27,13 @@ type QueryAPIService service
 type ApiTestEnumRefStringRequest struct {
 	ctx context.Context
 	ApiService *QueryAPIService
+	enumNonrefStringQuery *string
 	enumRefStringQuery *StringEnumRef
+}
+
+func (r ApiTestEnumRefStringRequest) EnumNonrefStringQuery(enumNonrefStringQuery string) ApiTestEnumRefStringRequest {
+	r.enumNonrefStringQuery = &enumNonrefStringQuery
+	return r
 }
 
 func (r ApiTestEnumRefStringRequest) EnumRefStringQuery(enumRefStringQuery StringEnumRef) ApiTestEnumRefStringRequest {
@@ -75,6 +81,9 @@ func (a *QueryAPIService) TestEnumRefStringExecute(r ApiTestEnumRefStringRequest
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.enumNonrefStringQuery != nil {
+		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_nonref_string_query", r.enumNonrefStringQuery, "")
+	}
 	if r.enumRefStringQuery != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "enum_ref_string_query", r.enumRefStringQuery, "")
 	}

--- a/samples/client/echo_api/go/docs/HeaderAPI.md
+++ b/samples/client/echo_api/go/docs/HeaderAPI.md
@@ -4,13 +4,13 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**TestHeaderIntegerBooleanString**](HeaderAPI.md#TestHeaderIntegerBooleanString) | **Get** /header/integer/boolean/string | Test header parameter(s)
+[**TestHeaderIntegerBooleanStringEnums**](HeaderAPI.md#TestHeaderIntegerBooleanStringEnums) | **Get** /header/integer/boolean/string/enums | Test header parameter(s)
 
 
 
-## TestHeaderIntegerBooleanString
+## TestHeaderIntegerBooleanStringEnums
 
-> string TestHeaderIntegerBooleanString(ctx).IntegerHeader(integerHeader).BooleanHeader(booleanHeader).StringHeader(stringHeader).Execute()
+> string TestHeaderIntegerBooleanStringEnums(ctx).IntegerHeader(integerHeader).BooleanHeader(booleanHeader).StringHeader(stringHeader).EnumNonrefStringHeader(enumNonrefStringHeader).EnumRefStringHeader(enumRefStringHeader).Execute()
 
 Test header parameter(s)
 
@@ -32,16 +32,18 @@ func main() {
     integerHeader := int32(56) // int32 |  (optional)
     booleanHeader := true // bool |  (optional)
     stringHeader := "stringHeader_example" // string |  (optional)
+    enumNonrefStringHeader := "enumNonrefStringHeader_example" // string |  (optional)
+    enumRefStringHeader := openapiclient.StringEnumRef("success") // StringEnumRef |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.HeaderAPI.TestHeaderIntegerBooleanString(context.Background()).IntegerHeader(integerHeader).BooleanHeader(booleanHeader).StringHeader(stringHeader).Execute()
+    resp, r, err := apiClient.HeaderAPI.TestHeaderIntegerBooleanStringEnums(context.Background()).IntegerHeader(integerHeader).BooleanHeader(booleanHeader).StringHeader(stringHeader).EnumNonrefStringHeader(enumNonrefStringHeader).EnumRefStringHeader(enumRefStringHeader).Execute()
     if err != nil {
-        fmt.Fprintf(os.Stderr, "Error when calling `HeaderAPI.TestHeaderIntegerBooleanString``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Error when calling `HeaderAPI.TestHeaderIntegerBooleanStringEnums``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
-    // response from `TestHeaderIntegerBooleanString`: string
-    fmt.Fprintf(os.Stdout, "Response from `HeaderAPI.TestHeaderIntegerBooleanString`: %v\n", resp)
+    // response from `TestHeaderIntegerBooleanStringEnums`: string
+    fmt.Fprintf(os.Stdout, "Response from `HeaderAPI.TestHeaderIntegerBooleanStringEnums`: %v\n", resp)
 }
 ```
 
@@ -51,7 +53,7 @@ func main() {
 
 ### Other Parameters
 
-Other parameters are passed through a pointer to a apiTestHeaderIntegerBooleanStringRequest struct via the builder pattern
+Other parameters are passed through a pointer to a apiTestHeaderIntegerBooleanStringEnumsRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
@@ -59,6 +61,8 @@ Name | Type | Description  | Notes
  **integerHeader** | **int32** |  | 
  **booleanHeader** | **bool** |  | 
  **stringHeader** | **string** |  | 
+ **enumNonrefStringHeader** | **string** |  | 
+ **enumRefStringHeader** | [**StringEnumRef**](StringEnumRef.md) |  | 
 
 ### Return type
 

--- a/samples/client/echo_api/go/docs/PathAPI.md
+++ b/samples/client/echo_api/go/docs/PathAPI.md
@@ -4,13 +4,13 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**TestsPathStringPathStringIntegerPathInteger**](PathAPI.md#TestsPathStringPathStringIntegerPathInteger) | **Get** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+[**TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](PathAPI.md#TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **Get** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 
 
 
-## TestsPathStringPathStringIntegerPathInteger
+## TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath
 
-> string TestsPathStringPathStringIntegerPathInteger(ctx, pathString, pathInteger).Execute()
+> string TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(ctx, pathString, pathInteger, enumNonrefStringPath, enumRefStringPath).Execute()
 
 Test path parameter(s)
 
@@ -31,16 +31,18 @@ import (
 func main() {
     pathString := "pathString_example" // string | 
     pathInteger := int32(56) // int32 | 
+    enumNonrefStringPath := "enumNonrefStringPath_example" // string | 
+    enumRefStringPath := openapiclient.StringEnumRef("success") // StringEnumRef | 
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.PathAPI.TestsPathStringPathStringIntegerPathInteger(context.Background(), pathString, pathInteger).Execute()
+    resp, r, err := apiClient.PathAPI.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(context.Background(), pathString, pathInteger, enumNonrefStringPath, enumRefStringPath).Execute()
     if err != nil {
-        fmt.Fprintf(os.Stderr, "Error when calling `PathAPI.TestsPathStringPathStringIntegerPathInteger``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Error when calling `PathAPI.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
     }
-    // response from `TestsPathStringPathStringIntegerPathInteger`: string
-    fmt.Fprintf(os.Stdout, "Response from `PathAPI.TestsPathStringPathStringIntegerPathInteger`: %v\n", resp)
+    // response from `TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath`: string
+    fmt.Fprintf(os.Stdout, "Response from `PathAPI.TestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath`: %v\n", resp)
 }
 ```
 
@@ -52,14 +54,18 @@ Name | Type | Description  | Notes
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
 **pathString** | **string** |  | 
 **pathInteger** | **int32** |  | 
+**enumNonrefStringPath** | **string** |  | 
+**enumRefStringPath** | [**StringEnumRef**](.md) |  | 
 
 ### Other Parameters
 
-Other parameters are passed through a pointer to a apiTestsPathStringPathStringIntegerPathIntegerRequest struct via the builder pattern
+Other parameters are passed through a pointer to a apiTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest struct via the builder pattern
 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+
+
 
 
 

--- a/samples/client/echo_api/go/docs/QueryAPI.md
+++ b/samples/client/echo_api/go/docs/QueryAPI.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 
 ## TestEnumRefString
 
-> string TestEnumRefString(ctx).EnumRefStringQuery(enumRefStringQuery).Execute()
+> string TestEnumRefString(ctx).EnumNonrefStringQuery(enumNonrefStringQuery).EnumRefStringQuery(enumRefStringQuery).Execute()
 
 Test query parameter(s)
 
@@ -36,11 +36,12 @@ import (
 )
 
 func main() {
+    enumNonrefStringQuery := "enumNonrefStringQuery_example" // string |  (optional)
     enumRefStringQuery := openapiclient.StringEnumRef("success") // StringEnumRef |  (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.QueryAPI.TestEnumRefString(context.Background()).EnumRefStringQuery(enumRefStringQuery).Execute()
+    resp, r, err := apiClient.QueryAPI.TestEnumRefString(context.Background()).EnumNonrefStringQuery(enumNonrefStringQuery).EnumRefStringQuery(enumRefStringQuery).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `QueryAPI.TestEnumRefString``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -61,6 +62,7 @@ Other parameters are passed through a pointer to a apiTestEnumRefStringRequest s
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **enumNonrefStringQuery** | **string** |  | 
  **enumRefStringQuery** | [**StringEnumRef**](StringEnumRef.md) |  | 
 
 ### Return type

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -120,8 +120,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**testHeaderIntegerBooleanStringEnums**](docs/HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**testQueryDatetimeDateString**](docs/QueryApi.md#testQueryDatetimeDateString) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**testQueryIntegerBooleanString**](docs/QueryApi.md#testQueryIntegerBooleanString) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -83,10 +101,10 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -109,6 +127,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -125,6 +161,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/java/apache-httpclient/docs/HeaderApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/HeaderApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testHeaderIntegerBooleanString**](HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**testHeaderIntegerBooleanStringEnums**](HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
 
 
-## testHeaderIntegerBooleanString
+## testHeaderIntegerBooleanStringEnums
 
-> String testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader)
+> String testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader)
 
 Test header parameter(s)
 
@@ -35,11 +35,13 @@ public class Example {
         Integer integerHeader = 56; // Integer | 
         Boolean booleanHeader = true; // Boolean | 
         String stringHeader = "stringHeader_example"; // String | 
+        String enumNonrefStringHeader = "success"; // String | 
+        StringEnumRef enumRefStringHeader = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+            String result = apiInstance.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanString");
+            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanStringEnums");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -57,6 +59,8 @@ public class Example {
 | **integerHeader** | **Integer**|  | [optional] |
 | **booleanHeader** | **Boolean**|  | [optional] |
 | **stringHeader** | **String**|  | [optional] |
+| **enumNonrefStringHeader** | **String**|  | [optional] [enum: success, failure, unclassified] |
+| **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/docs/PathApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/PathApi.md
@@ -4,13 +4,13 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testsPathStringPathStringIntegerPathInteger**](PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
 
 
-## testsPathStringPathStringIntegerPathInteger
+## testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath
 
-> String testsPathStringPathStringIntegerPathInteger(pathString, pathInteger)
+> String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath)
 
 Test path parameter(s)
 
@@ -34,11 +34,13 @@ public class Example {
         PathApi apiInstance = new PathApi(defaultClient);
         String pathString = "pathString_example"; // String | 
         Integer pathInteger = 56; // Integer | 
+        String enumNonrefStringPath = "success"; // String | 
+        StringEnumRef enumRefStringPath = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+            String result = apiInstance.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathInteger");
+            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -55,6 +57,8 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **pathString** | **String**|  | |
 | **pathInteger** | **Integer**|  | |
+| **enumNonrefStringPath** | **String**|  | [enum: success, failure, unclassified] |
+| **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/apache-httpclient/docs/QueryApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/QueryApi.md
@@ -17,7 +17,7 @@ All URIs are relative to *http://localhost:3000*
 
 ## testEnumRefString
 
-> String testEnumRefString(enumRefStringQuery)
+> String testEnumRefString(enumNonrefStringQuery, enumRefStringQuery)
 
 Test query parameter(s)
 
@@ -39,9 +39,10 @@ public class Example {
         defaultClient.setBasePath("http://localhost:3000");
 
         QueryApi apiInstance = new QueryApi(defaultClient);
+        String enumNonrefStringQuery = "success"; // String | 
         StringEnumRef enumRefStringQuery = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testEnumRefString(enumRefStringQuery);
+            String result = apiInstance.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling QueryApi#testEnumRefString");
@@ -59,6 +60,7 @@ public class Example {
 
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
+| **enumNonrefStringQuery** | **String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -19,6 +19,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.Configuration;
 import org.openapitools.client.Pair;
 
+import org.openapitools.client.model.StringEnumRef;
 
 
 import java.util.ArrayList;
@@ -56,11 +57,13 @@ public class HeaderApi {
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testHeaderIntegerBooleanString(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
-    return this.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader, Collections.emptyMap());
+  public String testHeaderIntegerBooleanStringEnums(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
+    return this.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader, Collections.emptyMap());
   }
 
 
@@ -70,15 +73,17 @@ public class HeaderApi {
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @param additionalHeaders additionalHeaders for this call
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testHeaderIntegerBooleanString(Integer integerHeader, Boolean booleanHeader, String stringHeader, Map<String, String> additionalHeaders) throws ApiException {
+  public String testHeaderIntegerBooleanStringEnums(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
-    String localVarPath = "/header/integer/boolean/string";
+    String localVarPath = "/header/integer/boolean/string/enums";
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
@@ -94,6 +99,10 @@ if (booleanHeader != null)
       localVarHeaderParams.put("boolean_header", apiClient.parameterToString(booleanHeader));
 if (stringHeader != null)
       localVarHeaderParams.put("string_header", apiClient.parameterToString(stringHeader));
+if (enumNonrefStringHeader != null)
+      localVarHeaderParams.put("enum_nonref_string_header", apiClient.parameterToString(enumNonrefStringHeader));
+if (enumRefStringHeader != null)
+      localVarHeaderParams.put("enum_ref_string_header", apiClient.parameterToString(enumRefStringHeader));
 
     localVarHeaderParams.putAll(additionalHeaders);
 

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/PathApi.java
@@ -19,6 +19,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.Configuration;
 import org.openapitools.client.Pair;
 
+import org.openapitools.client.model.StringEnumRef;
 
 
 import java.util.ArrayList;
@@ -55,11 +56,13 @@ public class PathApi {
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testsPathStringPathStringIntegerPathInteger(String pathString, Integer pathInteger) throws ApiException {
-    return this.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger, Collections.emptyMap());
+  public String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
+    return this.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath, Collections.emptyMap());
   }
 
 
@@ -68,27 +71,41 @@ public class PathApi {
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @param additionalHeaders additionalHeaders for this call
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testsPathStringPathStringIntegerPathInteger(String pathString, Integer pathInteger, Map<String, String> additionalHeaders) throws ApiException {
+  public String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     // verify the required parameter 'pathString' is set
     if (pathString == null) {
-      throw new ApiException(400, "Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathInteger");
+      throw new ApiException(400, "Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
     }
     
     // verify the required parameter 'pathInteger' is set
     if (pathInteger == null) {
-      throw new ApiException(400, "Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathInteger");
+      throw new ApiException(400, "Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+    }
+    
+    // verify the required parameter 'enumNonrefStringPath' is set
+    if (enumNonrefStringPath == null) {
+      throw new ApiException(400, "Missing the required parameter 'enumNonrefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+    }
+    
+    // verify the required parameter 'enumRefStringPath' is set
+    if (enumRefStringPath == null) {
+      throw new ApiException(400, "Missing the required parameter 'enumRefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
     }
     
     // create path and map variables
-    String localVarPath = "/path/string/{path_string}/integer/{path_integer}"
+    String localVarPath = "/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       .replaceAll("\\{" + "path_string" + "\\}", apiClient.escapeString(pathString.toString()))
-      .replaceAll("\\{" + "path_integer" + "\\}", apiClient.escapeString(pathInteger.toString()));
+      .replaceAll("\\{" + "path_integer" + "\\}", apiClient.escapeString(pathInteger.toString()))
+      .replaceAll("\\{" + "enum_nonref_string_path" + "\\}", apiClient.escapeString(enumNonrefStringPath.toString()))
+      .replaceAll("\\{" + "enum_ref_string_path" + "\\}", apiClient.escapeString(enumRefStringPath.toString()));
 
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -60,24 +60,26 @@ public class QueryApi {
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testEnumRefString(StringEnumRef enumRefStringQuery) throws ApiException {
-    return this.testEnumRefString(enumRefStringQuery, Collections.emptyMap());
+  public String testEnumRefString(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
+    return this.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery, Collections.emptyMap());
   }
 
 
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @param additionalHeaders additionalHeaders for this call
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testEnumRefString(StringEnumRef enumRefStringQuery, Map<String, String> additionalHeaders) throws ApiException {
+  public String testEnumRefString(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery, Map<String, String> additionalHeaders) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -91,6 +93,7 @@ public class QueryApi {
     Map<String, String> localVarCookieParams = new HashMap<String, String>();
     Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
+    localVarQueryParams.addAll(apiClient.parameterToPair("enum_nonref_string_query", enumNonrefStringQuery));
     localVarQueryParams.addAll(apiClient.parameterToPair("enum_ref_string_query", enumRefStringQuery));
     
     localVarHeaderParams.putAll(additionalHeaders);

--- a/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/api/HeaderApiTest.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/api/HeaderApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.Assert;
@@ -42,11 +43,13 @@ public class HeaderApiTest {
      *          if the Api call fails
      */
     @Test
-    public void testHeaderIntegerBooleanStringTest() throws ApiException {
+    public void testHeaderIntegerBooleanStringEnumsTest() throws ApiException {
         Integer integerHeader = null;
         Boolean booleanHeader = null;
         String stringHeader = null;
-        String response = api.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+        String enumNonrefStringHeader = null;
+        StringEnumRef enumRefStringHeader = null;
+        String response = api.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
 
         // TODO: test validations
     }

--- a/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/api/PathApiTest.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/test/java/org/openapitools/client/api/PathApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.Assert;
@@ -42,10 +43,12 @@ public class PathApiTest {
      *          if the Api call fails
      */
     @Test
-    public void testsPathStringPathStringIntegerPathIntegerTest() throws ApiException {
+    public void testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathTest() throws ApiException {
         String pathString = null;
         Integer pathInteger = null;
-        String response = api.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+        String enumNonrefStringPath = null;
+        StringEnumRef enumRefStringPath = null;
+        String response = api.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
 
         // TODO: test validations
     }

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -83,10 +101,10 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -109,6 +127,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -125,6 +161,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.EncodingUtils;
 import org.openapitools.client.model.ApiResponse;
 
+import org.openapitools.client.model.StringEnumRef;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,38 +22,50 @@ public interface HeaderApi extends ApiClient.Api {
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @return String
    */
-  @RequestLine("GET /header/integer/boolean/string")
+  @RequestLine("GET /header/integer/boolean/string/enums")
   @Headers({
     "Accept: text/plain",
     "integer_header: {integerHeader}",
     
     "boolean_header: {booleanHeader}",
     
-    "string_header: {stringHeader}"
+    "string_header: {stringHeader}",
+    
+    "enum_nonref_string_header: {enumNonrefStringHeader}",
+    
+    "enum_ref_string_header: {enumRefStringHeader}"
   })
-  String testHeaderIntegerBooleanString(@Param("integerHeader") Integer integerHeader, @Param("booleanHeader") Boolean booleanHeader, @Param("stringHeader") String stringHeader);
+  String testHeaderIntegerBooleanStringEnums(@Param("integerHeader") Integer integerHeader, @Param("booleanHeader") Boolean booleanHeader, @Param("stringHeader") String stringHeader, @Param("enumNonrefStringHeader") String enumNonrefStringHeader, @Param("enumRefStringHeader") StringEnumRef enumRefStringHeader);
 
   /**
    * Test header parameter(s)
-   * Similar to <code>testHeaderIntegerBooleanString</code> but it also returns the http response headers .
+   * Similar to <code>testHeaderIntegerBooleanStringEnums</code> but it also returns the http response headers .
    * Test header parameter(s)
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @return A ApiResponse that wraps the response boyd and the http headers.
    */
-  @RequestLine("GET /header/integer/boolean/string")
+  @RequestLine("GET /header/integer/boolean/string/enums")
   @Headers({
     "Accept: text/plain",
     "integer_header: {integerHeader}",
     
     "boolean_header: {booleanHeader}",
     
-    "string_header: {stringHeader}"
+    "string_header: {stringHeader}",
+    
+    "enum_nonref_string_header: {enumNonrefStringHeader}",
+    
+    "enum_ref_string_header: {enumRefStringHeader}"
   })
-  ApiResponse<String> testHeaderIntegerBooleanStringWithHttpInfo(@Param("integerHeader") Integer integerHeader, @Param("booleanHeader") Boolean booleanHeader, @Param("stringHeader") String stringHeader);
+  ApiResponse<String> testHeaderIntegerBooleanStringEnumsWithHttpInfo(@Param("integerHeader") Integer integerHeader, @Param("booleanHeader") Boolean booleanHeader, @Param("stringHeader") String stringHeader, @Param("enumNonrefStringHeader") String enumNonrefStringHeader, @Param("enumRefStringHeader") StringEnumRef enumRefStringHeader);
 
 
 }

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/PathApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.EncodingUtils;
 import org.openapitools.client.model.ApiResponse;
 
+import org.openapitools.client.model.StringEnumRef;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,27 +21,31 @@ public interface PathApi extends ApiClient.Api {
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @return String
    */
-  @RequestLine("GET /path/string/{pathString}/integer/{pathInteger}")
+  @RequestLine("GET /path/string/{pathString}/integer/{pathInteger}/{enumNonrefStringPath}/{enumRefStringPath}")
   @Headers({
     "Accept: text/plain",
   })
-  String testsPathStringPathStringIntegerPathInteger(@Param("pathString") String pathString, @Param("pathInteger") Integer pathInteger);
+  String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(@Param("pathString") String pathString, @Param("pathInteger") Integer pathInteger, @Param("enumNonrefStringPath") String enumNonrefStringPath, @Param("enumRefStringPath") StringEnumRef enumRefStringPath);
 
   /**
    * Test path parameter(s)
-   * Similar to <code>testsPathStringPathStringIntegerPathInteger</code> but it also returns the http response headers .
+   * Similar to <code>testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath</code> but it also returns the http response headers .
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @return A ApiResponse that wraps the response boyd and the http headers.
    */
-  @RequestLine("GET /path/string/{pathString}/integer/{pathInteger}")
+  @RequestLine("GET /path/string/{pathString}/integer/{pathInteger}/{enumNonrefStringPath}/{enumRefStringPath}")
   @Headers({
     "Accept: text/plain",
   })
-  ApiResponse<String> testsPathStringPathStringIntegerPathIntegerWithHttpInfo(@Param("pathString") String pathString, @Param("pathInteger") Integer pathInteger);
+  ApiResponse<String> testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(@Param("pathString") String pathString, @Param("pathInteger") Integer pathInteger, @Param("enumNonrefStringPath") String enumNonrefStringPath, @Param("enumRefStringPath") StringEnumRef enumRefStringPath);
 
 
 }

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -25,27 +25,29 @@ public interface QueryApi extends ApiClient.Api {
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @return String
    */
-  @RequestLine("GET /query/enum_ref_string?enum_ref_string_query={enumRefStringQuery}")
+  @RequestLine("GET /query/enum_ref_string?enum_nonref_string_query={enumNonrefStringQuery}&enum_ref_string_query={enumRefStringQuery}")
   @Headers({
     "Accept: text/plain",
   })
-  String testEnumRefString(@Param("enumRefStringQuery") StringEnumRef enumRefStringQuery);
+  String testEnumRefString(@Param("enumNonrefStringQuery") String enumNonrefStringQuery, @Param("enumRefStringQuery") StringEnumRef enumRefStringQuery);
 
   /**
    * Test query parameter(s)
    * Similar to <code>testEnumRefString</code> but it also returns the http response headers .
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @return A ApiResponse that wraps the response boyd and the http headers.
    */
-  @RequestLine("GET /query/enum_ref_string?enum_ref_string_query={enumRefStringQuery}")
+  @RequestLine("GET /query/enum_ref_string?enum_nonref_string_query={enumNonrefStringQuery}&enum_ref_string_query={enumRefStringQuery}")
   @Headers({
     "Accept: text/plain",
   })
-  ApiResponse<String> testEnumRefStringWithHttpInfo(@Param("enumRefStringQuery") StringEnumRef enumRefStringQuery);
+  ApiResponse<String> testEnumRefStringWithHttpInfo(@Param("enumNonrefStringQuery") String enumNonrefStringQuery, @Param("enumRefStringQuery") StringEnumRef enumRefStringQuery);
 
 
   /**
@@ -59,11 +61,12 @@ public interface QueryApi extends ApiClient.Api {
    * @param queryParams Map of query parameters as name-value pairs
    *   <p>The following elements may be specified in the query map:</p>
    *   <ul>
+   *   <li>enumNonrefStringQuery -  (optional)</li>
    *   <li>enumRefStringQuery -  (optional)</li>
    *   </ul>
    * @return String
    */
-  @RequestLine("GET /query/enum_ref_string?enum_ref_string_query={enumRefStringQuery}")
+  @RequestLine("GET /query/enum_ref_string?enum_nonref_string_query={enumNonrefStringQuery}&enum_ref_string_query={enumRefStringQuery}")
   @Headers({
   "Accept: text/plain",
   })
@@ -77,11 +80,12 @@ public interface QueryApi extends ApiClient.Api {
       * @param queryParams Map of query parameters as name-value pairs
       *   <p>The following elements may be specified in the query map:</p>
       *   <ul>
+          *   <li>enumNonrefStringQuery -  (optional)</li>
           *   <li>enumRefStringQuery -  (optional)</li>
       *   </ul>
           * @return String
       */
-      @RequestLine("GET /query/enum_ref_string?enum_ref_string_query={enumRefStringQuery}")
+      @RequestLine("GET /query/enum_ref_string?enum_nonref_string_query={enumNonrefStringQuery}&enum_ref_string_query={enumRefStringQuery}")
       @Headers({
     "Accept: text/plain",
       })
@@ -93,6 +97,10 @@ public interface QueryApi extends ApiClient.Api {
    * <code>testEnumRefString</code> method in a fluent style.
    */
   public static class TestEnumRefStringQueryParams extends HashMap<String, Object> {
+    public TestEnumRefStringQueryParams enumNonrefStringQuery(final String value) {
+      put("enum_nonref_string_query", EncodingUtils.encode(value));
+      return this;
+    }
     public TestEnumRefStringQueryParams enumRefStringQuery(final StringEnumRef value) {
       put("enum_ref_string_query", EncodingUtils.encode(value));
       return this;

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -124,10 +124,10 @@ Class | Method | HTTP request | Description
 *FormApi* | [**testFormIntegerBooleanStringWithHttpInfo**](docs/FormApi.md#testFormIntegerBooleanStringWithHttpInfo) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *FormApi* | [**testFormOneofWithHttpInfo**](docs/FormApi.md#testFormOneofWithHttpInfo) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*HeaderApi* | [**testHeaderIntegerBooleanStringWithHttpInfo**](docs/HeaderApi.md#testHeaderIntegerBooleanStringWithHttpInfo) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
-*PathApi* | [**testsPathStringPathStringIntegerPathIntegerWithHttpInfo**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerWithHttpInfo) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**testHeaderIntegerBooleanStringEnums**](docs/HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*HeaderApi* | [**testHeaderIntegerBooleanStringEnumsWithHttpInfo**](docs/HeaderApi.md#testHeaderIntegerBooleanStringEnumsWithHttpInfo) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**testEnumRefStringWithHttpInfo**](docs/QueryApi.md#testEnumRefStringWithHttpInfo) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**testQueryDatetimeDateString**](docs/QueryApi.md#testQueryDatetimeDateString) | **GET** /query/datetime/date/string | Test query parameter(s)

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -83,10 +101,10 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -109,6 +127,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -125,6 +161,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/java/native/docs/HeaderApi.md
+++ b/samples/client/echo_api/java/native/docs/HeaderApi.md
@@ -4,14 +4,14 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testHeaderIntegerBooleanString**](HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s) |
-| [**testHeaderIntegerBooleanStringWithHttpInfo**](HeaderApi.md#testHeaderIntegerBooleanStringWithHttpInfo) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**testHeaderIntegerBooleanStringEnums**](HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
+| [**testHeaderIntegerBooleanStringEnumsWithHttpInfo**](HeaderApi.md#testHeaderIntegerBooleanStringEnumsWithHttpInfo) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
 
 
-## testHeaderIntegerBooleanString
+## testHeaderIntegerBooleanStringEnums
 
-> String testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader)
+> String testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader)
 
 Test header parameter(s)
 
@@ -36,11 +36,13 @@ public class Example {
         Integer integerHeader = 56; // Integer | 
         Boolean booleanHeader = true; // Boolean | 
         String stringHeader = "stringHeader_example"; // String | 
+        String enumNonrefStringHeader = "success"; // String | 
+        StringEnumRef enumRefStringHeader = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+            String result = apiInstance.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanString");
+            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanStringEnums");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -58,6 +60,8 @@ public class Example {
 | **integerHeader** | **Integer**|  | [optional] |
 | **booleanHeader** | **Boolean**|  | [optional] |
 | **stringHeader** | **String**|  | [optional] |
+| **enumNonrefStringHeader** | **String**|  | [optional] [enum: success, failure, unclassified] |
+| **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
 
@@ -78,9 +82,9 @@ No authorization required
 |-------------|-------------|------------------|
 | **200** | Successful operation |  -  |
 
-## testHeaderIntegerBooleanStringWithHttpInfo
+## testHeaderIntegerBooleanStringEnumsWithHttpInfo
 
-> ApiResponse<String> testHeaderIntegerBooleanString testHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader)
+> ApiResponse<String> testHeaderIntegerBooleanStringEnums testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader)
 
 Test header parameter(s)
 
@@ -106,13 +110,15 @@ public class Example {
         Integer integerHeader = 56; // Integer | 
         Boolean booleanHeader = true; // Boolean | 
         String stringHeader = "stringHeader_example"; // String | 
+        String enumNonrefStringHeader = "success"; // String | 
+        StringEnumRef enumRefStringHeader = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            ApiResponse<String> response = apiInstance.testHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader);
+            ApiResponse<String> response = apiInstance.testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
             System.out.println("Status code: " + response.getStatusCode());
             System.out.println("Response headers: " + response.getHeaders());
             System.out.println("Response body: " + response.getData());
         } catch (ApiException e) {
-            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanString");
+            System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanStringEnums");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Response headers: " + e.getResponseHeaders());
             System.err.println("Reason: " + e.getResponseBody());
@@ -130,6 +136,8 @@ public class Example {
 | **integerHeader** | **Integer**|  | [optional] |
 | **booleanHeader** | **Boolean**|  | [optional] |
 | **stringHeader** | **String**|  | [optional] |
+| **enumNonrefStringHeader** | **String**|  | [optional] [enum: success, failure, unclassified] |
+| **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/native/docs/PathApi.md
+++ b/samples/client/echo_api/java/native/docs/PathApi.md
@@ -4,14 +4,14 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testsPathStringPathStringIntegerPathInteger**](PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
-| [**testsPathStringPathStringIntegerPathIntegerWithHttpInfo**](PathApi.md#testsPathStringPathStringIntegerPathIntegerWithHttpInfo) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
+| [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo**](PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
 
 
-## testsPathStringPathStringIntegerPathInteger
+## testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath
 
-> String testsPathStringPathStringIntegerPathInteger(pathString, pathInteger)
+> String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath)
 
 Test path parameter(s)
 
@@ -35,11 +35,13 @@ public class Example {
         PathApi apiInstance = new PathApi(defaultClient);
         String pathString = "pathString_example"; // String | 
         Integer pathInteger = 56; // Integer | 
+        String enumNonrefStringPath = "success"; // String | 
+        StringEnumRef enumRefStringPath = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+            String result = apiInstance.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathInteger");
+            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Reason: " + e.getResponseBody());
             System.err.println("Response headers: " + e.getResponseHeaders());
@@ -56,6 +58,8 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **pathString** | **String**|  | |
 | **pathInteger** | **Integer**|  | |
+| **enumNonrefStringPath** | **String**|  | [enum: success, failure, unclassified] |
+| **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type
 
@@ -76,9 +80,9 @@ No authorization required
 |-------------|-------------|------------------|
 | **200** | Successful operation |  -  |
 
-## testsPathStringPathStringIntegerPathIntegerWithHttpInfo
+## testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo
 
-> ApiResponse<String> testsPathStringPathStringIntegerPathInteger testsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger)
+> ApiResponse<String> testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath)
 
 Test path parameter(s)
 
@@ -103,13 +107,15 @@ public class Example {
         PathApi apiInstance = new PathApi(defaultClient);
         String pathString = "pathString_example"; // String | 
         Integer pathInteger = 56; // Integer | 
+        String enumNonrefStringPath = "success"; // String | 
+        StringEnumRef enumRefStringPath = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            ApiResponse<String> response = apiInstance.testsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger);
+            ApiResponse<String> response = apiInstance.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
             System.out.println("Status code: " + response.getStatusCode());
             System.out.println("Response headers: " + response.getHeaders());
             System.out.println("Response body: " + response.getData());
         } catch (ApiException e) {
-            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathInteger");
+            System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
             System.err.println("Status code: " + e.getCode());
             System.err.println("Response headers: " + e.getResponseHeaders());
             System.err.println("Reason: " + e.getResponseBody());
@@ -126,6 +132,8 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **pathString** | **String**|  | |
 | **pathInteger** | **Integer**|  | |
+| **enumNonrefStringPath** | **String**|  | [enum: success, failure, unclassified] |
+| **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/native/docs/QueryApi.md
+++ b/samples/client/echo_api/java/native/docs/QueryApi.md
@@ -25,7 +25,7 @@ All URIs are relative to *http://localhost:3000*
 
 ## testEnumRefString
 
-> String testEnumRefString(enumRefStringQuery)
+> String testEnumRefString(enumNonrefStringQuery, enumRefStringQuery)
 
 Test query parameter(s)
 
@@ -47,9 +47,10 @@ public class Example {
         defaultClient.setBasePath("http://localhost:3000");
 
         QueryApi apiInstance = new QueryApi(defaultClient);
+        String enumNonrefStringQuery = "success"; // String | 
         StringEnumRef enumRefStringQuery = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            String result = apiInstance.testEnumRefString(enumRefStringQuery);
+            String result = apiInstance.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling QueryApi#testEnumRefString");
@@ -67,6 +68,7 @@ public class Example {
 
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
+| **enumNonrefStringQuery** | **String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
@@ -90,7 +92,7 @@ No authorization required
 
 ## testEnumRefStringWithHttpInfo
 
-> ApiResponse<String> testEnumRefString testEnumRefStringWithHttpInfo(enumRefStringQuery)
+> ApiResponse<String> testEnumRefString testEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery)
 
 Test query parameter(s)
 
@@ -113,9 +115,10 @@ public class Example {
         defaultClient.setBasePath("http://localhost:3000");
 
         QueryApi apiInstance = new QueryApi(defaultClient);
+        String enumNonrefStringQuery = "success"; // String | 
         StringEnumRef enumRefStringQuery = StringEnumRef.fromValue("success"); // StringEnumRef | 
         try {
-            ApiResponse<String> response = apiInstance.testEnumRefStringWithHttpInfo(enumRefStringQuery);
+            ApiResponse<String> response = apiInstance.testEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery);
             System.out.println("Status code: " + response.getStatusCode());
             System.out.println("Response headers: " + response.getHeaders());
             System.out.println("Response body: " + response.getData());
@@ -135,6 +138,7 @@ public class Example {
 
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
+| **enumNonrefStringQuery** | **String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.ApiResponse;
 import org.openapitools.client.Pair;
 
+import org.openapitools.client.model.StringEnumRef;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -92,11 +93,13 @@ public class HeaderApi {
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testHeaderIntegerBooleanString(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
-    ApiResponse<String> localVarResponse = testHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader);
+  public String testHeaderIntegerBooleanStringEnums(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
+    ApiResponse<String> localVarResponse = testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
     return localVarResponse.getData();
   }
 
@@ -106,11 +109,13 @@ public class HeaderApi {
    * @param integerHeader  (optional)
    * @param booleanHeader  (optional)
    * @param stringHeader  (optional)
+   * @param enumNonrefStringHeader  (optional)
+   * @param enumRefStringHeader  (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<String> testHeaderIntegerBooleanStringWithHttpInfo(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
-    HttpRequest.Builder localVarRequestBuilder = testHeaderIntegerBooleanStringRequestBuilder(integerHeader, booleanHeader, stringHeader);
+  public ApiResponse<String> testHeaderIntegerBooleanStringEnumsWithHttpInfo(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testHeaderIntegerBooleanStringEnumsRequestBuilder(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
     try {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
@@ -120,7 +125,7 @@ public class HeaderApi {
       }
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
-          throw getApiException("testHeaderIntegerBooleanString", localVarResponse);
+          throw getApiException("testHeaderIntegerBooleanStringEnums", localVarResponse);
         }
         // for plain text response
         if (localVarResponse.headers().map().containsKey("Content-Type") &&
@@ -146,11 +151,11 @@ public class HeaderApi {
     }
   }
 
-  private HttpRequest.Builder testHeaderIntegerBooleanStringRequestBuilder(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
+  private HttpRequest.Builder testHeaderIntegerBooleanStringEnumsRequestBuilder(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
 
     HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
-    String localVarPath = "/header/integer/boolean/string";
+    String localVarPath = "/header/integer/boolean/string/enums";
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 
@@ -162,6 +167,12 @@ public class HeaderApi {
     }
     if (stringHeader != null) {
       localVarRequestBuilder.header("string_header", stringHeader.toString());
+    }
+    if (enumNonrefStringHeader != null) {
+      localVarRequestBuilder.header("enum_nonref_string_header", enumNonrefStringHeader.toString());
+    }
+    if (enumRefStringHeader != null) {
+      localVarRequestBuilder.header("enum_ref_string_header", enumRefStringHeader.toString());
     }
     localVarRequestBuilder.header("Accept", "text/plain");
 

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/PathApi.java
@@ -17,6 +17,7 @@ import org.openapitools.client.ApiException;
 import org.openapitools.client.ApiResponse;
 import org.openapitools.client.Pair;
 
+import org.openapitools.client.model.StringEnumRef;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -91,11 +92,13 @@ public class PathApi {
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testsPathStringPathStringIntegerPathInteger(String pathString, Integer pathInteger) throws ApiException {
-    ApiResponse<String> localVarResponse = testsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger);
+  public String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
+    ApiResponse<String> localVarResponse = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
     return localVarResponse.getData();
   }
 
@@ -104,11 +107,13 @@ public class PathApi {
    * Test path parameter(s)
    * @param pathString  (required)
    * @param pathInteger  (required)
+   * @param enumNonrefStringPath  (required)
+   * @param enumRefStringPath  (required)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<String> testsPathStringPathStringIntegerPathIntegerWithHttpInfo(String pathString, Integer pathInteger) throws ApiException {
-    HttpRequest.Builder localVarRequestBuilder = testsPathStringPathStringIntegerPathIntegerRequestBuilder(pathString, pathInteger);
+  public ApiResponse<String> testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequestBuilder(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
     try {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
@@ -118,7 +123,7 @@ public class PathApi {
       }
       try {
         if (localVarResponse.statusCode()/ 100 != 2) {
-          throw getApiException("testsPathStringPathStringIntegerPathInteger", localVarResponse);
+          throw getApiException("testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath", localVarResponse);
         }
         // for plain text response
         if (localVarResponse.headers().map().containsKey("Content-Type") &&
@@ -144,21 +149,31 @@ public class PathApi {
     }
   }
 
-  private HttpRequest.Builder testsPathStringPathStringIntegerPathIntegerRequestBuilder(String pathString, Integer pathInteger) throws ApiException {
+  private HttpRequest.Builder testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequestBuilder(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
     // verify the required parameter 'pathString' is set
     if (pathString == null) {
-      throw new ApiException(400, "Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathInteger");
+      throw new ApiException(400, "Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
     }
     // verify the required parameter 'pathInteger' is set
     if (pathInteger == null) {
-      throw new ApiException(400, "Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathInteger");
+      throw new ApiException(400, "Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+    }
+    // verify the required parameter 'enumNonrefStringPath' is set
+    if (enumNonrefStringPath == null) {
+      throw new ApiException(400, "Missing the required parameter 'enumNonrefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
+    }
+    // verify the required parameter 'enumRefStringPath' is set
+    if (enumRefStringPath == null) {
+      throw new ApiException(400, "Missing the required parameter 'enumRefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
     }
 
     HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
-    String localVarPath = "/path/string/{path_string}/integer/{path_integer}"
+    String localVarPath = "/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
         .replace("{path_string}", ApiClient.urlEncode(pathString.toString()))
-        .replace("{path_integer}", ApiClient.urlEncode(pathInteger.toString()));
+        .replace("{path_integer}", ApiClient.urlEncode(pathInteger.toString()))
+        .replace("{enum_nonref_string_path}", ApiClient.urlEncode(enumNonrefStringPath.toString()))
+        .replace("{enum_ref_string_path}", ApiClient.urlEncode(enumRefStringPath.toString()));
 
     localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
 

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -96,24 +96,26 @@ public class QueryApi {
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @return String
    * @throws ApiException if fails to make API call
    */
-  public String testEnumRefString(StringEnumRef enumRefStringQuery) throws ApiException {
-    ApiResponse<String> localVarResponse = testEnumRefStringWithHttpInfo(enumRefStringQuery);
+  public String testEnumRefString(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
+    ApiResponse<String> localVarResponse = testEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery);
     return localVarResponse.getData();
   }
 
   /**
    * Test query parameter(s)
    * Test query parameter(s)
+   * @param enumNonrefStringQuery  (optional)
    * @param enumRefStringQuery  (optional)
    * @return ApiResponse&lt;String&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<String> testEnumRefStringWithHttpInfo(StringEnumRef enumRefStringQuery) throws ApiException {
-    HttpRequest.Builder localVarRequestBuilder = testEnumRefStringRequestBuilder(enumRefStringQuery);
+  public ApiResponse<String> testEnumRefStringWithHttpInfo(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testEnumRefStringRequestBuilder(enumNonrefStringQuery, enumRefStringQuery);
     try {
       HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
           localVarRequestBuilder.build(),
@@ -149,7 +151,7 @@ public class QueryApi {
     }
   }
 
-  private HttpRequest.Builder testEnumRefStringRequestBuilder(StringEnumRef enumRefStringQuery) throws ApiException {
+  private HttpRequest.Builder testEnumRefStringRequestBuilder(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
 
     HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
@@ -158,6 +160,8 @@ public class QueryApi {
     List<Pair> localVarQueryParams = new ArrayList<>();
     StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
     String localVarQueryParameterBaseName;
+    localVarQueryParameterBaseName = "enum_nonref_string_query";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("enum_nonref_string_query", enumNonrefStringQuery));
     localVarQueryParameterBaseName = "enum_ref_string_query";
     localVarQueryParams.addAll(ApiClient.parameterToPairs("enum_ref_string_query", enumRefStringQuery));
 

--- a/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/api/HeaderApiTest.java
+++ b/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/api/HeaderApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.Test;
 import org.junit.Ignore;
 
@@ -42,12 +43,14 @@ public class HeaderApiTest {
      *          if the Api call fails
      */
     @Test
-    public void testHeaderIntegerBooleanStringTest() throws ApiException {
+    public void testHeaderIntegerBooleanStringEnumsTest() throws ApiException {
         Integer integerHeader = null;
         Boolean booleanHeader = null;
         String stringHeader = null;
+        String enumNonrefStringHeader = null;
+        StringEnumRef enumRefStringHeader = null;
         String response = 
-        api.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+        api.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
         
         // TODO: test validations
     }

--- a/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/api/PathApiTest.java
+++ b/samples/client/echo_api/java/native/src/test/java/org/openapitools/client/api/PathApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.Test;
 import org.junit.Ignore;
 
@@ -42,11 +43,13 @@ public class PathApiTest {
      *          if the Api call fails
      */
     @Test
-    public void testsPathStringPathStringIntegerPathIntegerTest() throws ApiException {
+    public void testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathTest() throws ApiException {
         String pathString = null;
         Integer pathInteger = null;
+        String enumNonrefStringPath = null;
+        StringEnumRef enumRefStringPath = null;
         String response = 
-        api.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+        api.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
         
         // TODO: test validations
     }

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -128,8 +128,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**testHeaderIntegerBooleanString**](docs/HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**testHeaderIntegerBooleanStringEnums**](docs/HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/QueryApi.md#testEnumRefString) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**testQueryDatetimeDateString**](docs/QueryApi.md#testQueryDatetimeDateString) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**testQueryIntegerBooleanString**](docs/QueryApi.md#testQueryIntegerBooleanString) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -11,10 +11,10 @@ info:
 servers:
 - url: http://localhost:3000/
 paths:
-  /path/string/{path_string}/integer/{path_integer}:
+  /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}:
     get:
       description: Test path parameter(s)
-      operationId: "tests/path/string/{path_string}/integer/{path_integer}"
+      operationId: "tests/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
       parameters:
       - explode: false
         in: path
@@ -29,6 +29,24 @@ paths:
         required: true
         schema:
           type: integer
+        style: simple
+      - explode: false
+        in: path
+        name: enum_nonref_string_path
+        required: true
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: enum_ref_string_path
+        required: true
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
         style: simple
       responses:
         "200":
@@ -83,10 +101,10 @@ paths:
       - form
       x-content-type: application/x-www-form-urlencoded
       x-accepts: text/plain
-  /header/integer/boolean/string:
+  /header/integer/boolean/string/enums:
     get:
       description: Test header parameter(s)
-      operationId: test/header/integer/boolean/string
+      operationId: test/header/integer/boolean/string/enums
       parameters:
       - explode: true
         in: header
@@ -109,6 +127,24 @@ paths:
         schema:
           type: string
         style: form
+      - explode: true
+        in: header
+        name: enum_nonref_string_header
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
+      - explode: true
+        in: header
+        name: enum_ref_string_header
+        required: false
+        schema:
+          $ref: '#/components/schemas/StringEnumRef'
+        style: form
       responses:
         "200":
           content:
@@ -125,6 +161,17 @@ paths:
       description: Test query parameter(s)
       operationId: test/enum_ref_string
       parameters:
+      - explode: true
+        in: query
+        name: enum_nonref_string_query
+        required: false
+        schema:
+          enum:
+          - success
+          - failure
+          - unclassified
+          type: string
+        style: form
       - explode: true
         in: query
         name: enum_ref_string_query

--- a/samples/client/echo_api/java/okhttp-gson/docs/HeaderApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/HeaderApi.md
@@ -4,12 +4,12 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testHeaderIntegerBooleanString**](HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**testHeaderIntegerBooleanStringEnums**](HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
 
-<a id="testHeaderIntegerBooleanString"></a>
-# **testHeaderIntegerBooleanString**
-> String testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader)
+<a id="testHeaderIntegerBooleanStringEnums"></a>
+# **testHeaderIntegerBooleanStringEnums**
+> String testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader)
 
 Test header parameter(s)
 
@@ -33,11 +33,13 @@ public class Example {
     Integer integerHeader = 56; // Integer | 
     Boolean booleanHeader = true; // Boolean | 
     String stringHeader = "stringHeader_example"; // String | 
+    String enumNonrefStringHeader = "success"; // String | 
+    StringEnumRef enumRefStringHeader = StringEnumRef.fromValue("success"); // StringEnumRef | 
     try {
-      String result = apiInstance.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+      String result = apiInstance.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
       System.out.println(result);
     } catch (ApiException e) {
-      System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanString");
+      System.err.println("Exception when calling HeaderApi#testHeaderIntegerBooleanStringEnums");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());
@@ -54,6 +56,8 @@ public class Example {
 | **integerHeader** | **Integer**|  | [optional] |
 | **booleanHeader** | **Boolean**|  | [optional] |
 | **stringHeader** | **String**|  | [optional] |
+| **enumNonrefStringHeader** | **String**|  | [optional] [enum: success, failure, unclassified] |
+| **enumRefStringHeader** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/okhttp-gson/docs/PathApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/PathApi.md
@@ -4,12 +4,12 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**testsPathStringPathStringIntegerPathInteger**](PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
 
-<a id="testsPathStringPathStringIntegerPathInteger"></a>
-# **testsPathStringPathStringIntegerPathInteger**
-> String testsPathStringPathStringIntegerPathInteger(pathString, pathInteger)
+<a id="testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath"></a>
+# **testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**
+> String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath)
 
 Test path parameter(s)
 
@@ -32,11 +32,13 @@ public class Example {
     PathApi apiInstance = new PathApi(defaultClient);
     String pathString = "pathString_example"; // String | 
     Integer pathInteger = 56; // Integer | 
+    String enumNonrefStringPath = "success"; // String | 
+    StringEnumRef enumRefStringPath = StringEnumRef.fromValue("success"); // StringEnumRef | 
     try {
-      String result = apiInstance.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+      String result = apiInstance.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
       System.out.println(result);
     } catch (ApiException e) {
-      System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathInteger");
+      System.err.println("Exception when calling PathApi#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());
@@ -52,6 +54,8 @@ public class Example {
 |------------- | ------------- | ------------- | -------------|
 | **pathString** | **String**|  | |
 | **pathInteger** | **Integer**|  | |
+| **enumNonrefStringPath** | **String**|  | [enum: success, failure, unclassified] |
+| **enumRefStringPath** | [**StringEnumRef**](.md)|  | [enum: success, failure, unclassified] |
 
 ### Return type
 

--- a/samples/client/echo_api/java/okhttp-gson/docs/QueryApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/QueryApi.md
@@ -16,7 +16,7 @@ All URIs are relative to *http://localhost:3000*
 
 <a id="testEnumRefString"></a>
 # **testEnumRefString**
-> String testEnumRefString(enumRefStringQuery)
+> String testEnumRefString(enumNonrefStringQuery, enumRefStringQuery)
 
 Test query parameter(s)
 
@@ -37,9 +37,10 @@ public class Example {
     defaultClient.setBasePath("http://localhost:3000");
 
     QueryApi apiInstance = new QueryApi(defaultClient);
+    String enumNonrefStringQuery = "success"; // String | 
     StringEnumRef enumRefStringQuery = StringEnumRef.fromValue("success"); // StringEnumRef | 
     try {
-      String result = apiInstance.testEnumRefString(enumRefStringQuery);
+      String result = apiInstance.testEnumRefString(enumNonrefStringQuery, enumRefStringQuery);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling QueryApi#testEnumRefString");
@@ -56,6 +57,7 @@ public class Example {
 
 | Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
+| **enumNonrefStringQuery** | **String**|  | [optional] [enum: success, failure, unclassified] |
 | **enumRefStringQuery** | [**StringEnumRef**](.md)|  | [optional] [enum: success, failure, unclassified] |
 
 ### Return type

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/HeaderApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/HeaderApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import org.openapitools.client.model.StringEnumRef;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -72,10 +73,12 @@ public class HeaderApi {
     }
 
     /**
-     * Build call for testHeaderIntegerBooleanString
+     * Build call for testHeaderIntegerBooleanStringEnums
      * @param integerHeader  (optional)
      * @param booleanHeader  (optional)
      * @param stringHeader  (optional)
+     * @param enumNonrefStringHeader  (optional)
+     * @param enumRefStringHeader  (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -85,7 +88,7 @@ public class HeaderApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testHeaderIntegerBooleanStringCall(Integer integerHeader, Boolean booleanHeader, String stringHeader, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testHeaderIntegerBooleanStringEnumsCall(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -102,7 +105,7 @@ public class HeaderApi {
         Object localVarPostBody = null;
 
         // create path and map variables
-        String localVarPath = "/header/integer/boolean/string";
+        String localVarPath = "/header/integer/boolean/string/enums";
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -120,6 +123,14 @@ public class HeaderApi {
 
         if (stringHeader != null) {
             localVarHeaderParams.put("string_header", localVarApiClient.parameterToString(stringHeader));
+        }
+
+        if (enumNonrefStringHeader != null) {
+            localVarHeaderParams.put("enum_nonref_string_header", localVarApiClient.parameterToString(enumNonrefStringHeader));
+        }
+
+        if (enumRefStringHeader != null) {
+            localVarHeaderParams.put("enum_ref_string_header", localVarApiClient.parameterToString(enumRefStringHeader));
         }
 
         final String[] localVarAccepts = {
@@ -142,8 +153,8 @@ public class HeaderApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testHeaderIntegerBooleanStringValidateBeforeCall(Integer integerHeader, Boolean booleanHeader, String stringHeader, final ApiCallback _callback) throws ApiException {
-        return testHeaderIntegerBooleanStringCall(integerHeader, booleanHeader, stringHeader, _callback);
+    private okhttp3.Call testHeaderIntegerBooleanStringEnumsValidateBeforeCall(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader, final ApiCallback _callback) throws ApiException {
+        return testHeaderIntegerBooleanStringEnumsCall(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader, _callback);
 
     }
 
@@ -153,6 +164,8 @@ public class HeaderApi {
      * @param integerHeader  (optional)
      * @param booleanHeader  (optional)
      * @param stringHeader  (optional)
+     * @param enumNonrefStringHeader  (optional)
+     * @param enumRefStringHeader  (optional)
      * @return String
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -161,8 +174,8 @@ public class HeaderApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public String testHeaderIntegerBooleanString(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
-        ApiResponse<String> localVarResp = testHeaderIntegerBooleanStringWithHttpInfo(integerHeader, booleanHeader, stringHeader);
+    public String testHeaderIntegerBooleanStringEnums(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
+        ApiResponse<String> localVarResp = testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
         return localVarResp.getData();
     }
 
@@ -172,6 +185,8 @@ public class HeaderApi {
      * @param integerHeader  (optional)
      * @param booleanHeader  (optional)
      * @param stringHeader  (optional)
+     * @param enumNonrefStringHeader  (optional)
+     * @param enumRefStringHeader  (optional)
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -180,8 +195,8 @@ public class HeaderApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> testHeaderIntegerBooleanStringWithHttpInfo(Integer integerHeader, Boolean booleanHeader, String stringHeader) throws ApiException {
-        okhttp3.Call localVarCall = testHeaderIntegerBooleanStringValidateBeforeCall(integerHeader, booleanHeader, stringHeader, null);
+    public ApiResponse<String> testHeaderIntegerBooleanStringEnumsWithHttpInfo(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader) throws ApiException {
+        okhttp3.Call localVarCall = testHeaderIntegerBooleanStringEnumsValidateBeforeCall(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -192,6 +207,8 @@ public class HeaderApi {
      * @param integerHeader  (optional)
      * @param booleanHeader  (optional)
      * @param stringHeader  (optional)
+     * @param enumNonrefStringHeader  (optional)
+     * @param enumRefStringHeader  (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -201,9 +218,9 @@ public class HeaderApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testHeaderIntegerBooleanStringAsync(Integer integerHeader, Boolean booleanHeader, String stringHeader, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call testHeaderIntegerBooleanStringEnumsAsync(Integer integerHeader, Boolean booleanHeader, String stringHeader, String enumNonrefStringHeader, StringEnumRef enumRefStringHeader, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testHeaderIntegerBooleanStringValidateBeforeCall(integerHeader, booleanHeader, stringHeader, _callback);
+        okhttp3.Call localVarCall = testHeaderIntegerBooleanStringEnumsValidateBeforeCall(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/PathApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/PathApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import org.openapitools.client.model.StringEnumRef;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -72,9 +73,11 @@ public class PathApi {
     }
 
     /**
-     * Build call for testsPathStringPathStringIntegerPathInteger
+     * Build call for testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath
      * @param pathString  (required)
      * @param pathInteger  (required)
+     * @param enumNonrefStringPath  (required)
+     * @param enumRefStringPath  (required)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -84,7 +87,7 @@ public class PathApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testsPathStringPathStringIntegerPathIntegerCall(String pathString, Integer pathInteger, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathCall(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -101,9 +104,11 @@ public class PathApi {
         Object localVarPostBody = null;
 
         // create path and map variables
-        String localVarPath = "/path/string/{path_string}/integer/{path_integer}"
+        String localVarPath = "/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}"
             .replace("{" + "path_string" + "}", localVarApiClient.escapeString(pathString.toString()))
-            .replace("{" + "path_integer" + "}", localVarApiClient.escapeString(pathInteger.toString()));
+            .replace("{" + "path_integer" + "}", localVarApiClient.escapeString(pathInteger.toString()))
+            .replace("{" + "enum_nonref_string_path" + "}", localVarApiClient.escapeString(enumNonrefStringPath.toString()))
+            .replace("{" + "enum_ref_string_path" + "}", localVarApiClient.escapeString(enumRefStringPath.toString()));
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
@@ -131,18 +136,28 @@ public class PathApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testsPathStringPathStringIntegerPathIntegerValidateBeforeCall(String pathString, Integer pathInteger, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathValidateBeforeCall(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'pathString' is set
         if (pathString == null) {
-            throw new ApiException("Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathInteger(Async)");
+            throw new ApiException("Missing the required parameter 'pathString' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(Async)");
         }
 
         // verify the required parameter 'pathInteger' is set
         if (pathInteger == null) {
-            throw new ApiException("Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathInteger(Async)");
+            throw new ApiException("Missing the required parameter 'pathInteger' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(Async)");
         }
 
-        return testsPathStringPathStringIntegerPathIntegerCall(pathString, pathInteger, _callback);
+        // verify the required parameter 'enumNonrefStringPath' is set
+        if (enumNonrefStringPath == null) {
+            throw new ApiException("Missing the required parameter 'enumNonrefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(Async)");
+        }
+
+        // verify the required parameter 'enumRefStringPath' is set
+        if (enumRefStringPath == null) {
+            throw new ApiException("Missing the required parameter 'enumRefStringPath' when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(Async)");
+        }
+
+        return testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathCall(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath, _callback);
 
     }
 
@@ -151,6 +166,8 @@ public class PathApi {
      * Test path parameter(s)
      * @param pathString  (required)
      * @param pathInteger  (required)
+     * @param enumNonrefStringPath  (required)
+     * @param enumRefStringPath  (required)
      * @return String
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -159,8 +176,8 @@ public class PathApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public String testsPathStringPathStringIntegerPathInteger(String pathString, Integer pathInteger) throws ApiException {
-        ApiResponse<String> localVarResp = testsPathStringPathStringIntegerPathIntegerWithHttpInfo(pathString, pathInteger);
+    public String testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
+        ApiResponse<String> localVarResp = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
         return localVarResp.getData();
     }
 
@@ -169,6 +186,8 @@ public class PathApi {
      * Test path parameter(s)
      * @param pathString  (required)
      * @param pathInteger  (required)
+     * @param enumNonrefStringPath  (required)
+     * @param enumRefStringPath  (required)
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -177,8 +196,8 @@ public class PathApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> testsPathStringPathStringIntegerPathIntegerWithHttpInfo(String pathString, Integer pathInteger) throws ApiException {
-        okhttp3.Call localVarCall = testsPathStringPathStringIntegerPathIntegerValidateBeforeCall(pathString, pathInteger, null);
+    public ApiResponse<String> testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath) throws ApiException {
+        okhttp3.Call localVarCall = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathValidateBeforeCall(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -188,6 +207,8 @@ public class PathApi {
      * Test path parameter(s)
      * @param pathString  (required)
      * @param pathInteger  (required)
+     * @param enumNonrefStringPath  (required)
+     * @param enumRefStringPath  (required)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -197,9 +218,9 @@ public class PathApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testsPathStringPathStringIntegerPathIntegerAsync(String pathString, Integer pathInteger, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsync(String pathString, Integer pathInteger, String enumNonrefStringPath, StringEnumRef enumRefStringPath, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testsPathStringPathStringIntegerPathIntegerValidateBeforeCall(pathString, pathInteger, _callback);
+        okhttp3.Call localVarCall = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathValidateBeforeCall(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -80,6 +80,7 @@ public class QueryApi {
 
     /**
      * Build call for testEnumRefString
+     * @param enumNonrefStringQuery  (optional)
      * @param enumRefStringQuery  (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
@@ -90,7 +91,7 @@ public class QueryApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumRefStringCall(StringEnumRef enumRefStringQuery, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call testEnumRefStringCall(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -114,6 +115,10 @@ public class QueryApi {
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (enumNonrefStringQuery != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("enum_nonref_string_query", enumNonrefStringQuery));
+        }
 
         if (enumRefStringQuery != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("enum_ref_string_query", enumRefStringQuery));
@@ -139,14 +144,15 @@ public class QueryApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call testEnumRefStringValidateBeforeCall(StringEnumRef enumRefStringQuery, final ApiCallback _callback) throws ApiException {
-        return testEnumRefStringCall(enumRefStringQuery, _callback);
+    private okhttp3.Call testEnumRefStringValidateBeforeCall(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery, final ApiCallback _callback) throws ApiException {
+        return testEnumRefStringCall(enumNonrefStringQuery, enumRefStringQuery, _callback);
 
     }
 
     /**
      * Test query parameter(s)
      * Test query parameter(s)
+     * @param enumNonrefStringQuery  (optional)
      * @param enumRefStringQuery  (optional)
      * @return String
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -156,14 +162,15 @@ public class QueryApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public String testEnumRefString(StringEnumRef enumRefStringQuery) throws ApiException {
-        ApiResponse<String> localVarResp = testEnumRefStringWithHttpInfo(enumRefStringQuery);
+    public String testEnumRefString(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
+        ApiResponse<String> localVarResp = testEnumRefStringWithHttpInfo(enumNonrefStringQuery, enumRefStringQuery);
         return localVarResp.getData();
     }
 
     /**
      * Test query parameter(s)
      * Test query parameter(s)
+     * @param enumNonrefStringQuery  (optional)
      * @param enumRefStringQuery  (optional)
      * @return ApiResponse&lt;String&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -173,8 +180,8 @@ public class QueryApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<String> testEnumRefStringWithHttpInfo(StringEnumRef enumRefStringQuery) throws ApiException {
-        okhttp3.Call localVarCall = testEnumRefStringValidateBeforeCall(enumRefStringQuery, null);
+    public ApiResponse<String> testEnumRefStringWithHttpInfo(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery) throws ApiException {
+        okhttp3.Call localVarCall = testEnumRefStringValidateBeforeCall(enumNonrefStringQuery, enumRefStringQuery, null);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -182,6 +189,7 @@ public class QueryApi {
     /**
      * Test query parameter(s) (asynchronously)
      * Test query parameter(s)
+     * @param enumNonrefStringQuery  (optional)
      * @param enumRefStringQuery  (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -192,9 +200,9 @@ public class QueryApi {
         <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call testEnumRefStringAsync(StringEnumRef enumRefStringQuery, final ApiCallback<String> _callback) throws ApiException {
+    public okhttp3.Call testEnumRefStringAsync(String enumNonrefStringQuery, StringEnumRef enumRefStringQuery, final ApiCallback<String> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = testEnumRefStringValidateBeforeCall(enumRefStringQuery, _callback);
+        okhttp3.Call localVarCall = testEnumRefStringValidateBeforeCall(enumNonrefStringQuery, enumRefStringQuery, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/samples/client/echo_api/java/okhttp-gson/src/test/java/org/openapitools/client/api/HeaderApiTest.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/test/java/org/openapitools/client/api/HeaderApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -38,11 +39,13 @@ public class HeaderApiTest {
      * @throws ApiException if the Api call fails
      */
     @Test
-    public void testHeaderIntegerBooleanStringTest() throws ApiException {
+    public void testHeaderIntegerBooleanStringEnumsTest() throws ApiException {
         Integer integerHeader = null;
         Boolean booleanHeader = null;
         String stringHeader = null;
-        String response = api.testHeaderIntegerBooleanString(integerHeader, booleanHeader, stringHeader);
+        String enumNonrefStringHeader = null;
+        StringEnumRef enumRefStringHeader = null;
+        String response = api.testHeaderIntegerBooleanStringEnums(integerHeader, booleanHeader, stringHeader, enumNonrefStringHeader, enumRefStringHeader);
         // TODO: test validations
     }
 

--- a/samples/client/echo_api/java/okhttp-gson/src/test/java/org/openapitools/client/api/PathApiTest.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/test/java/org/openapitools/client/api/PathApiTest.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.api;
 
 import org.openapitools.client.ApiException;
+import org.openapitools.client.model.StringEnumRef;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -38,10 +39,12 @@ public class PathApiTest {
      * @throws ApiException if the Api call fails
      */
     @Test
-    public void testsPathStringPathStringIntegerPathIntegerTest() throws ApiException {
+    public void testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathTest() throws ApiException {
         String pathString = null;
         Integer pathInteger = null;
-        String response = api.testsPathStringPathStringIntegerPathInteger(pathString, pathInteger);
+        String enumNonrefStringPath = null;
+        StringEnumRef enumRefStringPath = null;
+        String response = api.testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString, pathInteger, enumNonrefStringPath, enumRefStringPath);
         // TODO: test validations
     }
 

--- a/samples/client/echo_api/php-nextgen/README.md
+++ b/samples/client/echo_api/php-nextgen/README.md
@@ -86,8 +86,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/Api/BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/Api/FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/Api/FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**testHeaderIntegerBooleanString**](docs/Api/HeaderApi.md#testheaderintegerbooleanstring) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**testsPathStringPathStringIntegerPathInteger**](docs/Api/PathApi.md#testspathstringpathstringintegerpathinteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**testHeaderIntegerBooleanStringEnums**](docs/Api/HeaderApi.md#testheaderintegerbooleanstringenums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath**](docs/Api/PathApi.md#testspathstringpathstringintegerpathintegerenumnonrefstringpathenumrefstringpath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**testEnumRefString**](docs/Api/QueryApi.md#testenumrefstring) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**testQueryDatetimeDateString**](docs/Api/QueryApi.md#testquerydatetimedatestring) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**testQueryIntegerBooleanString**](docs/Api/QueryApi.md#testqueryintegerbooleanstring) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/php-nextgen/docs/Api/HeaderApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/HeaderApi.md
@@ -4,13 +4,13 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
-| [**testHeaderIntegerBooleanString()**](HeaderApi.md#testHeaderIntegerBooleanString) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**testHeaderIntegerBooleanStringEnums()**](HeaderApi.md#testHeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
 
-## `testHeaderIntegerBooleanString()`
+## `testHeaderIntegerBooleanStringEnums()`
 
 ```php
-testHeaderIntegerBooleanString($integer_header, $boolean_header, $string_header): string
+testHeaderIntegerBooleanStringEnums($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header): string
 ```
 
 Test header parameter(s)
@@ -33,12 +33,14 @@ $apiInstance = new OpenAPI\Client\Api\HeaderApi(
 $integer_header = 56; // int
 $boolean_header = True; // bool
 $string_header = 'string_header_example'; // string
+$enum_nonref_string_header = 'enum_nonref_string_header_example'; // string
+$enum_ref_string_header = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
 
 try {
-    $result = $apiInstance->testHeaderIntegerBooleanString($integer_header, $boolean_header, $string_header);
+    $result = $apiInstance->testHeaderIntegerBooleanStringEnums($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling HeaderApi->testHeaderIntegerBooleanString: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling HeaderApi->testHeaderIntegerBooleanStringEnums: ', $e->getMessage(), PHP_EOL;
 }
 ```
 
@@ -49,6 +51,8 @@ try {
 | **integer_header** | **int**|  | [optional] |
 | **boolean_header** | **bool**|  | [optional] |
 | **string_header** | **string**|  | [optional] |
+| **enum_nonref_string_header** | **string**|  | [optional] |
+| **enum_ref_string_header** | [**StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/docs/Api/PathApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/PathApi.md
@@ -4,13 +4,13 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 
 | Method | HTTP request | Description |
 | ------------- | ------------- | ------------- |
-| [**testsPathStringPathStringIntegerPathInteger()**](PathApi.md#testsPathStringPathStringIntegerPathInteger) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath()**](PathApi.md#testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
 
-## `testsPathStringPathStringIntegerPathInteger()`
+## `testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath()`
 
 ```php
-testsPathStringPathStringIntegerPathInteger($path_string, $path_integer): string
+testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path): string
 ```
 
 Test path parameter(s)
@@ -32,12 +32,14 @@ $apiInstance = new OpenAPI\Client\Api\PathApi(
 );
 $path_string = 'path_string_example'; // string
 $path_integer = 56; // int
+$enum_nonref_string_path = 'enum_nonref_string_path_example'; // string
+$enum_ref_string_path = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
 
 try {
-    $result = $apiInstance->testsPathStringPathStringIntegerPathInteger($path_string, $path_integer);
+    $result = $apiInstance->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling PathApi->testsPathStringPathStringIntegerPathInteger: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling PathApi->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath: ', $e->getMessage(), PHP_EOL;
 }
 ```
 
@@ -47,6 +49,8 @@ try {
 | ------------- | ------------- | ------------- | ------------- |
 | **path_string** | **string**|  | |
 | **path_integer** | **int**|  | |
+| **enum_nonref_string_path** | **string**|  | |
+| **enum_ref_string_path** | [**StringEnumRef**](../Model/.md)|  | |
 
 ### Return type
 

--- a/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/QueryApi.md
@@ -17,7 +17,7 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 ## `testEnumRefString()`
 
 ```php
-testEnumRefString($enum_ref_string_query): string
+testEnumRefString($enum_nonref_string_query, $enum_ref_string_query): string
 ```
 
 Test query parameter(s)
@@ -37,10 +37,11 @@ $apiInstance = new OpenAPI\Client\Api\QueryApi(
     // This is optional, `GuzzleHttp\Client` will be used as default.
     new GuzzleHttp\Client()
 );
+$enum_nonref_string_query = 'enum_nonref_string_query_example'; // string
 $enum_ref_string_query = new \OpenAPI\Client\Model\StringEnumRef(); // StringEnumRef
 
 try {
-    $result = $apiInstance->testEnumRefString($enum_ref_string_query);
+    $result = $apiInstance->testEnumRefString($enum_nonref_string_query, $enum_ref_string_query);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling QueryApi->testEnumRefString: ', $e->getMessage(), PHP_EOL;
@@ -51,6 +52,7 @@ try {
 
 | Name | Type | Description  | Notes |
 | ------------- | ------------- | ------------- | ------------- |
+| **enum_nonref_string_query** | **string**|  | [optional] |
 | **enum_ref_string_query** | [**StringEnumRef**](../Model/.md)|  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -74,7 +74,7 @@ class HeaderApi
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
-        'testHeaderIntegerBooleanString' => [
+        'testHeaderIntegerBooleanStringEnums' => [
             'application/json',
         ],
     ];
@@ -126,52 +126,60 @@ class HeaderApi
     }
 
     /**
-     * Operation testHeaderIntegerBooleanString
+     * Operation testHeaderIntegerBooleanStringEnums
      *
      * Test header parameter(s)
      *
      * @param  int|null $integer_header integer_header (optional)
      * @param  bool|null $boolean_header boolean_header (optional)
      * @param  string|null $string_header string_header (optional)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanString'] to see the possible values for this operation
+     * @param  string|null $enum_nonref_string_header enum_nonref_string_header (optional)
+     * @param  StringEnumRef|null $enum_ref_string_header enum_ref_string_header (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return string
      */
-    public function testHeaderIntegerBooleanString(
+    public function testHeaderIntegerBooleanStringEnums(
         ?int $integer_header = null,
         ?bool $boolean_header = null,
         ?string $string_header = null,
-        string $contentType = self::contentTypes['testHeaderIntegerBooleanString'][0]
+        ?string $enum_nonref_string_header = null,
+        ?StringEnumRef $enum_ref_string_header = null,
+        string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): string
     {
-        list($response) = $this->testHeaderIntegerBooleanStringWithHttpInfo($integer_header, $boolean_header, $string_header, $contentType);
+        list($response) = $this->testHeaderIntegerBooleanStringEnumsWithHttpInfo($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header, $contentType);
         return $response;
     }
 
     /**
-     * Operation testHeaderIntegerBooleanStringWithHttpInfo
+     * Operation testHeaderIntegerBooleanStringEnumsWithHttpInfo
      *
      * Test header parameter(s)
      *
      * @param  int|null $integer_header (optional)
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanString'] to see the possible values for this operation
+     * @param  string|null $enum_nonref_string_header (optional)
+     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testHeaderIntegerBooleanStringWithHttpInfo(
+    public function testHeaderIntegerBooleanStringEnumsWithHttpInfo(
         ?int $integer_header = null,
         ?bool $boolean_header = null,
         ?string $string_header = null,
-        string $contentType = self::contentTypes['testHeaderIntegerBooleanString'][0]
+        ?string $enum_nonref_string_header = null,
+        ?StringEnumRef $enum_ref_string_header = null,
+        string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): array
     {
-        $request = $this->testHeaderIntegerBooleanStringRequest($integer_header, $boolean_header, $string_header, $contentType);
+        $request = $this->testHeaderIntegerBooleanStringEnumsRequest($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -258,26 +266,30 @@ class HeaderApi
     }
 
     /**
-     * Operation testHeaderIntegerBooleanStringAsync
+     * Operation testHeaderIntegerBooleanStringEnumsAsync
      *
      * Test header parameter(s)
      *
      * @param  int|null $integer_header (optional)
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanString'] to see the possible values for this operation
+     * @param  string|null $enum_nonref_string_header (optional)
+     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
-    public function testHeaderIntegerBooleanStringAsync(
+    public function testHeaderIntegerBooleanStringEnumsAsync(
         ?int $integer_header = null,
         ?bool $boolean_header = null,
         ?string $string_header = null,
-        string $contentType = self::contentTypes['testHeaderIntegerBooleanString'][0]
+        ?string $enum_nonref_string_header = null,
+        ?StringEnumRef $enum_ref_string_header = null,
+        string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
-        return $this->testHeaderIntegerBooleanStringAsyncWithHttpInfo($integer_header, $boolean_header, $string_header, $contentType)
+        return $this->testHeaderIntegerBooleanStringEnumsAsyncWithHttpInfo($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -286,27 +298,31 @@ class HeaderApi
     }
 
     /**
-     * Operation testHeaderIntegerBooleanStringAsyncWithHttpInfo
+     * Operation testHeaderIntegerBooleanStringEnumsAsyncWithHttpInfo
      *
      * Test header parameter(s)
      *
      * @param  int|null $integer_header (optional)
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanString'] to see the possible values for this operation
+     * @param  string|null $enum_nonref_string_header (optional)
+     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
-    public function testHeaderIntegerBooleanStringAsyncWithHttpInfo(
+    public function testHeaderIntegerBooleanStringEnumsAsyncWithHttpInfo(
         $integer_header = null,
         $boolean_header = null,
         $string_header = null,
-        string $contentType = self::contentTypes['testHeaderIntegerBooleanString'][0]
+        $enum_nonref_string_header = null,
+        $enum_ref_string_header = null,
+        string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): PromiseInterface
     {
         $returnType = 'string';
-        $request = $this->testHeaderIntegerBooleanStringRequest($integer_header, $boolean_header, $string_header, $contentType);
+        $request = $this->testHeaderIntegerBooleanStringEnumsRequest($integer_header, $boolean_header, $string_header, $enum_nonref_string_header, $enum_ref_string_header, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -345,21 +361,25 @@ class HeaderApi
     }
 
     /**
-     * Create request for operation 'testHeaderIntegerBooleanString'
+     * Create request for operation 'testHeaderIntegerBooleanStringEnums'
      *
      * @param  int|null $integer_header (optional)
      * @param  bool|null $boolean_header (optional)
      * @param  string|null $string_header (optional)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanString'] to see the possible values for this operation
+     * @param  string|null $enum_nonref_string_header (optional)
+     * @param  StringEnumRef|null $enum_ref_string_header (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testHeaderIntegerBooleanStringEnums'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testHeaderIntegerBooleanStringRequest(
+    public function testHeaderIntegerBooleanStringEnumsRequest(
         $integer_header = null,
         $boolean_header = null,
         $string_header = null,
-        string $contentType = self::contentTypes['testHeaderIntegerBooleanString'][0]
+        $enum_nonref_string_header = null,
+        $enum_ref_string_header = null,
+        string $contentType = self::contentTypes['testHeaderIntegerBooleanStringEnums'][0]
     ): Request
     {
 
@@ -367,7 +387,9 @@ class HeaderApi
 
 
 
-        $resourcePath = '/header/integer/boolean/string';
+
+
+        $resourcePath = '/header/integer/boolean/string/enums';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -386,6 +408,14 @@ class HeaderApi
         // header params
         if ($string_header !== null) {
             $headerParams['string_header'] = ObjectSerializer::toHeaderValue($string_header);
+        }
+        // header params
+        if ($enum_nonref_string_header !== null) {
+            $headerParams['enum_nonref_string_header'] = ObjectSerializer::toHeaderValue($enum_nonref_string_header);
+        }
+        // header params
+        if ($enum_ref_string_header !== null) {
+            $headerParams['enum_ref_string_header'] = ObjectSerializer::toHeaderValue($enum_ref_string_header);
         }
 
 

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -74,7 +74,7 @@ class PathApi
 
     /** @var string[] $contentTypes **/
     public const contentTypes = [
-        'testsPathStringPathStringIntegerPathInteger' => [
+        'testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath' => [
             'application/json',
         ],
     ];
@@ -126,48 +126,56 @@ class PathApi
     }
 
     /**
-     * Operation testsPathStringPathStringIntegerPathInteger
+     * Operation testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath
      *
      * Test path parameter(s)
      *
      * @param  string $path_string path_string (required)
      * @param  int $path_integer path_integer (required)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathInteger'] to see the possible values for this operation
+     * @param  string $enum_nonref_string_path enum_nonref_string_path (required)
+     * @param  StringEnumRef $enum_ref_string_path enum_ref_string_path (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return string
      */
-    public function testsPathStringPathStringIntegerPathInteger(
+    public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(
         string $path_string,
         int $path_integer,
-        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathInteger'][0]
+        string $enum_nonref_string_path,
+        StringEnumRef $enum_ref_string_path,
+        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): string
     {
-        list($response) = $this->testsPathStringPathStringIntegerPathIntegerWithHttpInfo($path_string, $path_integer, $contentType);
+        list($response) = $this->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path, $contentType);
         return $response;
     }
 
     /**
-     * Operation testsPathStringPathStringIntegerPathIntegerWithHttpInfo
+     * Operation testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo
      *
      * Test path parameter(s)
      *
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathInteger'] to see the possible values for this operation
+     * @param  string $enum_nonref_string_path (required)
+     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws ApiException on non-2xx response
      * @throws InvalidArgumentException
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
-    public function testsPathStringPathStringIntegerPathIntegerWithHttpInfo(
+    public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(
         string $path_string,
         int $path_integer,
-        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathInteger'][0]
+        string $enum_nonref_string_path,
+        StringEnumRef $enum_ref_string_path,
+        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): array
     {
-        $request = $this->testsPathStringPathStringIntegerPathIntegerRequest($path_string, $path_integer, $contentType);
+        $request = $this->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -254,24 +262,28 @@ class PathApi
     }
 
     /**
-     * Operation testsPathStringPathStringIntegerPathIntegerAsync
+     * Operation testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsync
      *
      * Test path parameter(s)
      *
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathInteger'] to see the possible values for this operation
+     * @param  string $enum_nonref_string_path (required)
+     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
-    public function testsPathStringPathStringIntegerPathIntegerAsync(
+    public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsync(
         string $path_string,
         int $path_integer,
-        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathInteger'][0]
+        string $enum_nonref_string_path,
+        StringEnumRef $enum_ref_string_path,
+        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
-        return $this->testsPathStringPathStringIntegerPathIntegerAsyncWithHttpInfo($path_string, $path_integer, $contentType)
+        return $this->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsyncWithHttpInfo($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -280,25 +292,29 @@ class PathApi
     }
 
     /**
-     * Operation testsPathStringPathStringIntegerPathIntegerAsyncWithHttpInfo
+     * Operation testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsyncWithHttpInfo
      *
      * Test path parameter(s)
      *
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathInteger'] to see the possible values for this operation
+     * @param  string $enum_nonref_string_path (required)
+     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return PromiseInterface
      */
-    public function testsPathStringPathStringIntegerPathIntegerAsyncWithHttpInfo(
+    public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathAsyncWithHttpInfo(
         $path_string,
         $path_integer,
-        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathInteger'][0]
+        $enum_nonref_string_path,
+        $enum_ref_string_path,
+        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): PromiseInterface
     {
         $returnType = 'string';
-        $request = $this->testsPathStringPathStringIntegerPathIntegerRequest($path_string, $path_integer, $contentType);
+        $request = $this->testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest($path_string, $path_integer, $enum_nonref_string_path, $enum_ref_string_path, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -337,38 +353,56 @@ class PathApi
     }
 
     /**
-     * Create request for operation 'testsPathStringPathStringIntegerPathInteger'
+     * Create request for operation 'testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
      *
      * @param  string $path_string (required)
      * @param  int $path_integer (required)
-     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathInteger'] to see the possible values for this operation
+     * @param  string $enum_nonref_string_path (required)
+     * @param  StringEnumRef $enum_ref_string_path (required)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'] to see the possible values for this operation
      *
      * @throws InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    public function testsPathStringPathStringIntegerPathIntegerRequest(
+    public function testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequest(
         $path_string,
         $path_integer,
-        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathInteger'][0]
+        $enum_nonref_string_path,
+        $enum_ref_string_path,
+        string $contentType = self::contentTypes['testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'][0]
     ): Request
     {
 
         // verify the required parameter 'path_string' is set
         if ($path_string === null || (is_array($path_string) && count($path_string) === 0)) {
             throw new InvalidArgumentException(
-                'Missing the required parameter $path_string when calling testsPathStringPathStringIntegerPathInteger'
+                'Missing the required parameter $path_string when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
 
         // verify the required parameter 'path_integer' is set
         if ($path_integer === null || (is_array($path_integer) && count($path_integer) === 0)) {
             throw new InvalidArgumentException(
-                'Missing the required parameter $path_integer when calling testsPathStringPathStringIntegerPathInteger'
+                'Missing the required parameter $path_integer when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
+            );
+        }
+
+        // verify the required parameter 'enum_nonref_string_path' is set
+        if ($enum_nonref_string_path === null || (is_array($enum_nonref_string_path) && count($enum_nonref_string_path) === 0)) {
+            throw new InvalidArgumentException(
+                'Missing the required parameter $enum_nonref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
+            );
+        }
+
+        // verify the required parameter 'enum_ref_string_path' is set
+        if ($enum_ref_string_path === null || (is_array($enum_ref_string_path) && count($enum_ref_string_path) === 0)) {
+            throw new InvalidArgumentException(
+                'Missing the required parameter $enum_ref_string_path when calling testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath'
             );
         }
 
 
-        $resourcePath = '/path/string/{path_string}/integer/{path_integer}';
+        $resourcePath = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}';
         $formParams = [];
         $queryParams = [];
         $headerParams = [];
@@ -390,6 +424,22 @@ class PathApi
             $resourcePath = str_replace(
                 '{' . 'path_integer' . '}',
                 ObjectSerializer::toPathValue($path_integer),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($enum_nonref_string_path !== null) {
+            $resourcePath = str_replace(
+                '{' . 'enum_nonref_string_path' . '}',
+                ObjectSerializer::toPathValue($enum_nonref_string_path),
+                $resourcePath
+            );
+        }
+        // path params
+        if ($enum_ref_string_path !== null) {
+            $resourcePath = str_replace(
+                '{' . 'enum_ref_string_path' . '}',
+                ObjectSerializer::toPathValue($enum_ref_string_path),
                 $resourcePath
             );
         }

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -151,6 +151,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
+     * @param  string|null $enum_nonref_string_query enum_nonref_string_query (optional)
      * @param  StringEnumRef|null $enum_ref_string_query enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
@@ -159,11 +160,12 @@ class QueryApi
      * @return string
      */
     public function testEnumRefString(
+        ?string $enum_nonref_string_query = null,
         ?StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): string
     {
-        list($response) = $this->testEnumRefStringWithHttpInfo($enum_ref_string_query, $contentType);
+        list($response) = $this->testEnumRefStringWithHttpInfo($enum_nonref_string_query, $enum_ref_string_query, $contentType);
         return $response;
     }
 
@@ -172,6 +174,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
+     * @param  string|null $enum_nonref_string_query (optional)
      * @param  StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
@@ -180,11 +183,12 @@ class QueryApi
      * @return array of string, HTTP status code, HTTP response headers (array of strings)
      */
     public function testEnumRefStringWithHttpInfo(
+        ?string $enum_nonref_string_query = null,
         ?StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): array
     {
-        $request = $this->testEnumRefStringRequest($enum_ref_string_query, $contentType);
+        $request = $this->testEnumRefStringRequest($enum_nonref_string_query, $enum_ref_string_query, $contentType);
 
         try {
             $options = $this->createHttpClientOption();
@@ -275,6 +279,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
+     * @param  string|null $enum_nonref_string_query (optional)
      * @param  StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
@@ -282,11 +287,12 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testEnumRefStringAsync(
+        ?string $enum_nonref_string_query = null,
         ?StringEnumRef $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
-        return $this->testEnumRefStringAsyncWithHttpInfo($enum_ref_string_query, $contentType)
+        return $this->testEnumRefStringAsyncWithHttpInfo($enum_nonref_string_query, $enum_ref_string_query, $contentType)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -299,6 +305,7 @@ class QueryApi
      *
      * Test query parameter(s)
      *
+     * @param  string|null $enum_nonref_string_query (optional)
      * @param  StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
@@ -306,12 +313,13 @@ class QueryApi
      * @return PromiseInterface
      */
     public function testEnumRefStringAsyncWithHttpInfo(
+        $enum_nonref_string_query = null,
         $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): PromiseInterface
     {
         $returnType = 'string';
-        $request = $this->testEnumRefStringRequest($enum_ref_string_query, $contentType);
+        $request = $this->testEnumRefStringRequest($enum_nonref_string_query, $enum_ref_string_query, $contentType);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -352,6 +360,7 @@ class QueryApi
     /**
      * Create request for operation 'testEnumRefString'
      *
+     * @param  string|null $enum_nonref_string_query (optional)
      * @param  StringEnumRef|null $enum_ref_string_query (optional)
      * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEnumRefString'] to see the possible values for this operation
      *
@@ -359,10 +368,12 @@ class QueryApi
      * @return \GuzzleHttp\Psr7\Request
      */
     public function testEnumRefStringRequest(
+        $enum_nonref_string_query = null,
         $enum_ref_string_query = null,
         string $contentType = self::contentTypes['testEnumRefString'][0]
     ): Request
     {
+
 
 
 
@@ -373,6 +384,15 @@ class QueryApi
         $httpBody = '';
         $multipart = false;
 
+        // query params
+        $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
+            $enum_nonref_string_query,
+            'enum_nonref_string_query', // param base name
+            'string', // openApiType
+            'form', // style
+            true, // explode
+            false // required
+        ) ?? []);
         // query params
         $queryParams = array_merge($queryParams, ObjectSerializer::toQueryValue(
             $enum_ref_string_query,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/README.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/README.md
@@ -104,8 +104,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**test_header_integer_boolean_string_enums**](docs/HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**test_enum_ref_string**](docs/QueryApi.md#test_enum_ref_string) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**test_query_datetime_date_string**](docs/QueryApi.md#test_query_datetime_date_string) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**test_query_integer_boolean_string**](docs/QueryApi.md#test_query_integer_boolean_string) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/HeaderApi.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/HeaderApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**test_header_integer_boolean_string**](HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
+[**test_header_integer_boolean_string_enums**](HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
 
 
-# **test_header_integer_boolean_string**
-> str test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
+# **test_header_integer_boolean_string_enums**
+> str test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
 
 Test header parameter(s)
 
@@ -20,6 +20,7 @@ Test header parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -37,14 +38,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     integer_header = 56 # int |  (optional)
     boolean_header = True # bool |  (optional)
     string_header = 'string_header_example' # str |  (optional)
+    enum_nonref_string_header = 'enum_nonref_string_header_example' # str |  (optional)
+    enum_ref_string_header = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test header parameter(s)
-        api_response = api_instance.test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
-        print("The response of HeaderApi->test_header_integer_boolean_string:\n")
+        api_response = api_instance.test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
+        print("The response of HeaderApi->test_header_integer_boolean_string_enums:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling HeaderApi->test_header_integer_boolean_string: %s\n" % e)
+        print("Exception when calling HeaderApi->test_header_integer_boolean_string_enums: %s\n" % e)
 ```
 
 
@@ -56,6 +59,8 @@ Name | Type | Description  | Notes
  **integer_header** | **int**|  | [optional] 
  **boolean_header** | **bool**|  | [optional] 
  **string_header** | **str**|  | [optional] 
+ **enum_nonref_string_header** | **str**|  | [optional] 
+ **enum_ref_string_header** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/PathApi.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/PathApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**tests_path_string_path_string_integer_path_integer**](PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+[**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 
 
-# **tests_path_string_path_string_integer_path_integer**
-> str tests_path_string_path_string_integer_path_integer(path_string, path_integer)
+# **tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**
+> str tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
 
 Test path parameter(s)
 
@@ -20,6 +20,7 @@ Test path parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -36,14 +37,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     api_instance = openapi_client.PathApi(api_client)
     path_string = 'path_string_example' # str | 
     path_integer = 56 # int | 
+    enum_nonref_string_path = 'enum_nonref_string_path_example' # str | 
+    enum_ref_string_path = openapi_client.StringEnumRef() # StringEnumRef | 
 
     try:
         # Test path parameter(s)
-        api_response = api_instance.tests_path_string_path_string_integer_path_integer(path_string, path_integer)
-        print("The response of PathApi->tests_path_string_path_string_integer_path_integer:\n")
+        api_response = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
+        print("The response of PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer: %s\n" % e)
+        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path: %s\n" % e)
 ```
 
 
@@ -54,6 +57,8 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **path_string** | **str**|  | 
  **path_integer** | **int**|  | 
+ **enum_nonref_string_path** | **str**|  | 
+ **enum_ref_string_path** | [**StringEnumRef**](.md)|  | 
 
 ### Return type
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/QueryApi.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/docs/QueryApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 
 
 # **test_enum_ref_string**
-> str test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+> str test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
 
 Test query parameter(s)
 
@@ -42,11 +42,12 @@ configuration = openapi_client.Configuration(
 with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.QueryApi(api_client)
+    enum_nonref_string_query = 'enum_nonref_string_query_example' # str |  (optional)
     enum_ref_string_query = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test query parameter(s)
-        api_response = api_instance.test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+        api_response = api_instance.test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
         print("The response of QueryApi->test_enum_ref_string:\n")
         pprint(api_response)
     except Exception as e:
@@ -59,6 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **enum_nonref_string_query** | **str**|  | [optional] 
  **enum_ref_string_query** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
@@ -20,10 +20,11 @@ import warnings
 from pydantic import validate_call, ValidationError
 from typing import Dict, List, Optional, Tuple
 
-from pydantic import StrictBool, StrictInt, StrictStr
+from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 
 from typing import Optional
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -46,14 +47,14 @@ class HeaderApi:
         self.api_client = api_client
 
     @validate_call
-    def test_header_integer_boolean_string(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+    def test_header_integer_boolean_string_enums(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -62,6 +63,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -75,19 +80,19 @@ class HeaderApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the test_header_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, **kwargs)  # noqa: E501
+        return self.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_header_integer_boolean_string_enums_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -96,6 +101,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -126,7 +135,9 @@ class HeaderApi:
         _all_params = [
             'integer_header',
             'boolean_header',
-            'string_header'
+            'string_header',
+            'enum_nonref_string_header',
+            'enum_ref_string_header'
         ]
         _all_params.extend(
             [
@@ -145,7 +156,7 @@ class HeaderApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method test_header_integer_boolean_string" % _key
+                    " to method test_header_integer_boolean_string_enums" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -168,6 +179,12 @@ class HeaderApi:
         if _params['string_header'] is not None:
             _header_params['string_header'] = _params['string_header']
 
+        if _params['enum_nonref_string_header'] is not None:
+            _header_params['enum_nonref_string_header'] = _params['enum_nonref_string_header']
+
+        if _params['enum_ref_string_header'] is not None:
+            _header_params['enum_ref_string_header'] = _params['enum_ref_string_header']
+
         # process the form parameters
         _form_params: List[Tuple[str, str]] = []
         _files: Dict[str, str] = {}
@@ -185,7 +202,7 @@ class HeaderApi:
         }
 
         return self.api_client.call_api(
-            '/header/integer/boolean/string', 'GET',
+            '/header/integer/boolean/string/enums', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -20,8 +20,9 @@ import warnings
 from pydantic import validate_call, ValidationError
 from typing import Dict, List, Optional, Tuple
 
-from pydantic import StrictInt, StrictStr
+from pydantic import StrictInt, StrictStr, field_validator
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -44,20 +45,24 @@ class PathApi:
         self.api_client = api_client
 
     @validate_call
-    def tests_path_string_path_string_integer_path_integer(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> str:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> str:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -71,25 +76,29 @@ class PathApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, **kwargs)  # noqa: E501
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, **kwargs)  # noqa: E501
 
     @validate_call
-    def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> ApiResponse:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> ApiResponse:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -119,7 +128,9 @@ class PathApi:
 
         _all_params = [
             'path_string',
-            'path_integer'
+            'path_integer',
+            'enum_nonref_string_path',
+            'enum_ref_string_path'
         ]
         _all_params.extend(
             [
@@ -138,7 +149,7 @@ class PathApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method tests_path_string_path_string_integer_path_integer" % _key
+                    " to method tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -152,6 +163,12 @@ class PathApi:
 
         if _params['path_integer'] is not None:
             _path_params['path_integer'] = _params['path_integer']
+
+        if _params['enum_nonref_string_path'] is not None:
+            _path_params['enum_nonref_string_path'] = _params['enum_nonref_string_path']
+
+        if _params['enum_ref_string_path'] is not None:
+            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path']
 
 
         # process the query parameters
@@ -175,7 +192,7 @@ class PathApi:
         }
 
         return self.api_client.call_api(
-            '/path/string/{path_string}/integer/{path_integer}', 'GET',
+            '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -168,7 +168,7 @@ class PathApi:
             _path_params['enum_nonref_string_path'] = _params['enum_nonref_string_path']
 
         if _params['enum_ref_string_path'] is not None:
-            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path']
+            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path'].value
 
 
         # process the query parameters

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
@@ -22,7 +22,7 @@ from typing import Dict, List, Optional, Tuple
 
 from datetime import date, datetime
 
-from pydantic import StrictBool, StrictInt, StrictStr
+from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 
 from typing import Any, Optional
 
@@ -51,16 +51,18 @@ class QueryApi:
         self.api_client = api_client
 
     @validate_call
-    def test_enum_ref_string(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
+    def test_enum_ref_string(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -78,19 +80,21 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_enum_ref_string_with_http_info(enum_ref_string_query, **kwargs)  # noqa: E501
+        return self.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_enum_ref_string_with_http_info(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string_with_http_info(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -121,6 +125,7 @@ class QueryApi:
         _params = locals()
 
         _all_params = [
+            'enum_nonref_string_query',
             'enum_ref_string_query'
         ]
         _all_params.extend(
@@ -152,6 +157,9 @@ class QueryApi:
 
         # process the query parameters
         _query_params: List[Tuple[str, str]] = []
+        if _params.get('enum_nonref_string_query') is not None:  # noqa: E501
+            _query_params.append(('enum_nonref_string_query', _params['enum_nonref_string_query']))
+
         if _params.get('enum_ref_string_query') is not None:  # noqa: E501
             _query_params.append(('enum_ref_string_query', _params['enum_ref_string_query'].value))
 

--- a/samples/client/echo_api/python-pydantic-v1/README.md
+++ b/samples/client/echo_api/python-pydantic-v1/README.md
@@ -104,8 +104,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**test_header_integer_boolean_string_enums**](docs/HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**test_enum_ref_string**](docs/QueryApi.md#test_enum_ref_string) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**test_query_datetime_date_string**](docs/QueryApi.md#test_query_datetime_date_string) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**test_query_integer_boolean_string**](docs/QueryApi.md#test_query_integer_boolean_string) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/python-pydantic-v1/docs/HeaderApi.md
+++ b/samples/client/echo_api/python-pydantic-v1/docs/HeaderApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**test_header_integer_boolean_string**](HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
+[**test_header_integer_boolean_string_enums**](HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
 
 
-# **test_header_integer_boolean_string**
-> str test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
+# **test_header_integer_boolean_string_enums**
+> str test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
 
 Test header parameter(s)
 
@@ -20,6 +20,7 @@ Test header parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -37,14 +38,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     integer_header = 56 # int |  (optional)
     boolean_header = True # bool |  (optional)
     string_header = 'string_header_example' # str |  (optional)
+    enum_nonref_string_header = 'enum_nonref_string_header_example' # str |  (optional)
+    enum_ref_string_header = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test header parameter(s)
-        api_response = api_instance.test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
-        print("The response of HeaderApi->test_header_integer_boolean_string:\n")
+        api_response = api_instance.test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
+        print("The response of HeaderApi->test_header_integer_boolean_string_enums:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling HeaderApi->test_header_integer_boolean_string: %s\n" % e)
+        print("Exception when calling HeaderApi->test_header_integer_boolean_string_enums: %s\n" % e)
 ```
 
 
@@ -56,6 +59,8 @@ Name | Type | Description  | Notes
  **integer_header** | **int**|  | [optional] 
  **boolean_header** | **bool**|  | [optional] 
  **string_header** | **str**|  | [optional] 
+ **enum_nonref_string_header** | **str**|  | [optional] 
+ **enum_ref_string_header** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python-pydantic-v1/docs/PathApi.md
+++ b/samples/client/echo_api/python-pydantic-v1/docs/PathApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**tests_path_string_path_string_integer_path_integer**](PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+[**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 
 
-# **tests_path_string_path_string_integer_path_integer**
-> str tests_path_string_path_string_integer_path_integer(path_string, path_integer)
+# **tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**
+> str tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
 
 Test path parameter(s)
 
@@ -20,6 +20,7 @@ Test path parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -36,14 +37,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     api_instance = openapi_client.PathApi(api_client)
     path_string = 'path_string_example' # str | 
     path_integer = 56 # int | 
+    enum_nonref_string_path = 'enum_nonref_string_path_example' # str | 
+    enum_ref_string_path = openapi_client.StringEnumRef() # StringEnumRef | 
 
     try:
         # Test path parameter(s)
-        api_response = api_instance.tests_path_string_path_string_integer_path_integer(path_string, path_integer)
-        print("The response of PathApi->tests_path_string_path_string_integer_path_integer:\n")
+        api_response = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
+        print("The response of PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer: %s\n" % e)
+        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path: %s\n" % e)
 ```
 
 
@@ -54,6 +57,8 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **path_string** | **str**|  | 
  **path_integer** | **int**|  | 
+ **enum_nonref_string_path** | **str**|  | 
+ **enum_ref_string_path** | [**StringEnumRef**](.md)|  | 
 
 ### Return type
 

--- a/samples/client/echo_api/python-pydantic-v1/docs/QueryApi.md
+++ b/samples/client/echo_api/python-pydantic-v1/docs/QueryApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 
 
 # **test_enum_ref_string**
-> str test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+> str test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
 
 Test query parameter(s)
 
@@ -42,11 +42,12 @@ configuration = openapi_client.Configuration(
 with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.QueryApi(api_client)
+    enum_nonref_string_query = 'enum_nonref_string_query_example' # str |  (optional)
     enum_ref_string_query = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test query parameter(s)
-        api_response = api_instance.test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+        api_response = api_instance.test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
         print("The response of QueryApi->test_enum_ref_string:\n")
         pprint(api_response)
     except Exception as e:
@@ -59,6 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **enum_nonref_string_query** | **str**|  | [optional] 
  **enum_ref_string_query** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api/header_api.py
@@ -23,6 +23,7 @@ from pydantic import StrictBool, StrictInt, StrictStr
 
 from typing import Optional
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -45,14 +46,14 @@ class HeaderApi:
         self.api_client = api_client
 
     @validate_arguments
-    def test_header_integer_boolean_string(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+    def test_header_integer_boolean_string_enums(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -61,6 +62,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -74,19 +79,19 @@ class HeaderApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the test_header_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, **kwargs)  # noqa: E501
+        return self.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_header_integer_boolean_string_enums_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -95,6 +100,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -125,7 +134,9 @@ class HeaderApi:
         _all_params = [
             'integer_header',
             'boolean_header',
-            'string_header'
+            'string_header',
+            'enum_nonref_string_header',
+            'enum_ref_string_header'
         ]
         _all_params.extend(
             [
@@ -144,7 +155,7 @@ class HeaderApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method test_header_integer_boolean_string" % _key
+                    " to method test_header_integer_boolean_string_enums" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -167,6 +178,12 @@ class HeaderApi:
         if _params['string_header'] is not None:
             _header_params['string_header'] = _params['string_header']
 
+        if _params['enum_nonref_string_header'] is not None:
+            _header_params['enum_nonref_string_header'] = _params['enum_nonref_string_header']
+
+        if _params['enum_ref_string_header'] is not None:
+            _header_params['enum_ref_string_header'] = _params['enum_ref_string_header']
+
         # process the form parameters
         _form_params = []
         _files = {}
@@ -184,7 +201,7 @@ class HeaderApi:
         }
 
         return self.api_client.call_api(
-            '/header/integer/boolean/string', 'GET',
+            '/header/integer/boolean/string/enums', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api/path_api.py
@@ -21,6 +21,7 @@ from pydantic import validate_arguments, ValidationError
 
 from pydantic import StrictInt, StrictStr
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -43,20 +44,24 @@ class PathApi:
         self.api_client = api_client
 
     @validate_arguments
-    def tests_path_string_path_string_integer_path_integer(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> str:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> str:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -70,25 +75,29 @@ class PathApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, **kwargs)  # noqa: E501
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> ApiResponse:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> ApiResponse:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -118,7 +127,9 @@ class PathApi:
 
         _all_params = [
             'path_string',
-            'path_integer'
+            'path_integer',
+            'enum_nonref_string_path',
+            'enum_ref_string_path'
         ]
         _all_params.extend(
             [
@@ -137,7 +148,7 @@ class PathApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method tests_path_string_path_string_integer_path_integer" % _key
+                    " to method tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -151,6 +162,12 @@ class PathApi:
 
         if _params['path_integer'] is not None:
             _path_params['path_integer'] = _params['path_integer']
+
+        if _params['enum_nonref_string_path'] is not None:
+            _path_params['enum_nonref_string_path'] = _params['enum_nonref_string_path']
+
+        if _params['enum_ref_string_path'] is not None:
+            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path']
 
 
         # process the query parameters
@@ -174,7 +191,7 @@ class PathApi:
         }
 
         return self.api_client.call_api(
-            '/path/string/{path_string}/integer/{path_integer}', 'GET',
+            '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api/query_api.py
@@ -50,16 +50,18 @@ class QueryApi:
         self.api_client = api_client
 
     @validate_arguments
-    def test_enum_ref_string(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
+    def test_enum_ref_string(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -77,19 +79,21 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_enum_ref_string_with_http_info(enum_ref_string_query, **kwargs)  # noqa: E501
+        return self.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_enum_ref_string_with_http_info(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string_with_http_info(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -120,6 +124,7 @@ class QueryApi:
         _params = locals()
 
         _all_params = [
+            'enum_nonref_string_query',
             'enum_ref_string_query'
         ]
         _all_params.extend(
@@ -151,6 +156,9 @@ class QueryApi:
 
         # process the query parameters
         _query_params = []
+        if _params.get('enum_nonref_string_query') is not None:  # noqa: E501
+            _query_params.append(('enum_nonref_string_query', _params['enum_nonref_string_query']))
+
         if _params.get('enum_ref_string_query') is not None:  # noqa: E501
             _query_params.append(('enum_ref_string_query', _params['enum_ref_string_query'].value))
 

--- a/samples/client/echo_api/python/README.md
+++ b/samples/client/echo_api/python/README.md
@@ -104,8 +104,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*HeaderApi* | [**test_header_integer_boolean_string_enums**](docs/HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*PathApi* | [**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *QueryApi* | [**test_enum_ref_string**](docs/QueryApi.md#test_enum_ref_string) | **GET** /query/enum_ref_string | Test query parameter(s)
 *QueryApi* | [**test_query_datetime_date_string**](docs/QueryApi.md#test_query_datetime_date_string) | **GET** /query/datetime/date/string | Test query parameter(s)
 *QueryApi* | [**test_query_integer_boolean_string**](docs/QueryApi.md#test_query_integer_boolean_string) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/python/docs/HeaderApi.md
+++ b/samples/client/echo_api/python/docs/HeaderApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**test_header_integer_boolean_string**](HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
+[**test_header_integer_boolean_string_enums**](HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
 
 
-# **test_header_integer_boolean_string**
-> str test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
+# **test_header_integer_boolean_string_enums**
+> str test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
 
 Test header parameter(s)
 
@@ -20,6 +20,7 @@ Test header parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -37,14 +38,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     integer_header = 56 # int |  (optional)
     boolean_header = True # bool |  (optional)
     string_header = 'string_header_example' # str |  (optional)
+    enum_nonref_string_header = 'enum_nonref_string_header_example' # str |  (optional)
+    enum_ref_string_header = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test header parameter(s)
-        api_response = api_instance.test_header_integer_boolean_string(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header)
-        print("The response of HeaderApi->test_header_integer_boolean_string:\n")
+        api_response = api_instance.test_header_integer_boolean_string_enums(integer_header=integer_header, boolean_header=boolean_header, string_header=string_header, enum_nonref_string_header=enum_nonref_string_header, enum_ref_string_header=enum_ref_string_header)
+        print("The response of HeaderApi->test_header_integer_boolean_string_enums:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling HeaderApi->test_header_integer_boolean_string: %s\n" % e)
+        print("Exception when calling HeaderApi->test_header_integer_boolean_string_enums: %s\n" % e)
 ```
 
 
@@ -56,6 +59,8 @@ Name | Type | Description  | Notes
  **integer_header** | **int**|  | [optional] 
  **boolean_header** | **bool**|  | [optional] 
  **string_header** | **str**|  | [optional] 
+ **enum_nonref_string_header** | **str**|  | [optional] 
+ **enum_ref_string_header** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type
 

--- a/samples/client/echo_api/python/docs/PathApi.md
+++ b/samples/client/echo_api/python/docs/PathApi.md
@@ -4,11 +4,11 @@ All URIs are relative to *http://localhost:3000*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**tests_path_string_path_string_integer_path_integer**](PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+[**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 
 
-# **tests_path_string_path_string_integer_path_integer**
-> str tests_path_string_path_string_integer_path_integer(path_string, path_integer)
+# **tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**
+> str tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
 
 Test path parameter(s)
 
@@ -20,6 +20,7 @@ Test path parameter(s)
 import time
 import os
 import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.rest import ApiException
 from pprint import pprint
 
@@ -36,14 +37,16 @@ with openapi_client.ApiClient(configuration) as api_client:
     api_instance = openapi_client.PathApi(api_client)
     path_string = 'path_string_example' # str | 
     path_integer = 56 # int | 
+    enum_nonref_string_path = 'enum_nonref_string_path_example' # str | 
+    enum_ref_string_path = openapi_client.StringEnumRef() # StringEnumRef | 
 
     try:
         # Test path parameter(s)
-        api_response = api_instance.tests_path_string_path_string_integer_path_integer(path_string, path_integer)
-        print("The response of PathApi->tests_path_string_path_string_integer_path_integer:\n")
+        api_response = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
+        print("The response of PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path:\n")
         pprint(api_response)
     except Exception as e:
-        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer: %s\n" % e)
+        print("Exception when calling PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path: %s\n" % e)
 ```
 
 
@@ -54,6 +57,8 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **path_string** | **str**|  | 
  **path_integer** | **int**|  | 
+ **enum_nonref_string_path** | **str**|  | 
+ **enum_ref_string_path** | [**StringEnumRef**](.md)|  | 
 
 ### Return type
 

--- a/samples/client/echo_api/python/docs/QueryApi.md
+++ b/samples/client/echo_api/python/docs/QueryApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 
 
 # **test_enum_ref_string**
-> str test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+> str test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
 
 Test query parameter(s)
 
@@ -42,11 +42,12 @@ configuration = openapi_client.Configuration(
 with openapi_client.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = openapi_client.QueryApi(api_client)
+    enum_nonref_string_query = 'enum_nonref_string_query_example' # str |  (optional)
     enum_ref_string_query = openapi_client.StringEnumRef() # StringEnumRef |  (optional)
 
     try:
         # Test query parameter(s)
-        api_response = api_instance.test_enum_ref_string(enum_ref_string_query=enum_ref_string_query)
+        api_response = api_instance.test_enum_ref_string(enum_nonref_string_query=enum_nonref_string_query, enum_ref_string_query=enum_ref_string_query)
         print("The response of QueryApi->test_enum_ref_string:\n")
         pprint(api_response)
     except Exception as e:
@@ -59,6 +60,7 @@ with openapi_client.ApiClient(configuration) as api_client:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
+ **enum_nonref_string_query** | **str**|  | [optional] 
  **enum_ref_string_query** | [**StringEnumRef**](.md)|  | [optional] 
 
 ### Return type

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -20,10 +20,11 @@ import warnings
 from pydantic import validate_call, ValidationError
 from typing import Dict, List, Optional, Tuple
 
-from pydantic import StrictBool, StrictInt, StrictStr
+from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 
 from typing import Optional
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -46,14 +47,14 @@ class HeaderApi:
         self.api_client = api_client
 
     @validate_call
-    def test_header_integer_boolean_string(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> str:  # noqa: E501
+    def test_header_integer_boolean_string_enums(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -62,6 +63,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -75,19 +80,19 @@ class HeaderApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the test_header_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, **kwargs)  # noqa: E501
+        return self.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_header_integer_boolean_string_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_header_integer_boolean_string_enums_with_http_info(self, integer_header : Optional[StrictInt] = None, boolean_header : Optional[StrictBool] = None, string_header : Optional[StrictStr] = None, enum_nonref_string_header : Optional[StrictStr] = None, enum_ref_string_header : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test header parameter(s)  # noqa: E501
 
         Test header parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_header_integer_boolean_string_with_http_info(integer_header, boolean_header, string_header, async_req=True)
+        >>> thread = api.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, async_req=True)
         >>> result = thread.get()
 
         :param integer_header:
@@ -96,6 +101,10 @@ class HeaderApi:
         :type boolean_header: bool
         :param string_header:
         :type string_header: str
+        :param enum_nonref_string_header:
+        :type enum_nonref_string_header: str
+        :param enum_ref_string_header:
+        :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -126,7 +135,9 @@ class HeaderApi:
         _all_params = [
             'integer_header',
             'boolean_header',
-            'string_header'
+            'string_header',
+            'enum_nonref_string_header',
+            'enum_ref_string_header'
         ]
         _all_params.extend(
             [
@@ -145,7 +156,7 @@ class HeaderApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method test_header_integer_boolean_string" % _key
+                    " to method test_header_integer_boolean_string_enums" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -168,6 +179,12 @@ class HeaderApi:
         if _params['string_header'] is not None:
             _header_params['string_header'] = _params['string_header']
 
+        if _params['enum_nonref_string_header'] is not None:
+            _header_params['enum_nonref_string_header'] = _params['enum_nonref_string_header']
+
+        if _params['enum_ref_string_header'] is not None:
+            _header_params['enum_ref_string_header'] = _params['enum_ref_string_header']
+
         # process the form parameters
         _form_params: List[Tuple[str, str]] = []
         _files: Dict[str, str] = {}
@@ -185,7 +202,7 @@ class HeaderApi:
         }
 
         return self.api_client.call_api(
-            '/header/integer/boolean/string', 'GET',
+            '/header/integer/boolean/string/enums', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -20,8 +20,9 @@ import warnings
 from pydantic import validate_call, ValidationError
 from typing import Dict, List, Optional, Tuple
 
-from pydantic import StrictInt, StrictStr
+from pydantic import StrictInt, StrictStr, field_validator
 
+from openapi_client.models.string_enum_ref import StringEnumRef
 
 from openapi_client.api_client import ApiClient
 from openapi_client.api_response import ApiResponse
@@ -44,20 +45,24 @@ class PathApi:
         self.api_client = api_client
 
     @validate_call
-    def tests_path_string_path_string_integer_path_integer(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> str:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> str:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _request_timeout: timeout setting for this request.
@@ -71,25 +76,29 @@ class PathApi:
         """
         kwargs['_return_http_data_only'] = True
         if '_preload_content' in kwargs:
-            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, **kwargs)  # noqa: E501
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, **kwargs)  # noqa: E501
 
     @validate_call
-    def tests_path_string_path_string_integer_path_integer_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, **kwargs) -> ApiResponse:  # noqa: E501
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(self, path_string : StrictStr, path_integer : StrictInt, enum_nonref_string_path : StrictStr, enum_ref_string_path : StringEnumRef, **kwargs) -> ApiResponse:  # noqa: E501
         """Test path parameter(s)  # noqa: E501
 
         Test path parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, async_req=True)
+        >>> thread = api.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, async_req=True)
         >>> result = thread.get()
 
         :param path_string: (required)
         :type path_string: str
         :param path_integer: (required)
         :type path_integer: int
+        :param enum_nonref_string_path: (required)
+        :type enum_nonref_string_path: str
+        :param enum_ref_string_path: (required)
+        :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the ApiResponse.data will
@@ -119,7 +128,9 @@ class PathApi:
 
         _all_params = [
             'path_string',
-            'path_integer'
+            'path_integer',
+            'enum_nonref_string_path',
+            'enum_ref_string_path'
         ]
         _all_params.extend(
             [
@@ -138,7 +149,7 @@ class PathApi:
             if _key not in _all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method tests_path_string_path_string_integer_path_integer" % _key
+                    " to method tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path" % _key
                 )
             _params[_key] = _val
         del _params['kwargs']
@@ -152,6 +163,12 @@ class PathApi:
 
         if _params['path_integer'] is not None:
             _path_params['path_integer'] = _params['path_integer']
+
+        if _params['enum_nonref_string_path'] is not None:
+            _path_params['enum_nonref_string_path'] = _params['enum_nonref_string_path']
+
+        if _params['enum_ref_string_path'] is not None:
+            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path']
 
 
         # process the query parameters
@@ -175,7 +192,7 @@ class PathApi:
         }
 
         return self.api_client.call_api(
-            '/path/string/{path_string}/integer/{path_integer}', 'GET',
+            '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -168,7 +168,7 @@ class PathApi:
             _path_params['enum_nonref_string_path'] = _params['enum_nonref_string_path']
 
         if _params['enum_ref_string_path'] is not None:
-            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path']
+            _path_params['enum_ref_string_path'] = _params['enum_ref_string_path'].value
 
 
         # process the query parameters

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -22,7 +22,7 @@ from typing import Dict, List, Optional, Tuple
 
 from datetime import date, datetime
 
-from pydantic import StrictBool, StrictInt, StrictStr
+from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 
 from typing import Any, Optional
 
@@ -51,16 +51,18 @@ class QueryApi:
         self.api_client = api_client
 
     @validate_call
-    def test_enum_ref_string(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
+    def test_enum_ref_string(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> str:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -78,19 +80,21 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_enum_ref_string_with_http_info(enum_ref_string_query, **kwargs)  # noqa: E501
+        return self.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, **kwargs)  # noqa: E501
 
     @validate_call
-    def test_enum_ref_string_with_http_info(self, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def test_enum_ref_string_with_http_info(self, enum_nonref_string_query : Optional[StrictStr] = None, enum_ref_string_query : Optional[StringEnumRef] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Test query parameter(s)  # noqa: E501
 
         Test query parameter(s)  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.test_enum_ref_string_with_http_info(enum_ref_string_query, async_req=True)
+        >>> thread = api.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, async_req=True)
         >>> result = thread.get()
 
+        :param enum_nonref_string_query:
+        :type enum_nonref_string_query: str
         :param enum_ref_string_query:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
@@ -121,6 +125,7 @@ class QueryApi:
         _params = locals()
 
         _all_params = [
+            'enum_nonref_string_query',
             'enum_ref_string_query'
         ]
         _all_params.extend(
@@ -152,6 +157,9 @@ class QueryApi:
 
         # process the query parameters
         _query_params: List[Tuple[str, str]] = []
+        if _params.get('enum_nonref_string_query') is not None:  # noqa: E501
+            _query_params.append(('enum_nonref_string_query', _params['enum_nonref_string_query']))
+
         if _params.get('enum_ref_string_query') is not None:  # noqa: E501
             _query_params.append(('enum_ref_string_query', _params['enum_ref_string_query'].value))
 

--- a/samples/client/echo_api/python/test/test_manual.py
+++ b/samples/client/echo_api/python/test/test_manual.py
@@ -46,7 +46,7 @@ class TestManual(unittest.TestCase):
             enum_ref_string_path=openapi_client.StringEnumRef.FAILURE,
         )
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/path/string/string_value/integer/123/success/StringEnumRef.FAILURE")
+        self.assertEqual(e.path, "/path/string/string_value/integer/123/success/failure")
 
     def testHeaderParameters(self):
         api_instance = openapi_client.HeaderApi()

--- a/samples/client/echo_api/python/test/test_manual.py
+++ b/samples/client/echo_api/python/test/test_manual.py
@@ -37,14 +37,47 @@ class TestManual(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def testEnumRefString(self):
-        api_instance = openapi_client.QueryApi()
-        q = openapi_client.StringEnumRef("unclassified")
-
-        # Test query parameter(s)
-        api_response = api_instance.test_enum_ref_string(enum_ref_string_query=q)
+    def testPathParameters(self):
+        api_instance = openapi_client.PathApi()
+        api_response = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(
+            path_string="string_value",
+            path_integer=123,
+            enum_nonref_string_path="success",
+            enum_ref_string_path=openapi_client.StringEnumRef.FAILURE,
+        )
         e = EchoServerResponseParser(api_response)
-        self.assertEqual(e.path, "/query/enum_ref_string?enum_ref_string_query=unclassified")
+        self.assertEqual(e.path, "/path/string/string_value/integer/123/success/StringEnumRef.FAILURE")
+
+    def testHeaderParameters(self):
+        api_instance = openapi_client.HeaderApi()
+        api_response = api_instance.test_header_integer_boolean_string_enums(
+            integer_header=123,
+            boolean_header=True,
+            string_header="string_value",
+            enum_nonref_string_header="success",
+            enum_ref_string_header=openapi_client.StringEnumRef.FAILURE,
+        )
+        e = EchoServerResponseParser(api_response)
+        expected_header = dict(
+            integer_header="123",
+            boolean_header="True",
+            string_header="string_value",
+            enum_nonref_string_header="success",
+            enum_ref_string_header="failure",
+        )
+        self.assertDictContainsSubset(expected_header, e.headers)
+
+    def testEnumQueryParameters(self):
+        api_instance = openapi_client.QueryApi()
+        api_response = api_instance.test_enum_ref_string(
+            enum_nonref_string_query="success",
+            enum_ref_string_query=openapi_client.StringEnumRef("unclassified"),
+        )
+        e = EchoServerResponseParser(api_response)
+        self.assertEqual(
+            e.path, 
+            "/query/enum_ref_string?enum_nonref_string_query=success&enum_ref_string_query=unclassified",
+        )
 
 
     def testDateTimeQueryWithDateTimeFormat(self):

--- a/samples/client/echo_api/ruby-httpx/README.md
+++ b/samples/client/echo_api/ruby-httpx/README.md
@@ -93,8 +93,8 @@ Class | Method | HTTP request | Description
 *OpenapiClient::BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *OpenapiClient::FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *OpenapiClient::FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
-*OpenapiClient::HeaderApi* | [**test_header_integer_boolean_string**](docs/HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s)
-*OpenapiClient::PathApi* | [**tests_path_string_path_string_integer_path_integer**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s)
+*OpenapiClient::HeaderApi* | [**test_header_integer_boolean_string_enums**](docs/HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)
+*OpenapiClient::PathApi* | [**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](docs/PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s)
 *OpenapiClient::QueryApi* | [**test_enum_ref_string**](docs/QueryApi.md#test_enum_ref_string) | **GET** /query/enum_ref_string | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_datetime_date_string**](docs/QueryApi.md#test_query_datetime_date_string) | **GET** /query/datetime/date/string | Test query parameter(s)
 *OpenapiClient::QueryApi* | [**test_query_integer_boolean_string**](docs/QueryApi.md#test_query_integer_boolean_string) | **GET** /query/integer/boolean/string | Test query parameter(s)

--- a/samples/client/echo_api/ruby-httpx/docs/HeaderApi.md
+++ b/samples/client/echo_api/ruby-httpx/docs/HeaderApi.md
@@ -4,12 +4,12 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 | ------ | ------------ | ----------- |
-| [**test_header_integer_boolean_string**](HeaderApi.md#test_header_integer_boolean_string) | **GET** /header/integer/boolean/string | Test header parameter(s) |
+| [**test_header_integer_boolean_string_enums**](HeaderApi.md#test_header_integer_boolean_string_enums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s) |
 
 
-## test_header_integer_boolean_string
+## test_header_integer_boolean_string_enums
 
-> String test_header_integer_boolean_string(opts)
+> String test_header_integer_boolean_string_enums(opts)
 
 Test header parameter(s)
 
@@ -25,33 +25,35 @@ api_instance = OpenapiClient::HeaderApi.new
 opts = {
   integer_header: 56, # Integer | 
   boolean_header: true, # Boolean | 
-  string_header: 'string_header_example' # String | 
+  string_header: 'string_header_example', # String | 
+  enum_nonref_string_header: 'success', # String | 
+  enum_ref_string_header: OpenapiClient::StringEnumRef::SUCCESS # StringEnumRef | 
 }
 
 begin
   # Test header parameter(s)
-  result = api_instance.test_header_integer_boolean_string(opts)
+  result = api_instance.test_header_integer_boolean_string_enums(opts)
   p result
 rescue OpenapiClient::ApiError => e
-  puts "Error when calling HeaderApi->test_header_integer_boolean_string: #{e}"
+  puts "Error when calling HeaderApi->test_header_integer_boolean_string_enums: #{e}"
 end
 ```
 
-#### Using the test_header_integer_boolean_string_with_http_info variant
+#### Using the test_header_integer_boolean_string_enums_with_http_info variant
 
 This returns an Array which contains the response data, status code and headers.
 
-> <Array(String, Integer, Hash)> test_header_integer_boolean_string_with_http_info(opts)
+> <Array(String, Integer, Hash)> test_header_integer_boolean_string_enums_with_http_info(opts)
 
 ```ruby
 begin
   # Test header parameter(s)
-  data, status_code, headers = api_instance.test_header_integer_boolean_string_with_http_info(opts)
+  data, status_code, headers = api_instance.test_header_integer_boolean_string_enums_with_http_info(opts)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => String
 rescue OpenapiClient::ApiError => e
-  puts "Error when calling HeaderApi->test_header_integer_boolean_string_with_http_info: #{e}"
+  puts "Error when calling HeaderApi->test_header_integer_boolean_string_enums_with_http_info: #{e}"
 end
 ```
 
@@ -62,6 +64,8 @@ end
 | **integer_header** | **Integer** |  | [optional] |
 | **boolean_header** | **Boolean** |  | [optional] |
 | **string_header** | **String** |  | [optional] |
+| **enum_nonref_string_header** | **String** |  | [optional] |
+| **enum_ref_string_header** | [**StringEnumRef**](.md) |  | [optional] |
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-httpx/docs/PathApi.md
+++ b/samples/client/echo_api/ruby-httpx/docs/PathApi.md
@@ -4,12 +4,12 @@ All URIs are relative to *http://localhost:3000*
 
 | Method | HTTP request | Description |
 | ------ | ------------ | ----------- |
-| [**tests_path_string_path_string_integer_path_integer**](PathApi.md#tests_path_string_path_string_integer_path_integer) | **GET** /path/string/{path_string}/integer/{path_integer} | Test path parameter(s) |
+| [**tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path**](PathApi.md#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path) | **GET** /path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path} | Test path parameter(s) |
 
 
-## tests_path_string_path_string_integer_path_integer
+## tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path
 
-> String tests_path_string_path_string_integer_path_integer(path_string, path_integer)
+> String tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
 
 Test path parameter(s)
 
@@ -24,31 +24,33 @@ require 'openapi_client'
 api_instance = OpenapiClient::PathApi.new
 path_string = 'path_string_example' # String | 
 path_integer = 56 # Integer | 
+enum_nonref_string_path = 'success' # String | 
+enum_ref_string_path = OpenapiClient::StringEnumRef::SUCCESS # StringEnumRef | 
 
 begin
   # Test path parameter(s)
-  result = api_instance.tests_path_string_path_string_integer_path_integer(path_string, path_integer)
+  result = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
   p result
 rescue OpenapiClient::ApiError => e
-  puts "Error when calling PathApi->tests_path_string_path_string_integer_path_integer: #{e}"
+  puts "Error when calling PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path: #{e}"
 end
 ```
 
-#### Using the tests_path_string_path_string_integer_path_integer_with_http_info variant
+#### Using the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info variant
 
 This returns an Array which contains the response data, status code and headers.
 
-> <Array(String, Integer, Hash)> tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer)
+> <Array(String, Integer, Hash)> tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
 
 ```ruby
 begin
   # Test path parameter(s)
-  data, status_code, headers = api_instance.tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer)
+  data, status_code, headers = api_instance.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path)
   p status_code # => 2xx
   p headers # => { ... }
   p data # => String
 rescue OpenapiClient::ApiError => e
-  puts "Error when calling PathApi->tests_path_string_path_string_integer_path_integer_with_http_info: #{e}"
+  puts "Error when calling PathApi->tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info: #{e}"
 end
 ```
 
@@ -58,6 +60,8 @@ end
 | ---- | ---- | ----------- | ----- |
 | **path_string** | **String** |  |  |
 | **path_integer** | **Integer** |  |  |
+| **enum_nonref_string_path** | **String** |  |  |
+| **enum_ref_string_path** | [**StringEnumRef**](.md) |  |  |
 
 ### Return type
 

--- a/samples/client/echo_api/ruby-httpx/docs/QueryApi.md
+++ b/samples/client/echo_api/ruby-httpx/docs/QueryApi.md
@@ -30,6 +30,7 @@ require 'openapi_client'
 
 api_instance = OpenapiClient::QueryApi.new
 opts = {
+  enum_nonref_string_query: 'success', # String | 
   enum_ref_string_query: OpenapiClient::StringEnumRef::SUCCESS # StringEnumRef | 
 }
 
@@ -64,6 +65,7 @@ end
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
+| **enum_nonref_string_query** | **String** |  | [optional] |
 | **enum_ref_string_query** | [**StringEnumRef**](.md) |  | [optional] |
 
 ### Return type

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/header_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/header_api.rb
@@ -25,9 +25,11 @@ module OpenapiClient
     # @option opts [Integer] :integer_header 
     # @option opts [Boolean] :boolean_header 
     # @option opts [String] :string_header 
+    # @option opts [String] :enum_nonref_string_header 
+    # @option opts [StringEnumRef] :enum_ref_string_header 
     # @return [String]
-    def test_header_integer_boolean_string(opts = {})
-      data, _status_code, _headers = test_header_integer_boolean_string_with_http_info(opts)
+    def test_header_integer_boolean_string_enums(opts = {})
+      data, _status_code, _headers = test_header_integer_boolean_string_enums_with_http_info(opts)
       data
     end
 
@@ -37,13 +39,19 @@ module OpenapiClient
     # @option opts [Integer] :integer_header 
     # @option opts [Boolean] :boolean_header 
     # @option opts [String] :string_header 
+    # @option opts [String] :enum_nonref_string_header 
+    # @option opts [StringEnumRef] :enum_ref_string_header 
     # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
-    def test_header_integer_boolean_string_with_http_info(opts = {})
+    def test_header_integer_boolean_string_enums_with_http_info(opts = {})
       if @api_client.config.debugging
-        @api_client.config.logger.debug 'Calling API: HeaderApi.test_header_integer_boolean_string ...'
+        @api_client.config.logger.debug 'Calling API: HeaderApi.test_header_integer_boolean_string_enums ...'
+      end
+      allowable_values = ["success", "failure", "unclassified"]
+      if @api_client.config.client_side_validation && opts[:'enum_nonref_string_header'] && !allowable_values.include?(opts[:'enum_nonref_string_header'])
+        fail ArgumentError, "invalid value for \"enum_nonref_string_header\", must be one of #{allowable_values}"
       end
       # resource path
-      local_var_path = '/header/integer/boolean/string'
+      local_var_path = '/header/integer/boolean/string/enums'
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -55,6 +63,8 @@ module OpenapiClient
       header_params['integer_header'] = opts[:'integer_header'] if !opts[:'integer_header'].nil?
       header_params['boolean_header'] = opts[:'boolean_header'] if !opts[:'boolean_header'].nil?
       header_params['string_header'] = opts[:'string_header'] if !opts[:'string_header'].nil?
+      header_params['enum_nonref_string_header'] = opts[:'enum_nonref_string_header'] if !opts[:'enum_nonref_string_header'].nil?
+      header_params['enum_ref_string_header'] = opts[:'enum_ref_string_header'] if !opts[:'enum_ref_string_header'].nil?
 
       # form parameters
       form_params = opts[:form_params] || {}
@@ -69,7 +79,7 @@ module OpenapiClient
       auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
-        :operation => :"HeaderApi.test_header_integer_boolean_string",
+        :operation => :"HeaderApi.test_header_integer_boolean_string_enums",
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -80,7 +90,7 @@ module OpenapiClient
 
       data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
-        @api_client.config.logger.debug "API called: HeaderApi#test_header_integer_boolean_string\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+        @api_client.config.logger.debug "API called: HeaderApi#test_header_integer_boolean_string_enums\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/path_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/path_api.rb
@@ -23,10 +23,12 @@ module OpenapiClient
     # Test path parameter(s)
     # @param path_string [String] 
     # @param path_integer [Integer] 
+    # @param enum_nonref_string_path [String] 
+    # @param enum_ref_string_path [StringEnumRef] 
     # @param [Hash] opts the optional parameters
     # @return [String]
-    def tests_path_string_path_string_integer_path_integer(path_string, path_integer, opts = {})
-      data, _status_code, _headers = tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, opts)
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, opts = {})
+      data, _status_code, _headers = tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, opts)
       data
     end
 
@@ -34,22 +36,37 @@ module OpenapiClient
     # Test path parameter(s)
     # @param path_string [String] 
     # @param path_integer [Integer] 
+    # @param enum_nonref_string_path [String] 
+    # @param enum_ref_string_path [StringEnumRef] 
     # @param [Hash] opts the optional parameters
     # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
-    def tests_path_string_path_string_integer_path_integer_with_http_info(path_string, path_integer, opts = {})
+    def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, opts = {})
       if @api_client.config.debugging
-        @api_client.config.logger.debug 'Calling API: PathApi.tests_path_string_path_string_integer_path_integer ...'
+        @api_client.config.logger.debug 'Calling API: PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path ...'
       end
       # verify the required parameter 'path_string' is set
       if @api_client.config.client_side_validation && path_string.nil?
-        fail ArgumentError, "Missing the required parameter 'path_string' when calling PathApi.tests_path_string_path_string_integer_path_integer"
+        fail ArgumentError, "Missing the required parameter 'path_string' when calling PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path"
       end
       # verify the required parameter 'path_integer' is set
       if @api_client.config.client_side_validation && path_integer.nil?
-        fail ArgumentError, "Missing the required parameter 'path_integer' when calling PathApi.tests_path_string_path_string_integer_path_integer"
+        fail ArgumentError, "Missing the required parameter 'path_integer' when calling PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path"
+      end
+      # verify the required parameter 'enum_nonref_string_path' is set
+      if @api_client.config.client_side_validation && enum_nonref_string_path.nil?
+        fail ArgumentError, "Missing the required parameter 'enum_nonref_string_path' when calling PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path"
+      end
+      # verify enum value
+      allowable_values = ["success", "failure", "unclassified"]
+      if @api_client.config.client_side_validation && !allowable_values.include?(enum_nonref_string_path)
+        fail ArgumentError, "invalid value for \"enum_nonref_string_path\", must be one of #{allowable_values}"
+      end
+      # verify the required parameter 'enum_ref_string_path' is set
+      if @api_client.config.client_side_validation && enum_ref_string_path.nil?
+        fail ArgumentError, "Missing the required parameter 'enum_ref_string_path' when calling PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path"
       end
       # resource path
-      local_var_path = '/path/string/{path_string}/integer/{path_integer}'.sub('{' + 'path_string' + '}', CGI.escape(path_string.to_s)).sub('{' + 'path_integer' + '}', CGI.escape(path_integer.to_s))
+      local_var_path = '/path/string/{path_string}/integer/{path_integer}/{enum_nonref_string_path}/{enum_ref_string_path}'.sub('{' + 'path_string' + '}', CGI.escape(path_string.to_s)).sub('{' + 'path_integer' + '}', CGI.escape(path_integer.to_s)).sub('{' + 'enum_nonref_string_path' + '}', CGI.escape(enum_nonref_string_path.to_s)).sub('{' + 'enum_ref_string_path' + '}', CGI.escape(enum_ref_string_path.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}
@@ -72,7 +89,7 @@ module OpenapiClient
       auth_names = opts[:debug_auth_names] || []
 
       new_options = opts.merge(
-        :operation => :"PathApi.tests_path_string_path_string_integer_path_integer",
+        :operation => :"PathApi.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path",
         :header_params => header_params,
         :query_params => query_params,
         :form_params => form_params,
@@ -83,7 +100,7 @@ module OpenapiClient
 
       data, status_code, headers = @api_client.call_api(:GET, local_var_path, new_options)
       if @api_client.config.debugging
-        @api_client.config.logger.debug "API called: PathApi#tests_path_string_path_string_integer_path_integer\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+        @api_client.config.logger.debug "API called: PathApi#tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
       end
       return data, status_code, headers
     end

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/query_api.rb
@@ -22,6 +22,7 @@ module OpenapiClient
     # Test query parameter(s)
     # Test query parameter(s)
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :enum_nonref_string_query 
     # @option opts [StringEnumRef] :enum_ref_string_query 
     # @return [String]
     def test_enum_ref_string(opts = {})
@@ -32,17 +33,23 @@ module OpenapiClient
     # Test query parameter(s)
     # Test query parameter(s)
     # @param [Hash] opts the optional parameters
+    # @option opts [String] :enum_nonref_string_query 
     # @option opts [StringEnumRef] :enum_ref_string_query 
     # @return [Array<(String, Integer, Hash)>] String data, response status code and response headers
     def test_enum_ref_string_with_http_info(opts = {})
       if @api_client.config.debugging
         @api_client.config.logger.debug 'Calling API: QueryApi.test_enum_ref_string ...'
       end
+      allowable_values = ["success", "failure", "unclassified"]
+      if @api_client.config.client_side_validation && opts[:'enum_nonref_string_query'] && !allowable_values.include?(opts[:'enum_nonref_string_query'])
+        fail ArgumentError, "invalid value for \"enum_nonref_string_query\", must be one of #{allowable_values}"
+      end
       # resource path
       local_var_path = '/query/enum_ref_string'
 
       # query parameters
       query_params = opts[:query_params] || {}
+      query_params[:'enum_nonref_string_query'] = opts[:'enum_nonref_string_query'] if !opts[:'enum_nonref_string_query'].nil?
       query_params[:'enum_ref_string_query'] = opts[:'enum_ref_string_query'] if !opts[:'enum_ref_string_query'].nil?
 
       # header parameters


### PR DESCRIPTION
First commit: Add tests for different enum parameter types in `test_manual.py`.

Second commit: Closes https://github.com/OpenAPITools/openapi-generator/issues/16688

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [c] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@krjakbrjak @wing328 @multani @john-odonnell