### PR TITLE
fix(rust-server): remove redundant clone

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/example-server-operation.mustache
@@ -13,7 +13,6 @@
 {{/allParams}}
         context: &C) -> Result<{{{operationId}}}Response, ApiError>
     {
-        let context = context.clone();
         info!("{{#vendorExtensions}}{{{x-operation-id}}}{{/vendorExtensions}}({{#allParams}}{{#vendorExtensions}}{{{x-format-string}}}{{/vendorExtensions}}{{^-last}}, {{/-last}}{{/allParams}}) - X-Span-ID: {:?}"{{#allParams}}, {{{paramName}}}{{/allParams}}, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/multipart-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/examples/server/server.rs
@@ -112,7 +112,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         optional_binary_field: Option<swagger::ByteArray>,
         context: &C) -> Result<MultipartRelatedRequestPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("multipart_related_request_post({:?}, {:?}, {:?}) - X-Span-ID: {:?}", required_binary_field, object_field, optional_binary_field, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -125,7 +124,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         object_field: Option<models::MultipartRequestObjectField>,
         context: &C) -> Result<MultipartRequestPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("multipart_request_post(\"{}\", {:?}, {:?}, {:?}) - X-Span-ID: {:?}", string_field, binary_field, optional_string_field, object_field, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -136,7 +134,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         binary2: Option<swagger::ByteArray>,
         context: &C) -> Result<MultipleIdenticalMimeTypesPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("multiple_identical_mime_types_post({:?}, {:?}) - X-Span-ID: {:?}", binary1, binary2, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/no-example-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/examples/server/server.rs
@@ -108,7 +108,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         op_get_request: models::OpGetRequest,
         context: &C) -> Result<OpGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op_get({:?}) - X-Span-ID: {:?}", op_get_request, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/client/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/client/server.rs
@@ -107,7 +107,6 @@ impl<C> CallbackApi<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         information: Option<String>,
         context: &C) -> Result<CallbackCallbackWithHeaderPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("callback_callback_with_header_post({:?}) - X-Span-ID: {:?}", information, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -117,7 +116,6 @@ impl<C> CallbackApi<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         callback_request_query_url: String,
         context: &C) -> Result<CallbackCallbackPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("callback_callback_post() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/examples/server/server.rs
@@ -133,7 +133,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         any_of: Option<&Vec<models::AnyOfObject>>,
         context: &C) -> Result<AnyOfGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("any_of_get({:?}) - X-Span-ID: {:?}", any_of, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -143,7 +142,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         url: String,
         context: &C) -> Result<CallbackWithHeaderPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("callback_with_header_post(\"{}\") - X-Span-ID: {:?}", url, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -153,7 +151,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         list_of_strings: Option<&Vec<models::StringObject>>,
         context: &C) -> Result<ComplexQueryParamGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -163,7 +160,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         path_param: models::StringEnum,
         context: &C) -> Result<EnumInPathPathParamGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("enum_in_path_path_param_get({:?}) - X-Span-ID: {:?}", path_param, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -173,7 +169,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         list_of_strings: Option<&Vec<models::StringObject>>,
         context: &C) -> Result<JsonComplexQueryParamGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("json_complex_query_param_get({:?}) - X-Span-ID: {:?}", list_of_strings, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -183,7 +178,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         x_header: String,
         context: &C) -> Result<MandatoryRequestHeaderGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("mandatory_request_header_get(\"{}\") - X-Span-ID: {:?}", x_header, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -192,7 +186,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<MergePatchJsonGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("merge_patch_json_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -202,7 +195,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<MultigetGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("multiget_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -211,7 +203,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<MultipleAuthSchemeGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("multiple_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -220,7 +211,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<OneOfGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("one_of_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -229,7 +219,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<OverrideServerGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("override_server_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -242,7 +231,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         some_list: Option<models::MyIdList>,
         context: &C) -> Result<ParamgetGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("paramget_get({:?}, {:?}, {:?}) - X-Span-ID: {:?}", uuid, some_object, some_list, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -251,7 +239,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<ReadonlyAuthSchemeGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("readonly_auth_scheme_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -261,7 +248,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         url: String,
         context: &C) -> Result<RegisterCallbackPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("register_callback_post(\"{}\") - X-Span-ID: {:?}", url, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -271,7 +257,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: swagger::ByteArray,
         context: &C) -> Result<RequiredOctetStreamPutResponse, ApiError>
     {
-        let context = context.clone();
         info!("required_octet_stream_put({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -280,7 +265,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<ResponsesWithHeadersGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("responses_with_headers_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -289,7 +273,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Rfc7807GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("rfc7807_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -299,7 +282,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         object_untyped_props: Option<models::ObjectUntypedProps>,
         context: &C) -> Result<UntypedPropertyGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("untyped_property_get({:?}) - X-Span-ID: {:?}", object_untyped_props, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -308,7 +290,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<UuidGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("uuid_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -318,7 +299,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         duplicate_xml_object: Option<models::DuplicateXmlObject>,
         context: &C) -> Result<XmlExtraPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("xml_extra_post({:?}) - X-Span-ID: {:?}", duplicate_xml_object, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -328,7 +308,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         another_xml_object: Option<models::AnotherXmlObject>,
         context: &C) -> Result<XmlOtherPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("xml_other_post({:?}) - X-Span-ID: {:?}", another_xml_object, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -338,7 +317,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         another_xml_array: Option<models::AnotherXmlArray>,
         context: &C) -> Result<XmlOtherPutResponse, ApiError>
     {
-        let context = context.clone();
         info!("xml_other_put({:?}) - X-Span-ID: {:?}", another_xml_array, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -349,7 +327,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         xml_array: Option<models::XmlArray>,
         context: &C) -> Result<XmlPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("xml_post({:?}) - X-Span-ID: {:?}", xml_array, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -359,7 +336,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         xml_object: Option<models::XmlObject>,
         context: &C) -> Result<XmlPutResponse, ApiError>
     {
-        let context = context.clone();
         info!("xml_put({:?}) - X-Span-ID: {:?}", xml_object, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -369,7 +345,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         object_param: models::ObjectParam,
         context: &C) -> Result<CreateRepoResponse, ApiError>
     {
-        let context = context.clone();
         info!("create_repo({:?}) - X-Span-ID: {:?}", object_param, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -379,7 +354,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         repo_id: String,
         context: &C) -> Result<GetRepoInfoResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_repo_info(\"{}\") - X-Span-ID: {:?}", repo_id, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/ops-v3/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/examples/server/server.rs
@@ -143,7 +143,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op10GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op10_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -152,7 +151,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op11GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op11_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -161,7 +159,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op12GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op12_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -170,7 +167,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op13GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op13_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -179,7 +175,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op14GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op14_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -188,7 +183,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op15GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op15_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -197,7 +191,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op16GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op16_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -206,7 +199,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op17GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op17_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -215,7 +207,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op18GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op18_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -224,7 +215,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op19GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op19_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -233,7 +223,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op1GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op1_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -242,7 +231,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op20GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op20_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -251,7 +239,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op21GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op21_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -260,7 +247,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op22GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op22_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -269,7 +255,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op23GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op23_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -278,7 +263,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op24GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op24_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -287,7 +271,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op25GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op25_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -296,7 +279,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op26GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op26_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -305,7 +287,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op27GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op27_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -314,7 +295,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op28GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op28_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -323,7 +303,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op29GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op29_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -332,7 +311,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op2GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op2_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -341,7 +319,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op30GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op30_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -350,7 +327,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op31GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op31_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -359,7 +335,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op32GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op32_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -368,7 +343,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op33GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op33_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -377,7 +351,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op34GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op34_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -386,7 +359,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op35GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op35_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -395,7 +367,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op36GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op36_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -404,7 +375,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op37GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op37_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -413,7 +383,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op3GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op3_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -422,7 +391,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op4GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op4_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -431,7 +399,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op5GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op5_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -440,7 +407,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op6GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op6_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -449,7 +415,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op7GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op7_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -458,7 +423,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op8GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op8_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -467,7 +431,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Op9GetResponse, ApiError>
     {
-        let context = context.clone();
         info!("op9_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/examples/server/server.rs
@@ -143,7 +143,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Client,
         context: &C) -> Result<TestSpecialTagsResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_special_tags({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -152,7 +151,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<Call123exampleResponse, ApiError>
     {
-        let context = context.clone();
         info!("call123example() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -162,7 +160,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: Option<models::OuterBoolean>,
         context: &C) -> Result<FakeOuterBooleanSerializeResponse, ApiError>
     {
-        let context = context.clone();
         info!("fake_outer_boolean_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -172,7 +169,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: Option<models::OuterComposite>,
         context: &C) -> Result<FakeOuterCompositeSerializeResponse, ApiError>
     {
-        let context = context.clone();
         info!("fake_outer_composite_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -182,7 +178,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: Option<models::OuterNumber>,
         context: &C) -> Result<FakeOuterNumberSerializeResponse, ApiError>
     {
-        let context = context.clone();
         info!("fake_outer_number_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -192,7 +187,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: Option<models::OuterString>,
         context: &C) -> Result<FakeOuterStringSerializeResponse, ApiError>
     {
-        let context = context.clone();
         info!("fake_outer_string_serialize({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -201,7 +195,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<FakeResponseWithNumericalDescriptionResponse, ApiError>
     {
-        let context = context.clone();
         info!("fake_response_with_numerical_description() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -211,7 +204,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         hyphen_param: String,
         context: &C) -> Result<HyphenParamResponse, ApiError>
     {
-        let context = context.clone();
         info!("hyphen_param(\"{}\") - X-Span-ID: {:?}", hyphen_param, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -222,7 +214,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::User,
         context: &C) -> Result<TestBodyWithQueryParamsResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_body_with_query_params(\"{}\", {:?}) - X-Span-ID: {:?}", query, body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -233,7 +224,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Client,
         context: &C) -> Result<TestClientModelResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_client_model({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -257,7 +247,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         callback: Option<String>,
         context: &C) -> Result<TestEndpointParametersResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_endpoint_parameters({}, {}, \"{}\", {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", number, double, pattern_without_delimiter, byte, integer, int32, int64, float, string, binary, date, date_time, password, callback, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -274,7 +263,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         enum_form_string: Option<String>,
         context: &C) -> Result<TestEnumParametersResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_enum_parameters({:?}, {:?}, {:?}, {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", enum_header_string_array, enum_header_string, enum_query_string_array, enum_query_string, enum_query_integer, enum_query_double, enum_form_string, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -285,7 +273,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         param: std::collections::HashMap<String, String>,
         context: &C) -> Result<TestInlineAdditionalPropertiesResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_inline_additional_properties({:?}) - X-Span-ID: {:?}", param, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -297,7 +284,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         param2: String,
         context: &C) -> Result<TestJsonFormDataResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_json_form_data(\"{}\", \"{}\") - X-Span-ID: {:?}", param, param2, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -308,7 +294,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Client,
         context: &C) -> Result<TestClassnameResponse, ApiError>
     {
-        let context = context.clone();
         info!("test_classname({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -319,7 +304,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Pet,
         context: &C) -> Result<AddPetResponse, ApiError>
     {
-        let context = context.clone();
         info!("add_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -331,7 +315,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         api_key: Option<String>,
         context: &C) -> Result<DeletePetResponse, ApiError>
     {
-        let context = context.clone();
         info!("delete_pet({}, {:?}) - X-Span-ID: {:?}", pet_id, api_key, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -342,7 +325,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         status: &Vec<String>,
         context: &C) -> Result<FindPetsByStatusResponse, ApiError>
     {
-        let context = context.clone();
         info!("find_pets_by_status({:?}) - X-Span-ID: {:?}", status, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -353,7 +335,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         tags: &Vec<String>,
         context: &C) -> Result<FindPetsByTagsResponse, ApiError>
     {
-        let context = context.clone();
         info!("find_pets_by_tags({:?}) - X-Span-ID: {:?}", tags, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -364,7 +345,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         pet_id: i64,
         context: &C) -> Result<GetPetByIdResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_pet_by_id({}) - X-Span-ID: {:?}", pet_id, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -375,7 +355,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Pet,
         context: &C) -> Result<UpdatePetResponse, ApiError>
     {
-        let context = context.clone();
         info!("update_pet({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -388,7 +367,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         status: Option<String>,
         context: &C) -> Result<UpdatePetWithFormResponse, ApiError>
     {
-        let context = context.clone();
         info!("update_pet_with_form({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, name, status, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -401,7 +379,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         file: Option<swagger::ByteArray>,
         context: &C) -> Result<UploadFileResponse, ApiError>
     {
-        let context = context.clone();
         info!("upload_file({}, {:?}, {:?}) - X-Span-ID: {:?}", pet_id, additional_metadata, file, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -412,7 +389,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         order_id: String,
         context: &C) -> Result<DeleteOrderResponse, ApiError>
     {
-        let context = context.clone();
         info!("delete_order(\"{}\") - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -422,7 +398,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<GetInventoryResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_inventory() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -433,7 +408,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         order_id: i64,
         context: &C) -> Result<GetOrderByIdResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_order_by_id({}) - X-Span-ID: {:?}", order_id, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -444,7 +418,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::Order,
         context: &C) -> Result<PlaceOrderResponse, ApiError>
     {
-        let context = context.clone();
         info!("place_order({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -455,7 +428,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::User,
         context: &C) -> Result<CreateUserResponse, ApiError>
     {
-        let context = context.clone();
         info!("create_user({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -466,7 +438,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: &Vec<models::User>,
         context: &C) -> Result<CreateUsersWithArrayInputResponse, ApiError>
     {
-        let context = context.clone();
         info!("create_users_with_array_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -477,7 +448,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: &Vec<models::User>,
         context: &C) -> Result<CreateUsersWithListInputResponse, ApiError>
     {
-        let context = context.clone();
         info!("create_users_with_list_input({:?}) - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -488,7 +458,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         username: String,
         context: &C) -> Result<DeleteUserResponse, ApiError>
     {
-        let context = context.clone();
         info!("delete_user(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -499,7 +468,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         username: String,
         context: &C) -> Result<GetUserByNameResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_user_by_name(\"{}\") - X-Span-ID: {:?}", username, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -511,7 +479,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         password: String,
         context: &C) -> Result<LoginUserResponse, ApiError>
     {
-        let context = context.clone();
         info!("login_user(\"{}\", \"{}\") - X-Span-ID: {:?}", username, password, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -521,7 +488,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<LogoutUserResponse, ApiError>
     {
-        let context = context.clone();
         info!("logout_user() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -533,7 +499,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: models::User,
         context: &C) -> Result<UpdateUserResponse, ApiError>
     {
-        let context = context.clone();
         info!("update_user(\"{}\", {:?}) - X-Span-ID: {:?}", username, body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/examples/server/server.rs
@@ -107,7 +107,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<PingGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("ping_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }

--- a/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/examples/server/server.rs
@@ -115,7 +115,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<AllOfGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("all_of_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -125,7 +124,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<DummyGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("dummy_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -135,7 +133,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         nested_response: models::DummyPutRequest,
         context: &C) -> Result<DummyPutResponse, ApiError>
     {
-        let context = context.clone();
         info!("dummy_put({:?}) - X-Span-ID: {:?}", nested_response, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -145,7 +142,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<FileResponseGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("file_response_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -154,7 +150,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<GetStructuredYamlResponse, ApiError>
     {
-        let context = context.clone();
         info!("get_structured_yaml() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -165,7 +160,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         body: String,
         context: &C) -> Result<HtmlPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("html_post(\"{}\") - X-Span-ID: {:?}", body, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -175,7 +169,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         value: String,
         context: &C) -> Result<PostYamlResponse, ApiError>
     {
-        let context = context.clone();
         info!("post_yaml(\"{}\") - X-Span-ID: {:?}", value, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -185,7 +178,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         &self,
         context: &C) -> Result<RawJsonGetResponse, ApiError>
     {
-        let context = context.clone();
         info!("raw_json_get() - X-Span-ID: {:?}", context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
@@ -196,7 +188,6 @@ impl<C> Api<C> for Server<C> where C: Has<XSpanIdString> + Send + Sync
         value: serde_json::Value,
         context: &C) -> Result<SoloObjectPostResponse, ApiError>
     {
-        let context = context.clone();
         info!("solo_object_post({:?}) - X-Span-ID: {:?}", value, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }


### PR DESCRIPTION
The generated example code would clone the context. However as context is a generic type and is not declared to implement Clone, a clone of a reference is just a copy of the reference and therefore unnecessary. This change removes the redundant call and therefore avoids the `cargo clippy` warning.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


 @jacob-pro 