### PR TITLE
[python] Do not pydantic-validate function args twice

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -88,7 +88,13 @@ class {{classname}}:
         if '_preload_content' in kwargs:
             message = "Error! Please call the {{operationId}}_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return {{#asyncio}}await {{/asyncio}}self.{{operationId}}_with_http_info({{#allParams}}{{paramName}}, {{/allParams}}**kwargs)  # noqa: E501
+
+        return {{#asyncio}}await {{/asyncio}}self.{{operationId}}_with_http_info(
+            {{#allParams}}
+            {{paramName}},
+            {{/allParams}}
+            **kwargs,
+        )
 
     @validate_call
 {{#asyncio}}

--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -89,7 +89,7 @@ class {{classname}}:
             message = "Error! Please call the {{operationId}}_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return {{#asyncio}}await {{/asyncio}}self.{{operationId}}_with_http_info(
+        return {{#asyncio}}await {{/asyncio}}self.{{operationId}}_with_http_info.raw_function(
             {{#allParams}}
             {{paramName}},
             {{/allParams}}

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
@@ -70,7 +70,10 @@ class AuthApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_auth_http_basic_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_auth_http_basic_with_http_info(**kwargs)  # noqa: E501
+
+        return self.test_auth_http_basic_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def test_auth_http_basic_with_http_info(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
@@ -71,7 +71,7 @@ class AuthApi:
             message = "Error! Please call the test_auth_http_basic_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_auth_http_basic_with_http_info(
+        return self.test_auth_http_basic_with_http_info.raw_function(
             **kwargs,
         )
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
@@ -79,7 +79,7 @@ class BodyApi:
             message = "Error! Please call the test_binary_gif_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_binary_gif_with_http_info(
+        return self.test_binary_gif_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -223,7 +223,7 @@ class BodyApi:
             message = "Error! Please call the test_body_application_octetstream_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_application_octetstream_binary_with_http_info(
+        return self.test_body_application_octetstream_binary_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -387,7 +387,7 @@ class BodyApi:
             message = "Error! Please call the test_body_multipart_formdata_array_of_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_multipart_formdata_array_of_binary_with_http_info(
+        return self.test_body_multipart_formdata_array_of_binary_with_http_info.raw_function(
             files,
             **kwargs,
         )
@@ -547,7 +547,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_free_form_object_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_free_form_object_response_string_with_http_info(
+        return self.test_echo_body_free_form_object_response_string_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -706,7 +706,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_pet_with_http_info(
+        return self.test_echo_body_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -865,7 +865,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_pet_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_pet_response_string_with_http_info(
+        return self.test_echo_body_pet_response_string_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -1024,7 +1024,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_tag_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_tag_response_string_with_http_info(
+        return self.test_echo_body_tag_response_string_with_http_info.raw_function(
             tag,
             **kwargs,
         )

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
@@ -78,7 +78,10 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_binary_gif_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_binary_gif_with_http_info(**kwargs)  # noqa: E501
+
+        return self.test_binary_gif_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def test_binary_gif_with_http_info(
@@ -219,7 +222,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_application_octetstream_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_application_octetstream_binary_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.test_body_application_octetstream_binary_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_application_octetstream_binary_with_http_info(
@@ -379,7 +386,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_multipart_formdata_array_of_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_multipart_formdata_array_of_binary_with_http_info(files, **kwargs)  # noqa: E501
+
+        return self.test_body_multipart_formdata_array_of_binary_with_http_info(
+            files,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_multipart_formdata_array_of_binary_with_http_info(
@@ -535,7 +546,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_free_form_object_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_free_form_object_response_string_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_free_form_object_response_string_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_free_form_object_response_string_with_http_info(
@@ -690,7 +705,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_pet_with_http_info(
@@ -845,7 +864,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_pet_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_pet_response_string_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_pet_response_string_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_pet_response_string_with_http_info(
@@ -1000,7 +1023,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_tag_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_tag_response_string_with_http_info(tag, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_tag_response_string_with_http_info(
+            tag,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_tag_response_string_with_http_info(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
@@ -83,7 +83,13 @@ class FormApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_form_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_form_integer_boolean_string_with_http_info(integer_form, boolean_form, string_form, **kwargs)  # noqa: E501
+
+        return self.test_form_integer_boolean_string_with_http_info(
+            integer_form,
+            boolean_form,
+            string_form,
+            **kwargs,
+        )
 
     @validate_call
     def test_form_integer_boolean_string_with_http_info(
@@ -267,7 +273,16 @@ class FormApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_form_oneof_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_form_oneof_with_http_info(form1, form2, form3, form4, id, name, **kwargs)  # noqa: E501
+
+        return self.test_form_oneof_with_http_info(
+            form1,
+            form2,
+            form3,
+            form4,
+            id,
+            name,
+            **kwargs,
+        )
 
     @validate_call
     def test_form_oneof_with_http_info(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
@@ -84,7 +84,7 @@ class FormApi:
             message = "Error! Please call the test_form_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_form_integer_boolean_string_with_http_info(
+        return self.test_form_integer_boolean_string_with_http_info.raw_function(
             integer_form,
             boolean_form,
             string_form,
@@ -274,7 +274,7 @@ class FormApi:
             message = "Error! Please call the test_form_oneof_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_form_oneof_with_http_info(
+        return self.test_form_oneof_with_http_info.raw_function(
             form1,
             form2,
             form3,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
@@ -90,7 +90,15 @@ class HeaderApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, **kwargs)  # noqa: E501
+
+        return self.test_header_integer_boolean_string_enums_with_http_info(
+            integer_header,
+            boolean_header,
+            string_header,
+            enum_nonref_string_header,
+            enum_ref_string_header,
+            **kwargs,
+        )
 
     @validate_call
     def test_header_integer_boolean_string_enums_with_http_info(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
@@ -91,7 +91,7 @@ class HeaderApi:
             message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_header_integer_boolean_string_enums_with_http_info(
+        return self.test_header_integer_boolean_string_enums_with_http_info.raw_function(
             integer_header,
             boolean_header,
             string_header,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -86,7 +86,7 @@ class PathApi:
             message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info.raw_function(
             path_string,
             path_integer,
             enum_nonref_string_path,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -85,7 +85,14 @@ class PathApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, **kwargs)  # noqa: E501
+
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(
+            path_string,
+            path_integer,
+            enum_nonref_string_path,
+            enum_ref_string_path,
+            **kwargs,
+        )
 
     @validate_call
     def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
@@ -86,7 +86,7 @@ class QueryApi:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_enum_ref_string_with_http_info(
+        return self.test_enum_ref_string_with_http_info.raw_function(
             enum_nonref_string_query,
             enum_ref_string_query,
             **kwargs,
@@ -252,7 +252,7 @@ class QueryApi:
             message = "Error! Please call the test_query_datetime_date_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_datetime_date_string_with_http_info(
+        return self.test_query_datetime_date_string_with_http_info.raw_function(
             datetime_query,
             date_query,
             string_query,
@@ -432,7 +432,7 @@ class QueryApi:
             message = "Error! Please call the test_query_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_integer_boolean_string_with_http_info(
+        return self.test_query_integer_boolean_string_with_http_info.raw_function(
             integer_query,
             boolean_query,
             string_query,
@@ -600,7 +600,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_deep_object_explode_true_object_with_http_info(
+        return self.test_query_style_deep_object_explode_true_object_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -752,7 +752,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(
+        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -904,7 +904,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_array_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_array_string_with_http_info(
+        return self.test_query_style_form_explode_true_array_string_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -1056,7 +1056,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_object_with_http_info(
+        return self.test_query_style_form_explode_true_object_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -1208,7 +1208,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_object_all_of_with_http_info(
+        return self.test_query_style_form_explode_true_object_all_of_with_http_info.raw_function(
             query_object,
             **kwargs,
         )

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
@@ -85,7 +85,12 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, **kwargs)  # noqa: E501
+
+        return self.test_enum_ref_string_with_http_info(
+            enum_nonref_string_query,
+            enum_ref_string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_enum_ref_string_with_http_info(
@@ -246,7 +251,13 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_datetime_date_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
+
+        return self.test_query_datetime_date_string_with_http_info(
+            datetime_query,
+            date_query,
+            string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_datetime_date_string_with_http_info(
@@ -420,7 +431,13 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_integer_boolean_string_with_http_info(integer_query, boolean_query, string_query, **kwargs)  # noqa: E501
+
+        return self.test_query_integer_boolean_string_with_http_info(
+            integer_query,
+            boolean_query,
+            string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_integer_boolean_string_with_http_info(
@@ -582,7 +599,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_deep_object_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_deep_object_explode_true_object_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_deep_object_explode_true_object_with_http_info(
@@ -730,7 +751,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_deep_object_explode_true_object_all_of_with_http_info(
@@ -878,7 +903,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_array_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_array_string_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_array_string_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_array_string_with_http_info(
@@ -1026,7 +1055,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_object_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_object_with_http_info(
@@ -1174,7 +1207,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_object_all_of_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_object_all_of_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -70,7 +70,10 @@ class AuthApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_auth_http_basic_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_auth_http_basic_with_http_info(**kwargs)  # noqa: E501
+
+        return self.test_auth_http_basic_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def test_auth_http_basic_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -71,7 +71,7 @@ class AuthApi:
             message = "Error! Please call the test_auth_http_basic_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_auth_http_basic_with_http_info(
+        return self.test_auth_http_basic_with_http_info.raw_function(
             **kwargs,
         )
 

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -79,7 +79,7 @@ class BodyApi:
             message = "Error! Please call the test_binary_gif_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_binary_gif_with_http_info(
+        return self.test_binary_gif_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -223,7 +223,7 @@ class BodyApi:
             message = "Error! Please call the test_body_application_octetstream_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_application_octetstream_binary_with_http_info(
+        return self.test_body_application_octetstream_binary_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -387,7 +387,7 @@ class BodyApi:
             message = "Error! Please call the test_body_multipart_formdata_array_of_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_multipart_formdata_array_of_binary_with_http_info(
+        return self.test_body_multipart_formdata_array_of_binary_with_http_info.raw_function(
             files,
             **kwargs,
         )
@@ -547,7 +547,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_free_form_object_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_free_form_object_response_string_with_http_info(
+        return self.test_echo_body_free_form_object_response_string_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -706,7 +706,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_pet_with_http_info(
+        return self.test_echo_body_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -865,7 +865,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_pet_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_pet_response_string_with_http_info(
+        return self.test_echo_body_pet_response_string_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -1024,7 +1024,7 @@ class BodyApi:
             message = "Error! Please call the test_echo_body_tag_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_echo_body_tag_response_string_with_http_info(
+        return self.test_echo_body_tag_response_string_with_http_info.raw_function(
             tag,
             **kwargs,
         )

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -78,7 +78,10 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_binary_gif_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_binary_gif_with_http_info(**kwargs)  # noqa: E501
+
+        return self.test_binary_gif_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def test_binary_gif_with_http_info(
@@ -219,7 +222,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_application_octetstream_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_application_octetstream_binary_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.test_body_application_octetstream_binary_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_application_octetstream_binary_with_http_info(
@@ -379,7 +386,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_multipart_formdata_array_of_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_multipart_formdata_array_of_binary_with_http_info(files, **kwargs)  # noqa: E501
+
+        return self.test_body_multipart_formdata_array_of_binary_with_http_info(
+            files,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_multipart_formdata_array_of_binary_with_http_info(
@@ -535,7 +546,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_free_form_object_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_free_form_object_response_string_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_free_form_object_response_string_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_free_form_object_response_string_with_http_info(
@@ -690,7 +705,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_pet_with_http_info(
@@ -845,7 +864,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_pet_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_pet_response_string_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_pet_response_string_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_pet_response_string_with_http_info(
@@ -1000,7 +1023,11 @@ class BodyApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_echo_body_tag_response_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_echo_body_tag_response_string_with_http_info(tag, **kwargs)  # noqa: E501
+
+        return self.test_echo_body_tag_response_string_with_http_info(
+            tag,
+            **kwargs,
+        )
 
     @validate_call
     def test_echo_body_tag_response_string_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -83,7 +83,13 @@ class FormApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_form_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_form_integer_boolean_string_with_http_info(integer_form, boolean_form, string_form, **kwargs)  # noqa: E501
+
+        return self.test_form_integer_boolean_string_with_http_info(
+            integer_form,
+            boolean_form,
+            string_form,
+            **kwargs,
+        )
 
     @validate_call
     def test_form_integer_boolean_string_with_http_info(
@@ -267,7 +273,16 @@ class FormApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_form_oneof_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_form_oneof_with_http_info(form1, form2, form3, form4, id, name, **kwargs)  # noqa: E501
+
+        return self.test_form_oneof_with_http_info(
+            form1,
+            form2,
+            form3,
+            form4,
+            id,
+            name,
+            **kwargs,
+        )
 
     @validate_call
     def test_form_oneof_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -84,7 +84,7 @@ class FormApi:
             message = "Error! Please call the test_form_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_form_integer_boolean_string_with_http_info(
+        return self.test_form_integer_boolean_string_with_http_info.raw_function(
             integer_form,
             boolean_form,
             string_form,
@@ -274,7 +274,7 @@ class FormApi:
             message = "Error! Please call the test_form_oneof_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_form_oneof_with_http_info(
+        return self.test_form_oneof_with_http_info.raw_function(
             form1,
             form2,
             form3,

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -90,7 +90,15 @@ class HeaderApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_header_integer_boolean_string_enums_with_http_info(integer_header, boolean_header, string_header, enum_nonref_string_header, enum_ref_string_header, **kwargs)  # noqa: E501
+
+        return self.test_header_integer_boolean_string_enums_with_http_info(
+            integer_header,
+            boolean_header,
+            string_header,
+            enum_nonref_string_header,
+            enum_ref_string_header,
+            **kwargs,
+        )
 
     @validate_call
     def test_header_integer_boolean_string_enums_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -91,7 +91,7 @@ class HeaderApi:
             message = "Error! Please call the test_header_integer_boolean_string_enums_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_header_integer_boolean_string_enums_with_http_info(
+        return self.test_header_integer_boolean_string_enums_with_http_info.raw_function(
             integer_header,
             boolean_header,
             string_header,

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -86,7 +86,7 @@ class PathApi:
             message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info.raw_function(
             path_string,
             path_integer,
             enum_nonref_string_path,

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -85,7 +85,14 @@ class PathApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(path_string, path_integer, enum_nonref_string_path, enum_ref_string_path, **kwargs)  # noqa: E501
+
+        return self.tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(
+            path_string,
+            path_integer,
+            enum_nonref_string_path,
+            enum_ref_string_path,
+            **kwargs,
+        )
 
     @validate_call
     def tests_path_string_path_string_integer_path_integer_enum_nonref_string_path_enum_ref_string_path_with_http_info(

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -86,7 +86,7 @@ class QueryApi:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_enum_ref_string_with_http_info(
+        return self.test_enum_ref_string_with_http_info.raw_function(
             enum_nonref_string_query,
             enum_ref_string_query,
             **kwargs,
@@ -252,7 +252,7 @@ class QueryApi:
             message = "Error! Please call the test_query_datetime_date_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_datetime_date_string_with_http_info(
+        return self.test_query_datetime_date_string_with_http_info.raw_function(
             datetime_query,
             date_query,
             string_query,
@@ -432,7 +432,7 @@ class QueryApi:
             message = "Error! Please call the test_query_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_integer_boolean_string_with_http_info(
+        return self.test_query_integer_boolean_string_with_http_info.raw_function(
             integer_query,
             boolean_query,
             string_query,
@@ -600,7 +600,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_deep_object_explode_true_object_with_http_info(
+        return self.test_query_style_deep_object_explode_true_object_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -752,7 +752,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(
+        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -904,7 +904,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_array_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_array_string_with_http_info(
+        return self.test_query_style_form_explode_true_array_string_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -1056,7 +1056,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_object_with_http_info(
+        return self.test_query_style_form_explode_true_object_with_http_info.raw_function(
             query_object,
             **kwargs,
         )
@@ -1208,7 +1208,7 @@ class QueryApi:
             message = "Error! Please call the test_query_style_form_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_style_form_explode_true_object_all_of_with_http_info(
+        return self.test_query_style_form_explode_true_object_all_of_with_http_info.raw_function(
             query_object,
             **kwargs,
         )

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -85,7 +85,12 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_enum_ref_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_enum_ref_string_with_http_info(enum_nonref_string_query, enum_ref_string_query, **kwargs)  # noqa: E501
+
+        return self.test_enum_ref_string_with_http_info(
+            enum_nonref_string_query,
+            enum_ref_string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_enum_ref_string_with_http_info(
@@ -246,7 +251,13 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_datetime_date_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_datetime_date_string_with_http_info(datetime_query, date_query, string_query, **kwargs)  # noqa: E501
+
+        return self.test_query_datetime_date_string_with_http_info(
+            datetime_query,
+            date_query,
+            string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_datetime_date_string_with_http_info(
@@ -420,7 +431,13 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_integer_boolean_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_integer_boolean_string_with_http_info(integer_query, boolean_query, string_query, **kwargs)  # noqa: E501
+
+        return self.test_query_integer_boolean_string_with_http_info(
+            integer_query,
+            boolean_query,
+            string_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_integer_boolean_string_with_http_info(
@@ -582,7 +599,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_deep_object_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_deep_object_explode_true_object_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_deep_object_explode_true_object_with_http_info(
@@ -730,7 +751,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_deep_object_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_deep_object_explode_true_object_all_of_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_deep_object_explode_true_object_all_of_with_http_info(
@@ -878,7 +903,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_array_string_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_array_string_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_array_string_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_array_string_with_http_info(
@@ -1026,7 +1055,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_object_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_object_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_object_with_http_info(
@@ -1174,7 +1207,11 @@ class QueryApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_style_form_explode_true_object_all_of_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_style_form_explode_true_object_all_of_with_http_info(query_object, **kwargs)  # noqa: E501
+
+        return self.test_query_style_form_explode_true_object_all_of_with_http_info(
+            query_object,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_style_form_explode_true_object_all_of_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -68,7 +68,11 @@ class AnotherFakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
+
+        return await self.call_123_test_special_tags_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     async def call_123_test_special_tags_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -69,7 +69,7 @@ class AnotherFakeApi:
             message = "Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.call_123_test_special_tags_with_http_info(
+        return await self.call_123_test_special_tags_with_http_info.raw_function(
             client,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -62,7 +62,10 @@ class DefaultApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.foo_get_with_http_info(**kwargs)  # noqa: E501
+
+        return await self.foo_get_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     async def foo_get_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -63,7 +63,7 @@ class DefaultApi:
             message = "Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.foo_get_with_http_info(
+        return await self.foo_get_with_http_info.raw_function(
             **kwargs,
         )
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -82,7 +82,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
+
+        return await self.fake_any_type_request_body_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_any_type_request_body_with_http_info(
@@ -213,7 +217,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
+
+        return await self.fake_enum_ref_query_parameter_with_http_info(
+            enum_ref,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_enum_ref_query_parameter_with_http_info(
@@ -334,7 +342,10 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
+
+        return await self.fake_health_get_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     async def fake_health_get_with_http_info(
@@ -463,7 +474,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
+
+        return await self.fake_http_signature_test_with_http_info(
+            pet,
+            query_1,
+            header_1,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_http_signature_test_with_http_info(
@@ -609,7 +626,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return await self.fake_outer_boolean_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_outer_boolean_serialize_with_http_info(
@@ -748,7 +769,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
+
+        return await self.fake_outer_composite_serialize_with_http_info(
+            outer_composite,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_outer_composite_serialize_with_http_info(
@@ -887,7 +912,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return await self.fake_outer_number_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_outer_number_serialize_with_http_info(
@@ -1026,7 +1055,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return await self.fake_outer_string_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_outer_string_serialize_with_http_info(
@@ -1165,7 +1198,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
+
+        return await self.fake_property_enum_integer_serialize_with_http_info(
+            outer_object_with_enum_property,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_property_enum_integer_serialize_with_http_info(
@@ -1300,7 +1337,10 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
+
+        return await self.fake_return_list_of_objects_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     async def fake_return_list_of_objects_with_http_info(
@@ -1423,7 +1463,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
+
+        return await self.fake_uuid_example_with_http_info(
+            uuid_example,
+            **kwargs,
+        )
 
     @validate_call
     async def fake_uuid_example_with_http_info(
@@ -1548,7 +1592,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
+
+        return await self.test_body_with_binary_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     async def test_body_with_binary_with_http_info(
@@ -1686,7 +1734,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
+
+        return await self.test_body_with_file_schema_with_http_info(
+            file_schema_test_class,
+            **kwargs,
+        )
 
     @validate_call
     async def test_body_with_file_schema_with_http_info(
@@ -1821,7 +1873,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
+
+        return await self.test_body_with_query_params_with_http_info(
+            query,
+            user,
+            **kwargs,
+        )
 
     @validate_call
     async def test_body_with_query_params_with_http_info(
@@ -1960,7 +2017,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
+
+        return await self.test_client_model_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     async def test_client_model_with_http_info(
@@ -2101,7 +2162,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
+
+        return await self.test_date_time_query_parameter_with_http_info(
+            date_time_query,
+            str_query,
+            **kwargs,
+        )
 
     @validate_call
     async def test_date_time_query_parameter_with_http_info(
@@ -2278,7 +2344,25 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, var_float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
+
+        return await self.test_endpoint_parameters_with_http_info(
+            number,
+            double,
+            pattern_without_delimiter,
+            byte,
+            integer,
+            int32,
+            int64,
+            var_float,
+            string,
+            binary,
+            byte_with_max_length,
+            var_date,
+            date_time,
+            password,
+            param_callback,
+            **kwargs,
+        )
 
     @validate_call
     async def test_endpoint_parameters_with_http_info(
@@ -2524,7 +2608,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
+
+        return await self.test_group_parameters_with_http_info(
+            required_string_group,
+            required_boolean_group,
+            required_int64_group,
+            string_group,
+            boolean_group,
+            int64_group,
+            **kwargs,
+        )
 
     @validate_call
     async def test_group_parameters_with_http_info(
@@ -2685,7 +2778,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
+
+        return await self.test_inline_additional_properties_with_http_info(
+            request_body,
+            **kwargs,
+        )
 
     @validate_call
     async def test_inline_additional_properties_with_http_info(
@@ -2818,7 +2915,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_inline_freeform_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_inline_freeform_additional_properties_with_http_info(test_inline_freeform_additional_properties_request, **kwargs)  # noqa: E501
+
+        return await self.test_inline_freeform_additional_properties_with_http_info(
+            test_inline_freeform_additional_properties_request,
+            **kwargs,
+        )
 
     @validate_call
     async def test_inline_freeform_additional_properties_with_http_info(
@@ -2954,7 +3055,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
+
+        return await self.test_json_form_data_with_http_info(
+            param,
+            param2,
+            **kwargs,
+        )
 
     @validate_call
     async def test_json_form_data_with_http_info(
@@ -3112,7 +3218,17 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
+
+        return await self.test_query_parameter_collection_format_with_http_info(
+            pipe,
+            ioutil,
+            http,
+            url,
+            context,
+            allow_empty,
+            language,
+            **kwargs,
+        )
 
     @validate_call
     async def test_query_parameter_collection_format_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -83,7 +83,7 @@ class FakeApi:
             message = "Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_any_type_request_body_with_http_info(
+        return await self.fake_any_type_request_body_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -218,7 +218,7 @@ class FakeApi:
             message = "Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_enum_ref_query_parameter_with_http_info(
+        return await self.fake_enum_ref_query_parameter_with_http_info.raw_function(
             enum_ref,
             **kwargs,
         )
@@ -343,7 +343,7 @@ class FakeApi:
             message = "Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_health_get_with_http_info(
+        return await self.fake_health_get_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -475,7 +475,7 @@ class FakeApi:
             message = "Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_http_signature_test_with_http_info(
+        return await self.fake_http_signature_test_with_http_info.raw_function(
             pet,
             query_1,
             header_1,
@@ -627,7 +627,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_outer_boolean_serialize_with_http_info(
+        return await self.fake_outer_boolean_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -770,7 +770,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_outer_composite_serialize_with_http_info(
+        return await self.fake_outer_composite_serialize_with_http_info.raw_function(
             outer_composite,
             **kwargs,
         )
@@ -913,7 +913,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_outer_number_serialize_with_http_info(
+        return await self.fake_outer_number_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1056,7 +1056,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_outer_string_serialize_with_http_info(
+        return await self.fake_outer_string_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1199,7 +1199,7 @@ class FakeApi:
             message = "Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_property_enum_integer_serialize_with_http_info(
+        return await self.fake_property_enum_integer_serialize_with_http_info.raw_function(
             outer_object_with_enum_property,
             **kwargs,
         )
@@ -1338,7 +1338,7 @@ class FakeApi:
             message = "Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_return_list_of_objects_with_http_info(
+        return await self.fake_return_list_of_objects_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -1464,7 +1464,7 @@ class FakeApi:
             message = "Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.fake_uuid_example_with_http_info(
+        return await self.fake_uuid_example_with_http_info.raw_function(
             uuid_example,
             **kwargs,
         )
@@ -1593,7 +1593,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_body_with_binary_with_http_info(
+        return await self.test_body_with_binary_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1735,7 +1735,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_body_with_file_schema_with_http_info(
+        return await self.test_body_with_file_schema_with_http_info.raw_function(
             file_schema_test_class,
             **kwargs,
         )
@@ -1874,7 +1874,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_body_with_query_params_with_http_info(
+        return await self.test_body_with_query_params_with_http_info.raw_function(
             query,
             user,
             **kwargs,
@@ -2018,7 +2018,7 @@ class FakeApi:
             message = "Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_client_model_with_http_info(
+        return await self.test_client_model_with_http_info.raw_function(
             client,
             **kwargs,
         )
@@ -2163,7 +2163,7 @@ class FakeApi:
             message = "Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_date_time_query_parameter_with_http_info(
+        return await self.test_date_time_query_parameter_with_http_info.raw_function(
             date_time_query,
             str_query,
             **kwargs,
@@ -2345,7 +2345,7 @@ class FakeApi:
             message = "Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_endpoint_parameters_with_http_info(
+        return await self.test_endpoint_parameters_with_http_info.raw_function(
             number,
             double,
             pattern_without_delimiter,
@@ -2609,7 +2609,7 @@ class FakeApi:
             message = "Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_group_parameters_with_http_info(
+        return await self.test_group_parameters_with_http_info.raw_function(
             required_string_group,
             required_boolean_group,
             required_int64_group,
@@ -2779,7 +2779,7 @@ class FakeApi:
             message = "Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_inline_additional_properties_with_http_info(
+        return await self.test_inline_additional_properties_with_http_info.raw_function(
             request_body,
             **kwargs,
         )
@@ -2916,7 +2916,7 @@ class FakeApi:
             message = "Error! Please call the test_inline_freeform_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_inline_freeform_additional_properties_with_http_info(
+        return await self.test_inline_freeform_additional_properties_with_http_info.raw_function(
             test_inline_freeform_additional_properties_request,
             **kwargs,
         )
@@ -3056,7 +3056,7 @@ class FakeApi:
             message = "Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_json_form_data_with_http_info(
+        return await self.test_json_form_data_with_http_info.raw_function(
             param,
             param2,
             **kwargs,
@@ -3219,7 +3219,7 @@ class FakeApi:
             message = "Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_query_parameter_collection_format_with_http_info(
+        return await self.test_query_parameter_collection_format_with_http_info.raw_function(
             pipe,
             ioutil,
             http,

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -68,7 +68,11 @@ class FakeClassnameTags123Api:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
+
+        return await self.test_classname_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     async def test_classname_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -69,7 +69,7 @@ class FakeClassnameTags123Api:
             message = "Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.test_classname_with_http_info(
+        return await self.test_classname_with_http_info.raw_function(
             client,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -74,7 +74,7 @@ class PetApi:
             message = "Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.add_pet_with_http_info(
+        return await self.add_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -214,7 +214,7 @@ class PetApi:
             message = "Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.delete_pet_with_http_info(
+        return await self.delete_pet_with_http_info.raw_function(
             pet_id,
             api_key,
             **kwargs,
@@ -352,7 +352,7 @@ class PetApi:
             message = "Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.find_pets_by_status_with_http_info(
+        return await self.find_pets_by_status_with_http_info.raw_function(
             status,
             **kwargs,
         )
@@ -490,7 +490,7 @@ class PetApi:
             message = "Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.find_pets_by_tags_with_http_info(
+        return await self.find_pets_by_tags_with_http_info.raw_function(
             tags,
             **kwargs,
         )
@@ -630,7 +630,7 @@ class PetApi:
             message = "Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.get_pet_by_id_with_http_info(
+        return await self.get_pet_by_id_with_http_info.raw_function(
             pet_id,
             **kwargs,
         )
@@ -768,7 +768,7 @@ class PetApi:
             message = "Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.update_pet_with_http_info(
+        return await self.update_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -911,7 +911,7 @@ class PetApi:
             message = "Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.update_pet_with_form_with_http_info(
+        return await self.update_pet_with_form_with_http_info.raw_function(
             pet_id,
             name,
             status,
@@ -1070,7 +1070,7 @@ class PetApi:
             message = "Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.upload_file_with_http_info(
+        return await self.upload_file_with_http_info.raw_function(
             pet_id,
             additional_metadata,
             file,
@@ -1235,7 +1235,7 @@ class PetApi:
             message = "Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.upload_file_with_required_file_with_http_info(
+        return await self.upload_file_with_required_file_with_http_info.raw_function(
             pet_id,
             required_file,
             additional_metadata,

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -73,7 +73,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return await self.add_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     async def add_pet_with_http_info(
@@ -209,7 +213,12 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
+
+        return await self.delete_pet_with_http_info(
+            pet_id,
+            api_key,
+            **kwargs,
+        )
 
     @validate_call
     async def delete_pet_with_http_info(
@@ -342,7 +351,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
+
+        return await self.find_pets_by_status_with_http_info(
+            status,
+            **kwargs,
+        )
 
     @validate_call
     async def find_pets_by_status_with_http_info(
@@ -476,7 +489,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
+
+        return await self.find_pets_by_tags_with_http_info(
+            tags,
+            **kwargs,
+        )
 
     @validate_call
     async def find_pets_by_tags_with_http_info(
@@ -612,7 +629,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
+
+        return await self.get_pet_by_id_with_http_info(
+            pet_id,
+            **kwargs,
+        )
 
     @validate_call
     async def get_pet_by_id_with_http_info(
@@ -746,7 +767,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return await self.update_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     async def update_pet_with_http_info(
@@ -885,7 +910,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
+
+        return await self.update_pet_with_form_with_http_info(
+            pet_id,
+            name,
+            status,
+            **kwargs,
+        )
 
     @validate_call
     async def update_pet_with_form_with_http_info(
@@ -1038,7 +1069,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
+
+        return await self.upload_file_with_http_info(
+            pet_id,
+            additional_metadata,
+            file,
+            **kwargs,
+        )
 
     @validate_call
     async def upload_file_with_http_info(
@@ -1197,7 +1234,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
+
+        return await self.upload_file_with_required_file_with_http_info(
+            pet_id,
+            required_file,
+            additional_metadata,
+            **kwargs,
+        )
 
     @validate_call
     async def upload_file_with_required_file_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -72,7 +72,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
+
+        return await self.delete_order_with_http_info(
+            order_id,
+            **kwargs,
+        )
 
     @validate_call
     async def delete_order_with_http_info(
@@ -195,7 +199,10 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.get_inventory_with_http_info(**kwargs)  # noqa: E501
+
+        return await self.get_inventory_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     async def get_inventory_with_http_info(
@@ -320,7 +327,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
+
+        return await self.get_order_by_id_with_http_info(
+            order_id,
+            **kwargs,
+        )
 
     @validate_call
     async def get_order_by_id_with_http_info(
@@ -454,7 +465,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.place_order_with_http_info(order, **kwargs)  # noqa: E501
+
+        return await self.place_order_with_http_info(
+            order,
+            **kwargs,
+        )
 
     @validate_call
     async def place_order_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -73,7 +73,7 @@ class StoreApi:
             message = "Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.delete_order_with_http_info(
+        return await self.delete_order_with_http_info.raw_function(
             order_id,
             **kwargs,
         )
@@ -200,7 +200,7 @@ class StoreApi:
             message = "Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.get_inventory_with_http_info(
+        return await self.get_inventory_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -328,7 +328,7 @@ class StoreApi:
             message = "Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.get_order_by_id_with_http_info(
+        return await self.get_order_by_id_with_http_info.raw_function(
             order_id,
             **kwargs,
         )
@@ -466,7 +466,7 @@ class StoreApi:
             message = "Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.place_order_with_http_info(
+        return await self.place_order_with_http_info.raw_function(
             order,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -72,7 +72,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.create_user_with_http_info(user, **kwargs)  # noqa: E501
+
+        return await self.create_user_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     async def create_user_with_http_info(
@@ -220,7 +224,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
+
+        return await self.create_users_with_array_input_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     async def create_users_with_array_input_with_http_info(
@@ -353,7 +361,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
+
+        return await self.create_users_with_list_input_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     async def create_users_with_list_input_with_http_info(
@@ -486,7 +498,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
+
+        return await self.delete_user_with_http_info(
+            username,
+            **kwargs,
+        )
 
     @validate_call
     async def delete_user_with_http_info(
@@ -612,7 +628,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
+
+        return await self.get_user_by_name_with_http_info(
+            username,
+            **kwargs,
+        )
 
     @validate_call
     async def get_user_by_name_with_http_info(
@@ -749,7 +769,12 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
+
+        return await self.login_user_with_http_info(
+            username,
+            password,
+            **kwargs,
+        )
 
     @validate_call
     async def login_user_with_http_info(
@@ -886,7 +911,10 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.logout_user_with_http_info(**kwargs)  # noqa: E501
+
+        return await self.logout_user_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     async def logout_user_with_http_info(
@@ -1008,7 +1036,12 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return await self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
+
+        return await self.update_user_with_http_info(
+            username,
+            user,
+            **kwargs,
+        )
 
     @validate_call
     async def update_user_with_http_info(

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -73,7 +73,7 @@ class UserApi:
             message = "Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.create_user_with_http_info(
+        return await self.create_user_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -225,7 +225,7 @@ class UserApi:
             message = "Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.create_users_with_array_input_with_http_info(
+        return await self.create_users_with_array_input_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -362,7 +362,7 @@ class UserApi:
             message = "Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.create_users_with_list_input_with_http_info(
+        return await self.create_users_with_list_input_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -499,7 +499,7 @@ class UserApi:
             message = "Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.delete_user_with_http_info(
+        return await self.delete_user_with_http_info.raw_function(
             username,
             **kwargs,
         )
@@ -629,7 +629,7 @@ class UserApi:
             message = "Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.get_user_by_name_with_http_info(
+        return await self.get_user_by_name_with_http_info.raw_function(
             username,
             **kwargs,
         )
@@ -770,7 +770,7 @@ class UserApi:
             message = "Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.login_user_with_http_info(
+        return await self.login_user_with_http_info.raw_function(
             username,
             password,
             **kwargs,
@@ -912,7 +912,7 @@ class UserApi:
             message = "Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.logout_user_with_http_info(
+        return await self.logout_user_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -1037,7 +1037,7 @@ class UserApi:
             message = "Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return await self.update_user_with_http_info(
+        return await self.update_user_with_http_info.raw_function(
             username,
             user,
             **kwargs,

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -75,7 +75,11 @@ class AnotherFakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.call_123_test_special_tags_with_http_info(client, **kwargs)  # noqa: E501
+
+        return self.call_123_test_special_tags_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     def call_123_test_special_tags_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -76,7 +76,7 @@ class AnotherFakeApi:
             message = "Error! Please call the call_123_test_special_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.call_123_test_special_tags_with_http_info(
+        return self.call_123_test_special_tags_with_http_info.raw_function(
             client,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -69,7 +69,10 @@ class DefaultApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.foo_get_with_http_info(**kwargs)  # noqa: E501
+
+        return self.foo_get_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def foo_get_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -70,7 +70,7 @@ class DefaultApi:
             message = "Error! Please call the foo_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.foo_get_with_http_info(
+        return self.foo_get_with_http_info.raw_function(
             **kwargs,
         )
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -90,7 +90,7 @@ class FakeApi:
             message = "Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_any_type_request_body_with_http_info(
+        return self.fake_any_type_request_body_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -241,7 +241,7 @@ class FakeApi:
             message = "Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_enum_ref_query_parameter_with_http_info(
+        return self.fake_enum_ref_query_parameter_with_http_info.raw_function(
             enum_ref,
             **kwargs,
         )
@@ -382,7 +382,7 @@ class FakeApi:
             message = "Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_health_get_with_http_info(
+        return self.fake_health_get_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -530,7 +530,7 @@ class FakeApi:
             message = "Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_http_signature_test_with_http_info(
+        return self.fake_http_signature_test_with_http_info.raw_function(
             pet,
             query_1,
             header_1,
@@ -698,7 +698,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_outer_boolean_serialize_with_http_info(
+        return self.fake_outer_boolean_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -857,7 +857,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_outer_composite_serialize_with_http_info(
+        return self.fake_outer_composite_serialize_with_http_info.raw_function(
             outer_composite,
             **kwargs,
         )
@@ -1016,7 +1016,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_outer_number_serialize_with_http_info(
+        return self.fake_outer_number_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1175,7 +1175,7 @@ class FakeApi:
             message = "Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_outer_string_serialize_with_http_info(
+        return self.fake_outer_string_serialize_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1334,7 +1334,7 @@ class FakeApi:
             message = "Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_property_enum_integer_serialize_with_http_info(
+        return self.fake_property_enum_integer_serialize_with_http_info.raw_function(
             outer_object_with_enum_property,
             **kwargs,
         )
@@ -1489,7 +1489,7 @@ class FakeApi:
             message = "Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_return_list_of_objects_with_http_info(
+        return self.fake_return_list_of_objects_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -1631,7 +1631,7 @@ class FakeApi:
             message = "Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.fake_uuid_example_with_http_info(
+        return self.fake_uuid_example_with_http_info.raw_function(
             uuid_example,
             **kwargs,
         )
@@ -1776,7 +1776,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_with_binary_with_http_info(
+        return self.test_body_with_binary_with_http_info.raw_function(
             body,
             **kwargs,
         )
@@ -1934,7 +1934,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_with_file_schema_with_http_info(
+        return self.test_body_with_file_schema_with_http_info.raw_function(
             file_schema_test_class,
             **kwargs,
         )
@@ -2089,7 +2089,7 @@ class FakeApi:
             message = "Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_body_with_query_params_with_http_info(
+        return self.test_body_with_query_params_with_http_info.raw_function(
             query,
             user,
             **kwargs,
@@ -2249,7 +2249,7 @@ class FakeApi:
             message = "Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_client_model_with_http_info(
+        return self.test_client_model_with_http_info.raw_function(
             client,
             **kwargs,
         )
@@ -2410,7 +2410,7 @@ class FakeApi:
             message = "Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_date_time_query_parameter_with_http_info(
+        return self.test_date_time_query_parameter_with_http_info.raw_function(
             date_time_query,
             str_query,
             **kwargs,
@@ -2608,7 +2608,7 @@ class FakeApi:
             message = "Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_endpoint_parameters_with_http_info(
+        return self.test_endpoint_parameters_with_http_info.raw_function(
             number,
             double,
             pattern_without_delimiter,
@@ -2888,7 +2888,7 @@ class FakeApi:
             message = "Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_group_parameters_with_http_info(
+        return self.test_group_parameters_with_http_info.raw_function(
             required_string_group,
             required_boolean_group,
             required_int64_group,
@@ -3074,7 +3074,7 @@ class FakeApi:
             message = "Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_inline_additional_properties_with_http_info(
+        return self.test_inline_additional_properties_with_http_info.raw_function(
             request_body,
             **kwargs,
         )
@@ -3227,7 +3227,7 @@ class FakeApi:
             message = "Error! Please call the test_inline_freeform_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_inline_freeform_additional_properties_with_http_info(
+        return self.test_inline_freeform_additional_properties_with_http_info.raw_function(
             test_inline_freeform_additional_properties_request,
             **kwargs,
         )
@@ -3383,7 +3383,7 @@ class FakeApi:
             message = "Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_json_form_data_with_http_info(
+        return self.test_json_form_data_with_http_info.raw_function(
             param,
             param2,
             **kwargs,
@@ -3562,7 +3562,7 @@ class FakeApi:
             message = "Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_query_parameter_collection_format_with_http_info(
+        return self.test_query_parameter_collection_format_with_http_info.raw_function(
             pipe,
             ioutil,
             http,

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -89,7 +89,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_any_type_request_body_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_any_type_request_body_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.fake_any_type_request_body_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def fake_any_type_request_body_with_http_info(
@@ -236,7 +240,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_enum_ref_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_enum_ref_query_parameter_with_http_info(enum_ref, **kwargs)  # noqa: E501
+
+        return self.fake_enum_ref_query_parameter_with_http_info(
+            enum_ref,
+            **kwargs,
+        )
 
     @validate_call
     def fake_enum_ref_query_parameter_with_http_info(
@@ -373,7 +381,10 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_health_get_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_health_get_with_http_info(**kwargs)  # noqa: E501
+
+        return self.fake_health_get_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def fake_health_get_with_http_info(
@@ -518,7 +529,13 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_http_signature_test_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_http_signature_test_with_http_info(pet, query_1, header_1, **kwargs)  # noqa: E501
+
+        return self.fake_http_signature_test_with_http_info(
+            pet,
+            query_1,
+            header_1,
+            **kwargs,
+        )
 
     @validate_call
     def fake_http_signature_test_with_http_info(
@@ -680,7 +697,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_boolean_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_outer_boolean_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.fake_outer_boolean_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def fake_outer_boolean_serialize_with_http_info(
@@ -835,7 +856,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_composite_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_outer_composite_serialize_with_http_info(outer_composite, **kwargs)  # noqa: E501
+
+        return self.fake_outer_composite_serialize_with_http_info(
+            outer_composite,
+            **kwargs,
+        )
 
     @validate_call
     def fake_outer_composite_serialize_with_http_info(
@@ -990,7 +1015,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_number_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_outer_number_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.fake_outer_number_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def fake_outer_number_serialize_with_http_info(
@@ -1145,7 +1174,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_outer_string_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_outer_string_serialize_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.fake_outer_string_serialize_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def fake_outer_string_serialize_with_http_info(
@@ -1300,7 +1333,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_property_enum_integer_serialize_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_property_enum_integer_serialize_with_http_info(outer_object_with_enum_property, **kwargs)  # noqa: E501
+
+        return self.fake_property_enum_integer_serialize_with_http_info(
+            outer_object_with_enum_property,
+            **kwargs,
+        )
 
     @validate_call
     def fake_property_enum_integer_serialize_with_http_info(
@@ -1451,7 +1488,10 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_return_list_of_objects_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_return_list_of_objects_with_http_info(**kwargs)  # noqa: E501
+
+        return self.fake_return_list_of_objects_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def fake_return_list_of_objects_with_http_info(
@@ -1590,7 +1630,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the fake_uuid_example_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.fake_uuid_example_with_http_info(uuid_example, **kwargs)  # noqa: E501
+
+        return self.fake_uuid_example_with_http_info(
+            uuid_example,
+            **kwargs,
+        )
 
     @validate_call
     def fake_uuid_example_with_http_info(
@@ -1731,7 +1775,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_binary_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_with_binary_with_http_info(body, **kwargs)  # noqa: E501
+
+        return self.test_body_with_binary_with_http_info(
+            body,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_with_binary_with_http_info(
@@ -1885,7 +1933,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_file_schema_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_with_file_schema_with_http_info(file_schema_test_class, **kwargs)  # noqa: E501
+
+        return self.test_body_with_file_schema_with_http_info(
+            file_schema_test_class,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_with_file_schema_with_http_info(
@@ -2036,7 +2088,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_body_with_query_params_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_body_with_query_params_with_http_info(query, user, **kwargs)  # noqa: E501
+
+        return self.test_body_with_query_params_with_http_info(
+            query,
+            user,
+            **kwargs,
+        )
 
     @validate_call
     def test_body_with_query_params_with_http_info(
@@ -2191,7 +2248,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_client_model_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_client_model_with_http_info(client, **kwargs)  # noqa: E501
+
+        return self.test_client_model_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     def test_client_model_with_http_info(
@@ -2348,7 +2409,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_date_time_query_parameter_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_date_time_query_parameter_with_http_info(date_time_query, str_query, **kwargs)  # noqa: E501
+
+        return self.test_date_time_query_parameter_with_http_info(
+            date_time_query,
+            str_query,
+            **kwargs,
+        )
 
     @validate_call
     def test_date_time_query_parameter_with_http_info(
@@ -2541,7 +2607,25 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_endpoint_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_endpoint_parameters_with_http_info(number, double, pattern_without_delimiter, byte, integer, int32, int64, var_float, string, binary, byte_with_max_length, var_date, date_time, password, param_callback, **kwargs)  # noqa: E501
+
+        return self.test_endpoint_parameters_with_http_info(
+            number,
+            double,
+            pattern_without_delimiter,
+            byte,
+            integer,
+            int32,
+            int64,
+            var_float,
+            string,
+            binary,
+            byte_with_max_length,
+            var_date,
+            date_time,
+            password,
+            param_callback,
+            **kwargs,
+        )
 
     @validate_call
     def test_endpoint_parameters_with_http_info(
@@ -2803,7 +2887,16 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_group_parameters_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_group_parameters_with_http_info(required_string_group, required_boolean_group, required_int64_group, string_group, boolean_group, int64_group, **kwargs)  # noqa: E501
+
+        return self.test_group_parameters_with_http_info(
+            required_string_group,
+            required_boolean_group,
+            required_int64_group,
+            string_group,
+            boolean_group,
+            int64_group,
+            **kwargs,
+        )
 
     @validate_call
     def test_group_parameters_with_http_info(
@@ -2980,7 +3073,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_inline_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_inline_additional_properties_with_http_info(request_body, **kwargs)  # noqa: E501
+
+        return self.test_inline_additional_properties_with_http_info(
+            request_body,
+            **kwargs,
+        )
 
     @validate_call
     def test_inline_additional_properties_with_http_info(
@@ -3129,7 +3226,11 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_inline_freeform_additional_properties_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_inline_freeform_additional_properties_with_http_info(test_inline_freeform_additional_properties_request, **kwargs)  # noqa: E501
+
+        return self.test_inline_freeform_additional_properties_with_http_info(
+            test_inline_freeform_additional_properties_request,
+            **kwargs,
+        )
 
     @validate_call
     def test_inline_freeform_additional_properties_with_http_info(
@@ -3281,7 +3382,12 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_json_form_data_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_json_form_data_with_http_info(param, param2, **kwargs)  # noqa: E501
+
+        return self.test_json_form_data_with_http_info(
+            param,
+            param2,
+            **kwargs,
+        )
 
     @validate_call
     def test_json_form_data_with_http_info(
@@ -3455,7 +3561,17 @@ class FakeApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_query_parameter_collection_format_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_query_parameter_collection_format_with_http_info(pipe, ioutil, http, url, context, allow_empty, language, **kwargs)  # noqa: E501
+
+        return self.test_query_parameter_collection_format_with_http_info(
+            pipe,
+            ioutil,
+            http,
+            url,
+            context,
+            allow_empty,
+            language,
+            **kwargs,
+        )
 
     @validate_call
     def test_query_parameter_collection_format_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -76,7 +76,7 @@ class FakeClassnameTags123Api:
             message = "Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.test_classname_with_http_info(
+        return self.test_classname_with_http_info.raw_function(
             client,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -75,7 +75,11 @@ class FakeClassnameTags123Api:
         if '_preload_content' in kwargs:
             message = "Error! Please call the test_classname_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.test_classname_with_http_info(client, **kwargs)  # noqa: E501
+
+        return self.test_classname_with_http_info(
+            client,
+            **kwargs,
+        )
 
     @validate_call
     def test_classname_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -80,7 +80,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.add_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.add_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def add_pet_with_http_info(
@@ -232,7 +236,12 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.delete_pet_with_http_info(pet_id, api_key, **kwargs)  # noqa: E501
+
+        return self.delete_pet_with_http_info(
+            pet_id,
+            api_key,
+            **kwargs,
+        )
 
     @validate_call
     def delete_pet_with_http_info(
@@ -381,7 +390,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.find_pets_by_status_with_http_info(status, **kwargs)  # noqa: E501
+
+        return self.find_pets_by_status_with_http_info(
+            status,
+            **kwargs,
+        )
 
     @validate_call
     def find_pets_by_status_with_http_info(
@@ -531,7 +544,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.find_pets_by_tags_with_http_info(tags, **kwargs)  # noqa: E501
+
+        return self.find_pets_by_tags_with_http_info(
+            tags,
+            **kwargs,
+        )
 
     @validate_call
     def find_pets_by_tags_with_http_info(
@@ -683,7 +700,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.get_pet_by_id_with_http_info(pet_id, **kwargs)  # noqa: E501
+
+        return self.get_pet_by_id_with_http_info(
+            pet_id,
+            **kwargs,
+        )
 
     @validate_call
     def get_pet_by_id_with_http_info(
@@ -833,7 +854,11 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.update_pet_with_http_info(pet, **kwargs)  # noqa: E501
+
+        return self.update_pet_with_http_info(
+            pet,
+            **kwargs,
+        )
 
     @validate_call
     def update_pet_with_http_info(
@@ -988,7 +1013,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.update_pet_with_form_with_http_info(pet_id, name, status, **kwargs)  # noqa: E501
+
+        return self.update_pet_with_form_with_http_info(
+            pet_id,
+            name,
+            status,
+            **kwargs,
+        )
 
     @validate_call
     def update_pet_with_form_with_http_info(
@@ -1157,7 +1188,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.upload_file_with_http_info(pet_id, additional_metadata, file, **kwargs)  # noqa: E501
+
+        return self.upload_file_with_http_info(
+            pet_id,
+            additional_metadata,
+            file,
+            **kwargs,
+        )
 
     @validate_call
     def upload_file_with_http_info(
@@ -1332,7 +1369,13 @@ class PetApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.upload_file_with_required_file_with_http_info(pet_id, required_file, additional_metadata, **kwargs)  # noqa: E501
+
+        return self.upload_file_with_required_file_with_http_info(
+            pet_id,
+            required_file,
+            additional_metadata,
+            **kwargs,
+        )
 
     @validate_call
     def upload_file_with_required_file_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -81,7 +81,7 @@ class PetApi:
             message = "Error! Please call the add_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.add_pet_with_http_info(
+        return self.add_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -237,7 +237,7 @@ class PetApi:
             message = "Error! Please call the delete_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.delete_pet_with_http_info(
+        return self.delete_pet_with_http_info.raw_function(
             pet_id,
             api_key,
             **kwargs,
@@ -391,7 +391,7 @@ class PetApi:
             message = "Error! Please call the find_pets_by_status_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.find_pets_by_status_with_http_info(
+        return self.find_pets_by_status_with_http_info.raw_function(
             status,
             **kwargs,
         )
@@ -545,7 +545,7 @@ class PetApi:
             message = "Error! Please call the find_pets_by_tags_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.find_pets_by_tags_with_http_info(
+        return self.find_pets_by_tags_with_http_info.raw_function(
             tags,
             **kwargs,
         )
@@ -701,7 +701,7 @@ class PetApi:
             message = "Error! Please call the get_pet_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.get_pet_by_id_with_http_info(
+        return self.get_pet_by_id_with_http_info.raw_function(
             pet_id,
             **kwargs,
         )
@@ -855,7 +855,7 @@ class PetApi:
             message = "Error! Please call the update_pet_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.update_pet_with_http_info(
+        return self.update_pet_with_http_info.raw_function(
             pet,
             **kwargs,
         )
@@ -1014,7 +1014,7 @@ class PetApi:
             message = "Error! Please call the update_pet_with_form_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.update_pet_with_form_with_http_info(
+        return self.update_pet_with_form_with_http_info.raw_function(
             pet_id,
             name,
             status,
@@ -1189,7 +1189,7 @@ class PetApi:
             message = "Error! Please call the upload_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.upload_file_with_http_info(
+        return self.upload_file_with_http_info.raw_function(
             pet_id,
             additional_metadata,
             file,
@@ -1370,7 +1370,7 @@ class PetApi:
             message = "Error! Please call the upload_file_with_required_file_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.upload_file_with_required_file_with_http_info(
+        return self.upload_file_with_required_file_with_http_info.raw_function(
             pet_id,
             required_file,
             additional_metadata,

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -79,7 +79,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.delete_order_with_http_info(order_id, **kwargs)  # noqa: E501
+
+        return self.delete_order_with_http_info(
+            order_id,
+            **kwargs,
+        )
 
     @validate_call
     def delete_order_with_http_info(
@@ -218,7 +222,10 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.get_inventory_with_http_info(**kwargs)  # noqa: E501
+
+        return self.get_inventory_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def get_inventory_with_http_info(
@@ -359,7 +366,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.get_order_by_id_with_http_info(order_id, **kwargs)  # noqa: E501
+
+        return self.get_order_by_id_with_http_info(
+            order_id,
+            **kwargs,
+        )
 
     @validate_call
     def get_order_by_id_with_http_info(
@@ -509,7 +520,11 @@ class StoreApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.place_order_with_http_info(order, **kwargs)  # noqa: E501
+
+        return self.place_order_with_http_info(
+            order,
+            **kwargs,
+        )
 
     @validate_call
     def place_order_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -80,7 +80,7 @@ class StoreApi:
             message = "Error! Please call the delete_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.delete_order_with_http_info(
+        return self.delete_order_with_http_info.raw_function(
             order_id,
             **kwargs,
         )
@@ -223,7 +223,7 @@ class StoreApi:
             message = "Error! Please call the get_inventory_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.get_inventory_with_http_info(
+        return self.get_inventory_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -367,7 +367,7 @@ class StoreApi:
             message = "Error! Please call the get_order_by_id_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.get_order_by_id_with_http_info(
+        return self.get_order_by_id_with_http_info.raw_function(
             order_id,
             **kwargs,
         )
@@ -521,7 +521,7 @@ class StoreApi:
             message = "Error! Please call the place_order_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.place_order_with_http_info(
+        return self.place_order_with_http_info.raw_function(
             order,
             **kwargs,
         )

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -79,7 +79,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.create_user_with_http_info(user, **kwargs)  # noqa: E501
+
+        return self.create_user_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     def create_user_with_http_info(
@@ -243,7 +247,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.create_users_with_array_input_with_http_info(user, **kwargs)  # noqa: E501
+
+        return self.create_users_with_array_input_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     def create_users_with_array_input_with_http_info(
@@ -392,7 +400,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.create_users_with_list_input_with_http_info(user, **kwargs)  # noqa: E501
+
+        return self.create_users_with_list_input_with_http_info(
+            user,
+            **kwargs,
+        )
 
     @validate_call
     def create_users_with_list_input_with_http_info(
@@ -541,7 +553,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.delete_user_with_http_info(username, **kwargs)  # noqa: E501
+
+        return self.delete_user_with_http_info(
+            username,
+            **kwargs,
+        )
 
     @validate_call
     def delete_user_with_http_info(
@@ -683,7 +699,11 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.get_user_by_name_with_http_info(username, **kwargs)  # noqa: E501
+
+        return self.get_user_by_name_with_http_info(
+            username,
+            **kwargs,
+        )
 
     @validate_call
     def get_user_by_name_with_http_info(
@@ -836,7 +856,12 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.login_user_with_http_info(username, password, **kwargs)  # noqa: E501
+
+        return self.login_user_with_http_info(
+            username,
+            password,
+            **kwargs,
+        )
 
     @validate_call
     def login_user_with_http_info(
@@ -989,7 +1014,10 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.logout_user_with_http_info(**kwargs)  # noqa: E501
+
+        return self.logout_user_with_http_info(
+            **kwargs,
+        )
 
     @validate_call
     def logout_user_with_http_info(
@@ -1127,7 +1155,12 @@ class UserApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.update_user_with_http_info(username, user, **kwargs)  # noqa: E501
+
+        return self.update_user_with_http_info(
+            username,
+            user,
+            **kwargs,
+        )
 
     @validate_call
     def update_user_with_http_info(

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -80,7 +80,7 @@ class UserApi:
             message = "Error! Please call the create_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.create_user_with_http_info(
+        return self.create_user_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -248,7 +248,7 @@ class UserApi:
             message = "Error! Please call the create_users_with_array_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.create_users_with_array_input_with_http_info(
+        return self.create_users_with_array_input_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -401,7 +401,7 @@ class UserApi:
             message = "Error! Please call the create_users_with_list_input_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.create_users_with_list_input_with_http_info(
+        return self.create_users_with_list_input_with_http_info.raw_function(
             user,
             **kwargs,
         )
@@ -554,7 +554,7 @@ class UserApi:
             message = "Error! Please call the delete_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.delete_user_with_http_info(
+        return self.delete_user_with_http_info.raw_function(
             username,
             **kwargs,
         )
@@ -700,7 +700,7 @@ class UserApi:
             message = "Error! Please call the get_user_by_name_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.get_user_by_name_with_http_info(
+        return self.get_user_by_name_with_http_info.raw_function(
             username,
             **kwargs,
         )
@@ -857,7 +857,7 @@ class UserApi:
             message = "Error! Please call the login_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.login_user_with_http_info(
+        return self.login_user_with_http_info.raw_function(
             username,
             password,
             **kwargs,
@@ -1015,7 +1015,7 @@ class UserApi:
             message = "Error! Please call the logout_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.logout_user_with_http_info(
+        return self.logout_user_with_http_info.raw_function(
             **kwargs,
         )
 
@@ -1156,7 +1156,7 @@ class UserApi:
             message = "Error! Please call the update_user_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
 
-        return self.update_user_with_http_info(
+        return self.update_user_with_http_info.raw_function(
             username,
             user,
             **kwargs,


### PR DESCRIPTION
[refactor: Use newlines in _with_http_info call](https://github.com/OpenAPITools/openapi-generator/commit/1e5f48eb3e55caa8af536ac17a7a983e6cf749a8)
[fix: Do not pydantic-validate function args twice](https://github.com/OpenAPITools/openapi-generator/commit/e312d4260c07e295748df14579c75f3fcd73628b)

Closes #15757

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @multani 