### PR TITLE
Type import for oneOf models in ts-fetch template

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -1,7 +1,7 @@
 {{#hasImports}}
 {{#oneOf}}
+import type { {{{.}}} } from './{{.}}{{importFileExtension}}';
 import {
-    {{{.}}},
     instanceOf{{{.}}},
     {{{.}}}FromJSON,
     {{{.}}}FromJSONTyped,


### PR DESCRIPTION
Required for some compilation modes of TS, specifically for use with SvelteKit.

The error I'm getting when using the generated code on SvelteKit is:

```
TS1444:  XXX  is a type and must be imported using a type-only import when  preserveValueImports  and  isolatedModules  are both enabled.
```

Those options are deliberate and mandatory according to SvelteKit's doc.

As such I've made a change to the way types are imported, which actually already seems to be present in `modelGeneric`. This change is conclusive on my end and makes the generated code work in my project.

Now, to be perfectly transparent, I am extremely not used to the tooling of this project and I have no idea if did everything right. Specifically, I think I managed to run some tests but it stays pretty elusive to me, so let me know what/how I should fix it (and how can I avoid having `cargo` and a million other tools installed on my machine).

This seems to be a PR for @CodeNinjai, @frol and @cliffano

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
