### PR TITLE
Add List & ClassVar to always import typing modules

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -946,15 +946,22 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 }
             }
 
-            // if model_generic.mustache is used and support additionalProperties
+            // if model_generic.mustache is used
             if (model.oneOf.isEmpty() && model.anyOf.isEmpty()
-                    && !model.isEnum
-                    && !this.disallowAdditionalPropertiesIfNotPresent) {
-                typingImports.add("Dict");
-                typingImports.add("List");
-                typingImports.add("Any");
-                typingImports.add("ClassVar");
+                && !model.isEnum)
+                {
+                    // required for the __properties type hint
+                    typingImports.add("List");
+                    typingImports.add("ClassVar");
+
+                    // and support additionalProperties
+                    if (!this.disallowAdditionalPropertiesIfNotPresent) {
+                        typingImports.add("Dict");
+                        typingImports.add("Any");
+                    }
             }
+
+
 
             //loop through properties/schemas to set up typing, pydantic
             for (CodegenProperty cp : codegenProperties) {

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import StrictStr
 from pydantic import Field
 from openapi_client.models.query import Query

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from openapi_client.models.string_enum_ref import StringEnumRef
 from typing import Dict, Any

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional, Union
+from typing import ClassVar, List, Optional, Union
 from pydantic import BaseModel, StrictFloat, StrictInt
 from pydantic import Field
 from typing_extensions import Annotated

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from openapi_client.models.category import Category

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import StrictStr
 from pydantic import Field
 from openapi_client.models.query import Query

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from openapi_client.models.string_enum_ref import StringEnumRef
 from typing import Dict, Any

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional, Union
+from typing import ClassVar, List, Optional, Union
 from pydantic import BaseModel, StrictFloat, StrictInt
 from pydantic import Field
 from typing_extensions import Annotated

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from openapi_client.models.category import Category

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -19,7 +19,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.single_ref_type import SingleRefType

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional, Union
+from typing import ClassVar, List, Optional, Union
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.tag import Tag
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing_extensions import Annotated

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-
+from typing import ClassVar, List
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import StrictBool
 from petstore_api.models.animal import Animal
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-
+from typing import ClassVar, List
 from pydantic import BaseModel, StrictStr
 from petstore_api.models.creature_info import CreatureInfo
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-
+from typing import ClassVar, List
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-
+from typing import ClassVar, List
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import StrictStr
 from petstore_api.models.animal import Animal
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr, field_validator
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from petstore_api.models.outer_enum import OuterEnum

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.file import File
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.foo import Foo
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import date, datetime
-from typing import Optional, Union
+from typing import ClassVar, List, Optional, Union
 from pydantic import BaseModel, StrictBytes, StrictInt, StrictStr, field_validator
 from decimal import Decimal
 from pydantic import Field

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import BaseModel
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.tag import Tag

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictBool, StrictStr, field_validator
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.animal import Animal

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional, Union
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, field_validator
 from pydantic import Field
 from typing_extensions import Annotated

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictBool
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from petstore_api.models.deprecated_object import DeprecatedObject

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictBool, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel
 from petstore_api.models.outer_enum import OuterEnum
 from petstore_api.models.outer_enum_integer import OuterEnumInteger

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.inner_dict_with_property import InnerDictWithProperty

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from typing_extensions import Annotated

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr, field_validator
 from pydantic import Field
 from petstore_api.models.category import Category

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictStr
 from typing import Dict, Any
 try:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 from petstore_api.models.creature_info import CreatureInfo

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt, StrictStr
 from pydantic import Field
 from typing import Dict, Any

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 from pydantic import BaseModel, StrictInt
 from petstore_api.models.one_of_enum_string import OneOfEnumString
 from petstore_api.models.pig import Pig


### PR DESCRIPTION
With c6e9a4e1ae87793dda3b251e38b7fe6d636863b9 the __typing class variable got added to the Python models. However, that commit did not properly add the `ClassVar` and `List` imports to, at least not in all conditions. This results in broken models where the imported Model breaks as the type hint is undefined.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @krjakbrjak @wing328
