### PR TITLE
Bug Fix: Removing Hardcoded 'id' csharp-function

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp-functions/function.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp-functions/function.mustache
@@ -22,11 +22,9 @@ namespace {{apiPackage}}
         {{#generateBody}}
         {
             var method = this.GetType().GetMethod("{{operationId}}");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<{{{returnType}}}>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<{{{returnType}}}>)method.Invoke(this, new object[] { req, context{{#allParams}}{{#isPathParam}}, {{>paramName}}{{/isPathParam}}{{/allParams}} })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
         {{/generateBody}}
         {{/operation}}

--- a/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/PetApi.cs
+++ b/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/PetApi.cs
@@ -21,88 +21,72 @@ namespace Org.OpenAPITools.Functions
         public async Task<ActionResult<Pet>> _AddPet([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2pet")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("AddPet");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Pet>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Pet>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_DeletePet")]
         public async Task<ActionResult<>> _DeletePet([HttpTrigger(AuthorizationLevel.Anonymous, "Delete", Route = "v2pet/{petId}")]HttpRequest req, ExecutionContext context, long petId)
         {
             var method = this.GetType().GetMethod("DeletePet");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context, petId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_FindPetsByStatus")]
         public async Task<ActionResult<List<Pet>>> _FindPetsByStatus([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2pet/findByStatus")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("FindPetsByStatus");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<List<Pet>>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<List<Pet>>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_FindPetsByTags")]
         public async Task<ActionResult<List<Pet>>> _FindPetsByTags([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2pet/findByTags")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("FindPetsByTags");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<List<Pet>>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<List<Pet>>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_GetPetById")]
         public async Task<ActionResult<Pet>> _GetPetById([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2pet/{petId}")]HttpRequest req, ExecutionContext context, long petId)
         {
             var method = this.GetType().GetMethod("GetPetById");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Pet>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Pet>)method.Invoke(this, new object[] { req, context, petId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_UpdatePet")]
         public async Task<ActionResult<Pet>> _UpdatePet([HttpTrigger(AuthorizationLevel.Anonymous, "Put", Route = "v2pet")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("UpdatePet");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Pet>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Pet>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_UpdatePetWithForm")]
         public async Task<ActionResult<>> _UpdatePetWithForm([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2pet/{petId}")]HttpRequest req, ExecutionContext context, long petId)
         {
             var method = this.GetType().GetMethod("UpdatePetWithForm");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context, petId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("PetApi_UploadFile")]
         public async Task<ActionResult<ApiResponse>> _UploadFile([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2pet/{petId}/uploadImage")]HttpRequest req, ExecutionContext context, long petId)
         {
             var method = this.GetType().GetMethod("UploadFile");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<ApiResponse>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<ApiResponse>)method.Invoke(this, new object[] { req, context, petId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
     }
 }

--- a/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/StoreApi.cs
+++ b/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/StoreApi.cs
@@ -21,44 +21,36 @@ namespace Org.OpenAPITools.Functions
         public async Task<ActionResult<>> _DeleteOrder([HttpTrigger(AuthorizationLevel.Anonymous, "Delete", Route = "v2store/order/{orderId}")]HttpRequest req, ExecutionContext context, string orderId)
         {
             var method = this.GetType().GetMethod("DeleteOrder");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context, orderId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("StoreApi_GetInventory")]
         public async Task<ActionResult<Dictionary<string, int>>> _GetInventory([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2store/inventory")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("GetInventory");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Dictionary<string, int>>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Dictionary<string, int>>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("StoreApi_GetOrderById")]
         public async Task<ActionResult<Order>> _GetOrderById([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2store/order/{orderId}")]HttpRequest req, ExecutionContext context, [Range(1, 5)]long orderId)
         {
             var method = this.GetType().GetMethod("GetOrderById");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Order>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Order>)method.Invoke(this, new object[] { req, context, orderId })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("StoreApi_PlaceOrder")]
         public async Task<ActionResult<Order>> _PlaceOrder([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2store/order")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("PlaceOrder");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<Order>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<Order>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
     }
 }

--- a/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/UserApi.cs
+++ b/samples/client/petstore/csharp-functions/src/Org.OpenAPITools/Functions/UserApi.cs
@@ -21,88 +21,72 @@ namespace Org.OpenAPITools.Functions
         public async Task<ActionResult<>> _CreateUser([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2user")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("CreateUser");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_CreateUsersWithArrayInput")]
         public async Task<ActionResult<>> _CreateUsersWithArrayInput([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2user/createWithArray")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("CreateUsersWithArrayInput");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_CreateUsersWithListInput")]
         public async Task<ActionResult<>> _CreateUsersWithListInput([HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "v2user/createWithList")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("CreateUsersWithListInput");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_DeleteUser")]
         public async Task<ActionResult<>> _DeleteUser([HttpTrigger(AuthorizationLevel.Anonymous, "Delete", Route = "v2user/{username}")]HttpRequest req, ExecutionContext context, string username)
         {
             var method = this.GetType().GetMethod("DeleteUser");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context, username })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_GetUserByName")]
         public async Task<ActionResult<User>> _GetUserByName([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2user/{username}")]HttpRequest req, ExecutionContext context, string username)
         {
             var method = this.GetType().GetMethod("GetUserByName");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<User>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<User>)method.Invoke(this, new object[] { req, context, username })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_LoginUser")]
         public async Task<ActionResult<string>> _LoginUser([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2user/login")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("LoginUser");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<string>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<string>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_LogoutUser")]
         public async Task<ActionResult<>> _LogoutUser([HttpTrigger(AuthorizationLevel.Anonymous, "Get", Route = "v2user/logout")]HttpRequest req, ExecutionContext context)
         {
             var method = this.GetType().GetMethod("LogoutUser");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
 
         [FunctionName("UserApi_UpdateUser")]
         public async Task<ActionResult<>> _UpdateUser([HttpTrigger(AuthorizationLevel.Anonymous, "Put", Route = "v2user/{username}")]HttpRequest req, ExecutionContext context, string username)
         {
             var method = this.GetType().GetMethod("UpdateUser");
-            if(method == null)
-            {
-                return new StatusCodeResult((int)HttpStatusCode.NotImplemented);
-            }
-            return (await ((Task<>)method.Invoke(this, new object[] { req, context, id })).ConfigureAwait(false));
+            return method != null
+                ? (await ((Task<>)method.Invoke(this, new object[] { req, context, username })).ConfigureAwait(false))
+                : new StatusCodeResult((int)HttpStatusCode.NotImplemented);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
