### PR TITLE
[Postman Collection] Fix path parameter syntax

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -217,9 +217,12 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
         for(CodegenOperation codegenOperation : opList) {
 
             if(pathParamsAsVariables) {
+                // create Postman variable from path parameter
                 codegenOperation.path = doubleCurlyBraces(codegenOperation.path);
+            } else {
+                // use Postman notation for path parameter
+                codegenOperation.path = replacesBracesInPath(codegenOperation.path);
             }
-
             codegenOperation.summary = getSummary(codegenOperation);
 
             // request headers
@@ -501,6 +504,15 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
         return s;
 
+    }
+
+    // convert path from /users/{id} to /users/:id
+    String replacesBracesInPath(String path) {
+
+        String s = path.replace("{", ":");
+        s = s.replace("}", "");
+
+        return s;
     }
 
     public String extractExampleByName(String ref) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -73,6 +73,8 @@ public class PostmanCollectionCodegenTest {
 
         // verify request name (from summary)
         assertFileContains(path, "\"name\": \"Get User\"");
+        // verify request endpoint
+        TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
 
     }
 
@@ -155,6 +157,9 @@ public class PostmanCollectionCodegenTest {
         TestUtils.assertFileContains(path,
                 "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
 
+        // verify request endpoint
+        TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+
     }
 
     @Test
@@ -186,6 +191,9 @@ public class PostmanCollectionCodegenTest {
         assertEquals(4, ((ArrayNode) jsonNode.get("variable")).size());
 
         assertFileContains(path, "{{MY_VAR_NAME}}");
+
+        // verify request endpoint
+        TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
 
     }
 

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -13,7 +13,7 @@
 	            "name": "default",
 	            "item": [
 	                        {
-    "name": "/users/{userId} (DEPRECATED)",
+    "name": "/users/:userId (DEPRECATED)",
                 "description": "Update the information of an existing user.",
                  "item": [
                             {
@@ -52,13 +52,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/users/{userId}",
+                                        "raw": "{{baseUrl}}/users/:userId",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "users",
-                                            "{userId}"
+                                            ":userId"
                                         ],
                                         "variable": [
                                             {
@@ -81,7 +81,7 @@
 	            "name": "advanced",
 	            "item": [
 	                        {
-    "name": "/groups/{groupId}",
+    "name": "/groups/:groupId",
                 "description": "Get group of users",
                  "item": [
                             {
@@ -105,13 +105,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/groups/{groupId}",
+                                        "raw": "{{baseUrl}}/groups/:groupId",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "groups",
-                                            "{groupId}"
+                                            ":groupId"
                                         ],
                                         "variable": [
                                             {
@@ -129,7 +129,7 @@
                             ]
                         },
 	                        {
-    "name": "/users/{userId}",
+    "name": "/users/:userId",
                 "description": "Retrieve the information of the user with the matching user ID.",
                  "item": [
                             {
@@ -163,13 +163,13 @@
                                         }
                                     },
                                     "url": {
-                                        "raw": "{{baseUrl}}/users/{userId}",
+                                        "raw": "{{baseUrl}}/users/:userId",
                                         "host": [
                                             "{{baseUrl}}"
                                         ],
                                         "path": [
                                             "users",
-                                            "{userId}"
+                                            ":userId"
                                         ],
                                         "variable": [
                                             {


### PR DESCRIPTION
Use Postman syntax when creating path parameters to make sure that `{{baseUrl}}/users/{id}` is converted to `{{baseUrl}}/users/:id`

Fix #16826 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 
