### PR TITLE
Better isAlias detection

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -42,6 +42,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -63,6 +64,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import lombok.SneakyThrows;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -98,11 +100,11 @@ public class JavaClientCodegenTest {
 
         RequestBody body1 = new RequestBody();
         body1.setDescription("A list of ids");
-    body1.setContent(
-        new Content()
-            .addMediaType(
-                "application/json",
-                new MediaType().schema(new ArraySchema().items(new StringSchema()))));
+        body1.setContent(
+                new Content()
+                        .addMediaType(
+                                "application/json",
+                                new MediaType().schema(new ArraySchema().items(new StringSchema()))));
         CodegenParameter codegenParameter1 = codegen.fromRequestBody(body1, new HashSet<String>(), null);
         Assert.assertEquals(codegenParameter1.description, "A list of ids");
         Assert.assertEquals(codegenParameter1.dataType, "List<String>");
@@ -110,13 +112,13 @@ public class JavaClientCodegenTest {
 
         RequestBody body2 = new RequestBody();
         body2.setDescription("A list of list of values");
-    body2.setContent(
-        new Content()
-            .addMediaType(
-                "application/json",
-                new MediaType()
-                    .schema(
-                        new ArraySchema().items(new ArraySchema().items(new IntegerSchema())))));
+        body2.setContent(
+                new Content()
+                        .addMediaType(
+                                "application/json",
+                                new MediaType()
+                                        .schema(
+                                                new ArraySchema().items(new ArraySchema().items(new IntegerSchema())))));
         CodegenParameter codegenParameter2 = codegen.fromRequestBody(body2, new HashSet<String>(), null);
         Assert.assertEquals(codegenParameter2.description, "A list of list of values");
         Assert.assertEquals(codegenParameter2.dataType, "List<List<Integer>>");
@@ -124,14 +126,14 @@ public class JavaClientCodegenTest {
 
         RequestBody body3 = new RequestBody();
         body3.setDescription("A list of points");
-    body3.setContent(
-        new Content()
-            .addMediaType(
-                "application/json",
-                new MediaType()
-                    .schema(
-                        new ArraySchema()
-                            .items(new ObjectSchema().$ref("#/components/schemas/Point")))));
+        body3.setContent(
+                new Content()
+                        .addMediaType(
+                                "application/json",
+                                new MediaType()
+                                        .schema(
+                                                new ArraySchema()
+                                                        .items(new ObjectSchema().$ref("#/components/schemas/Point")))));
         ObjectSchema point = new ObjectSchema();
         point.addProperty("message", new StringSchema());
         point.addProperty("x", new IntegerSchema().format(SchemaTypeUtil.INTEGER32_FORMAT));
@@ -184,17 +186,17 @@ public class JavaClientCodegenTest {
         Assert.assertFalse(codegen.isHideGenerationTimestamp());
 
         Assert.assertEquals(codegen.modelPackage(), "org.openapitools.client.model");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
-        "org.openapitools.client.model");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
+                "org.openapitools.client.model");
         Assert.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
-        "org.openapitools.client.api");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
+                "org.openapitools.client.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "org.openapitools.client");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
-        "org.openapitools.client");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
+                "org.openapitools.client");
         Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON);
     }
 
@@ -211,16 +213,16 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertTrue(codegen.isHideGenerationTimestamp());
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.model");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.model");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.model");
         Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.api");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.API_PACKAGE), "xyz.yyyyy.zzzzzzz.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.invoker");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.invoker");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.invoker");
         Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_GSON); // the library JavaClientCodegen.OKHTTP_GSON only supports GSON
     }
 
@@ -228,13 +230,13 @@ public class JavaClientCodegenTest {
     public void testAdditionalPropertiesPutForConfigValues() throws Exception {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.additionalProperties().put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, "true");
-    codegen
-        .additionalProperties()
-        .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
-    codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
-    codegen
-        .additionalProperties()
-        .put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.zzzzzzz.iiii.invoker");
+        codegen
+                .additionalProperties()
+                .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        codegen
+                .additionalProperties()
+                .put(CodegenConstants.INVOKER_PACKAGE, "xyz.yyyyy.zzzzzzz.iiii.invoker");
         codegen.additionalProperties().put(CodegenConstants.SERIALIZATION_LIBRARY, "JACKSON");
         codegen.additionalProperties().put(CodegenConstants.LIBRARY, JavaClientCodegen.JERSEY2);
         codegen.processOpts();
@@ -242,17 +244,17 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(codegen.additionalProperties().get(CodegenConstants.HIDE_GENERATION_TIMESTAMP), Boolean.TRUE);
         Assert.assertTrue(codegen.isHideGenerationTimestamp());
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.aaaaa.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.iiii.invoker");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.iiii.invoker");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.iiii.invoker");
         Assert.assertEquals(codegen.getSerializationLibrary(), JavaClientCodegen.SERIALIZATION_LIBRARY_JACKSON);
     }
 
@@ -263,14 +265,14 @@ public class JavaClientCodegenTest {
 
         File output = Files.createTempDirectory("test").toFile();
 
-    final CodegenConfigurator configurator =
-        new CodegenConfigurator()
-            .setGeneratorName("java")
-            .setLibrary(JavaClientCodegen.JERSEY3)
-            .setAdditionalProperties(properties)
-            .setInputSpec(
-                "src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        final CodegenConfigurator configurator =
+                new CodegenConfigurator()
+                        .setGeneratorName("java")
+                        .setLibrary(JavaClientCodegen.JERSEY3)
+                        .setAdditionalProperties(properties)
+                        .setInputSpec(
+                                "src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing-with-http-signature.yaml")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
 
@@ -278,14 +280,14 @@ public class JavaClientCodegenTest {
 
         List<File> files = generator.opts(clientOptInput).generate();
 
-    TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/ApiKeyAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/auth/Authentication.java");
-    TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/HttpBasicAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/auth/HttpBearerAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/auth/HttpSignatureAuth.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/ApiKeyAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/auth/Authentication.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/HttpBasicAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/auth/HttpBearerAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/auth/HttpSignatureAuth.java");
     }
 
     @Test
@@ -305,9 +307,9 @@ public class JavaClientCodegenTest {
 
         List<File> files = generator.opts(clientOptInput).generate();
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/QueryApi.java"),
-        "import java.time.Instant;");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/QueryApi.java"),
+                "import java.time.Instant;");
     }
 
     @Test
@@ -322,52 +324,52 @@ public class JavaClientCodegenTest {
     @Test
     public void testPackageNamesSetInvokerDerivedFromApi() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
-    codegen
-        .additionalProperties()
-        .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
-    codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        codegen
+                .additionalProperties()
+                .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen.additionalProperties().put(CodegenConstants.API_PACKAGE, "xyz.yyyyy.zzzzzzz.aaaaa.api");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.apiPackage(), "xyz.yyyyy.zzzzzzz.aaaaa.api");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.aaaaa.api");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.aaaaa.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.aaaaa");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.aaaaa");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.aaaaa");
     }
 
     @Test
     public void testPackageNamesSetInvokerDerivedFromModel() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
-    codegen
-        .additionalProperties()
-        .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        codegen
+                .additionalProperties()
+                .put(CodegenConstants.MODEL_PACKAGE, "xyz.yyyyy.zzzzzzz.mmmmm.model");
         codegen.processOpts();
 
         Assert.assertEquals(codegen.modelPackage(), "xyz.yyyyy.zzzzzzz.mmmmm.model");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.mmmmm.model");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.MODEL_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.mmmmm.model");
         Assert.assertEquals(codegen.apiPackage(), "org.openapitools.client.api");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
-        "org.openapitools.client.api");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.API_PACKAGE),
+                "org.openapitools.client.api");
         Assert.assertEquals(codegen.getInvokerPackage(), "xyz.yyyyy.zzzzzzz.mmmmm");
-    Assert.assertEquals(
-        codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
-        "xyz.yyyyy.zzzzzzz.mmmmm");
+        Assert.assertEquals(
+                codegen.additionalProperties().get(CodegenConstants.INVOKER_PACKAGE),
+                "xyz.yyyyy.zzzzzzz.mmmmm");
     }
 
     @Test
     public void testGetSchemaTypeWithComposedSchemaWithAllOf() {
-    final OpenAPI openAPI =
-        TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
+        final OpenAPI openAPI =
+                TestUtils.parseFlattenSpec("src/test/resources/2_0/composed-allof.yaml");
         final JavaClientCodegen codegen = new JavaClientCodegen();
 
         Operation operation = openAPI.getPaths().get("/ping").getPost();
@@ -383,8 +385,8 @@ public class JavaClientCodegenTest {
 
         codegen.updateCodegenPropertyEnum(array);
 
-    List<Map<String, String>> enumVars =
-        (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
+        List<Map<String, String>> enumVars =
+                (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
         Assert.assertNotNull(enumVars);
         Map<String, String> testedEnumVar = enumVars.get(0);
         Assert.assertNotNull(testedEnumVar);
@@ -396,15 +398,15 @@ public class JavaClientCodegenTest {
     public void updateCodegenPropertyEnumWithCustomNames() {
         final JavaClientCodegen codegen = new JavaClientCodegen();
         CodegenProperty array = codegenPropertyWithArrayOfIntegerValues();
-    array
-        .getItems()
-        .setVendorExtensions(
-            Collections.singletonMap("x-enum-varnames", Collections.singletonList("ONE")));
+        array
+                .getItems()
+                .setVendorExtensions(
+                        Collections.singletonMap("x-enum-varnames", Collections.singletonList("ONE")));
 
         codegen.updateCodegenPropertyEnum(array);
 
-    List<Map<String, String>> enumVars =
-        (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
+        List<Map<String, String>> enumVars =
+                (List<Map<String, String>>) array.getItems().getAllowableValues().get("enumVars");
         Assert.assertNotNull(enumVars);
         Map<String, String> testedEnumVar = enumVars.get(0);
         Assert.assertNotNull(testedEnumVar);
@@ -455,32 +457,32 @@ public class JavaClientCodegenTest {
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/ApiClient.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/ApiException.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/ApiResponse.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/ServerConfiguration.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/ServerConfiguration.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/ServerVariable.java");
-    TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/ApiKeyAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/auth/Authentication.java");
-    TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/HttpBasicAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/auth/HttpBearerAuth.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/ApiKeyAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/auth/Authentication.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/auth/HttpBasicAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/auth/HttpBearerAuth.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/Configuration.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/GzipRequestInterceptor.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/GzipRequestInterceptor.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/JSON.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/Pair.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/ProgressRequestBody.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/xyz/abcdef/ProgressResponseBody.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/ProgressRequestBody.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/xyz/abcdef/ProgressResponseBody.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/xyz/abcdef/StringUtil.java");
-    TestUtils.ensureContainsFile(files, output, "src/test/java/xyz/abcdef/api/DefaultApiTest.java");
+        TestUtils.ensureContainsFile(files, output, "src/test/java/xyz/abcdef/api/DefaultApiTest.java");
 
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
-        "public class DefaultApi");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
+                "public class DefaultApi");
 
         output.deleteOnExit();
     }
@@ -528,49 +530,49 @@ public class JavaClientCodegenTest {
         TestUtils.ensureContainsFile(files, output, "api/openapi.yaml");
         TestUtils.ensureContainsFile(files, output, "src/main/AndroidManifest.xml");
         TestUtils.ensureContainsFile(files, output, "src/main/java/zz/yyyy/api/xxxx/PingApi.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiCallback.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiClient.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiException.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiResponse.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ServerConfiguration.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ServerVariable.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/ApiKeyAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/Authentication.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/HttpBasicAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/HttpBearerAuth.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/Configuration.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/GzipRequestInterceptor.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiCallback.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiClient.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiException.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ApiResponse.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ServerConfiguration.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ServerVariable.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/ApiKeyAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/Authentication.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/HttpBasicAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/auth/HttpBearerAuth.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/Configuration.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/GzipRequestInterceptor.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/zz/yyyy/invoker/xxxx/JSON.java");
         TestUtils.ensureContainsFile(files, output, "src/main/java/zz/yyyy/invoker/xxxx/Pair.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ProgressRequestBody.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/ProgressResponseBody.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/zz/yyyy/invoker/xxxx/StringUtil.java");
-    TestUtils.ensureContainsFile(files, output, "src/main/java/zz/yyyy/model/xxxx/SomeObj.java");
-    TestUtils.ensureContainsFile(files, output, "src/test/java/zz/yyyy/api/xxxx/PingApiTest.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/test/java/zz/yyyy/model/xxxx/SomeObjTest.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ProgressRequestBody.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/ProgressResponseBody.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/zz/yyyy/invoker/xxxx/StringUtil.java");
+        TestUtils.ensureContainsFile(files, output, "src/main/java/zz/yyyy/model/xxxx/SomeObj.java");
+        TestUtils.ensureContainsFile(files, output, "src/test/java/zz/yyyy/api/xxxx/PingApiTest.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/test/java/zz/yyyy/model/xxxx/SomeObjTest.java");
 
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/zz/yyyy/model/xxxx/SomeObj.java"),
-        "public class SomeObj",
-        "Boolean isActive()");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/zz/yyyy/model/xxxx/SomeObj.java"),
+                "public class SomeObj",
+                "Boolean isActive()");
 
         output.deleteOnExit();
     }
@@ -597,12 +599,12 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(files.size(), 32);
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
-        "public class DefaultApi",
-        "import java.net.http.HttpClient;",
-        "import java.net.http.HttpRequest;",
-        "import java.net.http.HttpResponse;");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
+                "public class DefaultApi",
+                "import java.net.http.HttpClient;",
+                "import java.net.http.HttpRequest;",
+                "import java.net.http.HttpResponse;");
 
         TestUtils.assertFileContains(Paths.get(output + "/src/main/java/xyz/abcdef/ApiClient.java"),
                 "public class ApiClient",
@@ -620,14 +622,14 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-    final CodegenConfigurator configurator =
-        new CodegenConfigurator()
-            .setGeneratorName("java")
-            .setLibrary(JavaClientCodegen.NATIVE)
-            .setAdditionalProperties(properties)
-            .setInputSpec(
-                "src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        final CodegenConfigurator configurator =
+                new CodegenConfigurator()
+                        .setGeneratorName("java")
+                        .setLibrary(JavaClientCodegen.NATIVE)
+                        .setAdditionalProperties(properties)
+                        .setInputSpec(
+                                "src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
@@ -706,26 +708,26 @@ public class JavaClientCodegenTest {
         clientOptInput.config(new JavaClientCodegen());
 
         defaultGenerator.opts(clientOptInput);
-    final List<CodegenOperation> codegenOperations =
-        defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
+        final List<CodegenOperation> codegenOperations =
+                defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
 
-    // Verify GET only has 'read' scope
-    final CodegenOperation getCodegenOperation =
-        codegenOperations.stream()
-            .filter(it -> it.httpMethod.equals("GET"))
-            .collect(Collectors.toList())
-            .get(0);
+        // Verify GET only has 'read' scope
+        final CodegenOperation getCodegenOperation =
+                codegenOperations.stream()
+                        .filter(it -> it.httpMethod.equals("GET"))
+                        .collect(Collectors.toList())
+                        .get(0);
         assertTrue(getCodegenOperation.hasAuthMethods);
         assertEquals(getCodegenOperation.authMethods.size(), 1);
         final List<Map<String, Object>> getScopes = getCodegenOperation.authMethods.get(0).scopes;
         assertEquals(getScopes.size(), 1, "GET scopes don't match. actual::" + getScopes);
 
-    // POST operation should have both 'read' and 'write' scope on it
-    final CodegenOperation postCodegenOperation =
-        codegenOperations.stream()
-            .filter(it -> it.httpMethod.equals("POST"))
-            .collect(Collectors.toList())
-            .get(0);
+        // POST operation should have both 'read' and 'write' scope on it
+        final CodegenOperation postCodegenOperation =
+                codegenOperations.stream()
+                        .filter(it -> it.httpMethod.equals("POST"))
+                        .collect(Collectors.toList())
+                        .get(0);
         assertTrue(postCodegenOperation.hasAuthMethods);
         assertEquals(postCodegenOperation.authMethods.size(), 1);
         final List<Map<String, Object>> postScopes = postCodegenOperation.authMethods.get(0).scopes;
@@ -773,14 +775,14 @@ public class JavaClientCodegenTest {
         clientOptInput.config(new JavaClientCodegen());
 
         defaultGenerator.opts(clientOptInput);
-    final List<CodegenOperation> codegenOperations =
-        defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
+        final List<CodegenOperation> codegenOperations =
+                defaultGenerator.processPaths(openAPI.getPaths()).get("Pet");
 
-    final CodegenOperation getCodegenOperation =
-        codegenOperations.stream()
-            .filter(it -> it.httpMethod.equals("GET"))
-            .collect(Collectors.toList())
-            .get(0);
+        final CodegenOperation getCodegenOperation =
+                codegenOperations.stream()
+                        .filter(it -> it.httpMethod.equals("GET"))
+                        .collect(Collectors.toList())
+                        .get(0);
         assertTrue(getCodegenOperation.hasAuthMethods);
         assertEquals(getCodegenOperation.authMethods.size(), 2);
     }
@@ -843,8 +845,8 @@ public class JavaClientCodegenTest {
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
-    Assert.assertEquals(
-        clientOptInput.getConfig().schemaMapping().get("TypeAlias"), "foo.bar.TypeAlias");
+        Assert.assertEquals(
+                clientOptInput.getConfig().schemaMapping().get("TypeAlias"), "foo.bar.TypeAlias");
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
@@ -859,19 +861,19 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Assert.assertEquals(files.size(), 1);
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/org/openapitools/client/model/ParentType.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/org/openapitools/client/model/ParentType.java");
 
         String parentTypeContents = "";
         try {
-      File file =
-          files.stream().filter(f -> f.getName().endsWith("ParentType.java")).findFirst().get();
+            File file =
+                    files.stream().filter(f -> f.getName().endsWith("ParentType.java")).findFirst().get();
             parentTypeContents = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
         } catch (IOException ignored) {
 
         }
 
-    final Pattern FIELD_PATTERN = Pattern.compile(".* private (.*?) typeAlias;.*", Pattern.DOTALL);
+        final Pattern FIELD_PATTERN = Pattern.compile(".* private (.*?) typeAlias;.*", Pattern.DOTALL);
         Matcher fieldMatcher = FIELD_PATTERN.matcher(parentTypeContents);
         Assert.assertTrue(fieldMatcher.matches());
 
@@ -882,8 +884,8 @@ public class JavaClientCodegenTest {
 
     @Test
     public void testBearerAuth() {
-    final OpenAPI openAPI =
-        TestUtils.parseFlattenSpec("src/test/resources/3_0/pingBearerAuth.yaml");
+        final OpenAPI openAPI =
+                TestUtils.parseFlattenSpec("src/test/resources/3_0/pingBearerAuth.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
 
         List<CodegenSecurity> security = codegen.fromSecurity(openAPI.getComponents().getSecuritySchemes());
@@ -1107,20 +1109,20 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/MultipartApi.java");
-    TestUtils.assertFileContains(
-        defaultApi,
-        // multiple files
-        "multipartArrayWithHttpInfo(List<File> files)",
-        "formParams.addAll(\"files\","
-            + " files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
+        TestUtils.assertFileContains(
+                defaultApi,
+                // multiple files
+                "multipartArrayWithHttpInfo(List<File> files)",
+                "formParams.addAll(\"files\","
+                        + " files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
 
-        // mixed
-        "multipartMixedWithHttpInfo(File file, MultipartMixedMarker marker)",
-        "formParams.add(\"file\", new FileSystemResource(file));",
+                // mixed
+                "multipartMixedWithHttpInfo(File file, MultipartMixedMarker marker)",
+                "formParams.add(\"file\", new FileSystemResource(file));",
 
-        // single file
-        "multipartSingleWithHttpInfo(File file)",
-        "formParams.add(\"file\", new FileSystemResource(file));");
+                // single file
+                "multipartSingleWithHttpInfo(File file)",
+                "formParams.add(\"file\", new FileSystemResource(file));");
     }
 
     /**
@@ -1156,20 +1158,20 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/MultipartApi.java");
-    TestUtils.assertFileContains(
-        defaultApi,
-        // multiple files
-        "multipartArray(List<File> files)",
-        "formParams.addAll(\"files\","
-            + " files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
+        TestUtils.assertFileContains(
+                defaultApi,
+                // multiple files
+                "multipartArray(List<File> files)",
+                "formParams.addAll(\"files\","
+                        + " files.stream().map(FileSystemResource::new).collect(Collectors.toList()));",
 
-        // mixed
-        "multipartMixed(File file, MultipartMixedMarker marker)",
-        "formParams.add(\"file\", new FileSystemResource(file));",
+                // mixed
+                "multipartMixed(File file, MultipartMixedMarker marker)",
+                "formParams.add(\"file\", new FileSystemResource(file));",
 
-        // single file
-        "multipartSingle(File file)",
-        "formParams.add(\"file\", new FileSystemResource(file));");
+                // single file
+                "multipartSingle(File file)",
+                "formParams.add(\"file\", new FileSystemResource(file));");
     }
 
     @Test
@@ -1181,32 +1183,32 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-    final CodegenConfigurator configurator =
-        new CodegenConfigurator()
-            .setGeneratorName("java")
-            .setLibrary(JavaClientCodegen.WEBCLIENT)
-            .setAdditionalProperties(properties)
-            .setInputSpec(
-                "src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        final CodegenConfigurator configurator =
+                new CodegenConfigurator()
+                        .setGeneratorName("java")
+                        .setLibrary(JavaClientCodegen.WEBCLIENT)
+                        .setAdditionalProperties(properties)
+                        .setInputSpec(
+                                "src/test/resources/3_0/petstore-with-fake-endpoints-models-for-testing.yaml")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         DefaultGenerator generator = new DefaultGenerator();
         Map<String, File> files = generator.opts(configurator.toClientOptInput()).generate().stream()
                 .collect(Collectors.toMap(File::getName, Function.identity()));
 
-    JavaFileAssert.assertThat(files.get("StoreApi.java"))
-        .assertMethod("getInventory")
-        .hasReturnType(
-            "Mono<Map<String, Integer>>") // explicit 'x-webclient-blocking: false' which overrides
-                                          // global config
-        .toFileAssert()
-        .assertMethod("placeOrder")
-        .hasReturnType("Order"); // use global config
+        JavaFileAssert.assertThat(files.get("StoreApi.java"))
+                .assertMethod("getInventory")
+                .hasReturnType(
+                        "Mono<Map<String, Integer>>") // explicit 'x-webclient-blocking: false' which overrides
+                // global config
+                .toFileAssert()
+                .assertMethod("placeOrder")
+                .hasReturnType("Order"); // use global config
 
-    JavaFileAssert.assertThat(files.get("PetApi.java"))
-        .assertMethod("findPetsByStatus")
-        .hasReturnType(
-            "List<Pet>"); // explicit 'x-webclient-blocking: true' which overrides global config
+        JavaFileAssert.assertThat(files.get("PetApi.java"))
+                .assertMethod("findPetsByStatus")
+                .hasReturnType(
+                        "List<Pet>"); // explicit 'x-webclient-blocking: true' which overrides global config
     }
 
     @Test
@@ -1224,20 +1226,20 @@ public class JavaClientCodegenTest {
         List<File> files = generator.opts(clientOptInput).generate();
 
         Assert.assertEquals(files.size(), 49);
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/org/openapitools/client/model/RealCommand.java");
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/org/openapitools/client/model/Command.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/org/openapitools/client/model/RealCommand.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/org/openapitools/client/model/Command.java");
 
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/model/RealCommand.java"),
-        "class RealCommand {");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/model/RealCommand.java"),
+                "class RealCommand {");
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/model/Command.java"),
-        "class Command {");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/model/Command.java"),
+                "class Command {");
 
         output.deleteOnExit();
     }
@@ -1276,29 +1278,29 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/MultipartApi.java");
-    TestUtils.assertFileContains(
-        defaultApi,
-        // multiple files
-        "multipartArray(java.util.Collection<org.springframework.core.io.Resource> files)",
-        "multipartArrayWithHttpInfo(java.util.Collection<org.springframework.core.io.Resource>"
-            + " files)",
-        "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
+        TestUtils.assertFileContains(
+                defaultApi,
+                // multiple files
+                "multipartArray(java.util.Collection<org.springframework.core.io.Resource> files)",
+                "multipartArrayWithHttpInfo(java.util.Collection<org.springframework.core.io.Resource>"
+                        + " files)",
+                "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
 
-        // mixed
-        "multipartMixed(org.springframework.core.io.Resource file, MultipartMixedMarker marker)",
-        "multipartMixedWithHttpInfo(org.springframework.core.io.Resource file, MultipartMixedMarker"
-            + " marker)",
-        "formParams.add(\"file\", file);",
+                // mixed
+                "multipartMixed(org.springframework.core.io.Resource file, MultipartMixedMarker marker)",
+                "multipartMixedWithHttpInfo(org.springframework.core.io.Resource file, MultipartMixedMarker"
+                        + " marker)",
+                "formParams.add(\"file\", file);",
 
-        // single file
-        "multipartSingle(org.springframework.core.io.Resource file)",
-        "multipartSingleWithHttpInfo(org.springframework.core.io.Resource file)",
-        "formParams.add(\"file\", file);");
+                // single file
+                "multipartSingle(org.springframework.core.io.Resource file)",
+                "multipartSingleWithHttpInfo(org.springframework.core.io.Resource file)",
+                "formParams.add(\"file\", file);");
     }
 
     @Test
     void testNotDuplicateOauth2FlowsScopes() {
-    final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_7614.yaml");
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/issue_7614.yaml");
 
         final ClientOptInput clientOptInput = new ClientOptInput()
                 .openAPI(openAPI)
@@ -1310,8 +1312,8 @@ public class JavaClientCodegenTest {
         final Map<String, List<CodegenOperation>> paths = defaultGenerator.processPaths(openAPI.getPaths());
         final List<CodegenOperation> codegenOperations = paths.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
 
-    final CodegenOperation getWithBasicAuthAndOauth =
-        getByOperationId(codegenOperations, "getWithBasicAuthAndOauth");
+        final CodegenOperation getWithBasicAuthAndOauth =
+                getByOperationId(codegenOperations, "getWithBasicAuthAndOauth");
         assertEquals(getWithBasicAuthAndOauth.authMethods.size(), 3);
         assertEquals(getWithBasicAuthAndOauth.authMethods.get(0).name, "basic_auth");
         final Map<String, Object> passwordFlowScope = getWithBasicAuthAndOauth.authMethods.get(1).scopes.get(0);
@@ -1319,10 +1321,10 @@ public class JavaClientCodegenTest {
         assertEquals(passwordFlowScope.get("description"), "create from password flow");
         final Map<String, Object> clientCredentialsFlow = getWithBasicAuthAndOauth.authMethods.get(2).scopes.get(0);
         assertEquals(clientCredentialsFlow.get("scope"), "something:create");
-    assertEquals(clientCredentialsFlow.get("description"), "create from client credentials flow");
+        assertEquals(clientCredentialsFlow.get("description"), "create from client credentials flow");
 
-    final CodegenOperation getWithOauthAuth =
-        getByOperationId(codegenOperations, "getWithOauthAuth");
+        final CodegenOperation getWithOauthAuth =
+                getByOperationId(codegenOperations, "getWithOauthAuth");
         assertEquals(getWithOauthAuth.authMethods.size(), 2);
         final Map<String, Object> passwordFlow = getWithOauthAuth.authMethods.get(0).scopes.get(0);
         assertEquals(passwordFlow.get("scope"), "something:create");
@@ -1330,22 +1332,22 @@ public class JavaClientCodegenTest {
 
         final Map<String, Object> clientCredentialsCreateFlow = getWithOauthAuth.authMethods.get(1).scopes.get(0);
         assertEquals(clientCredentialsCreateFlow.get("scope"), "something:create");
-    assertEquals(
-        clientCredentialsCreateFlow.get("description"), "create from client credentials flow");
+        assertEquals(
+                clientCredentialsCreateFlow.get("description"), "create from client credentials flow");
 
         final Map<String, Object> clientCredentialsProcessFlow = getWithOauthAuth.authMethods.get(1).scopes.get(1);
         assertEquals(clientCredentialsProcessFlow.get("scope"), "something:process");
-    assertEquals(
-        clientCredentialsProcessFlow.get("description"), "process from client credentials flow");
+        assertEquals(
+                clientCredentialsProcessFlow.get("description"), "process from client credentials flow");
     }
 
     private CodegenOperation getByOperationId(List<CodegenOperation> codegenOperations, String operationId) {
-    return getByCriteria(codegenOperations, (co) -> co.operationId.equals(operationId))
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    String.format(
-                        Locale.ROOT, "Operation with id [%s] does not exist", operationId)));
+        return getByCriteria(codegenOperations, (co) -> co.operationId.equals(operationId))
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        String.format(
+                                                Locale.ROOT, "Operation with id [%s] does not exist", operationId)));
     }
 
     private Optional<CodegenOperation> getByCriteria(List<CodegenOperation> codegenOperations, Predicate<CodegenOperation> filter) {
@@ -1369,22 +1371,22 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         List<File> files = generator.opts(clientOptInput).generate();
 
-    TestUtils.ensureContainsFile(
-        files, output, "src/main/java/org/openapitools/client/api/DefaultApi.java");
+        TestUtils.ensureContainsFile(
+                files, output, "src/main/java/org/openapitools/client/api/DefaultApi.java");
 
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
-        "@RequestLine(\"POST /events/{eventId}:undelete\")");
-    TestUtils.assertFileNotContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
-        "event_id");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
+                "@RequestLine(\"POST /events/{eventId}:undelete\")");
+        TestUtils.assertFileNotContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
+                "event_id");
 
-    // baseName is kept for form parameters
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
-        "@Param(\"some_file\") File someFile");
+        // baseName is kept for form parameters
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
+                "@Param(\"some_file\") File someFile");
 
         output.deleteOnExit();
     }
@@ -1422,20 +1424,20 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/MultipartApi.java");
-    TestUtils.assertFileContains(
-        defaultApi,
-        // multiple files
-        "multipartArray(java.util.Collection<org.springframework.core.io.AbstractResource> files)",
-        "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
+        TestUtils.assertFileContains(
+                defaultApi,
+                // multiple files
+                "multipartArray(java.util.Collection<org.springframework.core.io.AbstractResource> files)",
+                "formParams.addAll(\"files\", files.stream().collect(Collectors.toList()));",
 
-        // mixed
-        "multipartMixed(org.springframework.core.io.AbstractResource file, MultipartMixedMarker"
-            + " marker)",
-        "formParams.add(\"file\", file);",
+                // mixed
+                "multipartMixed(org.springframework.core.io.AbstractResource file, MultipartMixedMarker"
+                        + " marker)",
+                "formParams.add(\"file\", file);",
 
-        // single file
-        "multipartSingle(org.springframework.core.io.AbstractResource file)",
-        "formParams.add(\"file\", file);");
+                // single file
+                "multipartSingle(org.springframework.core.io.AbstractResource file)",
+                "formParams.add(\"file\", file);");
     }
 
     /**
@@ -1521,10 +1523,10 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(files.size(), 35);
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/ApiClient.java"),
-        "public static String urlEncode(String s) { return URLEncoder.encode(s,"
-            + " UTF_8).replaceAll(\"\\\\+\", \"%20\"); }");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/ApiClient.java"),
+                "public static String urlEncode(String s) { return URLEncoder.encode(s,"
+                        + " UTF_8).replaceAll(\"\\\\+\", \"%20\"); }");
     }
 
     /**
@@ -1552,16 +1554,16 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(files.size(), 38);
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
-        "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"since\","
-            + " queryObject.getSince()));",
-        "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"sinceBuild\","
-            + " queryObject.getSinceBuild()));",
-        "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"maxBuilds\","
-            + " queryObject.getMaxBuilds()));",
-        "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"maxWaitSecs\","
-            + " queryObject.getMaxWaitSecs()));");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
+                "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"since\","
+                        + " queryObject.getSince()));",
+                "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"sinceBuild\","
+                        + " queryObject.getSinceBuild()));",
+                "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"maxBuilds\","
+                        + " queryObject.getMaxBuilds()));",
+                "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"maxWaitSecs\","
+                        + " queryObject.getMaxWaitSecs()));");
     }
 
     @Test
@@ -1658,9 +1660,9 @@ public class JavaClientCodegenTest {
                 "<smallrye.rest.client.version>1.2.1</smallrye.rest.client.version>");
         TestUtils.assertFileContains(Paths.get(output + "/pom.xml"),
                 "<java.version>1.8</java.version>");
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
-        "import javax.");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
+                "import javax.");
 
         output.deleteOnExit();
     }
@@ -1687,26 +1689,26 @@ public class JavaClientCodegenTest {
 
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/pom.xml"),
-        "<microprofile.rest.client.api.version>1.4.1</microprofile.rest.client.api.version>");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/pom.xml"),
+                "<microprofile.rest.client.api.version>1.4.1</microprofile.rest.client.api.version>");
         TestUtils.assertFileContains(Paths.get(output + "/pom.xml"),
                 "<smallrye.rest.client.version>1.2.1</smallrye.rest.client.version>");
         TestUtils.assertFileContains(Paths.get(output + "/pom.xml"),
                 "<java.version>1.8</java.version>");
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
-        "import javax.");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
+                "import javax.");
 
         output.deleteOnExit();
     }
 
-  @Test(
-      expectedExceptions = IllegalArgumentException.class,
-      expectedExceptionsMessageRegExp =
-          "Version incorrectVersion of MicroProfile Rest Client is not supported or incorrect."
-              + " Supported versions are 1.4.1, 2.0, 3.0")
-  public void testMicroprofileRestClientIncorrectVersion() throws Exception {
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp =
+                    "Version incorrectVersion of MicroProfile Rest Client is not supported or incorrect."
+                            + " Supported versions are 1.4.1, 2.0, 3.0")
+    public void testMicroprofileRestClientIncorrectVersion() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(JavaClientCodegen.MICROPROFILE_REST_CLIENT_VERSION, "incorrectVersion");
 
@@ -1754,9 +1756,9 @@ public class JavaClientCodegenTest {
                 "<jersey.mp.rest.client.version>3.0.4</jersey.mp.rest.client.version>");
         TestUtils.assertFileContains(Paths.get(output + "/pom.xml"),
                 "<java.version>11</java.version>");
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
-        "import jakarta.");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/PetApi.java"),
+                "import jakarta.");
 
         output.deleteOnExit();
     }
@@ -1781,17 +1783,17 @@ public class JavaClientCodegenTest {
         Map<String, File> files = generator.opts(clientOptInput).generate().stream()
                 .collect(Collectors.toMap(File::getName, Function.identity()));
 
-    JavaFileAssert.assertThat(files.get("Foo.java"))
-        .assertConstructor("String", "Integer")
-        .hasParameter("b")
-        .assertParameterAnnotations()
-        .containsWithNameAndAttributes(
-            "JsonbProperty", ImmutableMap.of("value", "\"b\"", "nillable", "true"))
-        .toParameter()
-        .toConstructor()
-        .hasParameter("c")
-        .assertParameterAnnotations()
-        .containsWithNameAndAttributes("JsonbProperty", ImmutableMap.of("value", "\"c\""));
+        JavaFileAssert.assertThat(files.get("Foo.java"))
+                .assertConstructor("String", "Integer")
+                .hasParameter("b")
+                .assertParameterAnnotations()
+                .containsWithNameAndAttributes(
+                        "JsonbProperty", ImmutableMap.of("value", "\"b\"", "nillable", "true"))
+                .toParameter()
+                .toConstructor()
+                .hasParameter("c")
+                .assertParameterAnnotations()
+                .containsWithNameAndAttributes("JsonbProperty", ImmutableMap.of("value", "\"c\""));
     }
 
     @Test
@@ -1802,14 +1804,14 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-    final CodegenConfigurator configurator =
-        new CodegenConfigurator()
-            .setAdditionalProperties(properties)
-            .setGeneratorName("java")
-            .setLibrary(JavaClientCodegen.WEBCLIENT)
-            .setInputSpec(
-                "src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        final CodegenConfigurator configurator =
+                new CodegenConfigurator()
+                        .setAdditionalProperties(properties)
+                        .setGeneratorName("java")
+                        .setLibrary(JavaClientCodegen.WEBCLIENT)
+                        .setInputSpec(
+                                "src/test/resources/bugs/java-codegen-empty-array-as-default-value/issue_wrong-default.yaml")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
@@ -1847,13 +1849,13 @@ public class JavaClientCodegenTest {
         Map<String, File> files = generator.opts(clientOptInput).generate().stream()
                 .collect(Collectors.toMap(File::getName, Function.identity()));
 
-    JavaFileAssert.assertThat(files.get("TestObject.java"))
-        .printFileContent()
-        .assertConstructor("String", "String")
-        .bodyContainsLines(
-            "this.nullableProperty = nullableProperty == null ? JsonNullable.<String>undefined() :"
-                + " JsonNullable.of(nullableProperty);",
-            "this.notNullableProperty = notNullableProperty;");
+        JavaFileAssert.assertThat(files.get("TestObject.java"))
+                .printFileContent()
+                .assertConstructor("String", "String")
+                .bodyContainsLines(
+                        "this.nullableProperty = nullableProperty == null ? JsonNullable.<String>undefined() :"
+                                + " JsonNullable.of(nullableProperty);",
+                        "this.notNullableProperty = notNullableProperty;");
     }
 
     @Test
@@ -1881,12 +1883,12 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/ResourceApi.java");
-    TestUtils.assertFileContains(
-        defaultApi,
-        "org.springframework.core.io.Resource resourceInResponse()",
-        "ResponseEntity<org.springframework.core.io.Resource> resourceInResponseWithHttpInfo()",
-        "ParameterizedTypeReference<org.springframework.core.io.Resource> localReturnType = new"
-            + " ParameterizedTypeReference<org.springframework.core.io.Resource>()");
+        TestUtils.assertFileContains(
+                defaultApi,
+                "org.springframework.core.io.Resource resourceInResponse()",
+                "ResponseEntity<org.springframework.core.io.Resource> resourceInResponseWithHttpInfo()",
+                "ParameterizedTypeReference<org.springframework.core.io.Resource> localReturnType = new"
+                        + " ParameterizedTypeReference<org.springframework.core.io.Resource>()");
     }
 
     public void testExtraAnnotations(String library) throws IOException {
@@ -1914,8 +1916,8 @@ public class JavaClientCodegenTest {
         generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
         generator.opts(clientOptInput).generate();
 
-    TestUtils.assertExtraAnnotationFiles(
-        outputPath + "/src/main/java/org/openapitools/client/model");
+        TestUtils.assertExtraAnnotationFiles(
+                outputPath + "/src/main/java/org/openapitools/client/model");
     }
 
     /**
@@ -1958,17 +1960,17 @@ public class JavaClientCodegenTest {
         final CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("java")
                 .setInputSpec("src/test/resources/3_0/issue14525.yaml")
-                .addTypeMapping("array","Stack")
-                .addImportMapping("Stack","java.util.Stack")
+                .addTypeMapping("array", "Stack")
+                .addImportMapping("Stack", "java.util.Stack")
                 .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(clientOptInput).generate();
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
-        "import java.util.Stack;");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
+                "import java.util.Stack;");
     }
 
     @Test
@@ -1990,10 +1992,10 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
         generator.opts(clientOptInput).generate();
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
-        "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"multi\", \"values\","
-            + " queryObject.getValues()));");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/api/DefaultApi.java"),
+                "localVarQueryParams.addAll(ApiClient.parameterToPairs(\"multi\", \"values\","
+                        + " queryObject.getValues()));");
     }
 
     @Test
@@ -2023,15 +2025,15 @@ public class JavaClientCodegenTest {
         Assert.assertEquals(files.size(), 24);
         validateJavaSourceFiles(files);
 
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/model/Child.java"),
-        "public class Child extends Person {");
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/model/Adult.java"),
-        "public class Adult extends Person {");
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/xyz/abcdef/model/AnotherChild.java"),
-        "public class AnotherChild {");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/model/Child.java"),
+                "public class Child extends Person {");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/model/Adult.java"),
+                "public class Adult extends Person {");
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/xyz/abcdef/model/AnotherChild.java"),
+                "public class AnotherChild {");
     }
 
     @Test
@@ -2039,10 +2041,10 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation("src/test/resources/bugs/issue_14731.yaml", null, new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation("src/test/resources/bugs/issue_14731.yaml", null, new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2055,7 +2057,7 @@ public class JavaClientCodegenTest {
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
-    generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
 
         codegen.setUseOneOfInterfaces(true);
         codegen.setLegacyDiscriminatorBehavior(false);
@@ -2069,14 +2071,14 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileNotContains(
-        Paths.get(
-            outputPath + "/src/main/java/org/openapitools/client/model/ChildWithMappingADTO.java"),
-        "@JsonTypeName");
-    assertFileNotContains(
-        Paths.get(
-            outputPath + "/src/main/java/org/openapitools/client/model/ChildWithMappingBDTO.java"),
-        "@JsonTypeName");
+        assertFileNotContains(
+                Paths.get(
+                        outputPath + "/src/main/java/org/openapitools/client/model/ChildWithMappingADTO.java"),
+                "@JsonTypeName");
+        assertFileNotContains(
+                Paths.get(
+                        outputPath + "/src/main/java/org/openapitools/client/model/ChildWithMappingBDTO.java"),
+                "@JsonTypeName");
     }
 
     @Test
@@ -2084,10 +2086,10 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation("src/test/resources/bugs/issue_14731.yaml", null, new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation("src/test/resources/bugs/issue_14731.yaml", null, new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2100,7 +2102,7 @@ public class JavaClientCodegenTest {
 
         DefaultGenerator generator = new DefaultGenerator();
         generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "true");
-    generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.LEGACY_DISCRIMINATOR_BEHAVIOR, "false");
 
         codegen.setUseOneOfInterfaces(true);
         codegen.setLegacyDiscriminatorBehavior(false);
@@ -2116,16 +2118,16 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileContains(
-        Paths.get(
-            outputPath
-                + "/src/main/java/org/openapitools/client/model/ChildWithoutMappingADTO.java"),
-        "@JsonTypeName");
-    assertFileContains(
-        Paths.get(
-            outputPath
-                + "/src/main/java/org/openapitools/client/model/ChildWithoutMappingBDTO.java"),
-        "@JsonTypeName");
+        assertFileContains(
+                Paths.get(
+                        outputPath
+                                + "/src/main/java/org/openapitools/client/model/ChildWithoutMappingADTO.java"),
+                "@JsonTypeName");
+        assertFileContains(
+                Paths.get(
+                        outputPath
+                                + "/src/main/java/org/openapitools/client/model/ChildWithoutMappingBDTO.java"),
+                "@JsonTypeName");
     }
 
     @Test
@@ -2133,10 +2135,10 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation("src/test/resources/bugs/issue_14917.yaml", null, new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation("src/test/resources/bugs/issue_14917.yaml", null, new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2150,53 +2152,53 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "mappings.put(\"Cat\", Cat.class)");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "@JsonSubTypes");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "mappings.put(\"cat\", Cat.class);");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "mappings.put(\"dog\", Dog.class);");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "mappings.put(\"lizard\", Lizard.class);");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "mappings.put(\"Cat\", Cat.class)");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "@JsonSubTypes");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "mappings.put(\"cat\", Cat.class);");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "mappings.put(\"dog\", Dog.class);");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "mappings.put(\"lizard\", Lizard.class);");
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "mappings.put(\"cat\", Cat.class)");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "mappings.put(\"dog\", Dog.class)");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "mappings.put(\"lizard\", Lizard.class)");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "mappings.put(\"Pet\", Pet.class)");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "mappings.put(\"cat\", Cat.class)");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "mappings.put(\"dog\", Dog.class)");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "mappings.put(\"lizard\", Lizard.class)");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "mappings.put(\"Pet\", Pet.class)");
 
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Cat.class, name = \"Cat\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Dog.class, name = \"Dog\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Lizard.class, name = \"Lizard\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Cat.class, name = \"Cat\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Dog.class, name = \"Dog\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Lizard.class, name = \"Lizard\")");
     }
 
     @Test
@@ -2207,21 +2209,21 @@ public class JavaClientCodegenTest {
                 JavaClientCodegen.RESTTEMPLATE
         );
 
-    JavaFileAssert.assertThat(files.get("DefaultApi.java"))
-        .printFileContent()
-        .assertMethod("searchWithHttpInfo")
-        .bodyContainsLines(
-            "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"regular-param\","
-                + " regularParam));")
-        .bodyContainsLines(
-            "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someString\","
-                + " objectParam.getSomeString()));")
-        .bodyContainsLines(
-            "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someBoolean\","
-                + " objectParam.getSomeBoolean()));")
-        .bodyContainsLines(
-            "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someInteger\","
-                + " objectParam.getSomeInteger()));");
+        JavaFileAssert.assertThat(files.get("DefaultApi.java"))
+                .printFileContent()
+                .assertMethod("searchWithHttpInfo")
+                .bodyContainsLines(
+                        "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"regular-param\","
+                                + " regularParam));")
+                .bodyContainsLines(
+                        "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someString\","
+                                + " objectParam.getSomeString()));")
+                .bodyContainsLines(
+                        "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someBoolean\","
+                                + " objectParam.getSomeBoolean()));")
+                .bodyContainsLines(
+                        "localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, \"someInteger\","
+                                + " objectParam.getSomeInteger()));");
     }
 
     private static Map<String, File> generateFromContract(final String pathToSpecification, final String library) {
@@ -2255,10 +2257,10 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation("src/test/resources/bugs/issue_14917.yaml", null, new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation("src/test/resources/bugs/issue_14917.yaml", null, new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2272,51 +2274,51 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property ="
-            + " \"petType\", visible = true)");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "mappings.put");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property ="
+                        + " \"petType\", visible = true)");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "mappings.put");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property ="
-            + " \"petType\", visible = true)");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Cat.class, name = \"Cat\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Dog.class, name = \"Dog\")");
-    assertFileNotContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "@JsonSubTypes.Type(value = Lizard.class, name = \"Lizard\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property ="
+                        + " \"petType\", visible = true)");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Cat.class, name = \"cat\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Dog.class, name = \"dog\")");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Lizard.class, name = \"lizard\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Cat.class, name = \"Cat\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Dog.class, name = \"Dog\")");
+        assertFileNotContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "@JsonSubTypes.Type(value = Lizard.class, name = \"Lizard\")");
     }
 
     @Test
     public void testIsOverriddenProperty() {
-    final OpenAPI openAPI =
-        TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition_discriminator.yaml");
+        final OpenAPI openAPI =
+                TestUtils.parseFlattenSpec("src/test/resources/3_0/allOf_composition_discriminator.yaml");
         JavaClientCodegen codegen = new JavaClientCodegen();
 
         Schema test1 = openAPI.getComponents().getSchemas().get("Cat");
@@ -2337,13 +2339,13 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation(
-                "src/test/resources/3_0/allOf_composition_discriminator.yaml",
-                null,
-                new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation(
+                                "src/test/resources/3_0/allOf_composition_discriminator.yaml",
+                                null,
+                                new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2357,12 +2359,12 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "  @Override\n" + "  public Cat petType(String petType) {");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "  }\n" + "\n" + "  public Pet petType(String petType) {\n");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "  @Override\n" + "  public Cat petType(String petType) {");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "  }\n" + "\n" + "  public Pet petType(String petType) {\n");
     }
 
     @Test
@@ -2370,13 +2372,13 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();
         String outputPath = output.getAbsolutePath().replace('\\', '/');
-    OpenAPI openAPI =
-        new OpenAPIParser()
-            .readLocation(
-                "src/test/resources/3_0/allOf_composition_discriminator.yaml",
-                null,
-                new ParseOptions())
-            .getOpenAPI();
+        OpenAPI openAPI =
+                new OpenAPIParser()
+                        .readLocation(
+                                "src/test/resources/3_0/allOf_composition_discriminator.yaml",
+                                null,
+                                new ParseOptions())
+                        .getOpenAPI();
 
         JavaClientCodegen codegen = new JavaClientCodegen();
         codegen.setOutputDir(output.getAbsolutePath());
@@ -2390,12 +2392,12 @@ public class JavaClientCodegenTest {
 
         generator.opts(input).generate();
 
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
-        "  @Override\n" + "  public Cat petType(String petType) {");
-    assertFileContains(
-        Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
-        "  }\n" + "\n" + "  public Pet petType(String petType) {\n");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Cat.java"),
+                "  @Override\n" + "  public Cat petType(String petType) {");
+        assertFileContains(
+                Paths.get(outputPath + "/src/main/java/org/openapitools/client/model/Pet.java"),
+                "  }\n" + "\n" + "  public Pet petType(String petType) {\n");
     }
 
     @Test
@@ -2414,29 +2416,29 @@ public class JavaClientCodegenTest {
 
         validateJavaSourceFiles(files);
 
-    // deprecated builder method
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
-        "@Deprecated\n" + " public BigDog declawed(Boolean declawed) {");
+        // deprecated builder method
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
+                "@Deprecated\n" + " public BigDog declawed(Boolean declawed) {");
 
-    // deprecated getter
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
-        "@Deprecated\n"
-            + " @javax.annotation.Nullable\n"
-            + "\n"
-            + " public Boolean getDeclawed() {");
-    // deprecated setter
-    TestUtils.assertFileContains(
-        Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
-        "@Deprecated\n" + " public void setDeclawed(Boolean declawed) {");
+        // deprecated getter
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
+                "@Deprecated\n"
+                        + " @javax.annotation.Nullable\n"
+                        + "\n"
+                        + " public Boolean getDeclawed() {");
+        // deprecated setter
+        TestUtils.assertFileContains(
+                Paths.get(output + "/src/main/java/org/openapitools/client/model/BigDog.java"),
+                "@Deprecated\n" + " public void setDeclawed(Boolean declawed) {");
 
         output.deleteOnExit();
     }
 
     @DataProvider(name = "shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684")
     public static Object[][] shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684_dataProvider() {
-        return new Object[][] {{"okhttp-gson"}, {"jersey2"}, {"jersey3"}, {"native"}};
+        return new Object[][]{{"okhttp-gson"}, {"jersey2"}, {"jersey3"}, {"native"}};
     }
 
     @Test(dataProvider = "shouldNotAddAdditionalModelAnnotationsToAbstractOpenApiSchema_issue15684")
@@ -2444,14 +2446,14 @@ public class JavaClientCodegenTest {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();
 
-    final CodegenConfigurator configurator =
-        new CodegenConfigurator()
-            .setGeneratorName("java")
-            .setLibrary(library)
-            .addAdditionalProperty(
-                AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS, "@annotation1;@annotation2")
-            .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+        final CodegenConfigurator configurator =
+                new CodegenConfigurator()
+                        .setGeneratorName("java")
+                        .setLibrary(library)
+                        .addAdditionalProperty(
+                                AbstractJavaCodegen.ADDITIONAL_MODEL_TYPE_ANNOTATIONS, "@annotation1;@annotation2")
+                        .setInputSpec("src/test/resources/3_0/deprecated-properties.yaml")
+                        .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
         final ClientOptInput clientOptInput = configurator.toClientOptInput();
         DefaultGenerator generator = new DefaultGenerator();
@@ -2459,13 +2461,13 @@ public class JavaClientCodegenTest {
                 .collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert.assertThat(files.get("AbstractOpenApiSchema.java"))
-            .assertTypeAnnotations()
-            .doesNotContainsWithName("annotation1")
-            .doesNotContainsWithName("annotation2");
+                .assertTypeAnnotations()
+                .doesNotContainsWithName("annotation1")
+                .doesNotContainsWithName("annotation2");
         JavaFileAssert.assertThat(files.get("Animal.java"))
-            .assertTypeAnnotations()
-            .containsWithName("annotation1")
-            .containsWithName("annotation2");
+                .assertTypeAnnotations()
+                .containsWithName("annotation1")
+                .containsWithName("annotation2");
     }
 
     @Test
@@ -2577,16 +2579,16 @@ public class JavaClientCodegenTest {
         validateJavaSourceFiles(files);
 
         Path userApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/UsersApi.java");
-    TestUtils.assertFileContains(
-        userApi,
-        // set of string
-        "ParameterizedTypeReference<Set<String>> localVarReturnType = new"
-            + " ParameterizedTypeReference<Set<String>>() {};",
-        "getUserIdSetRequestCreation().toEntity(localVarReturnType)",
-        // list of string
-        "ParameterizedTypeReference<List<String>> localVarReturnType = new"
-            + " ParameterizedTypeReference<List<String>>() {};",
-        "getUserIdListRequestCreation().toEntity(localVarReturnType)");
+        TestUtils.assertFileContains(
+                userApi,
+                // set of string
+                "ParameterizedTypeReference<Set<String>> localVarReturnType = new"
+                        + " ParameterizedTypeReference<Set<String>>() {};",
+                "getUserIdSetRequestCreation().toEntity(localVarReturnType)",
+                // list of string
+                "ParameterizedTypeReference<List<String>> localVarReturnType = new"
+                        + " ParameterizedTypeReference<List<String>>() {};",
+                "getUserIdListRequestCreation().toEntity(localVarReturnType)");
     }
 
     @Test
@@ -2607,12 +2609,12 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
 
         Map<String, File> files = generator.opts(input).generate().stream()
-            .collect(Collectors.toMap(File::getName, Function.identity()));
+                .collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert javaFileAssert = JavaFileAssert.assertThat(files.get("EnumTest.java"));
         javaFileAssert
-            .assertMethod("fromValue")
-            .bodyContainsLines("if (b.value.equalsIgnoreCase(value)) {");
+                .assertMethod("fromValue")
+                .bodyContainsLines("if (b.value.equalsIgnoreCase(value)) {");
     }
 
     @Test
@@ -2633,12 +2635,12 @@ public class JavaClientCodegenTest {
         DefaultGenerator generator = new DefaultGenerator();
 
         Map<String, File> files = generator.opts(input).generate().stream()
-            .collect(Collectors.toMap(File::getName, Function.identity()));
+                .collect(Collectors.toMap(File::getName, Function.identity()));
 
         JavaFileAssert javaFileAssert = JavaFileAssert.assertThat(files.get("EnumTest.java"));
         javaFileAssert
-            .assertMethod("fromValue")
-            .bodyContainsLines("if (b.value.equals(value)) {");
+                .assertMethod("fromValue")
+                .bodyContainsLines("if (b.value.equals(value)) {");
     }
 
     @Test
@@ -2651,11 +2653,11 @@ public class JavaClientCodegenTest {
         output.deleteOnExit();
 
         final CodegenConfigurator configurator = new CodegenConfigurator()
-            .setGeneratorName("java")
-            .setLibrary(JavaClientCodegen.WEBCLIENT)
-            .setAdditionalProperties(properties)
-            .setInputSpec("src/test/resources/3_0/issue13146_file_abstraction_response.yaml")
-            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+                .setGeneratorName("java")
+                .setLibrary(JavaClientCodegen.WEBCLIENT)
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_0/issue13146_file_abstraction_response.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
 
 
         DefaultGenerator generator = new DefaultGenerator();
@@ -2667,9 +2669,9 @@ public class JavaClientCodegenTest {
         Path defaultApi = Paths.get(output + "/src/main/java/xyz/abcdef/api/ResourceApi.java");
 
         TestUtils.assertFileContains(defaultApi,
-            "Mono<org.springframework.core.io.Resource> resourceInResponse()",
-            "Mono<ResponseEntity<org.springframework.core.io.Resource>> resourceInResponseWithHttpInfo()",
-            "ParameterizedTypeReference<org.springframework.core.io.Resource> localVarReturnType = new ParameterizedTypeReference<org.springframework.core.io.Resource>()"
+                "Mono<org.springframework.core.io.Resource> resourceInResponse()",
+                "Mono<ResponseEntity<org.springframework.core.io.Resource>> resourceInResponseWithHttpInfo()",
+                "ParameterizedTypeReference<org.springframework.core.io.Resource> localVarReturnType = new ParameterizedTypeReference<org.springframework.core.io.Resource>()"
         );
     }
 
@@ -2689,15 +2691,15 @@ public class JavaClientCodegenTest {
         defaultGenerator.opts(clientOptInput);
 
         Map<String, File> files = defaultGenerator.generate().stream()
-                        .collect(Collectors.toMap(File::getName, Function.identity()));
+                .collect(Collectors.toMap(File::getName, Function.identity()));
 
         File apiFile = files.get("HelloExampleApi.java");
 
         assertNotNull(apiFile);
         JavaFileAssert.assertThat(apiFile)
-                        .assertMethod("helloCall", "String", "ApiCallback")
-                        .bodyContainsLines(
-                                        "localVarHeaderParams.put(\"X-CUSTOM_CONSTANT_HEADER\", \"CONSTANT_VALUE\")");
+                .assertMethod("helloCall", "String", "ApiCallback")
+                .bodyContainsLines(
+                        "localVarHeaderParams.put(\"X-CUSTOM_CONSTANT_HEADER\", \"CONSTANT_VALUE\")");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2699,4 +2699,25 @@ public class JavaClientCodegenTest {
                         .bodyContainsLines(
                                         "localVarHeaderParams.put(\"X-CUSTOM_CONSTANT_HEADER\", \"CONSTANT_VALUE\")");
     }
+
+    @Test
+    public void testAllOfWithSinglePrimitiveTypeRef() throws IOException {
+        File output = Files.createTempDirectory("test_allOf_primitive_type").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/allof_primitive.yaml");
+        final DefaultGenerator defaultGenerator = new DefaultGenerator();
+        final ClientOptInput clientOptInput = new ClientOptInput();
+        clientOptInput.openAPI(openAPI);
+        JavaClientCodegen javaClientCodegen = new JavaClientCodegen();
+        javaClientCodegen.setOutputDir(output.getAbsolutePath());
+        javaClientCodegen.setAutosetConstants(true);
+        clientOptInput.config(javaClientCodegen);
+        defaultGenerator.opts(clientOptInput);
+
+        Map<String, File> files = defaultGenerator.generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        File apiFile = files.get("AllOfDatetime.java");
+        assertEquals(apiFile, null);
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/allof_primitive.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/allof_primitive.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Foo
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: example
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                 $ref: '#/components/schemas/Payment'
+components:
+  schemas:
+    DateTime:
+      type: string
+      format: date-time
+      example: "2019-01-01T00:00:00"
+    # the following schema shouldn't be generated as model
+    AllOfDatetime:
+      allOf:
+        - $ref: '#/components/schemas/DateTime'
+      example: "2019-01-01 00:00:00" 
+    Payment:
+      type: object
+      properties:
+        date:
+          $ref: '#/components/schemas/AllOfDatetime'
+        amount:
+          type: number
+          format: float
+          example: 625.0


### PR DESCRIPTION
To close https://github.com/OpenAPITools/openapi-generator/issues/16857

Better `isAlias` detection for allOf with a single item.

cc @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

