### PR TITLE
[N4JS] Fix issue with broken module names in case of same names

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/N4jsClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/N4jsClientCodegen.java
@@ -229,11 +229,10 @@ public class N4jsClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelFilename(String name) {
-        String modelFilename = super.toModelFilename(name);
-        if (typeMapping.containsKey(modelFilename) || defaultIncludes.contains(modelFilename)) {
-            return modelFilename;
+        if (typeMapping.containsKey(name) || defaultIncludes.contains(name)) {
+            return name;
         }
-        return modelFilename;
+        return super.toModelFilename(name);
     }
 
     public boolean checkRequiredBodyPropsNotNull() {
@@ -485,10 +484,11 @@ public class N4jsClientCodegen extends DefaultCodegen implements CodegenConfig {
 
     @Override
     public String toModelImport(String name) {
+     String modelImportName = toModelFilename(name);
         if ("".equals(modelPackage())) {
-            return name;
+            return modelImportName;
         } else {
-            return modelPackage() + "/" + name;
+            return modelPackage() + "/" + modelImportName;
         }
     }
 
@@ -564,7 +564,11 @@ public class N4jsClientCodegen extends DefaultCodegen implements CodegenConfig {
                 return numericEnumValuesToEnumTypeUnion(new ArrayList<Number>(p.getEnum()));
             }
         }
-        return this.getTypeDeclaration(p);
+        String result = this.getTypeDeclaration(p);
+        if (result != null) {
+            result = toModelFilename(result);
+        }
+        return result;
     }
 
     @Override
@@ -578,7 +582,11 @@ public class N4jsClientCodegen extends DefaultCodegen implements CodegenConfig {
                 }
             }
         }
-        return super.getSingleSchemaType(unaliasSchema);
+        String result = super.getSingleSchemaType(unaliasSchema);
+        if (result != null) {
+            result = toModelFilename(result);
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
Fixes situation where two modules have the same name and a '_1' is appended to one of both. However, before the fix the postfix '_1' is sometimes transformed to '1' only, due to a call to `StringUtils#camelize(String)`. The fix in this PR mitigates the situation by always calling `camelize(String)`.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
