### PR TITLE
[Go] validate required fields when unmarshalling JSON

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -479,13 +479,21 @@ public class GoClientCodegen extends AbstractGoCodegen {
             }
 
             // additional import for different cases
+            boolean addedFmtImport = false;
+
             // oneOf
             if (model.oneOf != null && !model.oneOf.isEmpty()) {
                 imports.add(createMapping("import", "fmt"));
+                addedFmtImport = true;
             }
 
             // anyOf
             if (model.anyOf != null && !model.anyOf.isEmpty()) {
+                imports.add(createMapping("import", "fmt"));
+                addedFmtImport = true;
+            }
+
+            if (!addedFmtImport && model.hasRequired) {
                 imports.add(createMapping("import", "fmt"));
             }
 

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -33,6 +33,12 @@ type {{classname}} struct {
 type _{{{classname}}} {{{classname}}}
 
 {{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+type _{{{classname}}} {{{classname}}}
+
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
 // New{{classname}} instantiates a new {{classname}} object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
@@ -333,6 +339,38 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+{{#requiredVars}}
+		"{{baseName}}",
+{{/requiredVars}}
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+{{/hasRequired}}
+{{#isAdditionalPropertiesTrue}}
 {{#parent}}
 {{^isMap}}
 	type {{classname}}WithoutEmbeddedStruct struct {
@@ -446,8 +484,27 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	return err
 {{/parent}}
+{{/isAdditionalPropertiesTrue}}
+{{#isAdditionalPropertiesTrue}}
 }
 
+{{/isAdditionalPropertiesTrue}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	var{{{classname}}} := _{{{classname}}}{}
+
+	err = json.Unmarshal(bytes, &var{{{classname}}})
+
+	if err != nil {
+		return err
+	}
+
+	*o = {{{classname}}}(var{{{classname}}})
+
+	return err
+}
+
+{{/hasRequired}}
 {{/isAdditionalPropertiesTrue}}
 {{#isArray}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {

--- a/samples/client/echo_api/go/model_pet.go
+++ b/samples/client/echo_api/go/model_pet.go
@@ -13,6 +13,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Pet type satisfies the MappedNullable interface at compile time
@@ -28,6 +29,8 @@ type Pet struct {
 	// pet status in the store
 	Status *string `json:"status,omitempty"`
 }
+
+type _Pet Pet
 
 // NewPet instantiates a new Pet object
 // This constructor will assign default values to properties that have it defined,
@@ -249,6 +252,42 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 		toSerialize["status"] = o.Status
 	}
 	return toSerialize, nil
+}
+
+func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+		"photoUrls",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varPet := _Pet{}
+
+	err = json.Unmarshal(bytes, &varPet)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Pet(varPet)
+
+	return err
 }
 
 type NullablePet struct {

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Animal type satisfies the MappedNullable interface at compile time
@@ -22,6 +23,8 @@ type Animal struct {
 	ClassName string `json:"className"`
 	Color *string `json:"color,omitempty"`
 }
+
+type _Animal Animal
 
 // NewAnimal instantiates a new Animal object
 // This constructor will assign default values to properties that have it defined,
@@ -116,6 +119,41 @@ func (o Animal) ToMap() (map[string]interface{}, error) {
 		toSerialize["color"] = o.Color
 	}
 	return toSerialize, nil
+}
+
+func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varAnimal := _Animal{}
+
+	err = json.Unmarshal(bytes, &varAnimal)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Animal(varAnimal)
+
+	return err
 }
 
 type NullableAnimal struct {

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the BigCat type satisfies the MappedNullable interface at compile time
@@ -22,6 +23,8 @@ type BigCat struct {
 	Cat
 	Kind *string `json:"kind,omitempty"`
 }
+
+type _BigCat BigCat
 
 // NewBigCat instantiates a new BigCat object
 // This constructor will assign default values to properties that have it defined,
@@ -97,6 +100,41 @@ func (o BigCat) ToMap() (map[string]interface{}, error) {
 		toSerialize["kind"] = o.Kind
 	}
 	return toSerialize, nil
+}
+
+func (o *BigCat) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varBigCat := _BigCat{}
+
+	err = json.Unmarshal(bytes, &varBigCat)
+
+	if err != nil {
+		return err
+	}
+
+	*o = BigCat(varBigCat)
+
+	return err
 }
 
 type NullableBigCat struct {

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Cat type satisfies the MappedNullable interface at compile time
@@ -22,6 +23,8 @@ type Cat struct {
 	Animal
 	Declawed *bool `json:"declawed,omitempty"`
 }
+
+type _Cat Cat
 
 // NewCat instantiates a new Cat object
 // This constructor will assign default values to properties that have it defined,
@@ -97,6 +100,41 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 		toSerialize["declawed"] = o.Declawed
 	}
 	return toSerialize, nil
+}
+
+func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varCat := _Cat{}
+
+	err = json.Unmarshal(bytes, &varCat)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Cat(varCat)
+
+	return err
 }
 
 type NullableCat struct {

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Category type satisfies the MappedNullable interface at compile time
@@ -22,6 +23,8 @@ type Category struct {
 	Id *int64 `json:"id,omitempty"`
 	Name string `json:"name"`
 }
+
+type _Category Category
 
 // NewCategory instantiates a new Category object
 // This constructor will assign default values to properties that have it defined,
@@ -114,6 +117,41 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["name"] = o.Name
 	return toSerialize, nil
+}
+
+func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varCategory := _Category{}
+
+	err = json.Unmarshal(bytes, &varCategory)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Category(varCategory)
+
+	return err
 }
 
 type NullableCategory struct {

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Dog type satisfies the MappedNullable interface at compile time
@@ -22,6 +23,8 @@ type Dog struct {
 	Animal
 	Breed *string `json:"breed,omitempty"`
 }
+
+type _Dog Dog
 
 // NewDog instantiates a new Dog object
 // This constructor will assign default values to properties that have it defined,
@@ -97,6 +100,41 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 		toSerialize["breed"] = o.Breed
 	}
 	return toSerialize, nil
+}
+
+func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varDog := _Dog{}
+
+	err = json.Unmarshal(bytes, &varDog)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Dog(varDog)
+
+	return err
 }
 
 type NullableDog struct {

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the EnumTest type satisfies the MappedNullable interface at compile time
@@ -25,6 +26,8 @@ type EnumTest struct {
 	EnumNumber *float64 `json:"enum_number,omitempty"`
 	OuterEnum *OuterEnum `json:"outerEnum,omitempty"`
 }
+
+type _EnumTest EnumTest
 
 // NewEnumTest instantiates a new EnumTest object
 // This constructor will assign default values to properties that have it defined,
@@ -220,6 +223,41 @@ func (o EnumTest) ToMap() (map[string]interface{}, error) {
 		toSerialize["outerEnum"] = o.OuterEnum
 	}
 	return toSerialize, nil
+}
+
+func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"enum_string_required",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varEnumTest := _EnumTest{}
+
+	err = json.Unmarshal(bytes, &varEnumTest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = EnumTest(varEnumTest)
+
+	return err
 }
 
 type NullableEnumTest struct {

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"os"
 	"time"
+	"fmt"
 )
 
 // checks if the FormatTest type satisfies the MappedNullable interface at compile time
@@ -36,6 +37,8 @@ type FormatTest struct {
 	Password string `json:"password"`
 	BigDecimal *float64 `json:"BigDecimal,omitempty"`
 }
+
+type _FormatTest FormatTest
 
 // NewFormatTest instantiates a new FormatTest object
 // This constructor will assign default values to properties that have it defined,
@@ -519,6 +522,44 @@ func (o FormatTest) ToMap() (map[string]interface{}, error) {
 		toSerialize["BigDecimal"] = o.BigDecimal
 	}
 	return toSerialize, nil
+}
+
+func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"number",
+		"byte",
+		"date",
+		"password",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varFormatTest := _FormatTest{}
+
+	err = json.Unmarshal(bytes, &varFormatTest)
+
+	if err != nil {
+		return err
+	}
+
+	*o = FormatTest(varFormatTest)
+
+	return err
 }
 
 type NullableFormatTest struct {

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Name type satisfies the MappedNullable interface at compile time
@@ -24,6 +25,8 @@ type Name struct {
 	Property *string `json:"property,omitempty"`
 	Var123Number *int32 `json:"123Number,omitempty"`
 }
+
+type _Name Name
 
 // NewName instantiates a new Name object
 // This constructor will assign default values to properties that have it defined,
@@ -184,6 +187,41 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 		toSerialize["123Number"] = o.Var123Number
 	}
 	return toSerialize, nil
+}
+
+func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varName := _Name{}
+
+	err = json.Unmarshal(bytes, &varName)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Name(varName)
+
+	return err
 }
 
 type NullableName struct {

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Pet type satisfies the MappedNullable interface at compile time
@@ -27,6 +28,8 @@ type Pet struct {
 	// pet status in the store
 	Status *string `json:"status,omitempty"`
 }
+
+type _Pet Pet
 
 // NewPet instantiates a new Pet object
 // This constructor will assign default values to properties that have it defined,
@@ -248,6 +251,42 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 		toSerialize["status"] = o.Status
 	}
 	return toSerialize, nil
+}
+
+func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+		"photoUrls",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varPet := _Pet{}
+
+	err = json.Unmarshal(bytes, &varPet)
+
+	if err != nil {
+		return err
+	}
+
+	*o = Pet(varPet)
+
+	return err
 }
 
 type NullablePet struct {

--- a/samples/client/petstore/go/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_default.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the TypeHolderDefault type satisfies the MappedNullable interface at compile time
@@ -25,6 +26,8 @@ type TypeHolderDefault struct {
 	BoolItem bool `json:"bool_item"`
 	ArrayItem []int32 `json:"array_item"`
 }
+
+type _TypeHolderDefault TypeHolderDefault
 
 // NewTypeHolderDefault instantiates a new TypeHolderDefault object
 // This constructor will assign default values to properties that have it defined,
@@ -188,6 +191,45 @@ func (o TypeHolderDefault) ToMap() (map[string]interface{}, error) {
 	toSerialize["bool_item"] = o.BoolItem
 	toSerialize["array_item"] = o.ArrayItem
 	return toSerialize, nil
+}
+
+func (o *TypeHolderDefault) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"string_item",
+		"number_item",
+		"integer_item",
+		"bool_item",
+		"array_item",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varTypeHolderDefault := _TypeHolderDefault{}
+
+	err = json.Unmarshal(bytes, &varTypeHolderDefault)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TypeHolderDefault(varTypeHolderDefault)
+
+	return err
 }
 
 type NullableTypeHolderDefault struct {

--- a/samples/client/petstore/go/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_example.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the TypeHolderExample type satisfies the MappedNullable interface at compile time
@@ -26,6 +27,8 @@ type TypeHolderExample struct {
 	BoolItem bool `json:"bool_item"`
 	ArrayItem []int32 `json:"array_item"`
 }
+
+type _TypeHolderExample TypeHolderExample
 
 // NewTypeHolderExample instantiates a new TypeHolderExample object
 // This constructor will assign default values to properties that have it defined,
@@ -211,6 +214,46 @@ func (o TypeHolderExample) ToMap() (map[string]interface{}, error) {
 	toSerialize["bool_item"] = o.BoolItem
 	toSerialize["array_item"] = o.ArrayItem
 	return toSerialize, nil
+}
+
+func (o *TypeHolderExample) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"string_item",
+		"number_item",
+		"float_item",
+		"integer_item",
+		"bool_item",
+		"array_item",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
+	varTypeHolderExample := _TypeHolderExample{}
+
+	err = json.Unmarshal(bytes, &varTypeHolderExample)
+
+	if err != nil {
+		return err
+	}
+
+	*o = TypeHolderExample(varTypeHolderExample)
+
+	return err
 }
 
 type NullableTypeHolderExample struct {

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Animal type satisfies the MappedNullable interface at compile time
@@ -127,6 +128,27 @@ func (o Animal) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varAnimal := _Animal{}
 
 	err = json.Unmarshal(bytes, &varAnimal)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the AppleReq type satisfies the MappedNullable interface at compile time
@@ -123,6 +124,27 @@ func (o AppleReq) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"cultivar",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varAppleReq := _AppleReq{}
 
 	err = json.Unmarshal(bytes, &varAppleReq)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the BananaReq type satisfies the MappedNullable interface at compile time
@@ -123,6 +124,27 @@ func (o BananaReq) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"lengthCm",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varBananaReq := _BananaReq{}
 
 	err = json.Unmarshal(bytes, &varBananaReq)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -110,6 +111,27 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	type CatWithoutEmbeddedStruct struct {
 		Declawed *bool `json:"declawed,omitempty"`
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Category type satisfies the MappedNullable interface at compile time
@@ -125,6 +126,27 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varCategory := _Category{}
 
 	err = json.Unmarshal(bytes, &varCategory)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -110,6 +111,27 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	type DogWithoutEmbeddedStruct struct {
 		Breed *string `json:"breed,omitempty"`
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the DuplicatedPropParent type satisfies the MappedNullable interface at compile time
@@ -88,6 +89,27 @@ func (o DuplicatedPropParent) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"dup-prop",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varDuplicatedPropParent := _DuplicatedPropParent{}
 
 	err = json.Unmarshal(bytes, &varDuplicatedPropParent)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the EnumTest type satisfies the MappedNullable interface at compile time
@@ -357,6 +358,27 @@ func (o EnumTest) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"enum_string_required",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varEnumTest := _EnumTest{}
 
 	err = json.Unmarshal(bytes, &varEnumTest)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"os"
 	"time"
+	"fmt"
 )
 
 // checks if the FormatTest type satisfies the MappedNullable interface at compile time
@@ -568,6 +569,30 @@ func (o FormatTest) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"number",
+		"byte",
+		"date",
+		"password",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varFormatTest := _FormatTest{}
 
 	err = json.Unmarshal(bytes, &varFormatTest)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Name type satisfies the MappedNullable interface at compile time
@@ -195,6 +196,27 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varName := _Name{}
 
 	err = json.Unmarshal(bytes, &varName)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Pet type satisfies the MappedNullable interface at compile time
@@ -263,6 +264,28 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"name",
+		"photoUrls",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varPet := _Pet{}
 
 	err = json.Unmarshal(bytes, &varPet)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Whale type satisfies the MappedNullable interface at compile time
@@ -159,6 +160,27 @@ func (o Whale) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varWhale := _Whale{}
 
 	err = json.Unmarshal(bytes, &varWhale)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // checks if the Zebra type satisfies the MappedNullable interface at compile time
@@ -123,6 +124,27 @@ func (o Zebra) ToMap() (map[string]interface{}, error) {
 }
 
 func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
+    // This validates that all required properties are included in the JSON object
+	// by unmarshalling the object into a generic map with string keys and checking
+	// that every required field exists as a key in the generic map.
+	requiredProperties := []string{
+		"className",
+	}
+
+	allProperties := make(map[string]interface{})
+
+	err = json.Unmarshal(bytes, &allProperties)
+
+	if err != nil {
+		return err;
+	}
+
+	for _, requiredProperty := range(requiredProperties) {
+		if _, exists := allProperties[requiredProperty]; !exists {
+			return fmt.Errorf("no value given for required property %v", requiredProperty)
+		}
+	}
+
 	varZebra := _Zebra{}
 
 	err = json.Unmarshal(bytes, &varZebra)

--- a/samples/openapi3/client/petstore/go/model_test.go
+++ b/samples/openapi3/client/petstore/go/model_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	sw "go-petstore"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBanana(t *testing.T) {
@@ -50,4 +51,15 @@ func TestReadOnlyFirst(t *testing.T) {
 	expected := `{"bar":"Bar value","baz":"Baz value"}`
 
 	assert.Equal(expected, (string)(json), "ReadOnlyFirst JSON is incorrect")
+}
+
+func TestRequiredFieldsAreValidated(t *testing.T) {
+	assert := assert.New(t)
+
+	newPet := (sw.Pet{})
+	jsonPet := `{"foo": "Foo value"}`
+	err := newPet.UnmarshalJSON([]byte(jsonPet))
+	expected := "no value given for required property"
+
+	assert.ErrorContains(err, expected, "Pet should return error when missing required fields")
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Relates to #12201

Code generated by the Go client generator does not validate `required` fields, which is especially problematic in `oneOf` schemas where the sub-schemas are differentiated by required fields.

For example, consider the following schema:

```yaml
components:
  schemas:
    Thing:
      oneOf:
        - $ref: '#/components/schemas/ThingWithFoo'
        - $ref: '#/components/schemas/ThingWithBar'
    ThingWithFoo:
      type: object
      properties:
        foo:
          type: string
        id:
          type: string
    required:
      - foo
    ThingWithBar:
      type: object
      properties:
        bar:
          type: string
        id:
          type: string
    required:
      - bar
```

Assume that the API itself only returns an object that has `foo` or an object that has `bar`; it will not return an object with both properties.  Existing versions of `openapi-generator` Go client generator will generate models that do not enforce required properties; as a result, any attempt to use the `Thing` model will result in an error like `Error when calling <something>: data matches more than one schema in oneOf(Thing)`.

This PR replicates the required field validation that exists in the `okhttp-gson` generator:
- Models with required properties are generated with an array of required property names
- UnmarshalJSON is updated to unmarshal the JSON into a map with string keys
- If a required property is not found in the map, UnmarshalJSON returns an error

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
