### PR TITLE
replace allow_population_by_field_name by populate_by_name

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
@@ -75,7 +75,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
 {{#hasChildren}}

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/bird.py
@@ -32,7 +32,7 @@ class Bird(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/category.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/category.py
@@ -32,7 +32,7 @@ class Category(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
@@ -34,7 +34,7 @@ class DataQuery(Query):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/default_value.py
@@ -50,7 +50,7 @@ class DefaultValue(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/number_properties_only.py
@@ -33,7 +33,7 @@ class NumberPropertiesOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
@@ -48,7 +48,7 @@ class Pet(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
@@ -43,7 +43,7 @@ class Query(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/tag.py
@@ -32,7 +32,7 @@ class Tag(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -34,7 +34,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -31,7 +31,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesAnyType(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_class.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_object.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesObject(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -32,7 +32,7 @@ class AllOfWithSingleRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
@@ -31,7 +31,7 @@ class Animal(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     # JSON field name that stores the object type

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/api_response.py
@@ -32,7 +32,7 @@ class ApiResponse(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -31,7 +31,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -30,7 +30,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
@@ -30,7 +30,7 @@ class ArrayOfNumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_test.py
@@ -33,7 +33,7 @@ class ArrayTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
@@ -31,7 +31,7 @@ class BasquePig(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
@@ -35,7 +35,7 @@ class Capitalization(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/cat.py
@@ -31,7 +31,7 @@ class Cat(Animal):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/category.py
@@ -31,7 +31,7 @@ class Category(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/circular_reference_model.py
@@ -31,7 +31,7 @@ class CircularReferenceModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
@@ -30,7 +30,7 @@ class ClassModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/client.py
@@ -30,7 +30,7 @@ class Client(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/creature.py
@@ -32,7 +32,7 @@ class Creature(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/creature_info.py
@@ -30,7 +30,7 @@ class CreatureInfo(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
@@ -31,7 +31,7 @@ class DanishPig(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/deprecated_object.py
@@ -30,7 +30,7 @@ class DeprecatedObject(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/dog.py
@@ -31,7 +31,7 @@ class Dog(Animal):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/dummy_model.py
@@ -31,7 +31,7 @@ class DummyModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_arrays.py
@@ -52,7 +52,7 @@ class EnumArrays(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -89,7 +89,7 @@ class EnumTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
@@ -30,7 +30,7 @@ class File(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -32,7 +32,7 @@ class FileSchemaTestClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/first_ref.py
@@ -31,7 +31,7 @@ class FirstRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/foo.py
@@ -30,7 +30,7 @@ class Foo(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -31,7 +31,7 @@ class FooGetDefaultResponse(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
@@ -86,7 +86,7 @@ class FormatTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/has_only_read_only.py
@@ -31,7 +31,7 @@ class HasOnlyReadOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
@@ -30,7 +30,7 @@ class HealthCheckResult(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -30,7 +30,7 @@ class InnerDictWithProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list.py
@@ -30,7 +30,7 @@ class List(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
@@ -30,7 +30,7 @@ class ListClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -31,7 +31,7 @@ class MapOfArrayOfModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_test.py
@@ -43,7 +43,7 @@ class MapTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -33,7 +33,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
@@ -31,7 +31,7 @@ class Model200Response(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
@@ -30,7 +30,7 @@ class ModelReturn(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
@@ -33,7 +33,7 @@ class Name(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/nullable_class.py
@@ -43,7 +43,7 @@ class NullableClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/nullable_property.py
@@ -41,7 +41,7 @@ class NullableProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
@@ -30,7 +30,7 @@ class NumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -30,7 +30,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -34,7 +34,7 @@ class ObjectWithDeprecatedFields(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
@@ -45,7 +45,7 @@ class Order(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_composite.py
@@ -32,7 +32,7 @@ class OuterComposite(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -33,7 +33,7 @@ class OuterObjectWithEnumProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
@@ -31,7 +31,7 @@ class Parent(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -31,7 +31,7 @@ class ParentWithOptionalDict(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
@@ -47,7 +47,7 @@ class Pet(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
@@ -32,7 +32,7 @@ class PropertyNameCollision(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/read_only_first.py
@@ -31,7 +31,7 @@ class ReadOnlyFirst(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/second_ref.py
@@ -31,7 +31,7 @@ class SecondRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/self_reference_model.py
@@ -31,7 +31,7 @@ class SelfReferenceModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
@@ -30,7 +30,7 @@ class SpecialModelName(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
@@ -43,7 +43,7 @@ class SpecialName(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/tag.py
@@ -31,7 +31,7 @@ class Tag(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -31,7 +31,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/tiger.py
@@ -30,7 +30,7 @@ class Tiger(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -31,7 +31,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -30,7 +30,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
@@ -37,7 +37,7 @@ class User(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -34,7 +34,7 @@ class WithNestedOneOf(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_any_type.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesAnyType(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_class.py
@@ -32,7 +32,7 @@ class AdditionalPropertiesClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_object.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesObject(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/additional_properties_with_description_only.py
@@ -31,7 +31,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
@@ -33,7 +33,7 @@ class AllOfWithSingleRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
@@ -32,7 +32,7 @@ class Animal(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     # JSON field name that stores the object type

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/api_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/api_response.py
@@ -33,7 +33,7 @@ class ApiResponse(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_model.py
@@ -32,7 +32,7 @@ class ArrayOfArrayOfModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
@@ -31,7 +31,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
@@ -31,7 +31,7 @@ class ArrayOfNumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_test.py
@@ -34,7 +34,7 @@ class ArrayTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
@@ -32,7 +32,7 @@ class BasquePig(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
@@ -36,7 +36,7 @@ class Capitalization(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/cat.py
@@ -32,7 +32,7 @@ class Cat(Animal):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/category.py
@@ -32,7 +32,7 @@ class Category(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/circular_reference_model.py
@@ -32,7 +32,7 @@ class CircularReferenceModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
@@ -31,7 +31,7 @@ class ClassModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/client.py
@@ -31,7 +31,7 @@ class Client(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/creature.py
@@ -33,7 +33,7 @@ class Creature(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/creature_info.py
@@ -31,7 +31,7 @@ class CreatureInfo(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
@@ -32,7 +32,7 @@ class DanishPig(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/deprecated_object.py
@@ -31,7 +31,7 @@ class DeprecatedObject(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/dog.py
@@ -32,7 +32,7 @@ class Dog(Animal):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/dummy_model.py
@@ -32,7 +32,7 @@ class DummyModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_arrays.py
@@ -53,7 +53,7 @@ class EnumArrays(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -90,7 +90,7 @@ class EnumTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
@@ -31,7 +31,7 @@ class File(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file_schema_test_class.py
@@ -33,7 +33,7 @@ class FileSchemaTestClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/first_ref.py
@@ -32,7 +32,7 @@ class FirstRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/foo.py
@@ -31,7 +31,7 @@ class Foo(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/foo_get_default_response.py
@@ -32,7 +32,7 @@ class FooGetDefaultResponse(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
@@ -87,7 +87,7 @@ class FormatTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/has_only_read_only.py
@@ -32,7 +32,7 @@ class HasOnlyReadOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
@@ -31,7 +31,7 @@ class HealthCheckResult(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
@@ -31,7 +31,7 @@ class InnerDictWithProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list.py
@@ -31,7 +31,7 @@ class List(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
@@ -31,7 +31,7 @@ class ListClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
@@ -32,7 +32,7 @@ class MapOfArrayOfModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_test.py
@@ -44,7 +44,7 @@ class MapTest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -34,7 +34,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
@@ -32,7 +32,7 @@ class Model200Response(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
@@ -31,7 +31,7 @@ class ModelReturn(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
@@ -34,7 +34,7 @@ class Name(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/nullable_class.py
@@ -43,7 +43,7 @@ class NullableClass(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/nullable_property.py
@@ -42,7 +42,7 @@ class NullableProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
@@ -31,7 +31,7 @@ class NumberOnly(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
@@ -31,7 +31,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
@@ -35,7 +35,7 @@ class ObjectWithDeprecatedFields(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
@@ -46,7 +46,7 @@ class Order(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_composite.py
@@ -33,7 +33,7 @@ class OuterComposite(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/outer_object_with_enum_property.py
@@ -34,7 +34,7 @@ class OuterObjectWithEnumProperty(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
@@ -32,7 +32,7 @@ class Parent(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
@@ -32,7 +32,7 @@ class ParentWithOptionalDict(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
@@ -48,7 +48,7 @@ class Pet(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
@@ -33,7 +33,7 @@ class PropertyNameCollision(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/read_only_first.py
@@ -32,7 +32,7 @@ class ReadOnlyFirst(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/second_ref.py
@@ -32,7 +32,7 @@ class SecondRef(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/self_reference_model.py
@@ -32,7 +32,7 @@ class SelfReferenceModel(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
@@ -31,7 +31,7 @@ class SpecialModelName(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
@@ -44,7 +44,7 @@ class SpecialName(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/tag.py
@@ -32,7 +32,7 @@ class Tag(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -31,7 +31,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/tiger.py
@@ -31,7 +31,7 @@ class Tiger(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -32,7 +32,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -31,7 +31,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
@@ -38,7 +38,7 @@ class User(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/with_nested_one_of.py
@@ -35,7 +35,7 @@ class WithNestedOneOf(BaseModel):
 
     class Config:
         """Pydantic configuration"""
-        allow_population_by_field_name = True
+        populate_by_name = True
         validate_assignment = True
 
     def to_str(self) -> str:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
According to this [Migration Guide](https://docs.pydantic.dev/latest/migration/) allow_population_by_field_name is deprecated and should be replaced by populate_by_name. 

This caused the generated api to have some unexpected behavior, which could be fixed by adjusting this.  
<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
