### PR TITLE
[BUG][GO] Replace references to sw package with {{packageName}} in README template

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/README.mustache
+++ b/modules/openapi-generator/src/main/resources/go/README.mustache
@@ -47,7 +47,7 @@ Default configuration comes with `Servers` field that contains server objects as
 
 ### Select Server Configuration
 
-For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+For using other server than the one defined on index 0 set context value `{{packageName}}.ContextServerIndex` of type `int`.
 
 ```golang
 ctx := context.WithValue(context.Background(), {{packageName}}.ContextServerIndex, 1)
@@ -55,7 +55,7 @@ ctx := context.WithValue(context.Background(), {{packageName}}.ContextServerInde
 
 ### Templated Server URL
 
-Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+Templated server URL is formatted using default variables from configuration or from context value `{{packageName}}.ContextServerVariables` of type `map[string]string`.
 
 ```golang
 ctx := context.WithValue(context.Background(), {{packageName}}.ContextServerVariables, map[string]string{
@@ -69,7 +69,7 @@ Note, enum values are always validated and all unused variables are silently ign
 
 Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
 An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+Similar rules for overriding default operation server index and variables applies by using `{{packageName}}.ContextOperationServerIndices` and `{{packageName}}.ContextOperationServerVariables` context maps.
 
 ```golang
 ctx := context.WithValue(context.Background(), {{packageName}}.ContextOperationServerIndices, map[string]int{
@@ -115,8 +115,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		{{packageName}}.ContextAPIKeys,
+		map[string]{{packageName}}.APIKey{
 			"{{keyParamName}}": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -131,7 +131,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "BEARER_TOKEN_STRING")
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAccessToken, "BEARER_TOKEN_STRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -142,7 +142,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), {{packageName}}.ContextBasicAuth, {{packageName}}.BasicAuth{
     UserName: "username",
     Password: "password",
 })
@@ -156,20 +156,20 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-	authConfig := client.HttpSignatureAuth{
+	authConfig := {{packageName}}.HttpSignatureAuth{
 		KeyId:                "my-key-id",
 		PrivateKeyPath:       "rsa.pem",
 		Passphrase:           "my-passphrase",
-		SigningScheme:        sw.HttpSigningSchemeHs2019,
+		SigningScheme:        {{packageName}}.HttpSigningSchemeHs2019,
 		SignedHeaders:        []string{
-			sw.HttpSignatureParameterRequestTarget, // The special (request-target) parameter expresses the HTTP request target.
-			sw.HttpSignatureParameterCreated,       // Time when request was signed, formatted as a Unix timestamp integer value.
+			{{packageName}}.HttpSignatureParameterRequestTarget, // The special (request-target) parameter expresses the HTTP request target.
+			{{packageName}}.HttpSignatureParameterCreated,       // Time when request was signed, formatted as a Unix timestamp integer value.
 			"Host",                                 // The Host request header specifies the domain name of the server, and optionally the TCP port number.
 			"Date",                                 // The date and time at which the message was originated.
 			"Content-Type",                         // The Media type of the body of the request.
 			"Digest",                               // A cryptographic digest of the request body.
 		},
-		SigningAlgorithm:     sw.HttpSigningAlgorithmRsaPSS,
+		SigningAlgorithm:     {{packageName}}.HttpSigningAlgorithmRsaPSS,
 		SignatureMaxValidity: 5 * time.Minute,
 	}
 	var authCtx context.Context
@@ -194,7 +194,7 @@ Example
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), {{packageName}}.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -206,7 +206,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, {{packageName}}.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 

--- a/samples/client/echo_api/go/README.md
+++ b/samples/client/echo_api/go/README.md
@@ -36,7 +36,7 @@ Default configuration comes with `Servers` field that contains server objects as
 
 ### Select Server Configuration
 
-For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+For using other server than the one defined on index 0 set context value `openapi.ContextServerIndex` of type `int`.
 
 ```golang
 ctx := context.WithValue(context.Background(), openapi.ContextServerIndex, 1)
@@ -44,7 +44,7 @@ ctx := context.WithValue(context.Background(), openapi.ContextServerIndex, 1)
 
 ### Templated Server URL
 
-Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+Templated server URL is formatted using default variables from configuration or from context value `openapi.ContextServerVariables` of type `map[string]string`.
 
 ```golang
 ctx := context.WithValue(context.Background(), openapi.ContextServerVariables, map[string]string{
@@ -58,7 +58,7 @@ Note, enum values are always validated and all unused variables are silently ign
 
 Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
 An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+Similar rules for overriding default operation server index and variables applies by using `openapi.ContextOperationServerIndices` and `openapi.ContextOperationServerVariables` context maps.
 
 ```golang
 ctx := context.WithValue(context.Background(), openapi.ContextOperationServerIndices, map[string]int{
@@ -125,7 +125,7 @@ Authentication schemes defined for the API:
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), openapi.ContextBasicAuth, openapi.BasicAuth{
     UserName: "username",
     Password: "password",
 })

--- a/samples/client/petstore/go/go-petstore/README.md
+++ b/samples/client/petstore/go/go-petstore/README.md
@@ -37,7 +37,7 @@ Default configuration comes with `Servers` field that contains server objects as
 
 ### Select Server Configuration
 
-For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+For using other server than the one defined on index 0 set context value `petstore.ContextServerIndex` of type `int`.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextServerIndex, 1)
@@ -45,7 +45,7 @@ ctx := context.WithValue(context.Background(), petstore.ContextServerIndex, 1)
 
 ### Templated Server URL
 
-Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+Templated server URL is formatted using default variables from configuration or from context value `petstore.ContextServerVariables` of type `map[string]string`.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextServerVariables, map[string]string{
@@ -59,7 +59,7 @@ Note, enum values are always validated and all unused variables are silently ign
 
 Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
 An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+Similar rules for overriding default operation server index and variables applies by using `petstore.ContextOperationServerIndices` and `petstore.ContextOperationServerVariables` context maps.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextOperationServerIndices, map[string]int{
@@ -183,7 +183,7 @@ Authentication schemes defined for the API:
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -195,7 +195,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, petstore.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -212,8 +212,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		petstore.ContextAPIKeys,
+		map[string]petstore.APIKey{
 			"api_key": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -233,8 +233,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		petstore.ContextAPIKeys,
+		map[string]petstore.APIKey{
 			"api_key_query": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -248,7 +248,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), petstore.ContextBasicAuth, petstore.BasicAuth{
     UserName: "username",
     Password: "password",
 })

--- a/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/README.md
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/go-experimental/README.md
@@ -36,7 +36,7 @@ Default configuration comes with `Servers` field that contains server objects as
 
 ### Select Server Configuration
 
-For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+For using other server than the one defined on index 0 set context value `x_auth_id_alias.ContextServerIndex` of type `int`.
 
 ```golang
 ctx := context.WithValue(context.Background(), x_auth_id_alias.ContextServerIndex, 1)
@@ -44,7 +44,7 @@ ctx := context.WithValue(context.Background(), x_auth_id_alias.ContextServerInde
 
 ### Templated Server URL
 
-Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+Templated server URL is formatted using default variables from configuration or from context value `x_auth_id_alias.ContextServerVariables` of type `map[string]string`.
 
 ```golang
 ctx := context.WithValue(context.Background(), x_auth_id_alias.ContextServerVariables, map[string]string{
@@ -58,7 +58,7 @@ Note, enum values are always validated and all unused variables are silently ign
 
 Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
 An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+Similar rules for overriding default operation server index and variables applies by using `x_auth_id_alias.ContextOperationServerIndices` and `x_auth_id_alias.ContextOperationServerVariables` context maps.
 
 ```golang
 ctx := context.WithValue(context.Background(), x_auth_id_alias.ContextOperationServerIndices, map[string]int{
@@ -104,8 +104,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		x_auth_id_alias.ContextAPIKeys,
+		map[string]x_auth_id_alias.APIKey{
 			"X-Api-Key": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -125,8 +125,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		x_auth_id_alias.ContextAPIKeys,
+		map[string]x_auth_id_alias.APIKey{
 			"api_key": {Key: "API_KEY_STRING"},
 		},
 	)

--- a/samples/openapi3/client/petstore/go/go-petstore/README.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/README.md
@@ -37,7 +37,7 @@ Default configuration comes with `Servers` field that contains server objects as
 
 ### Select Server Configuration
 
-For using other server than the one defined on index 0 set context value `sw.ContextServerIndex` of type `int`.
+For using other server than the one defined on index 0 set context value `petstore.ContextServerIndex` of type `int`.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextServerIndex, 1)
@@ -45,7 +45,7 @@ ctx := context.WithValue(context.Background(), petstore.ContextServerIndex, 1)
 
 ### Templated Server URL
 
-Templated server URL is formatted using default variables from configuration or from context value `sw.ContextServerVariables` of type `map[string]string`.
+Templated server URL is formatted using default variables from configuration or from context value `petstore.ContextServerVariables` of type `map[string]string`.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextServerVariables, map[string]string{
@@ -59,7 +59,7 @@ Note, enum values are always validated and all unused variables are silently ign
 
 Each operation can use different server URL defined using `OperationServers` map in the `Configuration`.
 An operation is uniquely identified by `"{classname}Service.{nickname}"` string.
-Similar rules for overriding default operation server index and variables applies by using `sw.ContextOperationServerIndices` and `sw.ContextOperationServerVariables` context maps.
+Similar rules for overriding default operation server index and variables applies by using `petstore.ContextOperationServerIndices` and `petstore.ContextOperationServerVariables` context maps.
 
 ```golang
 ctx := context.WithValue(context.Background(), petstore.ContextOperationServerIndices, map[string]int{
@@ -206,7 +206,7 @@ Authentication schemes defined for the API:
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "ACCESSTOKENSTRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "ACCESSTOKENSTRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -218,7 +218,7 @@ import "golang.org/x/oauth2"
 /* Perform OAuth2 round trip request and obtain a token */
 
 tokenSource := oauth2cfg.TokenSource(createContext(httpClient), &token)
-auth := context.WithValue(oauth2.NoContext, sw.ContextOAuth2, tokenSource)
+auth := context.WithValue(oauth2.NoContext, petstore.ContextOAuth2, tokenSource)
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -235,8 +235,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		petstore.ContextAPIKeys,
+		map[string]petstore.APIKey{
 			"api_key": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -256,8 +256,8 @@ Example
 ```golang
 auth := context.WithValue(
 		context.Background(),
-		sw.ContextAPIKeys,
-		map[string]sw.APIKey{
+		petstore.ContextAPIKeys,
+		map[string]petstore.APIKey{
 			"api_key_query": {Key: "API_KEY_STRING"},
 		},
 	)
@@ -271,7 +271,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextBasicAuth, sw.BasicAuth{
+auth := context.WithValue(context.Background(), petstore.ContextBasicAuth, petstore.BasicAuth{
     UserName: "username",
     Password: "password",
 })
@@ -285,7 +285,7 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-auth := context.WithValue(context.Background(), sw.ContextAccessToken, "BEARER_TOKEN_STRING")
+auth := context.WithValue(context.Background(), petstore.ContextAccessToken, "BEARER_TOKEN_STRING")
 r, err := client.Service.Operation(auth, args)
 ```
 
@@ -296,20 +296,20 @@ r, err := client.Service.Operation(auth, args)
 Example
 
 ```golang
-	authConfig := client.HttpSignatureAuth{
+	authConfig := petstore.HttpSignatureAuth{
 		KeyId:                "my-key-id",
 		PrivateKeyPath:       "rsa.pem",
 		Passphrase:           "my-passphrase",
-		SigningScheme:        sw.HttpSigningSchemeHs2019,
+		SigningScheme:        petstore.HttpSigningSchemeHs2019,
 		SignedHeaders:        []string{
-			sw.HttpSignatureParameterRequestTarget, // The special (request-target) parameter expresses the HTTP request target.
-			sw.HttpSignatureParameterCreated,       // Time when request was signed, formatted as a Unix timestamp integer value.
+			petstore.HttpSignatureParameterRequestTarget, // The special (request-target) parameter expresses the HTTP request target.
+			petstore.HttpSignatureParameterCreated,       // Time when request was signed, formatted as a Unix timestamp integer value.
 			"Host",                                 // The Host request header specifies the domain name of the server, and optionally the TCP port number.
 			"Date",                                 // The date and time at which the message was originated.
 			"Content-Type",                         // The Media type of the body of the request.
 			"Digest",                               // A cryptographic digest of the request body.
 		},
-		SigningAlgorithm:     sw.HttpSigningAlgorithmRsaPSS,
+		SigningAlgorithm:     petstore.HttpSigningAlgorithmRsaPSS,
 		SignatureMaxValidity: 5 * time.Minute,
 	}
 	var authCtx context.Context


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

A few years ago the examples in the README template for the Go client were [updated](https://github.com/OpenAPITools/openapi-generator/commit/93488f41959b00a7ceb011b05430208d7216e825#diff-8dbc27f20275ea67d48781556602ad1dd99a94c3edeb4919aa356efb78b178bcR32-R34) to use the `{{packageName}}` provided to the generator instead of using `sw` as the hard-coded package name. However, not every reference to `sw` was replaced which caused me a good deal of confusion when trying to understand how to use the generated client. This PR updates the references to `sw` that were missed previously.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
