### PR TITLE
[PHP-SYMFONY] Debug Date and DateTime Assert

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/model_variables.mustache
@@ -42,11 +42,11 @@
 {{/isContainer}}
 {{^isContainer}}
     {{#isDate}}
-     * @Assert\Date()
+     * @Assert\Type("\Date")
      * @Type("DateTime<'Y-m-d'>")
     {{/isDate}}
     {{#isDateTime}}
-     * @Assert\DateTime()
+     * @Assert\Type("\DateTime"))
      * @Type("DateTime")
     {{/isDateTime}}
     {{^isDate}}

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Order.php
@@ -71,7 +71,7 @@ class Order
     /**
      * @var \DateTime|null
      * @SerializedName("shipDate")
-     * @Assert\DateTime()
+     * @Assert\Type("\DateTime"))
      * @Type("DateTime")
      */
     protected ?\DateTime $shipDate = null;


### PR DESCRIPTION
Previously a DateTime properties was generated like that:
```php
/**
 * @var \DateTime|null
 * @SerializedName("shipDate")
 * @Assert\DateTime()
 * @Type("DateTime")
 */
protected ?\DateTime $shipDate = null;
```
But when in our server base code, if we want to valid our object with Symfony\Component\Validator\Validator\ValidatorInterface (see [Symfony doc](https://symfony.com/doc/current/validation.html)), we have this error : `This value should be of type `

When we read [this documentation](https://symfony.com/doc/current/reference/constraints/DateTime.html) we understand why : our parameter is a DateTime type, not a string like in their example.

So we need to change this assert `@Assert\DateTime()` by `@Assert\Type("\DateTime"))`

All of this is similar with Date type.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
