### PR TITLE
[csharp] Introducing the `enumPropertyNaming` option to the C# Generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -1666,6 +1666,12 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         }
     }
 
+    /**
+     * Adjust the naming style of a given name based on the enumPropertyNaming option.
+     *
+     * @param name The original name
+     * @return The adjusted name
+     */
     private String adjustNamingStyle(String name)
     {
         switch (getEnumPropertyNaming()) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 
 import static org.openapitools.codegen.utils.CamelizeOption.LOWERCASE_FIRST_LETTER;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
+import static org.openapitools.codegen.utils.StringUtils.underscore;
 
 public abstract class AbstractCSharpCodegen extends DefaultCodegen implements CodegenConfig {
 
@@ -84,6 +85,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     protected String sourceFolder = "src";
     protected String invalidNamePrefix = "var";
+    protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.PascalCase;
 
     // TODO: Add option for test folder output location. Nice to allow e.g. ./test instead of ./src.
     //       This would require updating relative paths (e.g. path to main project file in test project file)
@@ -389,6 +391,10 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
         if (additionalProperties().containsKey(CodegenConstants.ENUM_VALUE_SUFFIX)) {
             setEnumValueSuffix(additionalProperties.get(CodegenConstants.ENUM_VALUE_SUFFIX).toString());
+        }
+
+        if (additionalProperties.containsKey(CodegenConstants.ENUM_PROPERTY_NAMING)) {
+            setEnumPropertyNaming((String) additionalProperties.get(CodegenConstants.ENUM_PROPERTY_NAMING));
         }
 
         // This either updates additionalProperties with the above fixes, or sets the default if the option was not specified.
@@ -1598,6 +1604,22 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         this.supportNullable = supportNullable;
     }
 
+    public CodegenConstants.ENUM_PROPERTY_NAMING_TYPE getEnumPropertyNaming() {
+        return this.enumPropertyNaming;
+    }
+
+    public void setEnumPropertyNaming(final String enumPropertyNamingType) {
+        try {
+            this.enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.valueOf(enumPropertyNamingType);
+        } catch (IllegalArgumentException ex) {
+            StringBuilder sb = new StringBuilder(enumPropertyNamingType + " is an invalid enum property naming option. Please choose from:");
+            for (CodegenConstants.ENUM_PROPERTY_NAMING_TYPE t : CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.values()) {
+                sb.append("\n  ").append(t.name());
+            }
+            throw new RuntimeException(sb.toString());
+        }
+    }
+
     @Override
     public String toEnumValue(String value, String datatype) {
         // C# only supports enums as literals for int, int?, long, long?, byte, and byte?. All else must be treated as strings.
@@ -1622,12 +1644,12 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     @Override
     public String toEnumVarName(String name, String datatype) {
         if (name.length() == 0) {
-            return "Empty";
+            return adjustNamingStyle("Empty");
         }
 
         // for symbol, e.g. $, #
         if (getSymbolName(name) != null) {
-            return camelize(getSymbolName(name));
+            return adjustNamingStyle(getSymbolName(name));
         }
 
         String enumName = sanitizeName(name);
@@ -1635,12 +1657,33 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");
 
-        enumName = camelize(enumName) + this.enumValueSuffix;
+        enumName = adjustNamingStyle(enumName) + this.enumValueSuffix;
 
         if (enumName.matches("\\d.*")) { // starts with number
             return "_" + enumName;
         } else {
             return enumName;
+        }
+    }
+
+    private String adjustNamingStyle(String name)
+    {
+        switch (getEnumPropertyNaming()) {
+            case original:
+                return name;
+            case camelCase:
+                // NOTE: Removes hyphens and underscores
+                return camelize(name, LOWERCASE_FIRST_LETTER);
+            case PascalCase:
+                // NOTE: Removes hyphens and underscores
+                return camelize(name);
+            case snake_case:
+                // NOTE: Removes hyphens
+                return underscore(name);
+            case UPPERCASE:
+                return underscore(name).toUpperCase(Locale.ROOT);
+            default:
+                return name;
         }
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpModelEnumTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpModelEnumTest.java
@@ -28,10 +28,14 @@ import org.openapitools.codegen.languages.AspNetServerCodegen;
 import org.openapitools.codegen.languages.CSharpClientCodegen;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.openapitools.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE;
+import static org.openapitools.codegen.CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.*;
 
 public class CSharpModelEnumTest {
     // TODO there's no parent/child method in ComposeSchema so we will need to revise the code
@@ -148,4 +152,54 @@ public class CSharpModelEnumTest {
         Assert.assertEquals(codegen.toEnumVarName("Aaaa", ""), "Aaaa");
     }
 
+    @Test(description = "support enum naming style options", dataProvider = "enumVarName")
+    public void testToEnumVarName(String name, String expected, ENUM_PROPERTY_NAMING_TYPE naming) throws Exception {
+        final AspNetServerCodegen codegen = new AspNetServerCodegen();
+        codegen.setEnumPropertyNaming(naming.name());
+        codegen.setEnumValueSuffix("");
+
+        Assert.assertEquals(codegen.toEnumVarName(name, "string"), expected);
+    }
+
+    @DataProvider(name = "enumVarName")
+    public Object[][] provideTestData()
+    {
+        return new Object[][] {
+            { "FooBar", "fooBar", camelCase },
+            { "fooBar", "fooBar", camelCase },
+            { "foo-bar", "fooBar", camelCase },
+            { "foo_bar", "fooBar", camelCase },
+            { "foo bar", "fooBar", camelCase },
+            { "FOO-BAR", "fOOBAR", camelCase }, // camelize doesn't support uppercase
+            { "FOO_BAR", "fOOBAR", camelCase }, // ditto
+            { "FooBar", "FooBar", PascalCase },
+            { "fooBar", "FooBar", PascalCase },
+            { "foo-bar", "FooBar", PascalCase },
+            { "foo_bar", "FooBar", PascalCase },
+            { "foo bar", "FooBar", PascalCase },
+            { "FOO-BAR", "FOOBAR", PascalCase }, // ditto
+            { "FOO_BAR", "FOOBAR", PascalCase }, // ditto
+            { "FooBar", "foo_bar", snake_case },
+            { "fooBar", "foo_bar", snake_case },
+            { "foo-bar", "foo_bar", snake_case },
+            { "foo_bar", "foo_bar", snake_case },
+            { "foo bar", "foo_bar", snake_case },
+            { "FOO-BAR", "foo_bar", snake_case },
+            { "FOO_BAR", "foo_bar", snake_case },
+            { "FooBar", "FOO_BAR", UPPERCASE },
+            { "fooBar", "FOO_BAR", UPPERCASE },
+            { "foo-bar", "FOO_BAR", UPPERCASE },
+            { "foo_bar", "FOO_BAR", UPPERCASE },
+            { "foo bar", "FOO_BAR", UPPERCASE },
+            { "FOO-BAR", "FOO_BAR", UPPERCASE },
+            { "FOO_BAR", "FOO_BAR", UPPERCASE },
+            { "FooBar", "FooBar", original },
+            { "fooBar", "fooBar", original },
+            { "foo-bar", "foo_bar", original },
+            { "foo_bar", "foo_bar", original },
+            { "foo bar", "foo_bar", original },
+            { "FOO-BAR", "FOO_BAR", original },
+            { "FOO_BAR", "FOO_BAR", original },
+        };
+    }
 }


### PR DESCRIPTION
This pull request introduces the `enumPropertyNaming` option to the C# generator. This option, which is currently supported by the Kotlin and TypeScript generators, allows you to control the naming style of enum names.

In our projects, we consistently use `UPPER_SNAKE_CASE` for constants in our OpenAPI definitions, and we prefer to maintain this naming style in our C# code. However, the current C# generator changes the enum names by removing the underscores, resulting in enum names like `UPPERSNAKECASE`.

While searching for a solution to this problem, I came across the `enumPropertyNaming` option available in the Kotlin and TypeScript generators. To resolve this discrepancy and ensure that our enum naming style remains consistent with `UPPER_SNAKE_CASE`, I ported this option to the C# generator.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean @shibayan @Blackclaws @lucamazzanti @iBicha