### PR TITLE
[Ruby] Add support for populating a gem metadata

### DIFF
--- a/docs/generators/ruby.md
+++ b/docs/generators/ruby.md
@@ -27,6 +27,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |gemDescription|gem description. | |This gem maps to a REST API|
 |gemHomepage|gem homepage. | |https://openapi-generator.tech|
 |gemLicense|gem license. | |unlicense|
+|gemMetadata|gem metadata.| |{}|
 |gemName|gem name (convention: underscore_case).| |openapi_client|
 |gemRequiredRubyVersion|gem required Ruby version. | |&gt;= 2.4|
 |gemSummary|gem summary. | |A ruby wrapper for the REST APIs|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -48,6 +48,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     public static final String GEM_DESCRIPTION = "gemDescription";
     public static final String GEM_AUTHOR = "gemAuthor";
     public static final String GEM_AUTHOR_EMAIL = "gemAuthorEmail";
+    public static final String GEM_METADATA = "gemMetadata";
     public static final String FARADAY = "faraday";
     public static final String HTTPX = "httpx";
     public static final String TYPHOEUS = "typhoeus";
@@ -66,6 +67,7 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
     protected String gemSummary = "A Ruby SDK for the REST API";
     protected String gemDescription = "This gem maps to a REST API";
     protected String gemAuthor = "";
+    protected String gemMetadata = "{}";
     protected String gemAuthorEmail = "";
     protected String apiDocPath = "docs/";
     protected String modelDocPath = "docs/";
@@ -170,6 +172,9 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
         cliOptions.add(new CliOption(GEM_AUTHOR_EMAIL, "gem author email (only one is supported)."));
 
+        cliOptions.add(new CliOption(GEM_METADATA, "gem metadata.").
+                defaultValue("{}"));
+
         cliOptions.add(new CliOption(CodegenConstants.HIDE_GENERATION_TIMESTAMP, CodegenConstants.HIDE_GENERATION_TIMESTAMP_DESC).
                 defaultValue(Boolean.TRUE.toString()));
 
@@ -244,6 +249,10 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
         if (additionalProperties.containsKey(GEM_AUTHOR_EMAIL)) {
             setGemAuthorEmail((String) additionalProperties.get(GEM_AUTHOR_EMAIL));
+        }
+
+        if (additionalProperties.containsKey(GEM_METADATA)) {
+            setGemMetadata((String) additionalProperties.get(GEM_METADATA));
         }
 
         if (additionalProperties.containsKey(USE_AUTOLOAD)) {
@@ -611,6 +620,10 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
     public void setGemAuthorEmail(String gemAuthorEmail) {
         this.gemAuthorEmail = gemAuthorEmail;
+    }
+
+    public void setGemMetadata(String gemMetadata) {
+        this.gemMetadata = gemMetadata;
     }
 
     public void setUseAutoload(boolean useAutoload) {

--- a/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/gemspec.mustache
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.description = "{{gemDescription}}{{^gemDescription}}{{{appDescription}}}{{^appDescription}}{{{appName}}} Ruby Gem{{/appDescription}}{{/gemDescription}}"
   s.license     = "{{{gemLicense}}}{{^gemLicense}}Unlicense{{/gemLicense}}"
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 2.7{{/gemRequiredRubyVersion}}"
+  s.metadata    = {{{gemMetadata}}}{{^gemMetadata}}{}{{/gemMetadata}}
 
   {{#isFaraday}}
   s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/RubyClientOptionsProvider.java
@@ -36,6 +36,7 @@ public class RubyClientOptionsProvider implements OptionsProvider {
     public static final String GEM_SUMMARY_VALUE = "summary";
     public static final String GEM_DESCRIPTION_VALUE = "description";
     public static final String GEM_AUTHOR_VALUE = "foo";
+    public static final String GEM_METADATA_VALUE = "{}";
     public static final String GEM_AUTHOR_EMAIL_VALUE = "foo";
     public static final String ALLOW_UNICODE_IDENTIFIERS_VALUE = "false";
     public static final String PREPEND_FORM_OR_BODY_PARAMETERS_VALUE = "true";
@@ -61,6 +62,7 @@ public class RubyClientOptionsProvider implements OptionsProvider {
                 .put(RubyClientCodegen.GEM_SUMMARY, GEM_SUMMARY_VALUE)
                 .put(RubyClientCodegen.GEM_AUTHOR, GEM_AUTHOR_VALUE)
                 .put(RubyClientCodegen.GEM_AUTHOR_EMAIL, GEM_AUTHOR_EMAIL_VALUE)
+                .put(RubyClientCodegen.GEM_METADATA, GEM_METADATA_VALUE)
                 .put(CodegenConstants.SORT_PARAMS_BY_REQUIRED_FLAG, SORT_PARAMS_VALUE)
                 .put(CodegenConstants.SORT_MODEL_PROPERTIES_BY_REQUIRED_FLAG, SORT_MODEL_PROPERTIES_VALUE)
                 .put(CodegenConstants.ENSURE_UNIQUE_PARAMS, ENSURE_UNIQUE_PARAMS_VALUE)

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ruby/RubyClientOptionsTest.java
@@ -50,6 +50,7 @@ public class RubyClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setGemSummary(RubyClientOptionsProvider.GEM_SUMMARY_VALUE);
         verify(clientCodegen).setGemAuthor(RubyClientOptionsProvider.GEM_AUTHOR_VALUE);
         verify(clientCodegen).setGemAuthorEmail(RubyClientOptionsProvider.GEM_AUTHOR_EMAIL_VALUE);
+        verify(clientCodegen).setGemMetadata(RubyClientOptionsProvider.GEM_METADATA_VALUE);
         verify(clientCodegen).setEnumUnknownDefaultCase(Boolean.parseBoolean(RubyClientOptionsProvider.ENUM_UNKNOWN_DEFAULT_CASE_VALUE));
         verify(clientCodegen).setUseAutoload(Boolean.parseBoolean(RubyClientOptionsProvider.USE_AUTOLOAD_VALUE));
     }

--- a/samples/client/echo_api/ruby-httpx/openapi_client.gemspec
+++ b/samples/client/echo_api/ruby-httpx/openapi_client.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "Echo Server API"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'httpx', '~> 1.0', '>= 1.0.0'
 

--- a/samples/client/petstore/ruby-autoload/petstore.gemspec
+++ b/samples/client/petstore/ruby-autoload/petstore.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/client/petstore/ruby-faraday/petstore.gemspec
+++ b/samples/client/petstore/ruby-faraday/petstore.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'
   s.add_runtime_dependency 'faraday-multipart'

--- a/samples/client/petstore/ruby-httpx/petstore.gemspec
+++ b/samples/client/petstore/ruby-httpx/petstore.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'httpx', '~> 1.0', '>= 1.0.0'
 

--- a/samples/client/petstore/ruby/petstore.gemspec
+++ b/samples/client/petstore/ruby/petstore.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This spec is mainly for testing Petstore server and contains fake endpoints, models. Please do not use this for any other purpose. Special characters: \" \\"
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/x_auth_id_alias.gemspec
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/ruby-client/x_auth_id_alias.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This specification shows how to use x-auth-id-alias extension for API keys."
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/openapi3/client/features/dynamic-servers/ruby/dynamic_servers.gemspec
+++ b/samples/openapi3/client/features/dynamic-servers/ruby/dynamic_servers.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This specification shows how to use dynamic servers."
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/petstore.gemspec
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/petstore.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.description = "This specification shows how to generate aliases to maps and arrays as models."
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 2.7"
+  s.metadata    = {}
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 


### PR DESCRIPTION
Currently there is no easy way to specify a gem's metadata. [Metadata](https://guides.rubygems.org/specification-reference/#metadata) is often used to reference related links for a given gem, but is otherwise a generic key/value dictionary that can be looked up by consumers of the gem. For example, can be used to specify if multi factor authentication is required when publishing on rubygems ([rails example](https://github.com/rails/rails/blob/main/rails.gemspec#L29)).

This pull request adds support for populating a gem's metadata by introducing an additional property (`gemMetadata`). This can be any arbitrary object, even though it should follow the rubygems [specs](https://guides.rubygems.org/specification-reference/#metadata).

I briefly considered using a list of entries instead where each entry would be a key/value pair in the hash. However the somewhat arbitrary nature of values (urls, strings, bools, ...) make the implementation quite complex with very little return of investment, given that complex cases with this PR can be easily worked around by just using a multiline yaml in the config file. E.g. something like this produces the correct result:

```yaml
additionalProperties:
  gemMetadata: >
  {
    "bug_tracker_uri"   => "https://google.com",
    "rubygems_mfa_required" => "true",
  }
```

Fixes #16870

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc @cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
