### PR TITLE
maven plugin: log global settings

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/config/GeneratorSettings.java
@@ -1198,7 +1198,6 @@ public final class GeneratorSettings implements Serializable {
          */
         public GeneratorSettings build() {
             GeneratorSettings instance = new GeneratorSettings(this);
-            //noinspection PlaceholderCountMatchesArgumentCount
             LOGGER.debug("GeneratorSettings#build: {}", instance);
             return instance;
         }

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -903,6 +903,7 @@ public class CodeGenMojo extends AbstractMojo {
                 return;
             }
             adjustAdditionalProperties(config);
+            GlobalSettings.log();
             new DefaultGenerator(dryRun).opts(input).generate();
 
             if (buildContext != null) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -606,7 +606,7 @@ public class DefaultGenerator implements Generator {
         }
         Map<String, List<CodegenOperation>> paths = processPaths(this.openAPI.getPaths());
         Set<String> apisToGenerate = null;
-        String apiNames = GlobalSettings.getProperty("apis");
+        String apiNames = GlobalSettings.getProperty(CodegenConstants.APIS);
         if (apiNames != null && !apiNames.isEmpty()) {
             apisToGenerate = new HashSet<>(Arrays.asList(apiNames.split(",")));
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/GlobalSettings.java
@@ -16,6 +16,11 @@
 
 package org.openapitools.codegen.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Properties;
 
 /**
@@ -30,6 +35,8 @@ import java.util.Properties;
  * @since 2018
  */
 public class GlobalSettings {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalSettings.class);
 
     private static ThreadLocal<Properties> properties = new InheritableThreadLocal<Properties>() {
         @Override
@@ -59,5 +66,11 @@ public class GlobalSettings {
 
     public static void reset() {
         properties.remove();
+    }
+
+    public static void log() {
+        StringWriter stringWriter = new StringWriter();
+        properties.get().list(new PrintWriter(stringWriter));
+        LOGGER.debug("GlobalSettings: {}", stringWriter);
     }
 }


### PR DESCRIPTION
In the maven plugin, add logging of `GlobalSettings`.
This adresses the suggestion in https://github.com/OpenAPITools/openapi-generator/issues/4506 to have complete logging of all relevant inputs in the maven plugin.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
