### PR TITLE
[python] Fix Circular imports on inherited discriminators.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -867,6 +867,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
         TreeSet<String> datetimeImports = new TreeSet<>();
         TreeSet<String> modelImports = new TreeSet<>();
         TreeSet<String> postponedModelImports = new TreeSet<>();
+        TreeSet<String> discriminatorModelImports = new TreeSet<>();
 
         for (ModelMap m : objs.getModels()) {
             TreeSet<String> exampleImports = new TreeSet<>();
@@ -929,7 +930,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                     typingImports.add("Union");
                     Set<CodegenDiscriminator.MappedModel> discriminator = model.getDiscriminator().getMappedModels();
                     for (CodegenDiscriminator.MappedModel mappedModel : discriminator) {
-                        postponedModelImports.add(mappedModel.getMappingName());
+                        discriminatorModelImports.add(mappedModel.getMappingName());
                     }
                 }
             }
@@ -1034,6 +1035,19 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 }
 
                 model.getVendorExtensions().putIfAbsent("x-py-postponed-model-imports", modelsToImport);
+            }
+
+            if (!discriminatorModelImports.isEmpty()) {
+                Set<String> modelsToImport = new TreeSet<>();
+                for (String modelImport : discriminatorModelImports) {
+                    if (modelImport.equals(model.classname)) {
+                        // skip self import
+                        continue;
+                    }
+                    modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
+                }
+
+                model.discriminator.getVendorExtensions().putIfAbsent("x-py-discriminator-model-imports", modelsToImport);
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -1044,7 +1044,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                         // skip self import
                         continue;
                     }
-                    modelsToImport.add("from " + packageName + ".models." + underscore(modelImport) + " import " + modelImport);
+                    modelsToImport.add("globals()[\"" + modelImport + "\"] = importlib.import_module(\"" + packageName + ".models." + underscore(modelImport) + "\")." + modelImport);
                 }
 
                 model.discriminator.getVendorExtensions().putIfAbsent("x-py-discriminator-model-imports", modelsToImport);

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -93,13 +93,22 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     __discriminator_property_name: ClassVar[List[str]] = '{{discriminator.propertyBaseName}}'
 
     # discriminator mappings
-    __discriminator_value_class_map: ClassVar[Dict[str, str]] = {
-        {{#mappedModels}}'{{{mappingName}}}': '{{{modelName}}}'{{^-last}},{{/-last}}{{/mappedModels}}
-    }
+    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:
         """Returns the discriminator value (object type) of the data"""
+
+        if cls.__discriminator_value_class_map == None:
+            # Prevent circular imports caused by mutually referencing classes
+            {{#vendorExtensions.x-py-discriminator-model-imports}}
+            {{{.}}}
+            {{/vendorExtensions.x-py-discriminator-model-imports}}
+
+            cls.__discriminator_value_class_map = {
+                {{#mappedModels}}'{{{mappingName}}}': {{{modelName}}}{{^-last}},{{/-last}}{{/mappedModels}}
+            }
+
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -93,7 +93,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     __discriminator_property_name: ClassVar[List[str]] = '{{discriminator.propertyBaseName}}'
 
     # discriminator mappings
-    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
+    __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -2,6 +2,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 {{#vendorExtensions.x-py-datetime-imports}}{{#-first}}from datetime import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-datetime-imports}}
 {{#vendorExtensions.x-py-typing-imports}}{{#-first}}from typing import{{/-first}} {{{.}}}{{^-last}},{{/-last}}{{/vendorExtensions.x-py-typing-imports}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -104,7 +104,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             {{/vendorExtensions.x-py-discriminator-model-imports}}
 
             cls.__discriminator_value_class_map = {
-                {{#mappedModels}}'{{{mappingName}}}': {{{modelName}}}{{^-last}},{{/-last}}{{/mappedModels}}
+                {{#mappedModels}}'{{{mappingName}}}': '{{{modelName}}}'{{^-last}},{{/-last}}{{/mappedModels}}
             }
         return cls.__discriminator_value_class_map
 

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -96,9 +96,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def get_discriminator_value(cls, obj: dict) -> str:
-        """Returns the discriminator value (object type) of the data"""
-
+    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             {{#vendorExtensions.x-py-discriminator-model-imports}}
@@ -108,10 +106,15 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             cls.__discriminator_value_class_map = {
                 {{#mappedModels}}'{{{mappingName}}}': {{{modelName}}}{{^-last}},{{/-last}}{{/mappedModels}}
             }
+        return cls.__discriminator_value_class_map
+
+    @classmethod
+    def get_discriminator_value(cls, obj: dict) -> str:
+        """Returns the discriminator value (object type) of the data"""
 
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
-            return cls.__discriminator_value_class_map.get(discriminator_value)
+            return cls._get_discriminator_value_class_map().get(discriminator_value)
         else:
             return None
 
@@ -259,7 +262,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             raise ValueError("{{{classname}}} failed to lookup discriminator value from " +
                              json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
-                             ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
+                             ", mapping: " + json.dumps(cls._get_discriminator_value_class_map()))
         {{/discriminator}}
         {{/hasChildren}}
         {{^hasChildren}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -96,7 +96,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
+    def _get_discriminator_value_class_map(cls) -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             {{#vendorExtensions.x-py-discriminator-model-imports}}

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional, Union

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Optional

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional, Union

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -55,7 +55,7 @@ class Animal(BaseModel):
             from petstore_api.models.dog import Dog
 
             cls.__discriminator_value_class_map = {
-                'Cat': Cat,'Dog': Dog
+                'Cat': 'Cat','Dog': 'Dog'
             }
         return cls.__discriminator_value_class_map
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -45,7 +45,7 @@ class Animal(BaseModel):
     __discriminator_property_name: ClassVar[List[str]] = 'className'
 
     # discriminator mappings
-    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
+    __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional, Union
@@ -51,8 +52,8 @@ class Animal(BaseModel):
     def _get_discriminator_value_class_map(cls) -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
-            from petstore_api.models.cat import Cat
-            from petstore_api.models.dog import Dog
+            globals()["Cat"] = importlib.import_module("petstore_api.models.cat").Cat
+            globals()["Dog"] = importlib.import_module("petstore_api.models.dog").Dog
 
             cls.__discriminator_value_class_map = {
                 'Cat': 'Cat','Dog': 'Dog'

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -45,13 +45,21 @@ class Animal(BaseModel):
     __discriminator_property_name: ClassVar[List[str]] = 'className'
 
     # discriminator mappings
-    __discriminator_value_class_map: ClassVar[Dict[str, str]] = {
-        'Cat': 'Cat','Dog': 'Dog'
-    }
+    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:
         """Returns the discriminator value (object type) of the data"""
+
+        if cls.__discriminator_value_class_map == None:
+            # Prevent circular imports caused by mutually referencing classes
+            from petstore_api.models.cat import Cat
+            from petstore_api.models.dog import Dog
+
+            cls.__discriminator_value_class_map = {
+                'Cat': Cat,'Dog': Dog
+            }
+
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
@@ -103,11 +111,4 @@ class Animal(BaseModel):
                              json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
                              ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
 
-from petstore_api.models.cat import Cat
-from petstore_api.models.dog import Dog
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # Animal.model_rebuild()
-    pass
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -48,7 +48,7 @@ class Animal(BaseModel):
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
+    def _get_discriminator_value_class_map(cls) -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             from petstore_api.models.cat import Cat

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -48,9 +48,7 @@ class Animal(BaseModel):
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def get_discriminator_value(cls, obj: dict) -> str:
-        """Returns the discriminator value (object type) of the data"""
-
+    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             from petstore_api.models.cat import Cat
@@ -59,10 +57,15 @@ class Animal(BaseModel):
             cls.__discriminator_value_class_map = {
                 'Cat': Cat,'Dog': Dog
             }
+        return cls.__discriminator_value_class_map
+
+    @classmethod
+    def get_discriminator_value(cls, obj: dict) -> str:
+        """Returns the discriminator value (object type) of the data"""
 
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
-            return cls.__discriminator_value_class_map.get(discriminator_value)
+            return cls._get_discriminator_value_class_map().get(discriminator_value)
         else:
             return None
 
@@ -109,6 +112,6 @@ class Animal(BaseModel):
         else:
             raise ValueError("Animal failed to lookup discriminator value from " +
                              json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
-                             ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
+                             ", mapping: " + json.dumps(cls._get_discriminator_value_class_map()))
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/api_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import date, datetime
 from typing import Optional, Union

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, Dict, Optional, Union

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Dict, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Dict, List, Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -56,7 +56,7 @@ class Animal(BaseModel):
             from petstore_api.models.dog import Dog
 
             cls.__discriminator_value_class_map = {
-                'Cat': Cat,'Dog': Dog
+                'Cat': 'Cat','Dog': 'Dog'
             }
         return cls.__discriminator_value_class_map
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -46,7 +46,7 @@ class Animal(BaseModel):
     __discriminator_property_name: ClassVar[List[str]] = 'className'
 
     # discriminator mappings
-    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
+    __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -49,9 +49,7 @@ class Animal(BaseModel):
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def get_discriminator_value(cls, obj: dict) -> str:
-        """Returns the discriminator value (object type) of the data"""
-
+    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             from petstore_api.models.cat import Cat
@@ -60,10 +58,15 @@ class Animal(BaseModel):
             cls.__discriminator_value_class_map = {
                 'Cat': Cat,'Dog': Dog
             }
+        return cls.__discriminator_value_class_map
+
+    @classmethod
+    def get_discriminator_value(cls, obj: dict) -> str:
+        """Returns the discriminator value (object type) of the data"""
 
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
-            return cls.__discriminator_value_class_map.get(discriminator_value)
+            return cls._get_discriminator_value_class_map().get(discriminator_value)
         else:
             return None
 
@@ -117,6 +120,6 @@ class Animal(BaseModel):
         else:
             raise ValueError("Animal failed to lookup discriminator value from " +
                              json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
-                             ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
+                             ", mapping: " + json.dumps(cls._get_discriminator_value_class_map()))
 
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional, Union
@@ -52,8 +53,8 @@ class Animal(BaseModel):
     def _get_discriminator_value_class_map(cls) -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
-            from petstore_api.models.cat import Cat
-            from petstore_api.models.dog import Dog
+            globals()["Cat"] = importlib.import_module("petstore_api.models.cat").Cat
+            globals()["Dog"] = importlib.import_module("petstore_api.models.dog").Dog
 
             cls.__discriminator_value_class_map = {
                 'Cat': 'Cat','Dog': 'Dog'

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -46,13 +46,21 @@ class Animal(BaseModel):
     __discriminator_property_name: ClassVar[List[str]] = 'className'
 
     # discriminator mappings
-    __discriminator_value_class_map: ClassVar[Dict[str, str]] = {
-        'Cat': 'Cat','Dog': 'Dog'
-    }
+    __discriminator_value_class_map: Union[ClassVar[Dict[str, str]], None] = None
 
     @classmethod
     def get_discriminator_value(cls, obj: dict) -> str:
         """Returns the discriminator value (object type) of the data"""
+
+        if cls.__discriminator_value_class_map == None:
+            # Prevent circular imports caused by mutually referencing classes
+            from petstore_api.models.cat import Cat
+            from petstore_api.models.dog import Dog
+
+            cls.__discriminator_value_class_map = {
+                'Cat': Cat,'Dog': Dog
+            }
+
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
             return cls.__discriminator_value_class_map.get(discriminator_value)
@@ -111,11 +119,4 @@ class Animal(BaseModel):
                              json.dumps(obj) + ". Discriminator property name: " + cls.__discriminator_property_name +
                              ", mapping: " + json.dumps(cls.__discriminator_value_class_map))
 
-from petstore_api.models.cat import Cat
-from petstore_api.models.dog import Dog
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # Animal.model_rebuild()
-    pass
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -49,7 +49,7 @@ class Animal(BaseModel):
     __discriminator_value_class_map: ClassVar[Union[Dict[str, str], None]] = None
 
     @classmethod
-    def _get_discriminator_value_class_map() -> ClassVar[Dict[str, str]]:
+    def _get_discriminator_value_class_map(cls) -> ClassVar[Dict[str, str]]:
         if cls.__discriminator_value_class_map == None:
             # Prevent circular imports caused by mutually referencing classes
             from petstore_api.models.cat import Cat

--- a/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/api_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List

--- a/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List

--- a/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List

--- a/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import date, datetime
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import date, datetime
 from typing import Any, ClassVar, Dict, List, Optional, Union

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/order.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/user.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional

--- a/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pprint
 import re  # noqa: F401
 import json
+import importlib
 
 
 from typing import Any, ClassVar, Dict, List, Optional


### PR DESCRIPTION
When generating a python client using the current snapshot of the openapi generator, a circular import occurs when a discriminator is inherited via AllOf.

See Issue  #16808 for example schema.

I fixed this by moving the initialization of the "__discriminator_value_class_map" attribute and all required imports to the "get_discriminator_value" method.
I know that imports outside of the top level aren't the most beautiful thing in the world but i can't think of any other way to break the import loop. This also should not affect performance too much as the attribute only gets initialized once.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@cbornet @tomplus @krjakbrjak @fa0311 @multani
