### PR TITLE
[ruby|client] Fix unmarshalling errors of enums inside other objects

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/base_object.mustache
@@ -63,7 +63,7 @@
       else # model
         # models (e.g. Pet) or oneOf
         klass = {{moduleName}}.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/bird.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/bird.rb
@@ -168,7 +168,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/category.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/category.rb
@@ -168,7 +168,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/data_query.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/data_query.rb
@@ -213,7 +213,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/default_value.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/default_value.rb
@@ -262,7 +262,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/number_properties_only.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/number_properties_only.rb
@@ -205,7 +205,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/pet.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/pet.rb
@@ -257,7 +257,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/query.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/query.rb
@@ -193,7 +193,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/tag.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/tag.rb
@@ -168,7 +168,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.rb
@@ -194,7 +194,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.rb
@@ -161,7 +161,7 @@ module OpenapiClient
       else # model
         # models (e.g. Pet) or oneOf
         klass = OpenapiClient.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/additional_properties_class.rb
@@ -172,7 +172,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/all_of_with_single_ref.rb
@@ -190,7 +190,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/animal.rb
@@ -182,7 +182,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/api_response.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/array_of_array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/array_test.rb
@@ -211,7 +211,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/capitalization.rb
@@ -205,7 +205,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/cat.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/category.rb
@@ -175,7 +175,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/child_with_nullable.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/child_with_nullable.rb
@@ -192,7 +192,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/class_model.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/client.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/deprecated_object.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/deprecated_object.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/dog.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/enum_arrays.rb
@@ -204,7 +204,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/enum_test.rb
@@ -304,7 +304,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/fake_big_decimal_map200_response.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/fake_big_decimal_map200_response.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/file.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/file_schema_test_class.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/foo.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/foo_get_default_response.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/foo_get_default_response.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/format_test.rb
@@ -555,7 +555,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/has_only_read_only.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/health_check_result.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/list.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/map_test.rb
@@ -216,7 +216,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -179,7 +179,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/model200_response.rb
@@ -169,7 +169,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/model_return.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/name.rb
@@ -194,7 +194,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/nullable_class.rb
@@ -280,7 +280,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/number_only.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/object_with_deprecated_fields.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/object_with_deprecated_fields.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/order.rb
@@ -241,7 +241,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/outer_composite.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/outer_object_with_enum_property.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/outer_object_with_enum_property.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/parent_with_nullable.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/parent_with_nullable.rb
@@ -208,7 +208,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/pet.rb
@@ -267,7 +267,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/read_only_first.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/special_model_name.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/tag.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-autoload/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby-autoload/lib/petstore/models/user.rb
@@ -223,7 +223,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/additional_properties_class.rb
@@ -172,7 +172,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/all_of_with_single_ref.rb
@@ -190,7 +190,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/animal.rb
@@ -182,7 +182,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/api_response.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/array_test.rb
@@ -211,7 +211,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/capitalization.rb
@@ -205,7 +205,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/cat.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/category.rb
@@ -175,7 +175,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/child_with_nullable.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/child_with_nullable.rb
@@ -192,7 +192,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/class_model.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/client.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/deprecated_object.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/deprecated_object.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/dog.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_arrays.rb
@@ -204,7 +204,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/enum_test.rb
@@ -304,7 +304,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/fake_big_decimal_map200_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/fake_big_decimal_map200_response.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/file_schema_test_class.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/foo.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/foo_get_default_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/foo_get_default_response.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/format_test.rb
@@ -555,7 +555,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/has_only_read_only.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/health_check_result.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/list.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/map_test.rb
@@ -216,7 +216,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -179,7 +179,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model200_response.rb
@@ -169,7 +169,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/model_return.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/name.rb
@@ -194,7 +194,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/nullable_class.rb
@@ -280,7 +280,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/number_only.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/object_with_deprecated_fields.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/object_with_deprecated_fields.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/order.rb
@@ -241,7 +241,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_composite.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_object_with_enum_property.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/outer_object_with_enum_property.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/parent_with_nullable.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/parent_with_nullable.rb
@@ -208,7 +208,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/pet.rb
@@ -267,7 +267,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/read_only_first.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/special_model_name.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/tag.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/models/user.rb
@@ -223,7 +223,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/additional_properties_class.rb
@@ -172,7 +172,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/all_of_with_single_ref.rb
@@ -190,7 +190,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/animal.rb
@@ -182,7 +182,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/api_response.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/array_of_array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/array_test.rb
@@ -211,7 +211,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/capitalization.rb
@@ -205,7 +205,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/cat.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/category.rb
@@ -175,7 +175,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/class_model.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/client.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/deprecated_object.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/deprecated_object.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/dog.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/enum_arrays.rb
@@ -204,7 +204,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/enum_test.rb
@@ -304,7 +304,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/fake_big_decimal_map200_response.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/fake_big_decimal_map200_response.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/file.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/file_schema_test_class.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/foo.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/foo_get_default_response.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/foo_get_default_response.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/format_test.rb
@@ -555,7 +555,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/has_only_read_only.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/health_check_result.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/list.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/map_test.rb
@@ -216,7 +216,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -179,7 +179,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/model200_response.rb
@@ -169,7 +169,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/model_return.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/name.rb
@@ -194,7 +194,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/nullable_class.rb
@@ -280,7 +280,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/number_only.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/object_with_deprecated_fields.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/object_with_deprecated_fields.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/order.rb
@@ -241,7 +241,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/outer_composite.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/outer_object_with_enum_property.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/outer_object_with_enum_property.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/pet.rb
@@ -267,7 +267,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/property_name_mapping.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/property_name_mapping.rb
@@ -186,7 +186,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/read_only_first.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/special_model_name.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/tag.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/user.rb
@@ -223,7 +223,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/whale.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/whale.rb
@@ -184,7 +184,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby-httpx/lib/petstore/models/zebra.rb
+++ b/samples/client/petstore/ruby-httpx/lib/petstore/models/zebra.rb
@@ -209,7 +209,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/additional_properties_class.rb
@@ -172,7 +172,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/all_of_with_single_ref.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/all_of_with_single_ref.rb
@@ -190,7 +190,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/animal.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/animal.rb
@@ -182,7 +182,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/api_response.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_of_number_only.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/array_test.rb
@@ -211,7 +211,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/capitalization.rb
@@ -205,7 +205,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/cat.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/cat.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/category.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/category.rb
@@ -175,7 +175,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/class_model.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/client.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/client.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/deprecated_object.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/deprecated_object.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/dog.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/dog.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_arrays.rb
@@ -204,7 +204,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/enum_test.rb
@@ -304,7 +304,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/fake_big_decimal_map200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/fake_big_decimal_map200_response.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/file.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/file_schema_test_class.rb
@@ -170,7 +170,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/foo.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/foo.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/foo_get_default_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/foo_get_default_response.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/format_test.rb
@@ -555,7 +555,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/has_only_read_only.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/health_check_result.rb
@@ -161,7 +161,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/list.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/list.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/map_test.rb
@@ -216,7 +216,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/mixed_properties_and_additional_properties_class.rb
@@ -179,7 +179,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model200_response.rb
@@ -169,7 +169,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/model_return.rb
@@ -160,7 +160,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/name.rb
@@ -194,7 +194,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/nullable_class.rb
@@ -280,7 +280,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/number_only.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/object_with_deprecated_fields.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/object_with_deprecated_fields.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/order.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/order.rb
@@ -241,7 +241,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_composite.rb
@@ -177,7 +177,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_object_with_enum_property.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_object_with_enum_property.rb
@@ -188,7 +188,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/pet.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/pet.rb
@@ -267,7 +267,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/property_name_mapping.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/property_name_mapping.rb
@@ -186,7 +186,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/read_only_first.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/special_model_name.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/tag.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/tag.rb
@@ -168,7 +168,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/test_inline_freeform_additional_properties_request.rb
@@ -159,7 +159,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/user.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/user.rb
@@ -223,7 +223,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/whale.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/whale.rb
@@ -184,7 +184,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/client/petstore/ruby/lib/petstore/models/zebra.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/zebra.rb
@@ -209,7 +209,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/array_alias.rb
@@ -154,7 +154,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 

--- a/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
+++ b/samples/openapi3/client/features/generate-alias-as-model/ruby-client/lib/petstore/models/map_alias.rb
@@ -150,7 +150,7 @@ module Petstore
       else # model
         # models (e.g. Pet) or oneOf
         klass = Petstore.const_get(type)
-        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
+        klass.respond_to?(:openapi_any_of) || klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
       end
     end
 


### PR DESCRIPTION
Ruby|Client autogenerated model classes for Enums do not expose openapi_one_of method. Instead they expose openapi_any_of method like:

      # List of class defined in anyOf (OpenAPI v3)
      def openapi_any_of
        [
          :String
        ]
      end

Both types (objects and enums) do respond to build() method.

### Addressing:
```
models/redacted_model.rb:1750:in `_deserialize': undefined method `build_from_hash' for XyzModel:Module (NoMethodError)

        klass.respond_to?(:openapi_one_of) ? klass.build(value) : klass.build_from_hash(value)
                                                                       ^^^^^^^^^^^^^^^^
        from models/redacted.rb:1705:in `block in build_from_hash'
```

----

- [x] PR checklist