### PR TITLE
[csharp] use full qualified name to fix cases where generated code doesn't build

### DIFF
--- a/samples/client/echo_api/csharp-restsharp/docs/BodyApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/BodyApi.md
@@ -373,7 +373,7 @@ No authorization required
 
 <a id="testechobodypet"></a>
 # **TestEchoBodyPet**
-> Pet TestEchoBodyPet (Pet? pet = null)
+> Model.Pet TestEchoBodyPet (Pet? pet = null)
 
 Test body parameter(s)
 
@@ -401,7 +401,7 @@ namespace Example
             try
             {
                 // Test body parameter(s)
-                Pet result = apiInstance.TestEchoBodyPet(pet);
+                Model.Pet result = apiInstance.TestEchoBodyPet(pet);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -422,7 +422,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Test body parameter(s)
-    ApiResponse<Pet> response = apiInstance.TestEchoBodyPetWithHttpInfo(pet);
+    ApiResponse<Model.Pet> response = apiInstance.TestEchoBodyPetWithHttpInfo(pet);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -443,7 +443,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet TestEchoBodyPet(Pet? pet = default(Pet?), int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet TestEchoBodyPet(Pet? pet = default(Pet?), int operationIndex = 0);
 
         /// <summary>
         /// Test body parameter(s)
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> TestEchoBodyPetWithHttpInfo(Pet? pet = default(Pet?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> TestEchoBodyPetWithHttpInfo(Pet? pet = default(Pet?), int operationIndex = 0);
         /// <summary>
         /// Test empty response body
         /// </summary>
@@ -303,8 +303,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> TestEchoBodyPetAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> TestEchoBodyPetAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Test body parameter(s)
@@ -316,8 +316,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> TestEchoBodyPetWithHttpInfoAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> TestEchoBodyPetWithHttpInfoAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test empty response body
         /// </summary>
@@ -1040,10 +1040,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet TestEchoBodyPet(Pet? pet = default(Pet?), int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet TestEchoBodyPet(Pet? pet = default(Pet?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = TestEchoBodyPetWithHttpInfo(pet);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = TestEchoBodyPetWithHttpInfo(pet);
             return localVarResponse.Data;
         }
 
@@ -1053,8 +1053,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> TestEchoBodyPetWithHttpInfo(Pet? pet = default(Pet?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> TestEchoBodyPetWithHttpInfo(Pet? pet = default(Pet?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1086,7 +1086,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Pet>("/echo/body/Pet", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Pet>("/echo/body/Pet", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestEchoBodyPet", localVarResponse);
@@ -1106,10 +1106,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> TestEchoBodyPetAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> TestEchoBodyPetAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await TestEchoBodyPetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await TestEchoBodyPetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1120,8 +1120,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> TestEchoBodyPetWithHttpInfoAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> TestEchoBodyPetWithHttpInfoAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Pet>("/echo/body/Pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Pet>("/echo/body/Pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/README.md
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/README.md
@@ -94,7 +94,7 @@ namespace Example
             try
             {
                 // parameter name mapping test
-                Env result = apiInstance.GetParameterNameMapping(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
+                Model.Env result = apiInstance.GetParameterNameMapping(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/FakeApi.md
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/FakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://localhost*
 
 <a id="getparameternamemapping"></a>
 # **GetParameterNameMapping**
-> Env GetParameterNameMapping (long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption)
+> Model.Env GetParameterNameMapping (long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption)
 
 parameter name mapping test
 
@@ -37,7 +37,7 @@ namespace Example
             try
             {
                 // parameter name mapping test
-                Env result = apiInstance.GetParameterNameMapping(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
+                Model.Env result = apiInstance.GetParameterNameMapping(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -58,7 +58,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // parameter name mapping test
-    ApiResponse<Env> response = apiInstance.GetParameterNameMappingWithHttpInfo(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
+    ApiResponse<Model.Env> response = apiInstance.GetParameterNameMappingWithHttpInfo(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -82,7 +82,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Env**](Env.md)
+[**Model.Env**](Env.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -35,8 +35,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="TypeWithUnderscore">type_</param>
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Env</returns>
-        Env GetParameterNameMapping(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0);
+        /// <returns>Model.Env</returns>
+        Model.Env GetParameterNameMapping(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0);
 
         /// <summary>
         /// parameter name mapping test
@@ -50,8 +50,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="TypeWithUnderscore">type_</param>
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Env</returns>
-        ApiResponse<Env> GetParameterNameMappingWithHttpInfo(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Env</returns>
+        ApiResponse<Model.Env> GetParameterNameMappingWithHttpInfo(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -74,8 +74,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Env</returns>
-        System.Threading.Tasks.Task<Env> GetParameterNameMappingAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Env</returns>
+        System.Threading.Tasks.Task<Model.Env> GetParameterNameMappingAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// parameter name mapping test
@@ -90,8 +90,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Env)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Env>> GetParameterNameMappingWithHttpInfoAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Env)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Env>> GetParameterNameMappingWithHttpInfoAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -221,10 +221,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="TypeWithUnderscore">type_</param>
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Env</returns>
-        public Env GetParameterNameMapping(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0)
+        /// <returns>Model.Env</returns>
+        public Model.Env GetParameterNameMapping(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Env> localVarResponse = GetParameterNameMappingWithHttpInfo(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
+            Org.OpenAPITools.Client.ApiResponse<Model.Env> localVarResponse = GetParameterNameMappingWithHttpInfo(UnderscoreType, type, TypeWithUnderscore, httpDebugOption);
             return localVarResponse.Data;
         }
 
@@ -237,8 +237,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="TypeWithUnderscore">type_</param>
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Env</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Env> GetParameterNameMappingWithHttpInfo(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Env</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Env> GetParameterNameMappingWithHttpInfo(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0)
         {
             // verify the required parameter 'type' is set
             if (type == null)
@@ -290,7 +290,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Env>("/fake/parameter-name-mapping", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Env>("/fake/parameter-name-mapping", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetParameterNameMapping", localVarResponse);
@@ -313,10 +313,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Env</returns>
-        public async System.Threading.Tasks.Task<Env> GetParameterNameMappingAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Env</returns>
+        public async System.Threading.Tasks.Task<Model.Env> GetParameterNameMappingAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Env> localVarResponse = await GetParameterNameMappingWithHttpInfoAsync(UnderscoreType, type, TypeWithUnderscore, httpDebugOption, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Env> localVarResponse = await GetParameterNameMappingWithHttpInfoAsync(UnderscoreType, type, TypeWithUnderscore, httpDebugOption, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="httpDebugOption">http debug option (to test parameter naming option)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Env)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Env>> GetParameterNameMappingWithHttpInfoAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Env)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Env>> GetParameterNameMappingWithHttpInfoAsync(long UnderscoreType, string type, string TypeWithUnderscore, string httpDebugOption, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'type' is set
             if (type == null)
@@ -384,7 +384,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Env>("/fake/parameter-name-mapping", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Env>("/fake/parameter-name-mapping", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/README.md
@@ -81,7 +81,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
+> Model.ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/docs/apis/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/src/UseSourceGeneration/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/src/UseSourceGeneration/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IAnotherFakeApi>();
             Call123TestSpecialTagsApiResponse apiResponse = await api.Call123TestSpecialTagsAsync("todo");
-            ModelClient model = apiResponse.Ok();
+            Model.ModelClient model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
+> Model.ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/docs/apis/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IAnotherFakeApi>();
             Call123TestSpecialTagsApiResponse apiResponse = await api.Call123TestSpecialTagsAsync("todo");
-            ModelClient model = apiResponse.Ok();
+            Model.ModelClient model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
+> Model.ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/docs/apis/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IAnotherFakeApi>();
             Call123TestSpecialTagsApiResponse apiResponse = await api.Call123TestSpecialTagsAsync("todo");
-            ModelClient model = apiResponse.Ok();
+            Model.ModelClient model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/docs/apis/DefaultApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://api.example.xyz/v1*
 
 <a id="list"></a>
 # **List**
-> Person List (string personId)
+> Model.Person List (string personId)
 
 
 
@@ -33,7 +33,7 @@ namespace Example
 
             try
             {
-                Person result = apiInstance.List(personId);
+                Model.Person result = apiInstance.List(personId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -53,7 +53,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<Person> response = apiInstance.ListWithHttpInfo(personId);
+    ApiResponse<Model.Person> response = apiInstance.ListWithHttpInfo(personId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -74,7 +74,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Person**](Person.md)
+[**Model.Person**](Person.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IDefaultApi>();
             ListApiResponse apiResponse = await api.ListAsync("todo");
-            Person model = apiResponse.Ok();
+            Model.Person model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/docs/apis/DefaultApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://localhost*
 
 <a id="rootget"></a>
 # **RootGet**
-> Fruit RootGet ()
+> Model.Fruit RootGet ()
 
 
 
@@ -32,7 +32,7 @@ namespace Example
 
             try
             {
-                Fruit result = apiInstance.RootGet();
+                Model.Fruit result = apiInstance.RootGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -52,7 +52,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<Fruit> response = apiInstance.RootGetWithHttpInfo();
+    ApiResponse<Model.Fruit> response = apiInstance.RootGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -69,7 +69,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**Fruit**](Fruit.md)
+[**Model.Fruit**](Fruit.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IDefaultApi>();
             RootGetApiResponse apiResponse = await api.RootGetAsync("todo");
-            Fruit model = apiResponse.Ok();
+            Model.Fruit model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/docs/apis/DefaultApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://localhost*
 
 <a id="rootget"></a>
 # **RootGet**
-> Fruit RootGet ()
+> Model.Fruit RootGet ()
 
 
 
@@ -32,7 +32,7 @@ namespace Example
 
             try
             {
-                Fruit result = apiInstance.RootGet();
+                Model.Fruit result = apiInstance.RootGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -52,7 +52,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<Fruit> response = apiInstance.RootGetWithHttpInfo();
+    ApiResponse<Model.Fruit> response = apiInstance.RootGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -69,7 +69,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**Fruit**](Fruit.md)
+[**Model.Fruit**](Fruit.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IDefaultApi>();
             RootGetApiResponse apiResponse = await api.RootGetAsync("todo");
-            Fruit model = apiResponse.Ok();
+            Model.Fruit model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
+> Model.ApiResponse UploadFile (long petId, System.IO.Stream file = null, string additionalMetadata = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, file, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, file, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (System.IO.Stream requiredFile, long petId, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(requiredFile, petId, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(requiredFile, petId, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/docs/apis/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netstandard2.0/src/Org.OpenAPITools/README.md
@@ -62,7 +62,7 @@ namespace YourProject
             var host = CreateHostBuilder(args).Build();
             var api = host.Services.GetRequiredService<IAnotherFakeApi>();
             Call123TestSpecialTagsApiResponse apiResponse = await api.Call123TestSpecialTagsAsync("todo");
-            ModelClient model = apiResponse.Ok();
+            Model.ModelClient model = apiResponse.Ok();
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) => Host.CreateDefaultBuilder(args)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/README.md
@@ -106,7 +106,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -40,7 +40,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -61,7 +61,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -82,7 +82,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -40,7 +40,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -60,7 +60,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -77,7 +77,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -361,7 +361,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -390,7 +390,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -411,7 +411,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -52,7 +52,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -73,7 +73,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -90,7 +90,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -204,7 +204,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -235,7 +235,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -255,7 +255,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -276,7 +276,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -751,7 +751,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -783,7 +783,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -804,7 +804,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -825,7 +825,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -45,7 +45,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -66,7 +66,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -87,7 +87,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/PetApi.md
@@ -400,7 +400,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -437,7 +437,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -458,7 +458,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -479,7 +479,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -692,7 +692,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, FileParameter file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, FileParameter file = null)
 
 uploads an image
 
@@ -727,7 +727,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -748,7 +748,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -771,7 +771,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -792,7 +792,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, FileParameter requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, FileParameter requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -827,7 +827,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -848,7 +848,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -871,7 +871,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/StoreApi.md
@@ -198,7 +198,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -230,7 +230,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -251,7 +251,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -272,7 +272,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -295,7 +295,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -325,7 +325,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -346,7 +346,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -367,7 +367,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/UserApi.md
@@ -376,7 +376,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -406,7 +406,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -427,7 +427,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -448,7 +448,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -35,8 +35,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient);
 
         /// <summary>
         /// To test special tags
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient);
         #endregion Synchronous Operations
     }
 
@@ -66,8 +66,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -78,8 +78,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -298,10 +298,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -310,8 +310,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -338,7 +338,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -355,10 +355,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -399,7 +399,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -31,8 +31,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet();
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet();
 
         /// <summary>
         /// 
@@ -41,8 +41,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo();
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo();
         /// <summary>
         /// 
         /// </summary>
@@ -100,8 +100,8 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test();
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test();
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -110,8 +110,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo();
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo();
         #endregion Synchronous Operations
     }
 
@@ -129,8 +129,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -215,8 +215,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -226,8 +226,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -445,10 +445,10 @@ namespace Org.OpenAPITools.Api
         ///  
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet()
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet()
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -456,8 +456,8 @@ namespace Org.OpenAPITools.Api
         ///  
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo()
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -478,7 +478,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -494,10 +494,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -506,8 +506,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -531,7 +531,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -861,10 +861,10 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test()
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test()
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -872,8 +872,8 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo()
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -894,7 +894,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -910,10 +910,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -922,8 +922,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -947,7 +947,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -31,8 +31,8 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet();
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet();
 
         /// <summary>
         /// Health check endpoint
@@ -41,8 +41,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo();
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo();
         /// <summary>
         /// 
         /// </summary>
@@ -72,8 +72,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite));
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite));
 
         /// <summary>
         /// 
@@ -83,8 +83,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite));
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite));
         /// <summary>
         /// 
         /// </summary>
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -205,8 +205,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -430,8 +430,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -441,8 +441,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -487,8 +487,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -615,8 +615,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -627,8 +627,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1075,10 +1075,10 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet()
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet()
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1086,8 +1086,8 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo()
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1108,7 +1108,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1124,10 +1124,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1136,8 +1136,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1161,7 +1161,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1286,10 +1286,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite))
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1298,8 +1298,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite))
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite))
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1322,7 +1322,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1339,10 +1339,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1352,8 +1352,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1379,7 +1379,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1960,10 +1960,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -1972,8 +1972,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2000,7 +2000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2017,10 +2017,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2030,8 +2030,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2061,7 +2061,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -35,8 +35,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient);
 
         /// <summary>
         /// To test class name in snake case
@@ -46,8 +46,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient);
         #endregion Synchronous Operations
     }
 
@@ -66,8 +66,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -78,8 +78,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -298,10 +298,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -310,8 +310,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -343,7 +343,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -360,10 +360,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -373,8 +373,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -409,7 +409,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -117,8 +117,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId);
 
         /// <summary>
         /// Find pet by ID
@@ -128,8 +128,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -177,8 +177,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter));
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter));
 
         /// <summary>
         /// uploads an image
@@ -190,8 +190,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter));
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -199,8 +199,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, FileParameter requiredFile, string additionalMetadata = default(string));
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, FileParameter requiredFile, string additionalMetadata = default(string));
 
         /// <summary>
         /// uploads an image (required)
@@ -212,8 +212,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, FileParameter requiredFile, string additionalMetadata = default(string));
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, FileParameter requiredFile, string additionalMetadata = default(string));
         #endregion Synchronous Operations
     }
 
@@ -328,8 +328,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -340,8 +340,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -403,8 +403,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -417,8 +417,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -430,8 +430,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -444,8 +444,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1276,10 +1276,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1288,8 +1288,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1317,7 +1317,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1334,10 +1334,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1347,8 +1347,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1379,7 +1379,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1697,10 +1697,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter))
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1711,8 +1711,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter))
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter))
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1749,7 +1749,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1768,10 +1768,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1783,8 +1783,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), FileParameter file = default(FileParameter), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1824,7 +1824,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1842,10 +1842,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, FileParameter requiredFile, string additionalMetadata = default(string))
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, FileParameter requiredFile, string additionalMetadata = default(string))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -1856,8 +1856,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, FileParameter requiredFile, string additionalMetadata = default(string))
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, FileParameter requiredFile, string additionalMetadata = default(string))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -1896,7 +1896,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1915,10 +1915,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1930,8 +1930,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, FileParameter requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -1973,7 +1973,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -75,8 +75,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId);
 
         /// <summary>
         /// Find purchase order by ID
@@ -86,15 +86,15 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order);
 
         /// <summary>
         /// Place an order for a pet
@@ -104,8 +104,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order);
         #endregion Synchronous Operations
     }
 
@@ -168,8 +168,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -180,8 +180,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -191,8 +191,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -203,8 +203,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -645,10 +645,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -657,8 +657,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -681,7 +681,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -698,10 +698,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -711,8 +711,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -738,7 +738,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -754,10 +754,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -766,8 +766,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -795,7 +795,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -812,10 +812,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -825,8 +825,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -857,7 +857,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Api/UserApi.cs
@@ -110,8 +110,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username);
 
         /// <summary>
         /// Get user by user name
@@ -121,8 +121,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -292,8 +292,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -304,8 +304,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1045,10 +1045,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1057,8 +1057,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1085,7 +1085,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1102,10 +1102,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1115,8 +1115,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1146,7 +1146,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/README.md
@@ -93,7 +93,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/README.md
@@ -93,7 +93,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/README.md
@@ -93,7 +93,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite? outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite? outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string? additionalMetadata = null, System.IO.Stream? file = null)
+> Model.ApiResponse UploadFile (long petId, string? additionalMetadata = null, System.IO.Stream? file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string? additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string? additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/README.md
@@ -66,7 +66,7 @@ namespace Org.OpenAPIToolsExample
             try
             {
                 // To test special tags
-                ModelClient result = await apiInstance.Call123TestSpecialTagsAsync(modelClient);
+                Model.ModelClient result = await apiInstance.Call123TestSpecialTagsAsync(modelClient);
                 Debug.Log(result);
                 Debug.Log("Done!");
             }

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -34,8 +34,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient);
 
         /// <summary>
         /// To test special tags
@@ -45,8 +45,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient);
         #endregion Synchronous Operations
     }
 
@@ -65,8 +65,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -228,10 +228,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -240,8 +240,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -268,7 +268,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -285,14 +285,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = Call123TestSpecialTagsWithHttpInfoAsync(modelClient, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -303,8 +303,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -334,7 +334,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -30,8 +30,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet();
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet();
 
         /// <summary>
         /// 
@@ -40,8 +40,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo();
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo();
         /// <summary>
         /// 
         /// </summary>
@@ -99,8 +99,8 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test();
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test();
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo();
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo();
         #endregion Synchronous Operations
     }
 
@@ -128,8 +128,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -139,8 +139,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -214,8 +214,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -225,8 +225,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -375,10 +375,10 @@ namespace Org.OpenAPITools.Api
         ///  
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet()
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet()
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -386,8 +386,8 @@ namespace Org.OpenAPITools.Api
         ///  
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo()
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -408,7 +408,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -424,14 +424,14 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = FooGetWithHttpInfoAsync(cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -441,8 +441,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -466,7 +466,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -835,10 +835,10 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test()
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test()
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -846,8 +846,8 @@ namespace Org.OpenAPITools.Api
         /// Retrieve an existing Notificationtest&#39;s Elements 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo()
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -868,7 +868,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -884,14 +884,14 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = TestWithHttpInfoAsync(cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -901,8 +901,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -926,7 +926,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -30,8 +30,8 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet();
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet();
 
         /// <summary>
         /// Health check endpoint
@@ -40,8 +40,8 @@ namespace Org.OpenAPITools.Api
         /// 
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo();
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo();
         /// <summary>
         /// 
         /// </summary>
@@ -71,8 +71,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite));
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite));
 
         /// <summary>
         /// 
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite));
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite));
         /// <summary>
         /// 
         /// </summary>
@@ -193,8 +193,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -204,8 +204,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -429,8 +429,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -440,8 +440,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -474,8 +474,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -486,8 +486,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -614,8 +614,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -626,8 +626,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1005,10 +1005,10 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet()
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet()
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1016,8 +1016,8 @@ namespace Org.OpenAPITools.Api
         /// Health check endpoint 
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo()
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo()
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1038,7 +1038,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1054,14 +1054,14 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = FakeHealthGetWithHttpInfoAsync(cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1071,8 +1071,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1096,7 +1096,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -1238,10 +1238,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite))
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1250,8 +1250,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite))
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite))
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1274,7 +1274,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1291,14 +1291,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1309,8 +1309,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1336,7 +1336,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -1978,10 +1978,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -1990,8 +1990,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2018,7 +2018,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2035,14 +2035,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = TestClientModelWithHttpInfoAsync(modelClient, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -2053,8 +2053,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2084,7 +2084,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -34,8 +34,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient);
 
         /// <summary>
         /// To test class name in snake case
@@ -45,8 +45,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient);
         #endregion Synchronous Operations
     }
 
@@ -65,8 +65,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -228,10 +228,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -240,8 +240,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -273,7 +273,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -290,14 +290,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = TestClassnameWithHttpInfoAsync(modelClient, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -308,8 +308,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -344,7 +344,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/PetApi.cs
@@ -116,8 +116,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId);
 
         /// <summary>
         /// Find pet by ID
@@ -127,8 +127,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -176,8 +176,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream));
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream));
 
         /// <summary>
         /// uploads an image
@@ -189,8 +189,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream));
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -198,8 +198,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string));
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string));
 
         /// <summary>
         /// uploads an image (required)
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string));
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string));
         #endregion Synchronous Operations
     }
 
@@ -327,8 +327,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -339,8 +339,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -402,8 +402,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -416,8 +416,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -429,8 +429,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -443,8 +443,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1250,10 +1250,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1262,8 +1262,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1291,7 +1291,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,14 +1308,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = GetPetByIdWithHttpInfoAsync(petId, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1326,8 +1326,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1358,7 +1358,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -1704,10 +1704,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1718,8 +1718,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream))
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1755,7 +1755,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1774,14 +1774,14 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1794,8 +1794,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1834,7 +1834,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -1858,10 +1858,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -1872,8 +1872,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to update</param>
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -1911,7 +1911,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1930,14 +1930,14 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1950,8 +1950,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -1992,7 +1992,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -74,8 +74,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId);
 
         /// <summary>
         /// Find purchase order by ID
@@ -85,15 +85,15 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order);
 
         /// <summary>
         /// Place an order for a pet
@@ -103,8 +103,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order);
         #endregion Synchronous Operations
     }
 
@@ -167,8 +167,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -179,8 +179,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -190,8 +190,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -202,8 +202,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -597,10 +597,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -609,8 +609,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -633,7 +633,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -650,14 +650,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = GetOrderByIdWithHttpInfoAsync(orderId, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -668,8 +668,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -695,7 +695,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);
@@ -717,10 +717,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -729,8 +729,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -758,7 +758,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -775,14 +775,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = PlaceOrderWithHttpInfoAsync(order, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -793,8 +793,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -825,7 +825,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Api/UserApi.cs
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username);
 
         /// <summary>
         /// Get user by user name
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -291,8 +291,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -303,8 +303,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1019,10 +1019,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1031,8 +1031,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1059,7 +1059,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1076,14 +1076,14 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var task = GetUserByNameWithHttpInfoAsync(username, cancellationToken);
 #if UNITY_EDITOR || !UNITY_WEBGL
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await task.ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await task.ConfigureAwait(false);
 #else
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await task;
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await task;
 #endif
             return localVarResponse.Data;
         }
@@ -1094,8 +1094,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1125,7 +1125,7 @@ namespace Org.OpenAPITools.Api
 
             // make the HTTP request
 
-            var task = this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken);
+            var task = this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken);
 
 #if UNITY_EDITOR || !UNITY_WEBGL
             var localVarResponse = await task.ConfigureAwait(false);

--- a/samples/client/petstore/csharp/OpenAPIClient/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/README.md
@@ -81,7 +81,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite outerComposite = default(OuterComposite), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string additionalMetadata = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/README.md
@@ -93,7 +93,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/AnotherFakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/AnotherFakeApi.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="call123testspecialtags"></a>
 # **Call123TestSpecialTags**
-> ModelClient Call123TestSpecialTags (ModelClient modelClient)
+> Model.ModelClient Call123TestSpecialTags (ModelClient modelClient)
 
 To test special tags
 
@@ -36,7 +36,7 @@ namespace Example
             try
             {
                 // To test special tags
-                ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
+                Model.ModelClient result = apiInstance.Call123TestSpecialTags(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -57,7 +57,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test special tags
-    ApiResponse<ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.Call123TestSpecialTagsWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -78,7 +78,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/DefaultApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/DefaultApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fooget"></a>
 # **FooGet**
-> FooGetDefaultResponse FooGet ()
+> Model.FooGetDefaultResponse FooGet ()
 
 
 
@@ -36,7 +36,7 @@ namespace Example
 
             try
             {
-                FooGetDefaultResponse result = apiInstance.FooGet();
+                Model.FooGetDefaultResponse result = apiInstance.FooGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -56,7 +56,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
+    ApiResponse<Model.FooGetDefaultResponse> response = apiInstance.FooGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -73,7 +73,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**FooGetDefaultResponse**](FooGetDefaultResponse.md)
+[**Model.FooGetDefaultResponse**](FooGetDefaultResponse.md)
 
 ### Authorization
 
@@ -345,7 +345,7 @@ No authorization required
 
 <a id="test"></a>
 # **Test**
-> NotificationtestGetElementsV1ResponseMPayload Test ()
+> Model.NotificationtestGetElementsV1ResponseMPayload Test ()
 
 Retrieve an existing Notificationtest's Elements
 
@@ -370,7 +370,7 @@ namespace Example
             try
             {
                 // Retrieve an existing Notificationtest's Elements
-                NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
+                Model.NotificationtestGetElementsV1ResponseMPayload result = apiInstance.Test();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -391,7 +391,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Retrieve an existing Notificationtest's Elements
-    ApiResponse<NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
+    ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> response = apiInstance.TestWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -408,7 +408,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
+[**Model.NotificationtestGetElementsV1ResponseMPayload**](NotificationtestGetElementsV1ResponseMPayload.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeApi.md
@@ -23,7 +23,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="fakehealthget"></a>
 # **FakeHealthGet**
-> HealthCheckResult FakeHealthGet ()
+> Model.HealthCheckResult FakeHealthGet ()
 
 Health check endpoint
 
@@ -48,7 +48,7 @@ namespace Example
             try
             {
                 // Health check endpoint
-                HealthCheckResult result = apiInstance.FakeHealthGet();
+                Model.HealthCheckResult result = apiInstance.FakeHealthGet();
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -69,7 +69,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Health check endpoint
-    ApiResponse<HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
+    ApiResponse<Model.HealthCheckResult> response = apiInstance.FakeHealthGetWithHttpInfo();
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 This endpoint does not need any parameter.
 ### Return type
 
-[**HealthCheckResult**](HealthCheckResult.md)
+[**Model.HealthCheckResult**](HealthCheckResult.md)
 
 ### Authorization
 
@@ -196,7 +196,7 @@ No authorization required
 
 <a id="fakeoutercompositeserialize"></a>
 # **FakeOuterCompositeSerialize**
-> OuterComposite FakeOuterCompositeSerialize (OuterComposite? outerComposite = null)
+> Model.OuterComposite FakeOuterCompositeSerialize (OuterComposite? outerComposite = null)
 
 
 
@@ -223,7 +223,7 @@ namespace Example
 
             try
             {
-                OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
+                Model.OuterComposite result = apiInstance.FakeOuterCompositeSerialize(outerComposite);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -243,7 +243,7 @@ This returns an ApiResponse object which contains the response data, status code
 ```csharp
 try
 {
-    ApiResponse<OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+    ApiResponse<Model.OuterComposite> response = apiInstance.FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -264,7 +264,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**OuterComposite**](OuterComposite.md)
+[**Model.OuterComposite**](OuterComposite.md)
 
 ### Authorization
 
@@ -719,7 +719,7 @@ No authorization required
 
 <a id="testclientmodel"></a>
 # **TestClientModel**
-> ModelClient TestClientModel (ModelClient modelClient)
+> Model.ModelClient TestClientModel (ModelClient modelClient)
 
 To test \"client\" model
 
@@ -747,7 +747,7 @@ namespace Example
             try
             {
                 // To test \"client\" model
-                ModelClient result = apiInstance.TestClientModel(modelClient);
+                Model.ModelClient result = apiInstance.TestClientModel(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -768,7 +768,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test \"client\" model
-    ApiResponse<ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClientModelWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -789,7 +789,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeClassnameTags123Api.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FakeClassnameTags123Api.md
@@ -8,7 +8,7 @@ All URIs are relative to *http://petstore.swagger.io:80/v2*
 
 <a id="testclassname"></a>
 # **TestClassname**
-> ModelClient TestClassname (ModelClient modelClient)
+> Model.ModelClient TestClassname (ModelClient modelClient)
 
 To test class name in snake case
 
@@ -41,7 +41,7 @@ namespace Example
             try
             {
                 // To test class name in snake case
-                ModelClient result = apiInstance.TestClassname(modelClient);
+                Model.ModelClient result = apiInstance.TestClassname(modelClient);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -62,7 +62,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // To test class name in snake case
-    ApiResponse<ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
+    ApiResponse<Model.ModelClient> response = apiInstance.TestClassnameWithHttpInfo(modelClient);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -83,7 +83,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ModelClient**](ModelClient.md)
+[**Model.ModelClient**](ModelClient.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/PetApi.md
@@ -384,7 +384,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -417,7 +417,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -438,7 +438,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -459,7 +459,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -664,7 +664,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string? additionalMetadata = null, System.IO.Stream? file = null)
+> Model.ApiResponse UploadFile (long petId, string? additionalMetadata = null, System.IO.Stream? file = null)
 
 uploads an image
 
@@ -695,7 +695,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -716,7 +716,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -739,7 +739,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 
@@ -760,7 +760,7 @@ catch (ApiException e)
 
 <a id="uploadfilewithrequiredfile"></a>
 # **UploadFileWithRequiredFile**
-> ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string? additionalMetadata = null)
+> Model.ApiResponse UploadFileWithRequiredFile (long petId, System.IO.Stream requiredFile, string? additionalMetadata = null)
 
 uploads an image (required)
 
@@ -791,7 +791,7 @@ namespace Example
             try
             {
                 // uploads an image (required)
-                ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
+                Model.ApiResponse result = apiInstance.UploadFileWithRequiredFile(petId, requiredFile, additionalMetadata);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -812,7 +812,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image (required)
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -835,7 +835,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/UserApi.md
@@ -360,7 +360,7 @@ No authorization required
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -386,7 +386,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -407,7 +407,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -428,7 +428,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/AnotherFakeApi.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test special tags
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test special tags
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient Call123TestSpecialTags(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = Call123TestSpecialTagsWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> Call123TestSpecialTagsWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -262,7 +262,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Call123TestSpecialTags", localVarResponse);
@@ -282,10 +282,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> Call123TestSpecialTagsAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await Call123TestSpecialTagsWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -296,8 +296,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> Call123TestSpecialTagsWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -336,7 +336,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/another-fake/dummy", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/DefaultApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/DefaultApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        FooGetDefaultResponse FooGet(int operationIndex = 0);
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        Model.FooGetDefaultResponse FooGet(int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -109,8 +109,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0);
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -120,8 +120,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -140,8 +140,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -152,8 +152,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -234,8 +234,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Retrieve an existing Notificationtest&#39;s Elements
@@ -246,8 +246,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -373,10 +373,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>FooGetDefaultResponse</returns>
-        public FooGetDefaultResponse FooGet(int operationIndex = 0)
+        /// <returns>Model.FooGetDefaultResponse</returns>
+        public Model.FooGetDefaultResponse FooGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = FooGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -385,8 +385,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of FooGetDefaultResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.FooGetDefaultResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> FooGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -416,7 +416,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FooGet", localVarResponse);
@@ -435,10 +435,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of FooGetDefaultResponse</returns>
-        public async System.Threading.Tasks.Task<FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.FooGetDefaultResponse</returns>
+        public async System.Threading.Tasks.Task<Model.FooGetDefaultResponse> FooGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse> localVarResponse = await FooGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -448,8 +448,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (FooGetDefaultResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.FooGetDefaultResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.FooGetDefaultResponse>> FooGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -480,7 +480,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.FooGetDefaultResponse>("/foo", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -893,10 +893,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>NotificationtestGetElementsV1ResponseMPayload</returns>
-        public NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
+        /// <returns>Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Model.NotificationtestGetElementsV1ResponseMPayload Test(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = TestWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -905,8 +905,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> TestWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -936,7 +936,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("Test", localVarResponse);
@@ -955,10 +955,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of NotificationtestGetElementsV1ResponseMPayload</returns>
-        public async System.Threading.Tasks.Task<NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.NotificationtestGetElementsV1ResponseMPayload</returns>
+        public async System.Threading.Tasks.Task<Model.NotificationtestGetElementsV1ResponseMPayload> TestAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload> localVarResponse = await TestWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -968,8 +968,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (NotificationtestGetElementsV1ResponseMPayload)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.NotificationtestGetElementsV1ResponseMPayload)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.NotificationtestGetElementsV1ResponseMPayload>> TestWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1000,7 +1000,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.NotificationtestGetElementsV1ResponseMPayload>("/test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeApi.cs
@@ -32,8 +32,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        HealthCheckResult FakeHealthGet(int operationIndex = 0);
+        /// <returns>Model.HealthCheckResult</returns>
+        Model.HealthCheckResult FakeHealthGet(int operationIndex = 0);
 
         /// <summary>
         /// Health check endpoint
@@ -43,8 +43,8 @@ namespace Org.OpenAPITools.Api
         /// </remarks>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -77,8 +77,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
+        /// <returns>Model.OuterComposite</returns>
+        Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
 
         /// <summary>
         /// 
@@ -89,8 +89,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0);
         /// <summary>
         /// 
         /// </summary>
@@ -211,8 +211,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -463,8 +463,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Health check endpoint
@@ -475,8 +475,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        System.Threading.Tasks.Task<ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -512,8 +512,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.OuterComposite</returns>
+        System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// 
@@ -525,8 +525,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        System.Threading.Tasks.Task<ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// 
         /// </summary>
@@ -664,8 +664,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test \&quot;client\&quot; model
@@ -677,8 +677,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
         /// </summary>
@@ -1047,10 +1047,10 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>HealthCheckResult</returns>
-        public HealthCheckResult FakeHealthGet(int operationIndex = 0)
+        /// <returns>Model.HealthCheckResult</returns>
+        public Model.HealthCheckResult FakeHealthGet(int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = FakeHealthGetWithHttpInfo();
             return localVarResponse.Data;
         }
 
@@ -1059,8 +1059,8 @@ namespace Org.OpenAPITools.Api
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of HealthCheckResult</returns>
-        public Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
+        /// <returns>ApiResponse of Model.HealthCheckResult</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> FakeHealthGetWithHttpInfo(int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1090,7 +1090,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeHealthGet", localVarResponse);
@@ -1109,10 +1109,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of HealthCheckResult</returns>
-        public async System.Threading.Tasks.Task<HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.HealthCheckResult</returns>
+        public async System.Threading.Tasks.Task<Model.HealthCheckResult> FakeHealthGetAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult> localVarResponse = await FakeHealthGetWithHttpInfoAsync(operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1122,8 +1122,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (HealthCheckResult)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.HealthCheckResult)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.HealthCheckResult>> FakeHealthGetWithHttpInfoAsync(int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1154,7 +1154,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.HealthCheckResult>("/fake/health", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1308,10 +1308,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>OuterComposite</returns>
-        public OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
+        /// <returns>Model.OuterComposite</returns>
+        public Model.OuterComposite FakeOuterCompositeSerialize(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = FakeOuterCompositeSerializeWithHttpInfo(outerComposite);
             return localVarResponse.Data;
         }
 
@@ -1321,8 +1321,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of OuterComposite</returns>
-        public Org.OpenAPITools.Client.ApiResponse<OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.OuterComposite</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> FakeOuterCompositeSerializeWithHttpInfo(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1354,7 +1354,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("FakeOuterCompositeSerialize", localVarResponse);
@@ -1374,10 +1374,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of OuterComposite</returns>
-        public async System.Threading.Tasks.Task<OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.OuterComposite</returns>
+        public async System.Threading.Tasks.Task<Model.OuterComposite> FakeOuterCompositeSerializeAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite> localVarResponse = await FakeOuterCompositeSerializeWithHttpInfoAsync(outerComposite, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1388,8 +1388,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="outerComposite">Input composite as post body (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (OuterComposite)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.OuterComposite)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.OuterComposite>> FakeOuterCompositeSerializeWithHttpInfoAsync(OuterComposite? outerComposite = default(OuterComposite?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1422,7 +1422,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.OuterComposite>("/fake/outer/composite", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2144,10 +2144,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClientModel(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClientModelWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClientModelWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2196,7 +2196,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClientModel", localVarResponse);
@@ -2216,10 +2216,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClientModelAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClientModelWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2230,8 +2230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClientModelWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -2270,7 +2270,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/FakeClassnameTags123Api.cs
@@ -36,8 +36,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>Model.ModelClient</returns>
+        Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0);
 
         /// <summary>
         /// To test class name in snake case
@@ -48,8 +48,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -69,8 +69,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ModelClient</returns>
+        System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// To test class name in snake case
@@ -82,8 +82,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -210,10 +210,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ModelClient</returns>
-        public ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>Model.ModelClient</returns>
+        public Model.ModelClient TestClassname(ModelClient modelClient, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = TestClassnameWithHttpInfo(modelClient);
             return localVarResponse.Data;
         }
 
@@ -223,8 +223,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ModelClient</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ModelClient</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> TestClassnameWithHttpInfo(ModelClient modelClient, int operationIndex = 0)
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -267,7 +267,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Patch<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Patch<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestClassname", localVarResponse);
@@ -287,10 +287,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ModelClient</returns>
-        public async System.Threading.Tasks.Task<ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ModelClient</returns>
+        public async System.Threading.Tasks.Task<Model.ModelClient> TestClassnameAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ModelClient> localVarResponse = await TestClassnameWithHttpInfoAsync(modelClient, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -301,8 +301,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="modelClient">client model</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ModelClient)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ModelClient)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ModelClient>> TestClassnameWithHttpInfoAsync(ModelClient modelClient, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'modelClient' is set
             if (modelClient == null)
@@ -346,7 +346,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PatchAsync<ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PatchAsync<Model.ModelClient>("/fake_classname_test", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/PetApi.cs
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,8 +138,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0);
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -216,8 +216,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image (required)
@@ -230,8 +230,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -355,8 +355,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -368,8 +368,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -436,8 +436,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -451,8 +451,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// uploads an image (required)
         /// </summary>
@@ -465,8 +465,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image (required)
@@ -480,8 +480,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -1412,10 +1412,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1425,8 +1425,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1463,7 +1463,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1483,10 +1483,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1497,8 +1497,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1536,7 +1536,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1952,10 +1952,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1967,8 +1967,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -2024,7 +2024,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -2046,10 +2046,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2062,8 +2062,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string? additionalMetadata = default(string?), System.IO.Stream? file = default(System.IO.Stream?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -2120,7 +2120,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -2142,10 +2142,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFileWithRequiredFile(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithRequiredFileWithHttpInfo(petId, requiredFile, additionalMetadata);
             return localVarResponse.Data;
         }
 
@@ -2157,8 +2157,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="requiredFile">file to upload</param>
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithRequiredFileWithHttpInfo(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0)
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2218,7 +2218,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFileWithRequiredFile", localVarResponse);
@@ -2240,10 +2240,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileWithRequiredFileAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithRequiredFileWithHttpInfoAsync(petId, requiredFile, additionalMetadata, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -2256,8 +2256,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithRequiredFileWithHttpInfoAsync(long petId, System.IO.Stream requiredFile, string? additionalMetadata = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'requiredFile' is set
             if (requiredFile == null)
@@ -2318,7 +2318,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/fake/{petId}/uploadImageWithRequiredFile", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{order_id}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1101,10 +1101,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1114,8 +1114,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1153,7 +1153,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1173,10 +1173,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1187,8 +1187,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1227,7 +1227,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/README.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/README.md
@@ -84,7 +84,7 @@ namespace Example
             try
             {
                 // Add a new pet to the store
-                Pet result = apiInstance.AddPet(pet);
+                Model.Pet result = apiInstance.AddPet(pet);
                 Debug.WriteLine(result);
             }
             catch (ApiException e)

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/PetApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/PetApi.md
@@ -15,7 +15,7 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 <a id="addpet"></a>
 # **AddPet**
-> Pet AddPet (Pet pet)
+> Model.Pet AddPet (Pet pet)
 
 Add a new pet to the store
 
@@ -44,7 +44,7 @@ namespace Example
             try
             {
                 // Add a new pet to the store
-                Pet result = apiInstance.AddPet(pet);
+                Model.Pet result = apiInstance.AddPet(pet);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -65,7 +65,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Add a new pet to the store
-    ApiResponse<Pet> response = apiInstance.AddPetWithHttpInfo(pet);
+    ApiResponse<Model.Pet> response = apiInstance.AddPetWithHttpInfo(pet);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -86,7 +86,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -388,7 +388,7 @@ catch (ApiException e)
 
 <a id="getpetbyid"></a>
 # **GetPetById**
-> Pet GetPetById (long petId)
+> Model.Pet GetPetById (long petId)
 
 Find pet by ID
 
@@ -421,7 +421,7 @@ namespace Example
             try
             {
                 // Find pet by ID
-                Pet result = apiInstance.GetPetById(petId);
+                Model.Pet result = apiInstance.GetPetById(petId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -442,7 +442,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find pet by ID
-    ApiResponse<Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
+    ApiResponse<Model.Pet> response = apiInstance.GetPetByIdWithHttpInfo(petId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -463,7 +463,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -486,7 +486,7 @@ catch (ApiException e)
 
 <a id="updatepet"></a>
 # **UpdatePet**
-> Pet UpdatePet (Pet pet)
+> Model.Pet UpdatePet (Pet pet)
 
 Update an existing pet
 
@@ -515,7 +515,7 @@ namespace Example
             try
             {
                 // Update an existing pet
-                Pet result = apiInstance.UpdatePet(pet);
+                Model.Pet result = apiInstance.UpdatePet(pet);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -536,7 +536,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Update an existing pet
-    ApiResponse<Pet> response = apiInstance.UpdatePetWithHttpInfo(pet);
+    ApiResponse<Model.Pet> response = apiInstance.UpdatePetWithHttpInfo(pet);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -557,7 +557,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Pet**](Pet.md)
+[**Model.Pet**](Pet.md)
 
 ### Authorization
 
@@ -673,7 +673,7 @@ void (empty response body)
 
 <a id="uploadfile"></a>
 # **UploadFile**
-> ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
+> Model.ApiResponse UploadFile (long petId, string additionalMetadata = null, System.IO.Stream file = null)
 
 uploads an image
 
@@ -704,7 +704,7 @@ namespace Example
             try
             {
                 // uploads an image
-                ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
+                Model.ApiResponse result = apiInstance.UploadFile(petId, additionalMetadata, file);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -725,7 +725,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // uploads an image
-    ApiResponse<ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
+    ApiResponse<Model.ApiResponse> response = apiInstance.UploadFileWithHttpInfo(petId, additionalMetadata, file);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -748,7 +748,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**ApiResponse**](ApiResponse.md)
+[**Model.ApiResponse**](ApiResponse.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/StoreApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/StoreApi.md
@@ -190,7 +190,7 @@ This endpoint does not need any parameter.
 
 <a id="getorderbyid"></a>
 # **GetOrderById**
-> Order GetOrderById (long orderId)
+> Model.Order GetOrderById (long orderId)
 
 Find purchase order by ID
 
@@ -218,7 +218,7 @@ namespace Example
             try
             {
                 // Find purchase order by ID
-                Order result = apiInstance.GetOrderById(orderId);
+                Model.Order result = apiInstance.GetOrderById(orderId);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -239,7 +239,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Find purchase order by ID
-    ApiResponse<Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
+    ApiResponse<Model.Order> response = apiInstance.GetOrderByIdWithHttpInfo(orderId);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -260,7 +260,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 
@@ -283,7 +283,7 @@ No authorization required
 
 <a id="placeorder"></a>
 # **PlaceOrder**
-> Order PlaceOrder (Order order)
+> Model.Order PlaceOrder (Order order)
 
 Place an order for a pet
 
@@ -309,7 +309,7 @@ namespace Example
             try
             {
                 // Place an order for a pet
-                Order result = apiInstance.PlaceOrder(order);
+                Model.Order result = apiInstance.PlaceOrder(order);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -330,7 +330,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Place an order for a pet
-    ApiResponse<Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
+    ApiResponse<Model.Order> response = apiInstance.PlaceOrderWithHttpInfo(order);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -351,7 +351,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**Order**](Order.md)
+[**Model.Order**](Order.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/UserApi.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/UserApi.md
@@ -380,7 +380,7 @@ void (empty response body)
 
 <a id="getuserbyname"></a>
 # **GetUserByName**
-> User GetUserByName (string username)
+> Model.User GetUserByName (string username)
 
 Get user by user name
 
@@ -406,7 +406,7 @@ namespace Example
             try
             {
                 // Get user by user name
-                User result = apiInstance.GetUserByName(username);
+                Model.User result = apiInstance.GetUserByName(username);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -427,7 +427,7 @@ This returns an ApiResponse object which contains the response data, status code
 try
 {
     // Get user by user name
-    ApiResponse<User> response = apiInstance.GetUserByNameWithHttpInfo(username);
+    ApiResponse<Model.User> response = apiInstance.GetUserByNameWithHttpInfo(username);
     Debug.Write("Status Code: " + response.StatusCode);
     Debug.Write("Response Headers: " + response.Headers);
     Debug.Write("Response Body: " + response.Data);
@@ -448,7 +448,7 @@ catch (ApiException e)
 
 ### Return type
 
-[**User**](User.md)
+[**Model.User**](User.md)
 
 ### Authorization
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/PetApi.cs
@@ -33,8 +33,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet AddPet(Pet pet, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet AddPet(Pet pet, int operationIndex = 0);
 
         /// <summary>
         /// Add a new pet to the store
@@ -45,8 +45,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> AddPetWithHttpInfo(Pet pet, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> AddPetWithHttpInfo(Pet pet, int operationIndex = 0);
         /// <summary>
         /// Deletes a pet
         /// </summary>
@@ -126,8 +126,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet GetPetById(long petId, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet GetPetById(long petId, int operationIndex = 0);
 
         /// <summary>
         /// Find pet by ID
@@ -138,16 +138,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0);
         /// <summary>
         /// Update an existing pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        Pet UpdatePet(Pet pet, int operationIndex = 0);
+        /// <returns>Model.Pet</returns>
+        Model.Pet UpdatePet(Pet pet, int operationIndex = 0);
 
         /// <summary>
         /// Update an existing pet
@@ -158,8 +158,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        ApiResponse<Pet> UpdatePetWithHttpInfo(Pet pet, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Pet</returns>
+        ApiResponse<Model.Pet> UpdatePetWithHttpInfo(Pet pet, int operationIndex = 0);
         /// <summary>
         /// Updates a pet in the store with form data
         /// </summary>
@@ -192,8 +192,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>Model.ApiResponse</returns>
+        Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
 
         /// <summary>
         /// uploads an image
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -227,8 +227,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> AddPetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> AddPetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Add a new pet to the store
@@ -240,8 +240,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> AddPetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> AddPetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Deletes a pet
         /// </summary>
@@ -331,8 +331,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find pet by ID
@@ -344,8 +344,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Update an existing pet
         /// </summary>
@@ -356,8 +356,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        System.Threading.Tasks.Task<Pet> UpdatePetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Pet</returns>
+        System.Threading.Tasks.Task<Model.Pet> UpdatePetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Update an existing pet
@@ -369,8 +369,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Pet>> UpdatePetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Pet>> UpdatePetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Updates a pet in the store with form data
         /// </summary>
@@ -412,8 +412,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.ApiResponse</returns>
+        System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// uploads an image
@@ -427,8 +427,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -555,10 +555,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet AddPet(Pet pet, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet AddPet(Pet pet, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = AddPetWithHttpInfo(pet);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = AddPetWithHttpInfo(pet);
             return localVarResponse.Data;
         }
 
@@ -568,8 +568,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> AddPetWithHttpInfo(Pet pet, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> AddPetWithHttpInfo(Pet pet, int operationIndex = 0)
         {
             // verify the required parameter 'pet' is set
             if (pet == null)
@@ -625,7 +625,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Pet>("/pet", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Pet>("/pet", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("AddPet", localVarResponse);
@@ -645,10 +645,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> AddPetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> AddPetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await AddPetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await AddPetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -659,8 +659,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> AddPetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> AddPetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'pet' is set
             if (pet == null)
@@ -717,7 +717,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Pet>("/pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Pet>("/pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1269,10 +1269,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet GetPetById(long petId, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet GetPetById(long petId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = GetPetByIdWithHttpInfo(petId);
             return localVarResponse.Data;
         }
 
@@ -1282,8 +1282,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> GetPetByIdWithHttpInfo(long petId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1320,7 +1320,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetPetById", localVarResponse);
@@ -1340,10 +1340,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> GetPetByIdAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await GetPetByIdWithHttpInfoAsync(petId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1354,8 +1354,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="petId">ID of pet to return</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> GetPetByIdWithHttpInfoAsync(long petId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1393,7 +1393,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Pet>("/pet/{petId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1413,10 +1413,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Pet</returns>
-        public Pet UpdatePet(Pet pet, int operationIndex = 0)
+        /// <returns>Model.Pet</returns>
+        public Model.Pet UpdatePet(Pet pet, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = UpdatePetWithHttpInfo(pet);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = UpdatePetWithHttpInfo(pet);
             return localVarResponse.Data;
         }
 
@@ -1426,8 +1426,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Pet</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Pet> UpdatePetWithHttpInfo(Pet pet, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Pet</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Pet> UpdatePetWithHttpInfo(Pet pet, int operationIndex = 0)
         {
             // verify the required parameter 'pet' is set
             if (pet == null)
@@ -1483,7 +1483,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Put<Pet>("/pet", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Put<Model.Pet>("/pet", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UpdatePet", localVarResponse);
@@ -1503,10 +1503,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Pet</returns>
-        public async System.Threading.Tasks.Task<Pet> UpdatePetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Pet</returns>
+        public async System.Threading.Tasks.Task<Model.Pet> UpdatePetAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Pet> localVarResponse = await UpdatePetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Pet> localVarResponse = await UpdatePetWithHttpInfoAsync(pet, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1517,8 +1517,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="pet">Pet object that needs to be added to the store</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Pet)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Pet>> UpdatePetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Pet)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Pet>> UpdatePetWithHttpInfoAsync(Pet pet, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'pet' is set
             if (pet == null)
@@ -1575,7 +1575,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PutAsync<Pet>("/pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PutAsync<Model.Pet>("/pet", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -1783,10 +1783,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse</returns>
-        public ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>Model.ApiResponse</returns>
+        public Model.ApiResponse UploadFile(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = UploadFileWithHttpInfo(petId, additionalMetadata, file);
             return localVarResponse.Data;
         }
 
@@ -1798,8 +1798,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="additionalMetadata">Additional data to pass to server (optional)</param>
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of ApiResponse</returns>
-        public Org.OpenAPITools.Client.ApiResponse<ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
+        /// <returns>ApiResponse of Model.ApiResponse</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> UploadFileWithHttpInfo(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -1855,7 +1855,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("UploadFile", localVarResponse);
@@ -1877,10 +1877,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.ApiResponse</returns>
+        public async System.Threading.Tasks.Task<Model.ApiResponse> UploadFileAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse> localVarResponse = await UploadFileWithHttpInfoAsync(petId, additionalMetadata, file, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1893,8 +1893,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="file">file to upload (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (ApiResponse)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.ApiResponse)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.ApiResponse>> UploadFileWithHttpInfoAsync(long petId, string additionalMetadata = default(string), System.IO.Stream file = default(System.IO.Stream), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -1951,7 +1951,7 @@ namespace Org.OpenAPITools.Api
             }
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.ApiResponse>("/pet/{petId}/uploadImage", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/StoreApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/StoreApi.cs
@@ -80,8 +80,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order GetOrderById(long orderId, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order GetOrderById(long orderId, int operationIndex = 0);
 
         /// <summary>
         /// Find purchase order by ID
@@ -92,16 +92,16 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0);
         /// <summary>
         /// Place an order for a pet
         /// </summary>
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        Order PlaceOrder(Order order, int operationIndex = 0);
+        /// <returns>Model.Order</returns>
+        Model.Order PlaceOrder(Order order, int operationIndex = 0);
 
         /// <summary>
         /// Place an order for a pet
@@ -112,8 +112,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.Order</returns>
+        ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0);
         #endregion Synchronous Operations
     }
 
@@ -181,8 +181,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Find purchase order by ID
@@ -194,8 +194,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Place an order for a pet
         /// </summary>
@@ -206,8 +206,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.Order</returns>
+        System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Place an order for a pet
@@ -219,8 +219,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        System.Threading.Tasks.Task<ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         #endregion Asynchronous Operations
     }
 
@@ -623,10 +623,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order GetOrderById(long orderId, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order GetOrderById(long orderId, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = GetOrderByIdWithHttpInfo(orderId);
             return localVarResponse.Data;
         }
 
@@ -636,8 +636,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> GetOrderByIdWithHttpInfo(long orderId, int operationIndex = 0)
         {
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
 
@@ -669,7 +669,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<Order>("/store/order/{orderId}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.Order>("/store/order/{orderId}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetOrderById", localVarResponse);
@@ -689,10 +689,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> GetOrderByIdAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await GetOrderByIdWithHttpInfoAsync(orderId, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -703,8 +703,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="orderId">ID of pet that needs to be fetched</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> GetOrderByIdWithHttpInfoAsync(long orderId, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
 
             Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
@@ -737,7 +737,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<Order>("/store/order/{orderId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.Order>("/store/order/{orderId}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {
@@ -757,10 +757,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>Order</returns>
-        public Order PlaceOrder(Order order, int operationIndex = 0)
+        /// <returns>Model.Order</returns>
+        public Model.Order PlaceOrder(Order order, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = PlaceOrderWithHttpInfo(order);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = PlaceOrderWithHttpInfo(order);
             return localVarResponse.Data;
         }
 
@@ -770,8 +770,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of Order</returns>
-        public Org.OpenAPITools.Client.ApiResponse<Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.Order</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.Order> PlaceOrderWithHttpInfo(Order order, int operationIndex = 0)
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -810,7 +810,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post<Order>("/store/order", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<Model.Order>("/store/order", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("PlaceOrder", localVarResponse);
@@ -830,10 +830,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of Order</returns>
-        public async System.Threading.Tasks.Task<Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.Order</returns>
+        public async System.Threading.Tasks.Task<Model.Order> PlaceOrderAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.Order> localVarResponse = await PlaceOrderWithHttpInfoAsync(order, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -844,8 +844,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="order">order placed for purchasing the pet</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (Order)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.Order)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.Order>> PlaceOrderWithHttpInfoAsync(Order order, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'order' is set
             if (order == null)
@@ -885,7 +885,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.PostAsync<Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.PostAsync<Model.Order>("/store/order", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/UserApi.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Api/UserApi.cs
@@ -119,8 +119,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        User GetUserByName(string username, int operationIndex = 0);
+        /// <returns>Model.User</returns>
+        Model.User GetUserByName(string username, int operationIndex = 0);
 
         /// <summary>
         /// Get user by user name
@@ -131,8 +131,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
+        /// <returns>ApiResponse of Model.User</returns>
+        ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0);
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -317,8 +317,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of Model.User</returns>
+        System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// Get user by user name
@@ -330,8 +330,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        System.Threading.Tasks.Task<ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        System.Threading.Tasks.Task<ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Logs user into the system
         /// </summary>
@@ -1141,10 +1141,10 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>User</returns>
-        public User GetUserByName(string username, int operationIndex = 0)
+        /// <returns>Model.User</returns>
+        public Model.User GetUserByName(string username, int operationIndex = 0)
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = GetUserByNameWithHttpInfo(username);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = GetUserByNameWithHttpInfo(username);
             return localVarResponse.Data;
         }
 
@@ -1154,8 +1154,8 @@ namespace Org.OpenAPITools.Api
         /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
-        /// <returns>ApiResponse of User</returns>
-        public Org.OpenAPITools.Client.ApiResponse<User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
+        /// <returns>ApiResponse of Model.User</returns>
+        public Org.OpenAPITools.Client.ApiResponse<Model.User> GetUserByNameWithHttpInfo(string username, int operationIndex = 0)
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1193,7 +1193,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get<User>("/user/{username}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration);
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("GetUserByName", localVarResponse);
@@ -1213,10 +1213,10 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of User</returns>
-        public async System.Threading.Tasks.Task<User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of Model.User</returns>
+        public async System.Threading.Tasks.Task<Model.User> GetUserByNameAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            Org.OpenAPITools.Client.ApiResponse<User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
+            Org.OpenAPITools.Client.ApiResponse<Model.User> localVarResponse = await GetUserByNameWithHttpInfoAsync(username, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -1227,8 +1227,8 @@ namespace Org.OpenAPITools.Api
         /// <param name="username">The name that needs to be fetched. Use user1 for testing.</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
-        /// <returns>Task of ApiResponse (User)</returns>
-        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        /// <returns>Task of ApiResponse (Model.User)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<Model.User>> GetUserByNameWithHttpInfoAsync(string username, int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'username' is set
             if (username == null)
@@ -1267,7 +1267,7 @@ namespace Org.OpenAPITools.Api
 
 
             // make the HTTP request
-            var localVarResponse = await this.AsynchronousClient.GetAsync<User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+            var localVarResponse = await this.AsynchronousClient.GetAsync<Model.User>("/user/{username}", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
 
             if (this.ExceptionFactory != null)
             {


### PR DESCRIPTION
This fixes #16123

The issue is that when a spec defines an entity with a name like `TimeZone`, the generated code does not build because it yields an ambiguous reference to either our entity or `System.TimeZone`.
That commit fixes it by adding the namespace in front of the entity name.
However, it adds the suffix only if need, ie: if we consider that the http call will return an `Object` or a `string`, then adding our package namespace would break the generated code. That commit hence ensures it does not do that.


To test this patch I:

* created that spec file

```
openapi: 3.0.3
info:
 title: test
 version: v0.1
 description: test
paths:
 /api/path1: # This path makes sure we fix our issue, because it would yield C# code that does not build without this commit
  get:
   responses:
    '200':
      description: ok
      content:
       application/json:
        schema:
         $ref: '#/components/schemas/TimeZone'
 /api/path2: # This path leads to C# code that manipulates an Object. This ensure I don't break support of that case.
  get:
   responses:
    '200':
      description: ok
      content:
       application/json:
        schema:
         $ref: '#/components/schemas/ObjectIsh'
 /api/path3: # This path leads to C# code that manipulates a string. This ensure I don't break support of that case.
  get:
   responses:
    '200':
      description: ok
      content:
       application/json:
        schema:
         $ref: '#/components/schemas/StringIsh'
components:
  schemas:
   TimeZone:
    type: object
    properties:
      someField:
       type: array
       items:
         type: string
   ObjectIsh:
    type: object
   StringIsh:
    type: string
```

I then generate C# code from this spec:

    java -jar openapi-generator-cli.jar generate --generator-name csharp --input-spec spec.yaml --output out

and then I build the generated code:

    dotnet build Org.OpenAPITools.sln

Expected behavior: the C# build is successful.
Actual behavior: without this commit the build fails. With this commit it succeeds


Ping @mandrean , @shibayan , @Blackclaws , @lucamazzanti , @muttleyxd 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] In case you are adding a new generator, run the following additional script : 
  ```
  ./bin/utils/ensure-up-to-date
  ``` 
  Commit all changed files.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (6.3.0) (minor release - breaking changes with fallbacks), `7.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
