### PR TITLE
16840 add jersey2 async methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1241,7 +1241,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     try {
       response = sendRequest(method, builderAndEntity.invocationBuilder, builderAndEntity.entity);
-
+      renewOauthIfNeeded(method, authNames, response.getStatus());
       return toApiResponse(returnType, response);
     } finally {
       try {
@@ -1253,18 +1253,8 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     }
   }
 
-  /**
-   * Convert the Jax RS Response to ApiResponse.
-   * @param returnType The return type into which to deserialize the response
-   * @param response The response from the jax-rs invocation.
-   * @return The ApiResponse that respresents this Jax RS response.
-   * @param <T> The type into which to deserialize the response
-   * @throws ApiException API Exceptions are thrown in case of failing status codes.
-   */
-  public <T> ApiResponse<T> toApiResponse(GenericType<T> returnType, Response response) throws ApiException {
-    int statusCode = response.getStatusInfo().getStatusCode();
-
-    {{#hasOAuthMethods}}
+  {{#hasOAuthMethods}}
+  public void renewOauthIfNeeded(String method, String[] authNames, int statusCode) {
     // If OAuth is used and a status 401 is received, renew the access token and retry the request
     if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
       for (String authName : authNames) {
@@ -1280,8 +1270,19 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
       }
     }
-    {{/hasOAuthMethods}}
+  }
+  {{/hasOAuthMethods}}
 
+  /**
+   * Convert the Jax RS Response to ApiResponse.
+   * @param returnType The return type into which to deserialize the response
+   * @param response The response from the jax-rs invocation.
+   * @return The ApiResponse that respresents this Jax RS response.
+   * @param <T> The type into which to deserialize the response
+   * @throws ApiException API Exceptions are thrown in case of failing status codes.
+   */
+  public <T> ApiResponse<T> toApiResponse(GenericType<T> returnType, Response response) throws ApiException {
+    int statusCode = response.getStatusInfo().getStatusCode();
     Map<String, List<String>> responseHeaders = buildResponseHeaders(response);
 
     if (response.getStatusInfo() == Status.NO_CONTENT) {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1,5 +1,6 @@
 package {{invokerPackage}};
 
+import {{javaxPackage}}.ws.rs.client.AsyncInvoker;
 import {{javaxPackage}}.ws.rs.client.Client;
 import {{javaxPackage}}.ws.rs.client.ClientBuilder;
 import {{javaxPackage}}.ws.rs.client.Entity;
@@ -39,6 +40,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import org.glassfish.jersey.logging.LoggingFeature;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.Collection;
@@ -1160,7 +1162,46 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   /**
-   * Invoke API by sending HTTP request with the given options.
+   * Asynchronously invoke API by sending HTTP request with the given options.
+   *
+   * @param <T> Type
+   * @param operation The qualified name of the operation
+   * @param path The sub-path of the HTTP URL
+   * @param method The request method, one of "GET", "POST", "PUT", "HEAD" and "DELETE"
+   * @param queryParams The query parameters
+   * @param body The request body object
+   * @param headerParams The header parameters
+   * @param cookieParams The cookie parameters
+   * @param formParams The form parameters
+   * @param accept The request's Accept header
+   * @param contentType The request's Content-Type header
+   * @param authNames The authentications to apply
+   * @param returnType The return type into which to deserialize the response
+   * @param isBodyNullable True if the body is nullable
+   * @return The future response body in type of string
+   * @throws ApiException API exception
+   */
+  public <T> Future<Response> invokeAPIAsync(
+          String operation,
+          String path,
+          String method,
+          List<Pair> queryParams,
+          Object body,
+          Map<String, String> headerParams,
+          Map<String, String> cookieParams,
+          Map<String, Object> formParams,
+          String accept,
+          String contentType,
+          String[] authNames,
+          GenericType<T> returnType,
+          boolean isBodyNullable)
+          throws ApiException {
+    BuilderAndEntity builderAndEntity = prepareInvoker(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, isBodyNullable);
+    return sendRequestAsync(method, builderAndEntity.invocationBuilder.async(), builderAndEntity.entity);
+  }
+
+  /**
+   * Invoke API synchronously by sending HTTP request with the given options.
    *
    * @param <T> Type
    * @param operation The qualified name of the operation
@@ -1180,38 +1221,112 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
    * @throws ApiException API exception
    */
   public <T> ApiResponse<T> invokeAPI(
-      String operation,
-      String path,
-      String method,
-      List<Pair> queryParams,
-      Object body,
-      Map<String, String> headerParams,
-      Map<String, String> cookieParams,
-      Map<String, Object> formParams,
-      String accept,
-      String contentType,
-      String[] authNames,
-      GenericType<T> returnType,
-      boolean isBodyNullable)
-      throws ApiException {
+          String operation,
+          String path,
+          String method,
+          List<Pair> queryParams,
+          Object body,
+          Map<String, String> headerParams,
+          Map<String, String> cookieParams,
+          Map<String, Object> formParams,
+          String accept,
+          String contentType,
+          String[] authNames,
+          GenericType<T> returnType,
+          boolean isBodyNullable)
+          throws ApiException {
+    BuilderAndEntity builderAndEntity = prepareInvoker(operation, path, method, queryParams, body, headerParams, cookieParams, formParams, accept, contentType, authNames, isBodyNullable);
 
+    Response response = null;
+
+    try {
+      response = sendRequest(method, builderAndEntity.invocationBuilder, builderAndEntity.entity);
+
+      return toApiResponse(returnType, response);
+    } finally {
+      try {
+        response.close();
+      } catch (Exception e) {
+        // it's not critical, since the response object is local in method invokeAPI; that's fine,
+        // just continue
+      }
+    }
+  }
+
+  /**
+   * Convert the Jax RS Response to ApiResponse.
+   * @param returnType The return type into which to deserialize the response
+   * @param response The response from the jax-rs invocation.
+   * @return The ApiResponse that respresents this Jax RS response.
+   * @param <T> The type into which to deserialize the response
+   * @throws ApiException API Exceptions are thrown in case of failing status codes.
+   */
+  public <T> ApiResponse<T> toApiResponse(GenericType<T> returnType, Response response) throws ApiException {
+    int statusCode = response.getStatusInfo().getStatusCode();
+
+    {{#hasOAuthMethods}}
+    // If OAuth is used and a status 401 is received, renew the access token and retry the request
+    if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
+      for (String authName : authNames) {
+        Authentication authentication = authentications.get(authName);
+        if (authentication instanceof OAuth) {
+          OAuth2AccessToken accessToken = ((OAuth) authentication).renewAccessToken();
+          if (accessToken != null) {
+            invocationBuilder.header("Authorization", null);
+            invocationBuilder.header("Authorization", "Bearer " + accessToken.getAccessToken());
+            response = sendRequest(method, invocationBuilder, entity);
+          }
+          break;
+        }
+      }
+    }
+    {{/hasOAuthMethods}}
+
+    Map<String, List<String>> responseHeaders = buildResponseHeaders(response);
+
+    if (response.getStatusInfo() == Status.NO_CONTENT) {
+      return new ApiResponse<T>(statusCode, responseHeaders);
+    } else if (response.getStatusInfo().getFamily() == Status.Family.SUCCESSFUL) {
+      if (returnType == null) {
+        return new ApiResponse<T>(statusCode, responseHeaders);
+      } else {
+        return new ApiResponse<T>(statusCode, responseHeaders, deserialize(response, returnType));
+      }
+    } else {
+      String message = "error";
+      String respBody = null;
+      if (response.hasEntity()) {
+        try {
+          respBody = String.valueOf(response.readEntity(String.class));
+          message = respBody;
+        } catch (RuntimeException e) {
+          // e.printStackTrace();
+        }
+      }
+      throw new ApiException(
+              response.getStatus(), message, buildResponseHeaders(response), respBody);
+    }
+  }
+
+  private BuilderAndEntity prepareInvoker(String operation, String path, String method, List<Pair> queryParams, Object body, Map<String, String> headerParams, Map<String, String> cookieParams, Map<String, Object> formParams, String accept, String contentType, String[] authNames, boolean isBodyNullable) throws ApiException {
+    // Not using `.target(targetURL).path(path)` below,
+    // to support (constant) query string in `path`, e.g. "/posts?draft=1"
     String targetURL;
-    List<ServerConfiguration> serverConfigurations;
-    if (serverIndex != null && (serverConfigurations = operationServers.get(operation)) != null) {
-      int index = operationServerIndex.getOrDefault(operation, serverIndex).intValue();
-      Map<String, String> variables = operationServerVariables.getOrDefault(operation, serverVariables);
+    if (serverIndex != null && operationServers.containsKey(operation)) {
+      Integer index = operationServerIndex.containsKey(operation) ? operationServerIndex.get(operation) : serverIndex;
+      Map<String, String> variables = operationServerVariables.containsKey(operation) ?
+              operationServerVariables.get(operation) : serverVariables;
+      List<ServerConfiguration> serverConfigurations = operationServers.get(operation);
       if (index < 0 || index >= serverConfigurations.size()) {
         throw new ArrayIndexOutOfBoundsException(
-            String.format(
-                "Invalid index %d when selecting the host settings. Must be less than %d",
-                index, serverConfigurations.size()));
+                String.format(
+                        "Invalid index %d when selecting the host settings. Must be less than %d",
+                        index, serverConfigurations.size()));
       }
       targetURL = serverConfigurations.get(index).URL(variables) + path;
     } else {
       targetURL = this.basePath + path;
     }
-    // Not using `.target(targetURL).path(path)` below,
-    // to support (constant) query string in `path`, e.g. "/posts?draft=1"
     WebTarget target = httpClient.target(targetURL);
 
     if (queryParams != null) {
@@ -1222,10 +1337,11 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
       }
     }
 
-    Invocation.Builder invocationBuilder = target.request();
-
+    Invocation.Builder invocationBuilder;
     if (accept != null) {
-      invocationBuilder = invocationBuilder.accept(accept);
+      invocationBuilder = target.request().accept(accept);
+    } else {
+      invocationBuilder = target.request();
     }
 
     for (Entry<String, String> entry : cookieParams.entrySet()) {
@@ -1248,22 +1364,15 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     Map<String, String> allHeaderParams = new HashMap<>(defaultHeaderMap);
     allHeaderParams.putAll(headerParams);
 
-    if (authNames != null) {
-      // update different parameters (e.g. headers) for authentication
-      updateParamsForAuth(
-          authNames,
-          queryParams,
-          allHeaderParams,
-          cookieParams,
-          {{#hasHttpSignatureMethods}}
-          serializeToString(body, formParams, contentType, isBodyNullable),
-          {{/hasHttpSignatureMethods}}
-          {{^hasHttpSignatureMethods}}
-          null,
-          {{/hasHttpSignatureMethods}}
-          method,
-          target.getUri());
-    }
+    // update different parameters (e.g. headers) for authentication
+    updateParamsForAuth(
+            authNames,
+            queryParams,
+            allHeaderParams,
+            cookieParams,
+            null,
+            method,
+            target.getUri());
 
     for (Entry<String, String> entry : allHeaderParams.entrySet()) {
       String value = entry.getValue();
@@ -1271,63 +1380,16 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         invocationBuilder = invocationBuilder.header(entry.getKey(), value);
       }
     }
+    return new BuilderAndEntity(invocationBuilder, entity);
+  }
 
-    Response response = null;
+  private static class BuilderAndEntity {
+    public final Invocation.Builder invocationBuilder;
+    public final Entity<?> entity;
 
-    try {
-      response = sendRequest(method, invocationBuilder, entity);
-
-      final int statusCode = response.getStatusInfo().getStatusCode();
-
-      {{#hasOAuthMethods}}
-      // If OAuth is used and a status 401 is received, renew the access token and retry the request
-      if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
-        for (String authName : authNames) {
-          Authentication authentication = authentications.get(authName);
-          if (authentication instanceof OAuth) {
-            OAuth2AccessToken accessToken = ((OAuth) authentication).renewAccessToken();
-            if (accessToken != null) {
-              invocationBuilder.header("Authorization", null);
-              invocationBuilder.header("Authorization", "Bearer " + accessToken.getAccessToken());
-              response = sendRequest(method, invocationBuilder, entity);
-            }
-            break;
-          }
-        }
-      }
-
-      {{/hasOAuthMethods}}
-      Map<String, List<String>> responseHeaders = buildResponseHeaders(response);
-
-      if (statusCode == Status.NO_CONTENT.getStatusCode()) {
-        return new ApiResponse<T>(statusCode, responseHeaders);
-      } else if (response.getStatusInfo().getFamily() == Status.Family.SUCCESSFUL) {
-        if (returnType == null) {
-          return new ApiResponse<T>(statusCode, responseHeaders);
-        } else {
-          return new ApiResponse<T>(statusCode, responseHeaders, deserialize(response, returnType));
-        }
-      } else {
-        String message = "error";
-        String respBody = null;
-        if (response.hasEntity()) {
-          try {
-            respBody = String.valueOf(response.readEntity(String.class));
-            message = respBody;
-          } catch (RuntimeException e) {
-            // e.printStackTrace();
-          }
-        }
-        throw new ApiException(
-            response.getStatus(), message, buildResponseHeaders(response), respBody);
-      }
-    } finally {
-      try {
-        response.close();
-      } catch (Exception e) {
-        // it's not critical, since the response object is local in method invokeAPI; that's fine,
-        // just continue
-      }
+    public BuilderAndEntity(Invocation.Builder invocationBuilder, Entity<?> entity) {
+      this.invocationBuilder = invocationBuilder;
+      this.entity = entity;
     }
   }
 
@@ -1343,6 +1405,22 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
       response = invocationBuilder.method("PATCH", entity);
     } else {
       response = invocationBuilder.method(method);
+    }
+    return response;
+  }
+
+  private Future<Response> sendRequestAsync(String method, AsyncInvoker asyncInvoker, Entity<?> entity) {
+    Future<Response> response;
+    if ("POST".equals(method)) {
+      response = asyncInvoker.post(entity);
+    } else if ("PUT".equals(method)) {
+      response = asyncInvoker.put(entity);
+    } else if ("DELETE".equals(method)) {
+      response = asyncInvoker.method("DELETE", entity);
+    } else if ("PATCH".equals(method)) {
+      response = asyncInvoker.method("PATCH", entity);
+    } else {
+      response = asyncInvoker.method(method);
     }
     return response;
   }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1242,7 +1242,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
     try {
       response = sendRequest(method, builderAndEntity.invocationBuilder, builderAndEntity.entity);
       {{#hasOAuthMethods}}
-      renewOauthIfNeeded(method, authNames, response.getStatus());
+      response = renewOauthIfNeeded(method, authNames, response.getStatus(), builderAndEntity.invocationBuilder, builderAndEntity.entity);
       {{/hasOAuthMethods}}
       return toApiResponse(returnType, response);
     } finally {
@@ -1256,8 +1256,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
   }
 
   {{#hasOAuthMethods}}
-  public void renewOauthIfNeeded(String method, String[] authNames, int statusCode) {
+  private Response renewOauthIfNeeded(String method, String[] authNames, int statusCode, Invocation.Builder invocationBuilder, Entity<?> entity) {
     // If OAuth is used and a status 401 is received, renew the access token and retry the request
+    Response response = null;
     if (authNames != null && statusCode == Status.UNAUTHORIZED.getStatusCode()) {
       for (String authName : authNames) {
         Authentication authentication = authentications.get(authName);
@@ -1272,6 +1273,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         }
       }
     }
+    return response;
   }
   {{/hasOAuthMethods}}
 

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -1241,7 +1241,9 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
     try {
       response = sendRequest(method, builderAndEntity.invocationBuilder, builderAndEntity.entity);
+      {{#hasOAuthMethods}}
       renewOauthIfNeeded(method, authNames, response.getStatus());
+      {{/hasOAuthMethods}}
       return toApiResponse(returnType, response);
     } finally {
       try {

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -6,6 +6,7 @@ import {{invokerPackage}}.ApiResponse;
 import {{invokerPackage}}.Configuration;
 import {{invokerPackage}}.Pair;
 
+import {{javaxPackage}}.ws.rs.core.Response;
 import {{javaxPackage}}.ws.rs.core.GenericType;
 
 {{#imports}}import {{import}};
@@ -16,6 +17,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 {{>generatedAnnotation}}
 {{#operations}}
@@ -82,6 +84,42 @@ public class {{classname}} {
   {{/isDeprecated}}
   public {{#returnType}}{{{.}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
     {{#returnType}}return {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}}){{#returnType}}.getData(){{/returnType}};
+  }
+  {{/vendorExtensions.x-group-parameters}}
+
+  {{^vendorExtensions.x-group-parameters}}
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#allParams}}
+   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+   {{/allParams}}
+   {{#returnType}}
+   * @return {{.}}
+   {{/returnType}}
+   * @throws ApiException if fails to make API call
+   {{#responses.0}}
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       {{#responses}}
+       <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+       {{/responses}}
+     </table>
+   {{/responses.0}}
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public Future<Response> {{operationId}}Async({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+    return {{operationId}}WithHttpInfoAsync({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
   }
   {{/vendorExtensions.x-group-parameters}}
 
@@ -191,6 +229,117 @@ public class {{classname}} {
     GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
     {{/returnType}}
     return apiClient.invokeAPI("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
+                               {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
+                               {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
+  }
+  {{#vendorExtensions.x-group-parameters}}
+
+  {{^vendorExtensions.x-group-parameters}}
+  /**
+   * {{summary}}
+   * {{notes}}
+   {{#allParams}}
+   * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{.}}{{/defaultValue}}){{/required}}
+   {{/allParams}}
+   * @return ApiResponse&lt;{{returnType}}{{^returnType}}Void{{/returnType}}&gt;
+   * @throws ApiException if fails to make API call
+   {{#responses.0}}
+   * @http.response.details
+     <table summary="Response Details" border="1">
+       <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+       {{#responses}}
+       <tr><td> {{code}} </td><td> {{message}} </td><td> {{#headers}} * {{baseName}} - {{description}} <br> {{/headers}}{{^headers.0}} - {{/headers.0}} </td></tr>
+       {{/responses}}
+     </table>
+   {{/responses.0}}
+   {{#isDeprecated}}
+   * @deprecated
+   {{/isDeprecated}}
+   {{#externalDocs}}
+   * {{description}}
+   * @see <a href="{{url}}">{{summary}} Documentation</a>
+   {{/externalDocs}}
+   */
+  {{#isDeprecated}}
+  @Deprecated
+  {{/isDeprecated}}
+  public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} Future<Response> {{operationId}}WithHttpInfoAsync({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+    {{#hasRequiredParams}}
+    // Check required parameters
+    {{#allParams}}
+    {{#required}}
+    if ({{paramName}} == null) {
+      throw new ApiException(400, "Missing the required parameter '{{paramName}}' when calling {{operationId}}");
+    }
+    {{/required}}
+    {{/allParams}}
+
+    {{/hasRequiredParams}}
+    {{#hasPathParams}}
+    // Path parameters
+    String localVarPath = "{{{path}}}"{{#pathParams}}
+            .replaceAll({{=% %=}}"\\{%baseName%}"%={{ }}=%, apiClient.escapeString({{{paramName}}}{{#isUuid}}.toString(){{/isUuid}}{{^isString}}.toString(){{/isString}})){{/pathParams}};
+
+    {{/hasPathParams}}
+    {{#queryParams}}
+    {{#-first}}
+    // Query parameters
+    List<Pair> localVarQueryParams = new ArrayList<>(
+            apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}})
+    );
+    {{/-first}}
+    {{^-first}}
+    localVarQueryParams.addAll(apiClient.parameterToPairs("{{{collectionFormat}}}", "{{baseName}}", {{paramName}}));
+    {{/-first}}
+    {{#-last}}
+
+    {{/-last}}
+    {{/queryParams}}
+    {{#headerParams}}
+    {{#-first}}
+    // Header parameters
+    Map<String, String> localVarHeaderParams = new LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarHeaderParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
+
+    {{/-last}}
+    {{/headerParams}}
+    {{#cookieParams}}
+    {{#-first}}
+    // Cookie parameters
+    Map<String, String> localVarCookieParams = new LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarCookieParams.put("{{baseName}}", apiClient.parameterToString({{paramName}}));{{^required}}
+    }{{/required}}
+    {{#-last}}
+
+    {{/-last}}
+    {{/cookieParams}}
+    {{#formParams}}
+    {{#-first}}
+    // Form parameters
+    Map<String, Object> localVarFormParams = new LinkedHashMap<>();
+    {{/-first}}
+    {{^required}}if ({{paramName}} != null) {
+      {{/required}}localVarFormParams.put("{{baseName}}", {{paramName}});{{^required}}
+    }{{/required}}
+    {{#-last}}
+
+    {{/-last}}
+    {{/formParams}}
+    String localVarAccept = apiClient.selectHeaderAccept({{#produces}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/produces}});
+    String localVarContentType = apiClient.selectHeaderContentType({{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}});
+    {{#hasAuthMethods}}
+    String[] localVarAuthNames = {{=% %=}}new String[] {%#authMethods%"%name%"%^-last%, %/-last%%/authMethods%};%={{ }}=%
+    {{/hasAuthMethods}}
+    {{#returnType}}
+    GenericType<{{{returnType}}}> localVarReturnType = new GenericType<{{{returnType}}}>() {};
+    {{/returnType}}
+    return apiClient.invokeAPIAsync("{{classname}}.{{operationId}}", {{#hasPathParams}}localVarPath{{/hasPathParams}}{{^hasPathParams}}"{{path}}"{{/hasPathParams}}, "{{httpMethod}}", {{#queryParams}}{{#-first}}localVarQueryParams{{/-first}}{{/queryParams}}{{^queryParams}}new ArrayList<>(){{/queryParams}}, {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}},
                                {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
                                {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/api.mustache
@@ -152,7 +152,7 @@ public class {{classname}} {
   {{#isDeprecated}}
   @Deprecated
   {{/isDeprecated}}
-  public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+  public ApiResponse<{{{returnType}}}{{^returnType}}Void{{/returnType}}> {{operationId}}WithHttpInfo({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
     {{#hasRequiredParams}}
     // Check required parameters
     {{#allParams}}
@@ -232,7 +232,7 @@ public class {{classname}} {
                                {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
                                {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }
-  {{#vendorExtensions.x-group-parameters}}
+  {{/vendorExtensions.x-group-parameters}}
 
   {{^vendorExtensions.x-group-parameters}}
   /**
@@ -263,7 +263,7 @@ public class {{classname}} {
   {{#isDeprecated}}
   @Deprecated
   {{/isDeprecated}}
-  public{{/vendorExtensions.x-group-parameters}}{{#vendorExtensions.x-group-parameters}}private{{/vendorExtensions.x-group-parameters}} Future<Response> {{operationId}}WithHttpInfoAsync({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
+  public Future<Response> {{operationId}}WithHttpInfoAsync({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws ApiException {
     {{#hasRequiredParams}}
     // Check required parameters
     {{#allParams}}
@@ -343,8 +343,9 @@ public class {{classname}} {
                                {{#headerParams}}{{#-first}}localVarHeaderParams{{/-first}}{{/headerParams}}{{^headerParams}}new LinkedHashMap<>(){{/headerParams}}, {{#cookieParams}}{{#-first}}localVarCookieParams{{/-first}}{{/cookieParams}}{{^cookieParams}}new LinkedHashMap<>(){{/cookieParams}}, {{#formParams}}{{#-first}}localVarFormParams{{/-first}}{{/formParams}}{{^formParams}}new LinkedHashMap<>(){{/formParams}}, localVarAccept, localVarContentType,
                                {{#hasAuthMethods}}localVarAuthNames{{/hasAuthMethods}}{{^hasAuthMethods}}null{{/hasAuthMethods}}, {{#returnType}}localVarReturnType{{/returnType}}{{^returnType}}null{{/returnType}}, {{#bodyParam}}{{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{/bodyParam}}{{^bodyParam}}false{{/bodyParam}});
   }
-  {{#vendorExtensions.x-group-parameters}}
+  {{/vendorExtensions.x-group-parameters}}
 
+  {{#vendorExtensions.x-group-parameters}}
   public class API{{operationId}}Request {
     {{#allParams}}
     private {{{dataType}}} {{paramName}};

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2717,7 +2717,10 @@ public class JavaClientCodegenTest {
         Map<String, File> files = generator.opts(clientOptInput).generate().stream()
                 .collect(Collectors.toMap(File::getName, Function.identity()));
 
-        JavaFileAssert.assertThat(files.get("ApiClient.java"))
+        validateJavaSourceFiles(new ArrayList<>(files.values()));
+
+        JavaFileAssert javaFileAssert = JavaFileAssert.assertThat(files.get("ApiClient.java"));
+        javaFileAssert
                 .assertMethod("invokeAPIAsync")
                 .bodyContainsLines("return sendRequestAsync(method, builderAndEntity.invocationBuilder.async(), builderAndEntity.entity);");
         JavaFileAssert.assertThat(files.get("UserApi.java"))


### PR DESCRIPTION
Add Jersey2 Async methods to the auto-generated clients in case people which to use the `AsyncInvoker`.

@bbdouglas 
@sreeshas 
@jfiala 
@lukoyanov 
@cbornet 
@jeff9finger 
@karismann
@Zomzog 
@lwlee2608 
@martin-mfg

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
