### PR TITLE
[typescript-axios] Upgrade axios to 1.6.0

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache
@@ -26,7 +26,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/samples/client/echo_api/typescript-axios/build/package.json
+++ b/samples/client/echo_api/typescript-axios/build/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/samples/client/petstore/typescript-axios/builds/es6-target/package.json
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/package.json
@@ -24,7 +24,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.11.5",


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

I have upgraded the Axios dependency for typescript-axios to version 1.6.0.
I have done it manually for my company's projects and it seems everything worked without any change. So I am happy to have it upgraded as default in this awesome project :) Thanks!

Related issue/request: https://github.com/OpenAPITools/openapi-generator/issues/14517

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Notifying the Comitee members:

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka