### PR TITLE
Add `BearerAuthInterceptor` to `dart-dio` library exports

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart/libraries/dio/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart/libraries/dio/lib.mustache
@@ -2,6 +2,7 @@
 export 'package:{{pubName}}/{{sourceFolder}}/api.dart';
 export 'package:{{pubName}}/{{sourceFolder}}/auth/api_key_auth.dart';
 export 'package:{{pubName}}/{{sourceFolder}}/auth/basic_auth.dart';
+export 'package:{{pubName}}/{{sourceFolder}}/auth/bearer_auth.dart';
 export 'package:{{pubName}}/{{sourceFolder}}/auth/oauth.dart';
 {{#useBuiltValue}}export 'package:{{pubName}}/{{sourceFolder}}/serializers.dart';
 {{#useDateLibCore}}export 'package:{{pubName}}/{{sourceFolder}}/{{modelPackage}}/date.dart';{{/useDateLibCore}}{{/useBuiltValue}}

--- a/samples/openapi3/client/petstore/dart-dio/oneof/lib/openapi.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof/lib/openapi.dart
@@ -5,6 +5,7 @@
 export 'package:openapi/src/api.dart';
 export 'package:openapi/src/auth/api_key_auth.dart';
 export 'package:openapi/src/auth/basic_auth.dart';
+export 'package:openapi/src/auth/bearer_auth.dart';
 export 'package:openapi/src/auth/oauth.dart';
 export 'package:openapi/src/serializers.dart';
 export 'package:openapi/src/model/date.dart';
@@ -14,3 +15,4 @@ export 'package:openapi/src/api/default_api.dart';
 export 'package:openapi/src/model/apple.dart';
 export 'package:openapi/src/model/banana.dart';
 export 'package:openapi/src/model/fruit.dart';
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/openapi.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_polymorphism_and_inheritance/lib/openapi.dart
@@ -5,6 +5,7 @@
 export 'package:openapi/src/api.dart';
 export 'package:openapi/src/auth/api_key_auth.dart';
 export 'package:openapi/src/auth/basic_auth.dart';
+export 'package:openapi/src/auth/bearer_auth.dart';
 export 'package:openapi/src/auth/oauth.dart';
 export 'package:openapi/src/serializers.dart';
 export 'package:openapi/src/model/date.dart';
@@ -30,3 +31,4 @@ export 'package:openapi/src/model/fruit_type.dart';
 export 'package:openapi/src/model/pasta.dart';
 export 'package:openapi/src/model/pizza.dart';
 export 'package:openapi/src/model/pizza_speziale.dart';
+

--- a/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/openapi.dart
+++ b/samples/openapi3/client/petstore/dart-dio/oneof_primitive/lib/openapi.dart
@@ -5,6 +5,7 @@
 export 'package:openapi/src/api.dart';
 export 'package:openapi/src/auth/api_key_auth.dart';
 export 'package:openapi/src/auth/basic_auth.dart';
+export 'package:openapi/src/auth/bearer_auth.dart';
 export 'package:openapi/src/auth/oauth.dart';
 export 'package:openapi/src/serializers.dart';
 export 'package:openapi/src/model/date.dart';
@@ -13,3 +14,4 @@ export 'package:openapi/src/api/default_api.dart';
 
 export 'package:openapi/src/model/child.dart';
 export 'package:openapi/src/model/example.dart';
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/openapi.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake-json_serializable/lib/openapi.dart
@@ -5,6 +5,7 @@
 export 'package:openapi/src/api.dart';
 export 'package:openapi/src/auth/api_key_auth.dart';
 export 'package:openapi/src/auth/basic_auth.dart';
+export 'package:openapi/src/auth/bearer_auth.dart';
 export 'package:openapi/src/auth/oauth.dart';
 
 
@@ -66,3 +67,4 @@ export 'package:openapi/src/model/special_model_name.dart';
 export 'package:openapi/src/model/tag.dart';
 export 'package:openapi/src/model/test_inline_freeform_additional_properties_request.dart';
 export 'package:openapi/src/model/user.dart';
+

--- a/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/openapi.dart
+++ b/samples/openapi3/client/petstore/dart-dio/petstore_client_lib_fake/lib/openapi.dart
@@ -5,6 +5,7 @@
 export 'package:openapi/src/api.dart';
 export 'package:openapi/src/auth/api_key_auth.dart';
 export 'package:openapi/src/auth/basic_auth.dart';
+export 'package:openapi/src/auth/bearer_auth.dart';
 export 'package:openapi/src/auth/oauth.dart';
 export 'package:openapi/src/serializers.dart';
 export 'package:openapi/src/model/date.dart';
@@ -67,3 +68,4 @@ export 'package:openapi/src/model/special_model_name.dart';
 export 'package:openapi/src/model/tag.dart';
 export 'package:openapi/src/model/test_inline_freeform_additional_properties_request.dart';
 export 'package:openapi/src/model/user.dart';
+


### PR DESCRIPTION
The `BearerAuthInterceptor` is missing from the generated library exports.
The other interceptors are included, so If we are exporting them, then it should be all or none

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
