### PR TITLE
[python] feat: Allow streaming large response bodies

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -136,9 +136,11 @@ class {{classname}}:
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
 {{/asyncio}}
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.{{#asyncio}}aiohttp{{/asyncio}}{{^asyncio}}urllib3{{/asyncio}}_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -13,6 +13,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
+from typing import Union
 
 from urllib.parse import quote
 {{#tornado}}
@@ -163,6 +164,9 @@ class ApiClient:
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
             _request_auth=None):
+        if _return_http_data_only:
+            # Remove in #16788
+            assert _preload_content, "_preload_content must be True if _return_http_data_only is True"
 
         config = self.configuration
 
@@ -237,48 +241,46 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
+        raw_data: Union[str, bytes] = response_data.data
         # data needs deserialization or returns HTTP data (deserialized) only
-        if _preload_content or _return_http_data_only:
-          response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
-              # if not found, look for '1XX', '2XX', etc.
-              response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
+        if _preload_content:
+            response_type = response_types_map.get(str(response_data.status), None)
+            if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
+                # if not found, look for '1XX', '2XX', etc.
+                response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-          if response_type == "bytearray":
-              response_data.data = response_data.data
-          else:
-              match = None
-              content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+            body_bytes = response_data.data
+            if response_type == "bytearray":
+                return_data = body_bytes
+            else:
+                match = None
+                content_type = response_data.getheader('content-type')
+                if content_type is not None:
+                    match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+                encoding = match.group(1) if match else "utf-8"
+                body_str = body_bytes.decode(encoding)
+                raw_data = body_str
 
-          # deserialize response data
-          if response_type == "bytearray":
-              return_data = response_data.data
-          elif response_type:
-              return_data = self.deserialize(response_data, response_type)
-          else:
-              return_data = None
+                # deserialize response data
+                if response_type:
+                    return_data = self.deserialize(response_data, response_type, body=body_str)
+                else:
+                    return_data = None
 
-{{^tornado}}
         if _return_http_data_only:
-            return return_data
+            result = return_data
         else:
-            return ApiResponse(status_code = response_data.status,
-                           data = return_data,
-                           headers = response_data.getheaders(),
-                           raw_data = response_data.data)
+            result = ApiResponse(
+                status_code=response_data.status,
+                data=return_data,
+                headers=response_data.getheaders(),
+                raw_data=raw_data,
+            )
+{{^tornado}}
+        return result
 {{/tornado}}
 {{#tornado}}
-        if _return_http_data_only:
-            raise tornado.gen.Return(return_data)
-        else:
-            raise tornado.gen.Return(ApiResponse(status_code = response_data.status,
-                                                 data = return_data,
-                                                 headers = response_data.getheaders(),
-                                                 raw_data = response_data.data))
+        raise tornado.gen.Return(result)
 {{/tornado}}
 
     def sanitize_for_serialization(self, obj):
@@ -321,7 +323,7 @@ class ApiClient:
         return {key: self.sanitize_for_serialization(val)
                 for key, val in obj_dict.items()}
 
-    def deserialize(self, response, response_type):
+    def deserialize(self, response: rest.RESTResponse, response_type, body: str):
         """Deserializes response into an object.
 
         :param response: RESTResponse object to be deserialized.
@@ -337,9 +339,9 @@ class ApiClient:
 
         # fetch data from response object
         try:
-            data = json.loads(response.data)
+            data = json.loads(body)
         except ValueError:
-            data = response.data
+            data = body
 
         return self.__deserialize(data, response_type)
 
@@ -467,9 +469,17 @@ class ApiClient:
         return self.pool.apply_async(self.__call_api, args)
 {{/asyncio}}
 
-    {{#asyncio}}async {{/asyncio}}def request(self, method, url, query_params=None, headers=None,
-                post_params=None, body=None, _preload_content=True,
-                _request_timeout=None):
+    {{#asyncio}}async {{/asyncio}}def request(
+        self,
+        method,
+        url,
+        query_params=None,
+        headers=None,
+        post_params=None,
+        body=None,
+        _preload_content=True,
+        _request_timeout=None,
+    ) -> rest.RESTResponse:
         """Makes the HTTP request using RESTClient."""
         if method == "GET":
             return {{#asyncio}}await {{/asyncio}}self.rest_client.get_request(url,
@@ -713,7 +723,7 @@ class ApiClient:
                 'Authentication token must be in `query` or `header`'
             )
 
-    def __deserialize_file(self, response):
+    def __deserialize_file(self, response: rest.RESTResponse):
         """Deserializes body to file
 
         Saves response body into a file in a temporary folder,

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -241,7 +241,7 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
-        raw_data: Union[str, bytes] = response_data.data
+        raw_data: Union[None, str, bytes] = None
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content:
             response_type = response_types_map.get(str(response_data.status), None)
@@ -250,7 +250,9 @@ class ApiClient:
                 response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
             body_bytes = response_data.data
+            assert isinstance(body_bytes, bytes), "Must not be None if _preload_content=True"
             if response_type == "bytearray":
+                raw_data = body_bytes
                 return_data = body_bytes
             else:
                 match = None
@@ -275,6 +277,12 @@ class ApiClient:
                 data=return_data,
                 headers=response_data.getheaders(),
                 raw_data=raw_data,
+                {{#asyncio}}
+                aiohttp_response=response_data.aiohttp_response,
+                {{/asyncio}}
+                {{^asyncio}}
+                urllib3_response=response_data.urllib3_response,
+                {{/asyncio}}
             )
 {{^tornado}}
         return result

--- a/modules/openapi-generator/src/main/resources/python/api_response.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_response.mustache
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional, Union
+{{^asyncio}}
+import warnings
+{{/asyncio}}
+
+{{#asyncio}}
+from aiohttp import ClientResponse
+{{/asyncio}}
 from pydantic import Field, StrictInt, StrictStr
+{{^asyncio}}
+from urllib3 import HTTPResponse
+{{/asyncio}}
 
 class ApiResponse:
     """
@@ -12,7 +22,17 @@ class ApiResponse:
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
+    {{^asyncio}}_{{/asyncio}}raw_data: Union[None, str, bytes] = Field(
+        title="Raw data (HTTP response body)",
+        description="`bytes` if the OpenAPI response body format is 'binary', "
+        "otherwise `str`. `None` if `_preload_content=False`.",
+    )
+    {{#asyncio}}
+    aiohttp_response: ClientResponse = Field(description="Raw aiohttp response for response streaming")
+    {{/asyncio}}
+    {{^asyncio}}
+    urllib3_response: HTTPResponse = Field(description="Raw urllib3 response for response streaming")
+    {{/asyncio}}
 
     def __init__(
         self,
@@ -21,8 +41,64 @@ class ApiResponse:
         data=None,
         *,
         raw_data,
+        {{#asyncio}}
+        aiohttp_response,
+        {{/asyncio}}
+        {{^asyncio}}
+        urllib3_response,
+        {{/asyncio}}
     ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data
-        self.raw_data = raw_data
+        self.{{^asyncio}}_{{/asyncio}}raw_data = raw_data
+        {{#asyncio}}
+        self.aiohttp_response = aiohttp_response
+        {{/asyncio}}
+        {{^asyncio}}
+        self.urllib3_response = urllib3_response
+        {{/asyncio}}
+
+    {{^asyncio}}
+    {{! 
+    With the next major release, the `_raw_data` attribute can be renamed to `raw_data`
+    in the urllib3 client and the `raw_data` property function removed.
+    For the asyncio client, `_preload_content=False` didn't work before, so no backwards-
+    compatibility is needed and the property function is not necessary.
+    }}
+    @property
+    def raw_data(self) -> Union[str, bytes]:
+        """Get raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        To stream responses, read from `self.{{#asyncio}}aiohttp{{/asyncio}}{{^asyncio}}urllib3{{/asyncio}}_response`.
+
+        :return: `str` if `preload_content=True`, `bytes` if not.
+        """
+        if self._raw_data is None:
+            warnings.warn(
+                "If `preload_content=False`, `ApiResponse.raw_data` will change to "
+                "`None` in a future version. Use `ApiResponse.read()` instead.",
+                DeprecationWarning,
+            )
+            return self.urllib3_response.data
+        return self._raw_data
+    {{/asyncio}}
+
+    {{#asyncio}}async {{/asyncio}}def read(self) -> Union[str, bytes]:
+        """Read raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        """
+        if self.{{^asyncio}}_{{/asyncio}}raw_data is not None:
+            return self.{{^asyncio}}_{{/asyncio}}raw_data
+        {{#asyncio}}
+        return await self.aiohttp_response.read()
+        {{/asyncio}}
+        {{^asyncio}}
+        return self.urllib3_response.data
+        {{/asyncio}}

--- a/modules/openapi-generator/src/main/resources/python/api_response.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_response.mustache
@@ -1,24 +1,27 @@
 """API response object."""
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """
-    API response object
+    API response object returned by `_with_http_info` API methods.
     """
 
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Optional[Any] = Field(None, description="Raw data (HTTP response body)")
+    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
 
-    def __init__(self,
-                 status_code=None,
-                 headers=None,
-                 data=None,
-                 raw_data=None) -> None:
+    def __init__(
+        self,
+        status_code=None,
+        headers=None,
+        data=None,
+        *,
+        raw_data,
+    ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 {{>partial_header}}
-
+from typing import Optional
 import io
 import json
 import logging
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp, data) -> None:
+    def __init__(self, resp: aiohttp.ClientResponse, *, data: Optional[bytes]) -> None:
         self.aiohttp_response = resp
         self.status = resp.status
         self.reason = resp.reason
@@ -158,17 +158,19 @@ class RESTClientObject:
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
-        r = await self.pool_manager.request(**args)
-        if _preload_content:
+        aiohttp_response = await self.pool_manager.request(**args)
 
-            data = await r.read()
-            r = RESTResponse(r, data)
+        if _preload_content:
+            data = await aiohttp_response.read()
+            r = RESTResponse(aiohttp_response, data=data)
 
             # log response body
             logger.debug("response body: %s", r.data)
+        else:
+            r = RESTResponse(aiohttp_response, data=None)
 
-            if not 200 <= r.status <= 299:
-                raise ApiException(http_resp=r)
+        if not 200 <= r.status <= 299:
+            raise ApiException(http_resp=r)
 
         return r
 

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 {{>partial_header}}
-
+from typing import Optional
 import io
 import json
 import logging
@@ -19,11 +19,11 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp) -> None:
+    def __init__(self, resp: urllib3.HTTPResponse, *, data: Optional[bytes]) -> None:
         self.urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
-        self.data = resp.data
+        self.data = data
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
@@ -202,10 +202,12 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         if _preload_content:
-            r = RESTResponse(r)
+            r = RESTResponse(r, data=r.data)
 
             # log response body
             logger.debug("response body: %s", r.data)
+        else:
+            r = RESTResponse(r, data=None)
 
         if not 200 <= r.status <= 299:
             if r.status == 400:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
@@ -91,9 +91,11 @@ class AuthApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
@@ -99,9 +99,11 @@ class BodyApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -247,9 +249,11 @@ class BodyApi:
         :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -411,9 +415,11 @@ class BodyApi:
         :type files: List[bytearray]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -571,9 +577,11 @@ class BodyApi:
         :type body: object
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -730,9 +738,11 @@ class BodyApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -889,9 +899,11 @@ class BodyApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1048,9 +1060,11 @@ class BodyApi:
         :type tag: Tag
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
@@ -116,9 +116,11 @@ class FormApi:
         :type string_form: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -318,9 +320,11 @@ class FormApi:
         :type name: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
@@ -131,9 +131,11 @@ class HeaderApi:
         :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -122,9 +122,11 @@ class PathApi:
         :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
@@ -114,9 +114,11 @@ class QueryApi:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -284,9 +286,11 @@ class QueryApi:
         :type string_query: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -464,9 +468,11 @@ class QueryApi:
         :type string_query: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -624,9 +630,11 @@ class QueryApi:
         :type query_object: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -776,9 +784,11 @@ class QueryApi:
         :type query_object: TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -928,9 +938,11 @@ class QueryApi:
         :type query_object: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1080,9 +1092,11 @@ class QueryApi:
         :type query_object: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1232,9 +1246,11 @@ class QueryApi:
         :type query_object: DataQuery
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
@@ -228,7 +228,7 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
-        raw_data: Union[str, bytes] = response_data.data
+        raw_data: Union[None, str, bytes] = None
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content:
             response_type = response_types_map.get(str(response_data.status), None)
@@ -237,7 +237,9 @@ class ApiClient:
                 response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
             body_bytes = response_data.data
+            assert isinstance(body_bytes, bytes), "Must not be None if _preload_content=True"
             if response_type == "bytearray":
+                raw_data = body_bytes
                 return_data = body_bytes
             else:
                 match = None
@@ -262,6 +264,7 @@ class ApiClient:
                 data=return_data,
                 headers=response_data.getheaders(),
                 raw_data=raw_data,
+                urllib3_response=response_data.urllib3_response,
             )
         return result
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_response.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_response.py
@@ -1,24 +1,27 @@
 """API response object."""
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """
-    API response object
+    API response object returned by `_with_http_info` API methods.
     """
 
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Optional[Any] = Field(None, description="Raw data (HTTP response body)")
+    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
 
-    def __init__(self,
-                 status_code=None,
-                 headers=None,
-                 data=None,
-                 raw_data=None) -> None:
+    def __init__(
+        self,
+        status_code=None,
+        headers=None,
+        data=None,
+        *,
+        raw_data,
+    ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_response.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_response.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional, Union
+import warnings
+
 from pydantic import Field, StrictInt, StrictStr
+from urllib3 import HTTPResponse
 
 class ApiResponse:
     """
@@ -12,7 +15,12 @@ class ApiResponse:
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
+    _raw_data: Union[None, str, bytes] = Field(
+        title="Raw data (HTTP response body)",
+        description="`bytes` if the OpenAPI response body format is 'binary', "
+        "otherwise `str`. `None` if `_preload_content=False`.",
+    )
+    urllib3_response: HTTPResponse = Field(description="Raw urllib3 response for response streaming")
 
     def __init__(
         self,
@@ -21,8 +29,41 @@ class ApiResponse:
         data=None,
         *,
         raw_data,
+        urllib3_response,
     ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data
-        self.raw_data = raw_data
+        self._raw_data = raw_data
+        self.urllib3_response = urllib3_response
+
+    @property
+    def raw_data(self) -> Union[str, bytes]:
+        """Get raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        To stream responses, read from `self.urllib3_response`.
+
+        :return: `str` if `preload_content=True`, `bytes` if not.
+        """
+        if self._raw_data is None:
+            warnings.warn(
+                "If `preload_content=False`, `ApiResponse.raw_data` will change to "
+                "`None` in a future version. Use `ApiResponse.read()` instead.",
+                DeprecationWarning,
+            )
+            return self.urllib3_response.data
+        return self._raw_data
+
+    def read(self) -> Union[str, bytes]:
+        """Read raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        """
+        if self._raw_data is not None:
+            return self._raw_data
+        return self.urllib3_response.data

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
@@ -12,7 +12,7 @@
     Do not edit the class manually.
 """  # noqa: E501
 
-
+from typing import Optional
 import io
 import json
 import logging
@@ -30,11 +30,11 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp) -> None:
+    def __init__(self, resp: urllib3.HTTPResponse, *, data: Optional[bytes]) -> None:
         self.urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
-        self.data = resp.data
+        self.data = data
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
@@ -213,10 +213,12 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         if _preload_content:
-            r = RESTResponse(r)
+            r = RESTResponse(r, data=r.data)
 
             # log response body
             logger.debug("response body: %s", r.data)
+        else:
+            r = RESTResponse(r, data=None)
 
         if not 200 <= r.status <= 299:
             if r.status == 400:

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -91,9 +91,11 @@ class AuthApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -99,9 +99,11 @@ class BodyApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -247,9 +249,11 @@ class BodyApi:
         :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -411,9 +415,11 @@ class BodyApi:
         :type files: List[bytearray]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -571,9 +577,11 @@ class BodyApi:
         :type body: object
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -730,9 +738,11 @@ class BodyApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -889,9 +899,11 @@ class BodyApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1048,9 +1060,11 @@ class BodyApi:
         :type tag: Tag
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -116,9 +116,11 @@ class FormApi:
         :type string_form: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -318,9 +320,11 @@ class FormApi:
         :type name: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -131,9 +131,11 @@ class HeaderApi:
         :type enum_ref_string_header: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -122,9 +122,11 @@ class PathApi:
         :type enum_ref_string_path: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -114,9 +114,11 @@ class QueryApi:
         :type enum_ref_string_query: StringEnumRef
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -284,9 +286,11 @@ class QueryApi:
         :type string_query: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -464,9 +468,11 @@ class QueryApi:
         :type string_query: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -624,9 +630,11 @@ class QueryApi:
         :type query_object: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -776,9 +784,11 @@ class QueryApi:
         :type query_object: TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -928,9 +938,11 @@ class QueryApi:
         :type query_object: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1080,9 +1092,11 @@ class QueryApi:
         :type query_object: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1232,9 +1246,11 @@ class QueryApi:
         :type query_object: DataQuery
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -228,7 +228,7 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
-        raw_data: Union[str, bytes] = response_data.data
+        raw_data: Union[None, str, bytes] = None
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content:
             response_type = response_types_map.get(str(response_data.status), None)
@@ -237,7 +237,9 @@ class ApiClient:
                 response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
             body_bytes = response_data.data
+            assert isinstance(body_bytes, bytes), "Must not be None if _preload_content=True"
             if response_type == "bytearray":
+                raw_data = body_bytes
                 return_data = body_bytes
             else:
                 match = None
@@ -262,6 +264,7 @@ class ApiClient:
                 data=return_data,
                 headers=response_data.getheaders(),
                 raw_data=raw_data,
+                urllib3_response=response_data.urllib3_response,
             )
         return result
 

--- a/samples/client/echo_api/python/openapi_client/api_response.py
+++ b/samples/client/echo_api/python/openapi_client/api_response.py
@@ -1,24 +1,27 @@
 """API response object."""
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """
-    API response object
+    API response object returned by `_with_http_info` API methods.
     """
 
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Optional[Any] = Field(None, description="Raw data (HTTP response body)")
+    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
 
-    def __init__(self,
-                 status_code=None,
-                 headers=None,
-                 data=None,
-                 raw_data=None) -> None:
+    def __init__(
+        self,
+        status_code=None,
+        headers=None,
+        data=None,
+        *,
+        raw_data,
+    ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data

--- a/samples/client/echo_api/python/openapi_client/api_response.py
+++ b/samples/client/echo_api/python/openapi_client/api_response.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional, Union
+import warnings
+
 from pydantic import Field, StrictInt, StrictStr
+from urllib3 import HTTPResponse
 
 class ApiResponse:
     """
@@ -12,7 +15,12 @@ class ApiResponse:
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
+    _raw_data: Union[None, str, bytes] = Field(
+        title="Raw data (HTTP response body)",
+        description="`bytes` if the OpenAPI response body format is 'binary', "
+        "otherwise `str`. `None` if `_preload_content=False`.",
+    )
+    urllib3_response: HTTPResponse = Field(description="Raw urllib3 response for response streaming")
 
     def __init__(
         self,
@@ -21,8 +29,41 @@ class ApiResponse:
         data=None,
         *,
         raw_data,
+        urllib3_response,
     ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data
-        self.raw_data = raw_data
+        self._raw_data = raw_data
+        self.urllib3_response = urllib3_response
+
+    @property
+    def raw_data(self) -> Union[str, bytes]:
+        """Get raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        To stream responses, read from `self.urllib3_response`.
+
+        :return: `str` if `preload_content=True`, `bytes` if not.
+        """
+        if self._raw_data is None:
+            warnings.warn(
+                "If `preload_content=False`, `ApiResponse.raw_data` will change to "
+                "`None` in a future version. Use `ApiResponse.read()` instead.",
+                DeprecationWarning,
+            )
+            return self.urllib3_response.data
+        return self._raw_data
+
+    def read(self) -> Union[str, bytes]:
+        """Read raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        """
+        if self._raw_data is not None:
+            return self._raw_data
+        return self.urllib3_response.data

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -12,7 +12,7 @@
     Do not edit the class manually.
 """  # noqa: E501
 
-
+from typing import Optional
 import io
 import json
 import logging
@@ -30,11 +30,11 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp) -> None:
+    def __init__(self, resp: urllib3.HTTPResponse, *, data: Optional[bytes]) -> None:
         self.urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
-        self.data = resp.data
+        self.data = data
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
@@ -213,10 +213,12 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         if _preload_content:
-            r = RESTResponse(r)
+            r = RESTResponse(r, data=r.data)
 
             # log response body
             logger.debug("response body: %s", r.data)
+        else:
+            r = RESTResponse(r, data=None)
 
         if not 200 <= r.status <= 299:
             if r.status == 400:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -86,9 +86,11 @@ class AnotherFakeApi:
 
         :param client: client model (required)
         :type client: Client
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -75,9 +75,11 @@ class DefaultApi:
         """foo_get  # noqa: E501
 
 
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -99,9 +99,11 @@ class FakeApi:
 
         :param body:
         :type body: object
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -234,9 +236,11 @@ class FakeApi:
 
         :param enum_ref: enum reference
         :type enum_ref: EnumClass
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -355,9 +359,11 @@ class FakeApi:
         """Health check endpoint  # noqa: E501
 
 
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -499,9 +505,11 @@ class FakeApi:
         :type query_1: str
         :param header_1: header parameter
         :type header_1: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -644,9 +652,11 @@ class FakeApi:
 
         :param body: Input boolean as post body
         :type body: bool
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -787,9 +797,11 @@ class FakeApi:
 
         :param outer_composite: Input composite as post body
         :type outer_composite: OuterComposite
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -930,9 +942,11 @@ class FakeApi:
 
         :param body: Input number as post body
         :type body: float
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1073,9 +1087,11 @@ class FakeApi:
 
         :param body: Input string as post body
         :type body: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1216,9 +1232,11 @@ class FakeApi:
 
         :param outer_object_with_enum_property: Input enum (int) as post body (required)
         :type outer_object_with_enum_property: OuterObjectWithEnumProperty
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1350,9 +1368,11 @@ class FakeApi:
         """test returning list of objects  # noqa: E501
 
 
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1480,9 +1500,11 @@ class FakeApi:
 
         :param uuid_example: uuid example (required)
         :type uuid_example: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1610,9 +1632,11 @@ class FakeApi:
 
         :param body: image to upload (required)
         :type body: bytearray
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1752,9 +1776,11 @@ class FakeApi:
 
         :param file_schema_test_class: (required)
         :type file_schema_test_class: FileSchemaTestClass
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1894,9 +1920,11 @@ class FakeApi:
         :type query: str
         :param user: (required)
         :type user: User
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2035,9 +2063,11 @@ class FakeApi:
 
         :param client: client model (required)
         :type client: Client
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2183,9 +2213,11 @@ class FakeApi:
         :type date_time_query: datetime
         :param str_query: (required)
         :type str_query: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2418,9 +2450,11 @@ class FakeApi:
         :type password: str
         :param param_callback: None
         :type param_callback: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2646,9 +2680,11 @@ class FakeApi:
         :type boolean_group: bool
         :param int64_group: Integer in group parameters
         :type int64_group: int
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2796,9 +2832,11 @@ class FakeApi:
 
         :param request_body: request body (required)
         :type request_body: Dict[str, str]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2933,9 +2971,11 @@ class FakeApi:
 
         :param test_inline_freeform_additional_properties_request: request body (required)
         :type test_inline_freeform_additional_properties_request: TestInlineFreeformAdditionalPropertiesRequest
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3077,9 +3117,11 @@ class FakeApi:
         :type param: str
         :param param2: field2 (required)
         :type param2: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3260,9 +3302,11 @@ class FakeApi:
         :type allow_empty: str
         :param language:
         :type language: Dict[str, str]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -86,9 +86,11 @@ class FakeClassnameTags123Api:
 
         :param client: client model (required)
         :type client: Client
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -91,9 +91,11 @@ class PetApi:
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -235,9 +237,11 @@ class PetApi:
         :type pet_id: int
         :param api_key:
         :type api_key: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -369,9 +373,11 @@ class PetApi:
 
         :param status: Status values that need to be considered for filter (required)
         :type status: List[str]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -507,9 +513,11 @@ class PetApi:
 
         :param tags: Tags to filter by (required)
         :type tags: List[str]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -647,9 +655,11 @@ class PetApi:
 
         :param pet_id: ID of pet to return (required)
         :type pet_id: int
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -785,9 +795,11 @@ class PetApi:
 
         :param pet: Pet object that needs to be added to the store (required)
         :type pet: Pet
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -936,9 +948,11 @@ class PetApi:
         :type name: str
         :param status: Updated status of the pet
         :type status: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1095,9 +1109,11 @@ class PetApi:
         :type additional_metadata: str
         :param file: file to upload
         :type file: bytearray
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1260,9 +1276,11 @@ class PetApi:
         :type required_file: bytearray
         :param additional_metadata: Additional data to pass to server
         :type additional_metadata: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -90,9 +90,11 @@ class StoreApi:
 
         :param order_id: ID of the order that needs to be deleted (required)
         :type order_id: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -213,9 +215,11 @@ class StoreApi:
 
         Returns a map of status codes to quantities  # noqa: E501
 
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -345,9 +349,11 @@ class StoreApi:
 
         :param order_id: ID of pet that needs to be fetched (required)
         :type order_id: int
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -483,9 +489,11 @@ class StoreApi:
 
         :param order: order placed for purchasing the pet (required)
         :type order: Order
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -90,9 +90,11 @@ class UserApi:
 
         :param user: Created user object (required)
         :type user: User
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -242,9 +244,11 @@ class UserApi:
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -379,9 +383,11 @@ class UserApi:
 
         :param user: List of user object (required)
         :type user: List[User]
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -516,9 +522,11 @@ class UserApi:
 
         :param username: The name that needs to be deleted (required)
         :type username: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -646,9 +654,11 @@ class UserApi:
 
         :param username: The name that needs to be fetched. Use user1 for testing. (required)
         :type username: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -791,9 +801,11 @@ class UserApi:
         :type username: str
         :param password: The password for login in clear text (required)
         :type password: str
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -925,9 +937,11 @@ class UserApi:
 
           # noqa: E501
 
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1058,9 +1072,11 @@ class UserApi:
         :type username: str
         :param user: Updated user object (required)
         :type user: User
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.aiohttp_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -20,6 +20,7 @@ import mimetypes
 import os
 import re
 import tempfile
+from typing import Union
 
 from urllib.parse import quote
 
@@ -130,6 +131,9 @@ class ApiClient:
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
             _request_auth=None):
+        if _return_http_data_only:
+            # Remove in #16788
+            assert _preload_content, "_preload_content must be True if _return_http_data_only is True"
 
         config = self.configuration
 
@@ -204,38 +208,42 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
+        raw_data: Union[str, bytes] = response_data.data
         # data needs deserialization or returns HTTP data (deserialized) only
-        if _preload_content or _return_http_data_only:
-          response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
-              # if not found, look for '1XX', '2XX', etc.
-              response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
+        if _preload_content:
+            response_type = response_types_map.get(str(response_data.status), None)
+            if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
+                # if not found, look for '1XX', '2XX', etc.
+                response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-          if response_type == "bytearray":
-              response_data.data = response_data.data
-          else:
-              match = None
-              content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+            body_bytes = response_data.data
+            if response_type == "bytearray":
+                return_data = body_bytes
+            else:
+                match = None
+                content_type = response_data.getheader('content-type')
+                if content_type is not None:
+                    match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+                encoding = match.group(1) if match else "utf-8"
+                body_str = body_bytes.decode(encoding)
+                raw_data = body_str
 
-          # deserialize response data
-          if response_type == "bytearray":
-              return_data = response_data.data
-          elif response_type:
-              return_data = self.deserialize(response_data, response_type)
-          else:
-              return_data = None
+                # deserialize response data
+                if response_type:
+                    return_data = self.deserialize(response_data, response_type, body=body_str)
+                else:
+                    return_data = None
 
         if _return_http_data_only:
-            return return_data
+            result = return_data
         else:
-            return ApiResponse(status_code = response_data.status,
-                           data = return_data,
-                           headers = response_data.getheaders(),
-                           raw_data = response_data.data)
+            result = ApiResponse(
+                status_code=response_data.status,
+                data=return_data,
+                headers=response_data.getheaders(),
+                raw_data=raw_data,
+            )
+        return result
 
     def sanitize_for_serialization(self, obj):
         """Builds a JSON POST object.
@@ -277,7 +285,7 @@ class ApiClient:
         return {key: self.sanitize_for_serialization(val)
                 for key, val in obj_dict.items()}
 
-    def deserialize(self, response, response_type):
+    def deserialize(self, response: rest.RESTResponse, response_type, body: str):
         """Deserializes response into an object.
 
         :param response: RESTResponse object to be deserialized.
@@ -293,9 +301,9 @@ class ApiClient:
 
         # fetch data from response object
         try:
-            data = json.loads(response.data)
+            data = json.loads(body)
         except ValueError:
-            data = response.data
+            data = body
 
         return self.__deserialize(data, response_type)
 
@@ -399,9 +407,17 @@ class ApiClient:
         )
         return await self.__call_api(*args)
 
-    async def request(self, method, url, query_params=None, headers=None,
-                post_params=None, body=None, _preload_content=True,
-                _request_timeout=None):
+    async def request(
+        self,
+        method,
+        url,
+        query_params=None,
+        headers=None,
+        post_params=None,
+        body=None,
+        _preload_content=True,
+        _request_timeout=None,
+    ) -> rest.RESTResponse:
         """Makes the HTTP request using RESTClient."""
         if method == "GET":
             return await self.rest_client.get_request(url,
@@ -643,7 +659,7 @@ class ApiClient:
                 'Authentication token must be in `query` or `header`'
             )
 
-    def __deserialize_file(self, response):
+    def __deserialize_file(self, response: rest.RESTResponse):
         """Deserializes body to file
 
         Saves response body into a file in a temporary folder,

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -208,7 +208,7 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
-        raw_data: Union[str, bytes] = response_data.data
+        raw_data: Union[None, str, bytes] = None
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content:
             response_type = response_types_map.get(str(response_data.status), None)
@@ -217,7 +217,9 @@ class ApiClient:
                 response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
             body_bytes = response_data.data
+            assert isinstance(body_bytes, bytes), "Must not be None if _preload_content=True"
             if response_type == "bytearray":
+                raw_data = body_bytes
                 return_data = body_bytes
             else:
                 match = None
@@ -242,6 +244,7 @@ class ApiClient:
                 data=return_data,
                 headers=response_data.getheaders(),
                 raw_data=raw_data,
+                aiohttp_response=response_data.aiohttp_response,
             )
         return result
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_response.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional, Union
+
+from aiohttp import ClientResponse
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
@@ -12,7 +14,12 @@ class ApiResponse:
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
+    raw_data: Union[None, str, bytes] = Field(
+        title="Raw data (HTTP response body)",
+        description="`bytes` if the OpenAPI response body format is 'binary', "
+        "otherwise `str`. `None` if `_preload_content=False`.",
+    )
+    aiohttp_response: ClientResponse = Field(description="Raw aiohttp response for response streaming")
 
     def __init__(
         self,
@@ -21,8 +28,22 @@ class ApiResponse:
         data=None,
         *,
         raw_data,
+        aiohttp_response,
     ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data
         self.raw_data = raw_data
+        self.aiohttp_response = aiohttp_response
+
+
+    async def read(self) -> Union[str, bytes]:
+        """Read raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        """
+        if self.raw_data is not None:
+            return self.raw_data
+        return await self.aiohttp_response.read()

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_response.py
@@ -1,24 +1,27 @@
 """API response object."""
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """
-    API response object
+    API response object returned by `_with_http_info` API methods.
     """
 
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Optional[Any] = Field(None, description="Raw data (HTTP response body)")
+    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
 
-    def __init__(self,
-                 status_code=None,
-                 headers=None,
-                 data=None,
-                 raw_data=None) -> None:
+    def __init__(
+        self,
+        status_code=None,
+        headers=None,
+        data=None,
+        *,
+        raw_data,
+    ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -100,9 +100,11 @@ class AnotherFakeApi:
         :type client: Client
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -89,9 +89,11 @@ class DefaultApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -113,9 +113,11 @@ class FakeApi:
         :type body: object
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -264,9 +266,11 @@ class FakeApi:
         :type enum_ref: EnumClass
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -401,9 +405,11 @@ class FakeApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -561,9 +567,11 @@ class FakeApi:
         :type header_1: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -722,9 +730,11 @@ class FakeApi:
         :type body: bool
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -881,9 +891,11 @@ class FakeApi:
         :type outer_composite: OuterComposite
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1040,9 +1052,11 @@ class FakeApi:
         :type body: float
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1199,9 +1213,11 @@ class FakeApi:
         :type body: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1358,9 +1374,11 @@ class FakeApi:
         :type outer_object_with_enum_property: OuterObjectWithEnumProperty
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1508,9 +1526,11 @@ class FakeApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1654,9 +1674,11 @@ class FakeApi:
         :type uuid_example: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1800,9 +1822,11 @@ class FakeApi:
         :type body: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1958,9 +1982,11 @@ class FakeApi:
         :type file_schema_test_class: FileSchemaTestClass
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2116,9 +2142,11 @@ class FakeApi:
         :type user: User
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2273,9 +2301,11 @@ class FakeApi:
         :type client: Client
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2437,9 +2467,11 @@ class FakeApi:
         :type str_query: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2688,9 +2720,11 @@ class FakeApi:
         :type param_callback: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -2932,9 +2966,11 @@ class FakeApi:
         :type int64_group: int
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3098,9 +3134,11 @@ class FakeApi:
         :type request_body: Dict[str, str]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3251,9 +3289,11 @@ class FakeApi:
         :type test_inline_freeform_additional_properties_request: TestInlineFreeformAdditionalPropertiesRequest
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3411,9 +3451,11 @@ class FakeApi:
         :type param2: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -3610,9 +3652,11 @@ class FakeApi:
         :type language: Dict[str, str]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -100,9 +100,11 @@ class FakeClassnameTags123Api:
         :type client: Client
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -105,9 +105,11 @@ class PetApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -265,9 +267,11 @@ class PetApi:
         :type api_key: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -415,9 +419,11 @@ class PetApi:
         :type status: List[str]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -569,9 +575,11 @@ class PetApi:
         :type tags: List[str]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -725,9 +733,11 @@ class PetApi:
         :type pet_id: int
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -879,9 +889,11 @@ class PetApi:
         :type pet: Pet
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1046,9 +1058,11 @@ class PetApi:
         :type status: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1221,9 +1235,11 @@ class PetApi:
         :type file: bytearray
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1402,9 +1418,11 @@ class PetApi:
         :type additional_metadata: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -104,9 +104,11 @@ class StoreApi:
         :type order_id: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -243,9 +245,11 @@ class StoreApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -391,9 +395,11 @@ class StoreApi:
         :type order_id: int
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -545,9 +551,11 @@ class StoreApi:
         :type order: Order
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -104,9 +104,11 @@ class UserApi:
         :type user: User
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -272,9 +274,11 @@ class UserApi:
         :type user: List[User]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -425,9 +429,11 @@ class UserApi:
         :type user: List[User]
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -578,9 +584,11 @@ class UserApi:
         :type username: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -724,9 +732,11 @@ class UserApi:
         :type username: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -885,9 +895,11 @@ class UserApi:
         :type password: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1035,9 +1047,11 @@ class UserApi:
 
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse
@@ -1184,9 +1198,11 @@ class UserApi:
         :type user: User
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
-        :param _preload_content: if False, the ApiResponse.data will
-                                 be set to none and raw_data will store the
-                                 HTTP response body without reading/decoding.
+        :param _preload_content: if False, ApiResponse.data and
+                                 ApiResponse.raw_data are set to None and the
+                                 raw response body can be accessed with
+                                 ApiResponse.read() or streamed using
+                                 ApiResponse.urllib3_response.
                                  Default is True.
         :type _preload_content: bool, optional
         :param _return_http_data_only: response data instead of ApiResponse

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -21,6 +21,7 @@ from multiprocessing.pool import ThreadPool
 import os
 import re
 import tempfile
+from typing import Union
 
 from urllib.parse import quote
 
@@ -149,6 +150,9 @@ class ApiClient:
             _return_http_data_only=None, collection_formats=None,
             _preload_content=True, _request_timeout=None, _host=None,
             _request_auth=None):
+        if _return_http_data_only:
+            # Remove in #16788
+            assert _preload_content, "_preload_content must be True if _return_http_data_only is True"
 
         config = self.configuration
 
@@ -223,38 +227,42 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
+        raw_data: Union[str, bytes] = response_data.data
         # data needs deserialization or returns HTTP data (deserialized) only
-        if _preload_content or _return_http_data_only:
-          response_type = response_types_map.get(str(response_data.status), None)
-          if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
-              # if not found, look for '1XX', '2XX', etc.
-              response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
+        if _preload_content:
+            response_type = response_types_map.get(str(response_data.status), None)
+            if not response_type and isinstance(response_data.status, int) and 100 <= response_data.status <= 599:
+                # if not found, look for '1XX', '2XX', etc.
+                response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-          if response_type == "bytearray":
-              response_data.data = response_data.data
-          else:
-              match = None
-              content_type = response_data.getheader('content-type')
-              if content_type is not None:
-                  match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
-              encoding = match.group(1) if match else "utf-8"
-              response_data.data = response_data.data.decode(encoding)
+            body_bytes = response_data.data
+            if response_type == "bytearray":
+                return_data = body_bytes
+            else:
+                match = None
+                content_type = response_data.getheader('content-type')
+                if content_type is not None:
+                    match = re.search(r"charset=([a-zA-Z\-\d]+)[\s;]?", content_type)
+                encoding = match.group(1) if match else "utf-8"
+                body_str = body_bytes.decode(encoding)
+                raw_data = body_str
 
-          # deserialize response data
-          if response_type == "bytearray":
-              return_data = response_data.data
-          elif response_type:
-              return_data = self.deserialize(response_data, response_type)
-          else:
-              return_data = None
+                # deserialize response data
+                if response_type:
+                    return_data = self.deserialize(response_data, response_type, body=body_str)
+                else:
+                    return_data = None
 
         if _return_http_data_only:
-            return return_data
+            result = return_data
         else:
-            return ApiResponse(status_code = response_data.status,
-                           data = return_data,
-                           headers = response_data.getheaders(),
-                           raw_data = response_data.data)
+            result = ApiResponse(
+                status_code=response_data.status,
+                data=return_data,
+                headers=response_data.getheaders(),
+                raw_data=raw_data,
+            )
+        return result
 
     def sanitize_for_serialization(self, obj):
         """Builds a JSON POST object.
@@ -296,7 +304,7 @@ class ApiClient:
         return {key: self.sanitize_for_serialization(val)
                 for key, val in obj_dict.items()}
 
-    def deserialize(self, response, response_type):
+    def deserialize(self, response: rest.RESTResponse, response_type, body: str):
         """Deserializes response into an object.
 
         :param response: RESTResponse object to be deserialized.
@@ -312,9 +320,9 @@ class ApiClient:
 
         # fetch data from response object
         try:
-            data = json.loads(response.data)
+            data = json.loads(body)
         except ValueError:
-            data = response.data
+            data = body
 
         return self.__deserialize(data, response_type)
 
@@ -428,9 +436,17 @@ class ApiClient:
 
         return self.pool.apply_async(self.__call_api, args)
 
-    def request(self, method, url, query_params=None, headers=None,
-                post_params=None, body=None, _preload_content=True,
-                _request_timeout=None):
+    def request(
+        self,
+        method,
+        url,
+        query_params=None,
+        headers=None,
+        post_params=None,
+        body=None,
+        _preload_content=True,
+        _request_timeout=None,
+    ) -> rest.RESTResponse:
         """Makes the HTTP request using RESTClient."""
         if method == "GET":
             return self.rest_client.get_request(url,
@@ -672,7 +688,7 @@ class ApiClient:
                 'Authentication token must be in `query` or `header`'
             )
 
-    def __deserialize_file(self, response):
+    def __deserialize_file(self, response: rest.RESTResponse):
         """Deserializes body to file
 
         Saves response body into a file in a temporary folder,

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -227,7 +227,7 @@ class ApiClient:
         self.last_response = response_data
 
         return_data = None # assuming deserialization is not needed
-        raw_data: Union[str, bytes] = response_data.data
+        raw_data: Union[None, str, bytes] = None
         # data needs deserialization or returns HTTP data (deserialized) only
         if _preload_content:
             response_type = response_types_map.get(str(response_data.status), None)
@@ -236,7 +236,9 @@ class ApiClient:
                 response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
             body_bytes = response_data.data
+            assert isinstance(body_bytes, bytes), "Must not be None if _preload_content=True"
             if response_type == "bytearray":
+                raw_data = body_bytes
                 return_data = body_bytes
             else:
                 match = None
@@ -261,6 +263,7 @@ class ApiClient:
                 data=return_data,
                 headers=response_data.getheaders(),
                 raw_data=raw_data,
+                urllib3_response=response_data.urllib3_response,
             )
         return result
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_response.py
@@ -1,24 +1,27 @@
 """API response object."""
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 from pydantic import Field, StrictInt, StrictStr
 
 class ApiResponse:
     """
-    API response object
+    API response object returned by `_with_http_info` API methods.
     """
 
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Optional[Any] = Field(None, description="Raw data (HTTP response body)")
+    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
 
-    def __init__(self,
-                 status_code=None,
-                 headers=None,
-                 data=None,
-                 raw_data=None) -> None:
+    def __init__(
+        self,
+        status_code=None,
+        headers=None,
+        data=None,
+        *,
+        raw_data,
+    ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data

--- a/samples/openapi3/client/petstore/python/petstore_api/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_response.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 from typing import Any, Dict, Optional, Union
+import warnings
+
 from pydantic import Field, StrictInt, StrictStr
+from urllib3 import HTTPResponse
 
 class ApiResponse:
     """
@@ -12,7 +15,12 @@ class ApiResponse:
     status_code: Optional[StrictInt] = Field(None, description="HTTP status code")
     headers: Optional[Dict[StrictStr, StrictStr]] = Field(None, description="HTTP headers")
     data: Optional[Any] = Field(None, description="Deserialized data given the data type")
-    raw_data: Union[str, bytes] = Field(description="Raw data (HTTP response body)")
+    _raw_data: Union[None, str, bytes] = Field(
+        title="Raw data (HTTP response body)",
+        description="`bytes` if the OpenAPI response body format is 'binary', "
+        "otherwise `str`. `None` if `_preload_content=False`.",
+    )
+    urllib3_response: HTTPResponse = Field(description="Raw urllib3 response for response streaming")
 
     def __init__(
         self,
@@ -21,8 +29,41 @@ class ApiResponse:
         data=None,
         *,
         raw_data,
+        urllib3_response,
     ) -> None:
         self.status_code = status_code
         self.headers = headers
         self.data = data
-        self.raw_data = raw_data
+        self._raw_data = raw_data
+        self.urllib3_response = urllib3_response
+
+    @property
+    def raw_data(self) -> Union[str, bytes]:
+        """Get raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        To stream responses, read from `self.urllib3_response`.
+
+        :return: `str` if `preload_content=True`, `bytes` if not.
+        """
+        if self._raw_data is None:
+            warnings.warn(
+                "If `preload_content=False`, `ApiResponse.raw_data` will change to "
+                "`None` in a future version. Use `ApiResponse.read()` instead.",
+                DeprecationWarning,
+            )
+            return self.urllib3_response.data
+        return self._raw_data
+
+    def read(self) -> Union[str, bytes]:
+        """Read raw response body.
+
+        If `preload_content=False`, this loads the entire response body into
+        memory. If `preload_content=True`, the response body is already loaded
+        earlier.
+        """
+        if self._raw_data is not None:
+            return self._raw_data
+        return self.urllib3_response.data

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -11,7 +11,7 @@
     Do not edit the class manually.
 """  # noqa: E501
 
-
+from typing import Optional
 import io
 import json
 import logging
@@ -29,11 +29,11 @@ logger = logging.getLogger(__name__)
 
 class RESTResponse(io.IOBase):
 
-    def __init__(self, resp) -> None:
+    def __init__(self, resp: urllib3.HTTPResponse, *, data: Optional[bytes]) -> None:
         self.urllib3_response = resp
         self.status = resp.status
         self.reason = resp.reason
-        self.data = resp.data
+        self.data = data
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
@@ -212,10 +212,12 @@ class RESTClientObject:
             raise ApiException(status=0, reason=msg)
 
         if _preload_content:
-            r = RESTResponse(r)
+            r = RESTResponse(r, data=r.data)
 
             # log response body
             logger.debug("response body: %s", r.data)
+        else:
+            r = RESTResponse(r, data=None)
 
         if not 200 <= r.status <= 299:
             if r.status == 400:

--- a/samples/openapi3/client/petstore/python/tests/test_deserialization.py
+++ b/samples/openapi3/client/petstore/python/tests/test_deserialization.py
@@ -9,17 +9,14 @@ $ cd OpenAPIPetstore-python
 $ pytest
 """
 from collections import namedtuple
+from unittest.mock import Mock
 import json
-import os
-import time
 import unittest
 import datetime
 
 import pytest as pytest
 
 import petstore_api
-
-MockResponse = namedtuple('MockResponse', 'data')
 
 
 class DeserializationTests(unittest.TestCase):
@@ -39,9 +36,7 @@ class DeserializationTests(unittest.TestCase):
                "outerEnum": "placed"
            }
        }
-       response = MockResponse(data=json.dumps(data))
-
-       deserialized = self.deserialize(response, 'Dict[str, EnumTest]')
+       deserialized = self.deserialize(Mock(), 'Dict[str, EnumTest]', body=json.dumps(data))
        self.assertTrue(isinstance(deserialized, dict))
        self.assertTrue(isinstance(deserialized['enum_test'], petstore_api.EnumTest))
        self.assertEqual(deserialized['enum_test'],
@@ -73,9 +68,7 @@ class DeserializationTests(unittest.TestCase):
                 "status": "available"
             }
         }
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, 'Dict[str, Pet]')
+        deserialized = self.deserialize(Mock(), 'Dict[str, Pet]', body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, dict))
         self.assertTrue(isinstance(deserialized['pet'], petstore_api.Pet))
 
@@ -90,9 +83,7 @@ class DeserializationTests(unittest.TestCase):
                 "bread": "Jack Russel Terrier"
             }
         }
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, 'Dict[str, Animal]')
+        deserialized = self.deserialize(Mock(), 'Dict[str, Animal]', body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, dict))
         self.assertTrue(isinstance(deserialized['dog'], petstore_api.Dog))
 
@@ -102,34 +93,26 @@ class DeserializationTests(unittest.TestCase):
         data = {
             'integer': 1
         }
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, 'Dict[str, int]')
+        deserialized = self.deserialize(Mock(), 'Dict[str, int]', body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, dict))
         self.assertTrue(isinstance(deserialized['integer'], int))
 
     def test_deserialize_str(self):
         """ deserialize str """
         data = "test str"
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "str")
+        deserialized = self.deserialize(Mock(), "str", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, str))
 
     def test_deserialize_date(self):
         """ deserialize date """
         data = "1997-07-16"
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "date")
+        deserialized = self.deserialize(Mock(), "date", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, datetime.date))
 
     def test_deserialize_datetime(self):
         """ deserialize datetime """
         data = "1997-07-16T19:20:30.45+01:00"
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "datetime")
+        deserialized = self.deserialize(Mock(), "datetime", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, datetime.datetime))
 
     def test_deserialize_pet(self):
@@ -152,9 +135,7 @@ class DeserializationTests(unittest.TestCase):
             ],
             "status": "available"
         }
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "Pet")
+        deserialized = self.deserialize(Mock(), "Pet", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, petstore_api.Pet))
         self.assertEqual(deserialized.id, 0)
         self.assertEqual(deserialized.name, "doggie")
@@ -202,9 +183,7 @@ class DeserializationTests(unittest.TestCase):
                 ],
                 "status": "available"
             }]
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "List[Pet]")
+        deserialized = self.deserialize(Mock(), "List[Pet]", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, list))
         self.assertTrue(isinstance(deserialized[0], petstore_api.Pet))
         self.assertEqual(deserialized[0].id, 0)
@@ -219,9 +198,7 @@ class DeserializationTests(unittest.TestCase):
                 "bar": 1
             }
         }
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "Dict[str, Dict[str, int]]")
+        deserialized = self.deserialize(Mock(), "Dict[str, Dict[str, int]]", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, dict))
         self.assertTrue(isinstance(deserialized["foo"], dict))
         self.assertTrue(isinstance(deserialized["foo"]["bar"], int))
@@ -229,18 +206,15 @@ class DeserializationTests(unittest.TestCase):
     def test_deserialize_nested_list(self):
         """ deserialize list[list[str]] """
         data = [["foo"]]
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "List[List[str]]")
+        deserialized = self.deserialize(Mock(), "List[List[str]]", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, list))
         self.assertTrue(isinstance(deserialized[0], list))
         self.assertTrue(isinstance(deserialized[0][0], str))
 
     def test_deserialize_none(self):
         """ deserialize None """
-        response = MockResponse(data=json.dumps(None))
-
-        deserialized = self.deserialize(response, "datetime")
+        data = None
+        deserialized = self.deserialize(Mock(), "datetime", body=json.dumps(data))
         self.assertIsNone(deserialized)
 
     def test_deserialize_pig(self):
@@ -249,9 +223,7 @@ class DeserializationTests(unittest.TestCase):
             "className": "BasqueBig",
             "color": "white"
         }
-
-        response = MockResponse(data=json.dumps(data))
-        deserialized = self.deserialize(response, "Pig")
+        deserialized = self.deserialize(Mock(), "Pig", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized.actual_instance,
                                    petstore_api.BasquePig))
         self.assertEqual(deserialized.actual_instance.class_name, "BasqueBig")
@@ -263,11 +235,8 @@ class DeserializationTests(unittest.TestCase):
             "declawed": True,
             "className": "Cat2222"  # incorrect class name
         }
-
-        response = MockResponse(data=json.dumps(data))
-
         with pytest.raises(ValueError) as ex:
-            deserialized = self.deserialize(response, "Animal")
+            self.deserialize(Mock(), "Animal", body=json.dumps(data))
         assert str(
             ex.value) == 'Animal failed to lookup discriminator value from {"declawed": true, "className": ' \
                          '"Cat2222"}. Discriminator property name: className, mapping: {"Cat": "Cat", "Dog": "Dog"}'
@@ -276,10 +245,7 @@ class DeserializationTests(unittest.TestCase):
             "declawed": True,
             "className": "Cat"  # correct class name
         }
-
-        response = MockResponse(data=json.dumps(data))
-
-        deserialized = self.deserialize(response, "Animal")
+        deserialized = self.deserialize(Mock(), "Animal", body=json.dumps(data))
         self.assertTrue(isinstance(deserialized, petstore_api.Cat))
         self.assertEqual(deserialized.class_name, "Cat")
         self.assertEqual(deserialized.declawed, True)


### PR DESCRIPTION
Closes #16640

I split off a first refactoring commit, the commit messages might be helpful for review

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @multani 