### PR TITLE
[Core] Issue #11110 - Enum Model Default Value Support

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3100,6 +3100,13 @@ public class DefaultCodegen implements CodegenConfig {
             // comment out below as allowableValues is not set in post processing model enum
             m.allowableValues = new HashMap<>();
             m.allowableValues.put("values", schema.getEnum());
+            if (schema.getDefault() != null) {
+                if (!schema.getEnum().contains(schema.getDefault())) {
+                    LOGGER.warn("Default value ({}) for enum ({}) not an allowable value", toDefaultValue(schema), m.name);
+                    return null;
+                }
+                m.defaultValue = toDefaultValue(schema);
+            }
         }
         if (!ModelUtils.isArraySchema(schema)) {
             m.dataType = getSchemaType(schema);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -911,6 +911,30 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testEnumModelWithDefault() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/issue_11110.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+
+        Schema testEnum = openAPI.getComponents().getSchemas().get("TestEnum");
+        codegen.setOpenAPI(openAPI);
+
+        CodegenModel testEnumModel = codegen.fromModel("TestEnum", testEnum);
+        Assert.assertEquals(testEnumModel.defaultValue, "valueOne");
+    }
+
+    @Test
+    public void testEnumModelWithDefaultErrors() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/bugs/issue_11110.yaml");
+        DefaultCodegen codegen = new DefaultCodegen();
+
+        Schema testFailEnum = openAPI.getComponents().getSchemas().get("TestFailEnum");
+        codegen.setOpenAPI(openAPI);
+
+        CodegenModel testFailEnumModel = codegen.fromModel("TestFailEnum", testFailEnum);
+        Assert.assertNull(testFailEnumModel);
+    }
+
+    @Test
     public void testExample1() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
         final DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/bugs/issue_11110.yaml
+++ b/modules/openapi-generator/src/test/resources/bugs/issue_11110.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.2
+info:
+  title: Content API
+  description: |
+    An API for getting and modifying rich-text documents, sections, presentations, slides, layout slides, and associated content, such as paragraphs, formatted text, shapes, and properties.
+  version: 0.0.0
+
+paths:
+  /:
+    get:
+      description: >
+        Test Return Of TestModel
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TestModel'
+
+components:
+  schemas:
+    TestFailEnum:
+      title: TestFailEnum
+      description: |
+        A model, intended to be an enumeration, with a defined default, but should error as default not in set
+      type: string
+      default: notReal
+      enum:
+        - valueOne
+        - valueTwo
+    TestEnum:
+      title: TestEnum
+      description: |
+        A model, intended to be an enumeration, with a defined default
+      type: string
+      default: valueOne
+      enum:
+        - valueOne
+        - valueTwo
+    TestModel:
+      title: TestModel
+      description: |
+        An example model consuming the TestEnum
+      type: object
+      properties:
+        testEnum:
+          $ref: '#/components/schemas/TestEnum'

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_class.py
@@ -44,3 +44,9 @@ class EnumClass(str, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'-efg'
+

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_default_value.py
@@ -44,3 +44,9 @@ class OuterEnumDefaultValue(str, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'placed'
+

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
@@ -45,3 +45,9 @@ class OuterEnumIntegerDefaultValue(int, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.0
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_class.py
@@ -39,3 +39,9 @@ class EnumClass(str, Enum):
         return EnumClass(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'-efg'
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_enum_default_value.py
@@ -39,3 +39,9 @@ class OuterEnumDefaultValue(str, Enum):
         return OuterEnumDefaultValue(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'placed'
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_enum_integer_default_value.py
@@ -40,3 +40,9 @@ class OuterEnumIntegerDefaultValue(int, Enum):
         return OuterEnumIntegerDefaultValue(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.0
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_class.py
@@ -39,3 +39,9 @@ class EnumClass(str, Enum):
         return EnumClass(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'-efg'
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_enum_default_value.py
@@ -39,3 +39,9 @@ class OuterEnumDefaultValue(str, Enum):
         return OuterEnumDefaultValue(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'placed'
+

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_enum_integer_default_value.py
@@ -40,3 +40,9 @@ class OuterEnumIntegerDefaultValue(int, Enum):
         return OuterEnumIntegerDefaultValue(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.0
+

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_class.py
@@ -44,3 +44,9 @@ class EnumClass(str, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'-efg'
+

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_default_value.py
@@ -44,3 +44,9 @@ class OuterEnumDefaultValue(str, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.'placed'
+

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_enum_integer_default_value.py
@@ -45,3 +45,9 @@ class OuterEnumIntegerDefaultValue(int, Enum):
         return cls(json.loads(json_str))
 
 
+    #
+    @classmethod
+    def _missing_value_(cls, value):
+        if value is no_arg:
+            return cls.0
+


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Currently, we can define models to be reusable enumerations.  A user may want the ability to set the default for the model in its usages on the model itself, rather than on the properties of consumption.


Example Desired Schema Spec
```yaml
components:
  schemas:
    TestEnum:
      title: TestEnum
      description: |
        A model, intended to be an enumeration, with a defined default
      type: string
      default: valueOne
      enum:
        - valueOne
        - valueTwo
    TestModel:
      title: TestModel
      description: |
        An example model consuming the TestEnum
      type: object
      properties:
        testEnum:
          $ref: '#/components/schemas/TestEnum'
```

Custom Model Template
```
{{#isEnum}}{{#defaultValue}}
// DefaultFor{{classname}} gets the default value for the {{classname}} enum.
func DefaultFor{{classname}}() {{classname}} {
	return {{classname}}({{#isString}}`{{/isString}}{{defaultValue}}{{#isString}}`{{/isString}})
}
{{/defaultValue}}{{/isEnum}}
```

Current master output
```go
func DefaultForTestEnum() TestEnum {
	return TestEnum(``)
}
```

Desired output (with this PR): Note this is odd, since it's not using `VALUE_ONE`, but that's because of enumVars construction and no way to convert `valueOne` as a default value in template to cap-snake case.
```go
func DefaultForTestEnum() TestEnum {
	return TestEnum(`valueOne`) 
}
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
