### PR TITLE
fix parameters_to_url_query returns booleans with upper letter

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
@@ -567,10 +567,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -481,10 +481,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
@@ -476,10 +476,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
@@ -529,10 +529,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
+++ b/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
@@ -145,6 +145,11 @@ class TestManual(unittest.TestCase):
         self.assertTrue("Authorization" in e.headers)
         self.assertEqual(e.headers["Authorization"], "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk")
 
+    def testParametersToUrlQuery(self):
+        client = openapi_client.ApiClient()
+        params = client.parameters_to_url_query([("boolean", True),], {})
+        self.assertEqual(params, "&boolean=true")
+
     def echoServerResponseParaserTest(self):
         s = """POST /echo/body/Pet/response_string HTTP/1.1
 Host: localhost:3000

--- a/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
+++ b/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
@@ -145,7 +145,7 @@ class TestManual(unittest.TestCase):
         self.assertTrue("Authorization" in e.headers)
         self.assertEqual(e.headers["Authorization"], "Basic dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk")
 
-    def testParametersToUrlQuery(self):
+    def test_parameters_to_url_query_boolean_value(self):
         client = openapi_client.ApiClient()
         params = client.parameters_to_url_query([("boolean", True),], {})
         self.assertEqual(params, "boolean=true")

--- a/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
+++ b/samples/client/echo_api/python-pydantic-v1/test/test_manual.py
@@ -148,7 +148,7 @@ class TestManual(unittest.TestCase):
     def testParametersToUrlQuery(self):
         client = openapi_client.ApiClient()
         params = client.parameters_to_url_query([("boolean", True),], {})
-        self.assertEqual(params, "&boolean=true")
+        self.assertEqual(params, "boolean=true")
 
     def echoServerResponseParaserTest(self):
         s = """POST /echo/body/Pet/response_string HTTP/1.1

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -476,10 +476,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/client/echo_api/python/test/test_manual.py
+++ b/samples/client/echo_api/python/test/test_manual.py
@@ -215,7 +215,7 @@ class TestManual(unittest.TestCase):
     def testParametersToUrlQuery(self):
         client = openapi_client.ApiClient()
         params = client.parameters_to_url_query([("boolean", True),], {})
-        self.assertEqual(params, "&boolean=true")
+        self.assertEqual(params, "boolean=true")
 
     def echoServerResponseParaserTest(self):
         s = """POST /echo/body/Pet/response_string HTTP/1.1

--- a/samples/client/echo_api/python/test/test_manual.py
+++ b/samples/client/echo_api/python/test/test_manual.py
@@ -212,7 +212,7 @@ class TestManual(unittest.TestCase):
         self.assertEqual(pet2.tags[0].name, "None")
         self.assertEqual(pet2.category.id, 1)
 
-    def testParametersToUrlQuery(self):
+    def test_parameters_to_url_query_boolean_value(self):
         client = openapi_client.ApiClient()
         params = client.parameters_to_url_query([("boolean", True),], {})
         self.assertEqual(params, "boolean=true")

--- a/samples/client/echo_api/python/test/test_manual.py
+++ b/samples/client/echo_api/python/test/test_manual.py
@@ -212,6 +212,11 @@ class TestManual(unittest.TestCase):
         self.assertEqual(pet2.tags[0].name, "None")
         self.assertEqual(pet2.category.id, 1)
 
+    def testParametersToUrlQuery(self):
+        client = openapi_client.ApiClient()
+        params = client.parameters_to_url_query([("boolean", True),], {})
+        self.assertEqual(params, "&boolean=true")
+
     def echoServerResponseParaserTest(self):
         s = """POST /echo/body/Pet/response_string HTTP/1.1
 Host: localhost:3000

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -483,10 +483,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
@@ -499,10 +499,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
@@ -528,10 +528,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:  # noqa: E501
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
@@ -257,5 +257,6 @@ class ApiClientTests(unittest.TestCase):
         result = self.api_client.parameters_to_url_query([('value', dictionary)], {})
         self.assertEqual(result, 'value=%7B%22strValues%22%3A%20%5B%22one%22%2C%20%22two%22%2C%20%22three%22%5D%2C%20%22dictValues%22%3A%20%5B%7B%22name%22%3A%20%22value1%22%2C%20%22age%22%3A%2014%7D%2C%20%7B%22name%22%3A%20%22value2%22%2C%20%22age%22%3A%2012%7D%5D%7D')
 
-
-
+    def test_parameters_to_url_query_boolean_value(self):
+        result = self.api_client.parameters_to_url_query([('boolean', True)], {})
+        self.assertEqual(result, "boolean=true")

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
@@ -259,4 +259,4 @@ class ApiClientTests(unittest.TestCase):
 
     def test_parameters_to_url_query_boolean_value(self):
         result = self.api_client.parameters_to_url_query([('boolean', True)], {})
-        self.assertEqual(result, "boolean=true")
+        self.assertEqual(result, "&boolean=true")

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_api_client.py
@@ -259,4 +259,4 @@ class ApiClientTests(unittest.TestCase):
 
     def test_parameters_to_url_query_boolean_value(self):
         result = self.api_client.parameters_to_url_query([('boolean', True)], {})
-        self.assertEqual(result, "&boolean=true")
+        self.assertEqual(result, "boolean=true")

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -475,10 +475,10 @@ class ApiClient:
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
-            if isinstance(v, (int, float)):
-                v = str(v)
             if isinstance(v, bool):
                 v = str(v).lower()
+            if isinstance(v, (int, float)):
+                v = str(v)
             if isinstance(v, dict):
                 v = json.dumps(v)
 

--- a/samples/openapi3/client/petstore/python/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_client.py
@@ -243,5 +243,6 @@ class ApiClientTests(unittest.TestCase):
         result = self.api_client.parameters_to_url_query([('value', dictionary)], {})
         self.assertEqual(result, 'value=%7B%22strValues%22%3A%20%5B%22one%22%2C%20%22two%22%2C%20%22three%22%5D%2C%20%22dictValues%22%3A%20%5B%7B%22name%22%3A%20%22value1%22%2C%20%22age%22%3A%2014%7D%2C%20%7B%22name%22%3A%20%22value2%22%2C%20%22age%22%3A%2012%7D%5D%7D')
 
-
-
+    def test_parameters_to_url_query_boolean_value(self):
+        result = self.api_client.parameters_to_url_query([('boolean', True)], {})
+        self.assertEqual(result, "boolean=true")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
