### PR TITLE
chore(deps,rust): requires reqwest 0.11 in blocking generated code

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/Cargo.mustache
@@ -54,7 +54,9 @@ secrecy = "0.8.0"
 {{/withAWSV4Signature}}
 {{#reqwest}}
 {{^supportAsync}}
-reqwest = "~0.9"
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "blocking", "multipart"]
 {{/supportAsync}}
 {{#supportAsync}}
 {{#supportMiddleware}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api.mustache
@@ -244,7 +244,7 @@ pub {{#supportAsync}}async {{/supportAsync}}fn {{{operationId}}}(configuration: 
     {{/hasAuthMethods}}
     {{#isMultipart}}
     {{#hasFormParams}}
-    let mut local_var_form = reqwest::multipart::Form::new();
+    let mut local_var_form = reqwest{{^supportAsync}}::blocking{{/supportAsync}}::multipart::Form::new();
     {{#formParams}}
     {{#isFile}}
     {{^supportAsync}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
@@ -11,7 +11,7 @@ use secrecy::{SecretString, ExposeSecret};
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest::Client{{/supportMiddleware}},
+    pub client: {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client{{/supportMiddleware}},
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
@@ -80,7 +80,7 @@ impl Default for Configuration {
         Configuration {
             base_path: "{{{basePath}}}".to_owned(),
             user_agent: {{#httpUserAgent}}Some("{{{.}}}".to_owned()){{/httpUserAgent}}{{^httpUserAgent}}Some("OpenAPI-Generator/{{{version}}}/rust".to_owned()){{/httpUserAgent}},
-            client: {{#supportMiddleware}}reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build(){{/supportMiddleware}}{{^supportMiddleware}}reqwest::Client::new(){{/supportMiddleware}},
+            client: {{#supportMiddleware}}reqwest_middleware::ClientBuilder::new(reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new()).build(){{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new(){{/supportMiddleware}},
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
+++ b/samples/client/others/rust/reqwest-regression-16119/Cargo.toml
@@ -13,4 +13,6 @@ serde_with = "^2.0"
 serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde", "v4"] }
-reqwest = "~0.9"
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "blocking", "multipart"]

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
@@ -14,7 +14,7 @@
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: reqwest::Client,
+    pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
@@ -42,7 +42,7 @@ impl Default for Configuration {
         Configuration {
             base_path: "http://api.example.xyz/v1".to_owned(),
             user_agent: Some("OpenAPI-Generator/0.1.0/rust".to_owned()),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/name-mapping/Cargo.toml
@@ -12,4 +12,6 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde", "v4"] }
-reqwest = "~0.9"
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "blocking", "multipart"]

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
@@ -14,7 +14,7 @@
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: reqwest::Client,
+    pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
@@ -42,7 +42,7 @@ impl Default for Configuration {
         Configuration {
             base_path: "http://petstore.swagger.io/v2".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/Cargo.toml
@@ -16,4 +16,6 @@ uuid = { version = "^1.0", features = ["serde", "v4"] }
 aws-sigv4 = "0.3.0"
 http = "0.2.5"
 secrecy = "0.8.0"
-reqwest = "~0.9"
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "blocking", "multipart"]

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
@@ -18,7 +18,7 @@ use secrecy::{SecretString, ExposeSecret};
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: reqwest::Client,
+    pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
@@ -83,7 +83,7 @@ impl Default for Configuration {
         Configuration {
             base_path: "http://petstore.swagger.io/v2".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/pet_api.rs
@@ -444,7 +444,7 @@ pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, ad
     if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
-    let mut local_var_form = reqwest::multipart::Form::new();
+    let mut local_var_form = reqwest::blocking::multipart::Form::new();
     if let Some(local_var_param_value) = additional_metadata {
         local_var_form = local_var_form.text("additionalMetadata", local_var_param_value.to_string());
     }

--- a/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
+++ b/samples/client/petstore/rust/reqwest/petstore/Cargo.toml
@@ -13,4 +13,6 @@ serde_with = "^2.0"
 serde_json = "^1.0"
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde", "v4"] }
-reqwest = "~0.9"
+[dependencies.reqwest]
+version = "^0.11"
+features = ["json", "blocking", "multipart"]

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
@@ -14,7 +14,7 @@
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub client: reqwest::Client,
+    pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
@@ -42,7 +42,7 @@ impl Default for Configuration {
         Configuration {
             base_path: "http://petstore.swagger.io/v2".to_owned(),
             user_agent: Some("OpenAPI-Generator/1.0.0/rust".to_owned()),
-            client: reqwest::Client::new(),
+            client: reqwest::blocking::Client::new(),
             basic_auth: None,
             oauth_access_token: None,
             bearer_access_token: None,

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/pet_api.rs
@@ -340,7 +340,7 @@ pub fn upload_file(configuration: &configuration::Configuration, pet_id: i64, ad
     if let Some(ref local_var_token) = local_var_configuration.oauth_access_token {
         local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
     };
-    let mut local_var_form = reqwest::multipart::Form::new();
+    let mut local_var_form = reqwest::blocking::multipart::Form::new();
     if let Some(local_var_param_value) = additional_metadata {
         local_var_form = local_var_form.text("additionalMetadata", local_var_param_value.to_string());
     }


### PR DESCRIPTION
Requires reqwest 0.11 even if code was generated in blocking mode.

close #15549

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
  - cc @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)