### PR TITLE
[php-symfony] Fix type hint for array in comments.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PhpSymfonyServerCodegen.java
@@ -407,13 +407,13 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
             for (CodegenParameter param : op.allParams) {
                 // Determine if the parameter type is supported as a type hint and make it available
                 // to the templating engine
-                String typeHint = getTypeHint(param.dataType);
+                String typeHint = getTypeHint(param.dataType, false);
                 if (!typeHint.isEmpty()) {
                     param.vendorExtensions.put("x-parameter-type", typeHint);
                 }
 
                 if (param.isContainer) {
-                    param.vendorExtensions.put("x-parameter-type", getTypeHint(param.dataType + "[]"));
+                    param.vendorExtensions.put("x-parameter-type", getTypeHint(param.dataType + "[]", false));
                 }
 
                 // Create a variable to display the correct data type in comments for interfaces
@@ -636,7 +636,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
     }
 
     protected String getTypeHintNullable(String type) {
-        String typeHint = getTypeHint(type);
+        String typeHint = getTypeHint(type, false);
         if (!typeHint.equals("")) {
             return "?" + typeHint;
         }
@@ -645,7 +645,7 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
     }
 
     protected String getTypeHintNullableForComments(String type) {
-        String typeHint = getTypeHint(type);
+        String typeHint = getTypeHint(type, true);
         if (!typeHint.equals("")) {
             return typeHint + "|null";
         }
@@ -653,10 +653,16 @@ public class PhpSymfonyServerCodegen extends AbstractPhpCodegen implements Codeg
         return typeHint;
     }
 
-    protected String getTypeHint(String type) {
+    protected String getTypeHint(String type, Boolean forComments) {
         // Type hint array types
         if (type.endsWith("[]")) {
-            return "array";
+            if (forComments) {
+                //Make type hints for array in comments. Call getTypeHint recursive for extractSimpleName for models
+                String typeWithoutArray = type.substring(0, type.length() - 2);
+                return this.getTypeHint(typeWithoutArray, true) + "[]";
+            } else {
+                return "array";
+            }
         }
 
         // Check if the type is a native type that is type hintable in PHP

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Model/Pet.php
@@ -70,7 +70,7 @@ class Pet
     protected ?string $name = null;
 
     /**
-     * @var array|null
+     * @var string[]|null
      * @SerializedName("photoUrls")
      * @Assert\NotNull()
      * @Assert\All({
@@ -81,7 +81,7 @@ class Pet
     protected ?array $photoUrls = null;
 
     /**
-     * @var array|null
+     * @var Tag[]|null
      * @SerializedName("tags")
      * @Assert\All({
      *   @Assert\Type("OpenAPI\Server\Model\Tag")
@@ -192,7 +192,7 @@ class Pet
     /**
      * Gets photoUrls.
      *
-     * @return array|null
+     * @return string[]|null
      */
     public function getPhotoUrls(): ?array
     {
@@ -202,7 +202,7 @@ class Pet
     /**
      * Sets photoUrls.
      *
-     * @param array|null $photoUrls
+     * @param string[]|null $photoUrls
      *
      * @return $this
      */
@@ -216,7 +216,7 @@ class Pet
     /**
      * Gets tags.
      *
-     * @return array|null
+     * @return Tag[]|null
      */
     public function getTags(): ?array
     {
@@ -226,7 +226,7 @@ class Pet
     /**
      * Sets tags.
      *
-     * @param array|null $tags
+     * @param Tag[]|null $tags
      *
      * @return $this
      */


### PR DESCRIPTION
This commit fix type hinting of model array items in PHPDoc comments.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), [@ybelenko](https://github.com/ybelenko) (2018/07), @renepardon (2018/12)