### PR TITLE
Prevent direnv errors when not using nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+has nix && use flake


### PR DESCRIPTION
Right now, if a developer uses `direnv` but does not use `nix`, an error
is reported whenever changing into the OpenAPI generator directory:

```console
$ cd ~/oss/forks/openapi-generator
direnv: loading ~/oss/forks/openapi-generator/.envrc
direnv: using flake
environment:1270: nix: command not found
```

This uses the `has()` function to check for `nix` to *conditionally* run
the `use_flake` function.
