### PR TITLE
fix(java): generate correct enum constructor when string format is uri

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1734,6 +1734,8 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         } else if ("BigDecimal".equals(datatype)) {
             // use BigDecimal String constructor
             return "new BigDecimal(\"" + value + "\")";
+        } else if ("URI".equals(datatype)) {
+            return "URI.create(\"" + escapeText(value) + "\")";
         } else {
             return "\"" + escapeText(value) + "\"";
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -332,6 +332,7 @@ public class AbstractJavaCodegenTest {
         Assert.assertEquals(codegen.toEnumValue("42", "Double"), "42");
         Assert.assertEquals(codegen.toEnumValue("1337", "Long"), "1337l");
         Assert.assertEquals(codegen.toEnumValue("3.14", "Float"), "3.14f");
+        Assert.assertEquals(codegen.toEnumValue("schema.json", "URI"), "URI.create(\"schema.json\")");
     }
 
     @Test


### PR DESCRIPTION
Using the following spec:

```yaml
openapi: 3.0.0
info:
  title: Sample API
  description: Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
  version: 0.1.9
servers:
  - url: http://api.example.com/v1
    description: Optional server description, e.g. Main (production) server
paths:
  /users:
    post:
      summary: Creates a user.
      requestBody:
        required: true
        content:
          application/json:
            schema:
              type: object
              properties:
                dataSchema:
                  type: string
                  format: uri
                  default: https://example.com/v1/schema.json
                  enum:
                    - https://example.com/v1/schema.json
                    - https://example.com/v2/schema.json

      responses: 
        '201':
          description: Created
```

The generated DataSchemaEnum is:

```java
public enum DataSchemaEnum {
    COM_V1_SCHEMA_JSON("https://example.com/v1/schema.json"), 
    COM_V2_SCHEMA_JSON("https://example.com/v2/schema.json");
                                                                                      
    private URI value;                                                                
                                                                                      
    DataSchemaEnum(URI value) {
      this.value = value;
    }
}

private DataSchemaEnum dataSchema = URI.create("https://example.com/v1/schema.json");
```
Causing the following compilation errors:

```
[ERROR] incompatible types: java.lang.String cannot be converted to java.net.URI
[ERROR] incompatible types: java.net.URI cannot be converted to org.openapitools.client.model.UsersPostRequest.DataSchemaEnum
```

With the fix applied:

```java
public enum DataSchemaEnum {
    COM_V1_SCHEMA_JSON(URI.create("https://example.com/v1/schema.json"),
    COM_V2_SCHEMA_JSON(URI.create("https://example.com/v2/schema.json");

    private URI value;                                                                
                                                                                      
    DataSchemaEnum(URI value) {
      this.value = value;
    }
}

private DataSchemaEnum dataSchema = DataSchemaEnum.COM_V1_SCHEMA_JSON;
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
