### PR TITLE
[Go] add generateMarshalJSON key for additional-properties settings

### DIFF
--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -21,6 +21,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |enumClassPrefix|Prefix enum with class name| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
+|generateMarshalJSON|Generate MarshalJSON method| |false|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |isGoSubmodule|whether the generated Go module is a submodule| |false|
 |packageName|Go package name (convention: lowercase).| |openapi|

--- a/docs/generators/go.md
+++ b/docs/generators/go.md
@@ -21,7 +21,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |enumClassPrefix|Prefix enum with class name| |false|
 |generateInterfaces|Generate interfaces for api classes| |false|
-|generateMarshalJSON|Generate MarshalJSON method| |false|
+|generateMarshalJSON|Generate MarshalJSON method| |true|
 |hideGenerationTimestamp|Hides the generation timestamp when files are generated.| |true|
 |isGoSubmodule|whether the generated Go module is a submodule| |false|
 |packageName|Go package name (convention: lowercase).| |openapi|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -433,4 +433,7 @@ public class CodegenConstants {
     public static final String FASTAPI_IMPLEMENTATION_PACKAGE = "fastapiImplementationPackage";
 
     public static final String WITH_GO_MOD = "withGoMod";
+
+    public static final String SKIP_GENERATING_MARSHAL_JSON = "skipGeneratingMarshalJSON";
+    public static final String SKIP_GENERATING_MARSHAL_JSON_DESC = "Skip generating MarshalJSON method";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -434,6 +434,6 @@ public class CodegenConstants {
 
     public static final String WITH_GO_MOD = "withGoMod";
 
-    public static final String SKIP_GENERATING_MARSHAL_JSON = "skipGeneratingMarshalJSON";
-    public static final String SKIP_GENERATING_MARSHAL_JSON_DESC = "Skip generating MarshalJSON method";
+    public static final String GENERATE_MARSHAL_JSON = "generateMarshalJSON";
+    public static final String GENERATE_MARSHAL_JSON_DESC = "Generate MarshalJSON method";
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -50,6 +50,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected boolean structPrefix = false;
     protected boolean generateInterfaces = false;
     protected boolean withGoMod = false;
+    protected boolean skipGeneratingMarshalJSON = false;
 
     protected String packageName = "openapi";
     protected Set<String> numberTypes;
@@ -667,7 +668,12 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 model.isNullable = true;
                 model.anyOf.remove("nil");
             }
+
+            if (skipGeneratingMarshalJSON) {
+                model.vendorExtensions.put("x-go-skip-generating-marshal-json", true);
+            }
         }
+
         // recursively add import for mapping one type to multiple imports
         List<Map<String, String>> recursiveImports = objs.getImports();
         if (recursiveImports == null)
@@ -807,6 +813,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     public void setWithGoMod(boolean withGoMod) {
         this.withGoMod = withGoMod;
+    }
+
+    public void setSkipGeneratingMarshalJSON(boolean skipGeneratingMarshalJSON) {
+        this.skipGeneratingMarshalJSON = skipGeneratingMarshalJSON;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -50,7 +50,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected boolean structPrefix = false;
     protected boolean generateInterfaces = false;
     protected boolean withGoMod = false;
-    protected boolean skipGeneratingMarshalJSON = false;
+    protected boolean generateMarshalJSON = false;
 
     protected String packageName = "openapi";
     protected Set<String> numberTypes;
@@ -669,8 +669,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
                 model.anyOf.remove("nil");
             }
 
-            if (skipGeneratingMarshalJSON) {
-                model.vendorExtensions.put("x-go-skip-generating-marshal-json", true);
+            if (generateMarshalJSON) {
+                model.vendorExtensions.put("x-go-generate-marshal-json", true);
             }
         }
 
@@ -815,8 +815,8 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
         this.withGoMod = withGoMod;
     }
 
-    public void setSkipGeneratingMarshalJSON(boolean skipGeneratingMarshalJSON) {
-        this.skipGeneratingMarshalJSON = skipGeneratingMarshalJSON;
+    public void setGenerateMarshalJSON(boolean generateMarshalJSON) {
+        this.generateMarshalJSON = generateMarshalJSON;
     }
 
     @Override

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -50,7 +50,7 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     protected boolean structPrefix = false;
     protected boolean generateInterfaces = false;
     protected boolean withGoMod = false;
-    protected boolean generateMarshalJSON = false;
+    protected boolean generateMarshalJSON = true;
 
     protected String packageName = "openapi";
     protected Set<String> numberTypes;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -139,7 +139,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
         cliOptions.add(CliOption.newBoolean(WITH_GO_MOD, "Generate go.mod and go.sum", true));
-        cliOptions.add(CliOption.newBoolean(CodegenConstants.GENERATE_MARSHAL_JSON, CodegenConstants.GENERATE_MARSHAL_JSON_DESC, false));
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.GENERATE_MARSHAL_JSON, CodegenConstants.GENERATE_MARSHAL_JSON_DESC, true));
         this.setWithGoMod(true);
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -139,7 +139,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
         cliOptions.add(CliOption.newBoolean(WITH_GO_MOD, "Generate go.mod and go.sum", true));
-        cliOptions.add(CliOption.newBoolean(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON, CodegenConstants.SKIP_GENERATING_MARSHAL_JSON_DESC, false));
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.GENERATE_MARSHAL_JSON, CodegenConstants.GENERATE_MARSHAL_JSON_DESC, false));
         this.setWithGoMod(true);
     }
 
@@ -273,8 +273,8 @@ public class GoClientCodegen extends AbstractGoCodegen {
             additionalProperties.put(WITH_GO_MOD, true);
         }
 
-        if (additionalProperties.containsKey(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON)) {
-            setSkipGeneratingMarshalJSON(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON).toString()));
+        if (additionalProperties.containsKey(CodegenConstants.GENERATE_MARSHAL_JSON)) {
+            setGenerateMarshalJSON(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.GENERATE_MARSHAL_JSON).toString()));
         }
 
         // add lambda for mustache templates to handle oneOf/anyOf naming

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -139,6 +139,7 @@ public class GoClientCodegen extends AbstractGoCodegen {
         cliOptions.add(disallowAdditionalPropertiesIfNotPresentOpt);
         this.setDisallowAdditionalPropertiesIfNotPresent(true);
         cliOptions.add(CliOption.newBoolean(WITH_GO_MOD, "Generate go.mod and go.sum", true));
+        cliOptions.add(CliOption.newBoolean(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON, CodegenConstants.SKIP_GENERATING_MARSHAL_JSON_DESC, false));
         this.setWithGoMod(true);
     }
 
@@ -270,6 +271,10 @@ public class GoClientCodegen extends AbstractGoCodegen {
             additionalProperties.put(WITH_GO_MOD, withGoMod);
         } else {
             additionalProperties.put(WITH_GO_MOD, true);
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON)) {
+            setSkipGeneratingMarshalJSON(Boolean.parseBoolean(additionalProperties.get(CodegenConstants.SKIP_GENERATING_MARSHAL_JSON).toString()));
         }
 
         // add lambda for mustache templates to handle oneOf/anyOf naming

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -260,7 +260,7 @@ func (o *{{classname}}) Unset{{name}}() {
 
 {{/required}}
 {{/vars}}
-{{^vendorExtensions.x-go-generate-marshal-json}}
+{{#vendorExtensions.x-go-generate-marshal-json}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -260,6 +260,7 @@ func (o *{{classname}}) Unset{{name}}() {
 
 {{/required}}
 {{/vars}}
+{{^vendorExtensions.x-go-skip-generating-marshal-json}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -268,6 +269,7 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
+{{/vendorExtensions.x-go-skip-generating-marshal-json}}
 func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
 	{{#parent}}

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -260,7 +260,7 @@ func (o *{{classname}}) Unset{{name}}() {
 
 {{/required}}
 {{/vars}}
-{{^vendorExtensions.x-go-skip-generating-marshal-json}}
+{{^vendorExtensions.x-go-generate-marshal-json}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	toSerialize,err := o.ToMap()
 	if err != nil {
@@ -269,7 +269,7 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-{{/vendorExtensions.x-go-skip-generating-marshal-json}}
+{{/vendorExtensions.x-go-generate-marshal-json}}
 func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
 	{{#parent}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientOptionsTest.java
@@ -52,5 +52,6 @@ public class GoClientOptionsTest extends AbstractOptionsTest {
         verify(clientCodegen).setWithAWSV4Signature(GoClientOptionsProvider.WITH_AWSV4_SIGNATURE);
         verify(clientCodegen).setUseOneOfDiscriminatorLookup(GoClientOptionsProvider.USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE);
         verify(clientCodegen).setWithGoMod(GoClientOptionsProvider.WITH_GO_MOD_VALUE);
+        verify(clientCodegen).setGenerateMarshalJSON(GoClientOptionsProvider.GENERATE_MARSHAL_JSON_VALUE);
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/options/GoClientOptionsProvider.java
@@ -37,6 +37,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
     public static final boolean DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT_VALUE = true;
     public static final boolean USE_ONE_OF_DISCRIMINATOR_LOOKUP_VALUE = true;
     public static final boolean WITH_GO_MOD_VALUE = true;
+    public static final boolean GENERATE_MARSHAL_JSON_VALUE = true;
 
     @Override
     public String getLanguage() {
@@ -58,6 +59,7 @@ public class GoClientOptionsProvider implements OptionsProvider {
                 .put(CodegenConstants.DISALLOW_ADDITIONAL_PROPERTIES_IF_NOT_PRESENT, "true")
                 .put(CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, "true")
                 .put(CodegenConstants.WITH_GO_MOD, "true")
+                .put(CodegenConstants.GENERATE_MARSHAL_JSON, "true")
                 .put("generateInterfaces", "true")
                 .put("structPrefix", "true")
                 .build();


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I added generateMarshalJSON (boolean) as a setting for additional-properties.
By default, it is set to true. However, if explicitly set to false, it will not implement the MarshalJSON using ToMap.

This PR is related to #16948.
I kindly ask for your review.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
