### PR TITLE
[python] add circular reference import 

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
@@ -183,10 +183,8 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    {{{.}}}
-    # TODO: pydantic v2
+{{{.}}}
 {{/vendorExtensions.x-py-postponed-model-imports}}
-    # {{classname}}.model_rebuild()
+# TODO: Rewrite to not use raise_errors
+{{classname}}.model_rebuild(raise_errors=False)
 {{/vendorExtensions.x-py-postponed-model-imports.size}}

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -379,9 +379,6 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 {{#vendorExtensions.x-py-postponed-model-imports}}
 {{{.}}}
 {{/vendorExtensions.x-py-postponed-model-imports}}
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # {{classname}}.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+{{classname}}.model_rebuild(raise_errors=False)
 {{/vendorExtensions.x-py-postponed-model-imports.size}}

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -207,10 +207,8 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
 {{#vendorExtensions.x-py-postponed-model-imports.size}}
 {{#vendorExtensions.x-py-postponed-model-imports}}
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    {{{.}}}
-    # TODO: pydantic v2
+{{{.}}}
 {{/vendorExtensions.x-py-postponed-model-imports}}
-    # {{classname}}.model_rebuild()
+# TODO: Rewrite to not use raise_errors
+{{classname}}.model_rebuild(raise_errors=False)
 {{/vendorExtensions.x-py-postponed-model-imports.size}}

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -105,9 +105,6 @@ class Animal(BaseModel):
 
 from petstore_api.models.cat import Cat
 from petstore_api.models.dog import Dog
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # Animal.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+Animal.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -91,9 +91,6 @@ class CircularReferenceModel(BaseModel):
         return _obj
 
 from petstore_api.models.first_ref import FirstRef
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # CircularReferenceModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+CircularReferenceModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -91,9 +91,6 @@ class DummyModel(BaseModel):
         return _obj
 
 from petstore_api.models.self_reference_model import SelfReferenceModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # DummyModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+DummyModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -91,9 +91,6 @@ class FirstRef(BaseModel):
         return _obj
 
 from petstore_api.models.second_ref import SecondRef
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # FirstRef.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+FirstRef.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -91,9 +91,6 @@ class SecondRef(BaseModel):
         return _obj
 
 from petstore_api.models.circular_reference_model import CircularReferenceModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # SecondRef.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+SecondRef.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -91,9 +91,6 @@ class SelfReferenceModel(BaseModel):
         return _obj
 
 from petstore_api.models.dummy_model import DummyModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # SelfReferenceModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+SelfReferenceModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -113,9 +113,6 @@ class Animal(BaseModel):
 
 from petstore_api.models.cat import Cat
 from petstore_api.models.dog import Dog
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # Animal.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+Animal.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -104,9 +104,6 @@ class CircularReferenceModel(BaseModel):
         return _obj
 
 from petstore_api.models.first_ref import FirstRef
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # CircularReferenceModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+CircularReferenceModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -104,9 +104,6 @@ class DummyModel(BaseModel):
         return _obj
 
 from petstore_api.models.self_reference_model import SelfReferenceModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # DummyModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+DummyModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -104,9 +104,6 @@ class FirstRef(BaseModel):
         return _obj
 
 from petstore_api.models.second_ref import SecondRef
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # FirstRef.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+FirstRef.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -104,9 +104,6 @@ class SecondRef(BaseModel):
         return _obj
 
 from petstore_api.models.circular_reference_model import CircularReferenceModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # SecondRef.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+SecondRef.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -104,9 +104,6 @@ class SelfReferenceModel(BaseModel):
         return _obj
 
 from petstore_api.models.dummy_model import DummyModel
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    # TODO: pydantic v2
-    # SelfReferenceModel.model_rebuild()
-    pass
+# TODO: Rewrite to not use raise_errors
+SelfReferenceModel.model_rebuild(raise_errors=False)
 

--- a/samples/openapi3/client/petstore/python/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python/tests/test_model.py
@@ -560,7 +560,6 @@ class ModelTests(unittest.TestCase):
         # should not throw the following errors:
         #   pydantic.errors.ConfigError: field "additional_properties" not yet prepared so type is still a ForwardRef, you might need to call ObjectToTestAdditionalProperties.update_forward_refs().
 
-    @unittest.skip("TODO: pydantic v2: fix circular dependencies between CircularReferenceModel, FirstRef, SecondRef")
     def test_first_ref(self):
         # shouldn't throw "still a ForwardRef" error
         a = petstore_api.FirstRef.from_dict({})


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

---

Pydantic v2 has made significant changes to the specifications regarding the reconstruction of models required for circular references.
This requires the construction of a very complex referencing algorithm to resolve.
I hope to have those issues resolved by the 7.1.0 release of openapi-generator. Because importing circular references is needed by many people.
I propose these temporary fixes because I do not want to spend time building a complex referencing algorithm.

I would prefer not to use raise_errors, but it is very useful as a temporary implementation.

@fa0311 @multani