### PR TITLE
[POSTMAN] [BUG] Correct order of the Postman requests

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -325,10 +325,16 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
         codegenOperationsByTag.put(key, list);
 
+        // sort requests by path
+        Collections.sort(list, Comparator.comparing(obj -> obj.path));
     }
 
-    void addToList(CodegenOperation codegenOperation) {
+    public void addToList(CodegenOperation codegenOperation) {
+
         codegenOperationsList.add(codegenOperation);
+
+        // sort requests by path
+        Collections.sort(codegenOperationsList, Comparator.comparing(obj -> obj.path));
     }
 
     String getResponseBody(CodegenResponse codegenResponse) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -75,9 +75,9 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
 
     // operations grouped by tag
-    protected Map<String, List<CodegenOperation>> codegenOperationsByTag = new HashMap<>();
+    public Map<String, List<CodegenOperation>> codegenOperationsByTag = new HashMap<>();
     // list of operations
-    protected List<CodegenOperation> codegenOperationsList = new ArrayList<>();
+    public List<CodegenOperation> codegenOperationsList = new ArrayList<>();
 
     /**
      * Configures the type of generator.
@@ -307,7 +307,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
      * The map groups the CodegenOperations by tag as defined in the OpenAPI spec
      * @param codegenOperation Codegen operation instance
      */
-    void addToMap(CodegenOperation codegenOperation){
+    public void addToMap(CodegenOperation codegenOperation){
 
         String key = null;
         if(codegenOperation.tags == null || codegenOperation.tags.isEmpty()) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.models.tags.Tag;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openapitools.codegen.*;
@@ -16,6 +17,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -688,6 +691,75 @@ public class PostmanCollectionCodegenTest {
 
         assertEquals(EXPECTED, new PostmanCollectionCodegen().convertToJson(city));
 
+    }
+
+    @Test
+    public void testAddToList()  {
+
+        PostmanCollectionCodegen postmanCollectionCodegen = new PostmanCollectionCodegen();
+
+        CodegenOperation operationUsers = new CodegenOperation();
+        operationUsers.path = "/users";
+        postmanCollectionCodegen.addToList(operationUsers);
+
+        CodegenOperation operationGroups = new CodegenOperation();
+        operationGroups.path = "/groups";
+        postmanCollectionCodegen.addToList(operationGroups);
+
+        CodegenOperation operationUserId = new CodegenOperation();
+        operationUserId.path = "/users/{id}";
+        postmanCollectionCodegen.addToList(operationUserId);
+
+        assertEquals(3, postmanCollectionCodegen.codegenOperationsList.size());
+        // verify order
+        assertEquals("/groups", postmanCollectionCodegen.codegenOperationsList.get(0).path);
+        assertEquals("/users", postmanCollectionCodegen.codegenOperationsList.get(1).path);
+        assertEquals("/users/{id}", postmanCollectionCodegen.codegenOperationsList.get(2).path);
+    }
+
+    @Test
+    public void testAddToMap() {
+
+        PostmanCollectionCodegen postmanV2Generator = new PostmanCollectionCodegen();
+
+        CodegenOperation operationUsers = new CodegenOperation();
+        operationUsers.path = "/users";
+        operationUsers.tags = new ArrayList<>(Arrays.asList(new Tag().name("basic")));
+        postmanV2Generator.addToMap(operationUsers);
+
+        CodegenOperation operationGroups = new CodegenOperation();
+        operationGroups.path = "/groups";
+        operationGroups.tags = new ArrayList<>(Arrays.asList(new Tag().name("basic")));
+        postmanV2Generator.addToMap(operationGroups);
+
+        CodegenOperation operationUserId = new CodegenOperation();
+        operationUserId.path = "/users/{id}";
+        operationUserId.tags = new ArrayList<>(Arrays.asList(new Tag().name("basic")));
+        postmanV2Generator.addToMap(operationUserId);
+
+        // verify tag 'basic'
+        assertEquals(1, postmanV2Generator.codegenOperationsByTag.size());
+        assertEquals(true, postmanV2Generator.codegenOperationsByTag.containsKey("basic"));
+
+        List<CodegenOperation> operations = postmanV2Generator.codegenOperationsByTag.get("basic");
+        // verify order
+        assertEquals("/groups", operations.get(0).path);
+        assertEquals("/users", operations.get(1).path);
+        assertEquals("/users/{id}", operations.get(2).path);
+    }
+
+    @Test
+    public void testAddToMapUsingDefaultTag() {
+
+        PostmanCollectionCodegen postmanV2Generator = new PostmanCollectionCodegen();
+
+        CodegenOperation operationUsers = new CodegenOperation();
+        operationUsers.path = "/users";
+        postmanV2Generator.addToMap(operationUsers);
+
+        // verify tag 'default' is used
+        assertEquals(1, postmanV2Generator.codegenOperationsByTag.size());
+        assertEquals(true, postmanV2Generator.codegenOperationsByTag.containsKey("default"));
     }
 
 }

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -192,6 +192,53 @@
 	            "name": "basic",
 	            "item": [
 	                        {
+    "name": "/user",
+                "description": "Create a new user.",
+                 "item": [
+                            {
+                                "name": "Example request for Get User",
+                                "request": {
+                                    "method": "POST",
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "application/json",
+                                            "disabled": false
+                                        },
+                                        {
+                                            "key": "Accept",
+                                            "value": "application/json",
+                                            "disabled": false
+                                        }
+                                    ],
+                                    "body": {
+                                        "mode": "raw",
+                                        "raw": "{\n  \"id\" : 777,\n  \"firstName\" : \"Alotta\",\n  \"lastName\" : \"Rotta\",\n  \"email\" : \"alotta.rotta@gmail.com\",\n  \"dateOfBirth\" : \"1997-10-31\",\n  \"emailVerified\" : true,\n  \"createDate\" : \"2019-08-24\"\n}",
+                                        "options": {
+                                            "raw": {
+                                                "language": "json"
+                                            }
+                                        }
+                                    },
+                                    "url": {
+                                        "raw": "{{baseUrl}}/user",
+                                        "host": [
+                                            "{{baseUrl}}"
+                                        ],
+                                        "path": [
+                                            "user"
+                                        ],
+                                        "variable": [
+                                        ],
+                                        "query": [
+                                        ]
+                                    },
+                                    "description": "Create a new user."
+                                }
+                            }
+                            ]
+                        },
+	                        {
     "name": "/users/",
                 "description": "Retrieve the information of the user with the matching user ID.",
                  "item": [
@@ -243,53 +290,6 @@
                                         ]
                                     },
                                     "description": "Retrieve the information of the user with the matching user ID."
-                                }
-                            }
-                            ]
-                        },
-	                        {
-    "name": "/user",
-                "description": "Create a new user.",
-                 "item": [
-                            {
-                                "name": "Example request for Get User",
-                                "request": {
-                                    "method": "POST",
-                                    "header": [
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/json",
-                                            "disabled": false
-                                        },
-                                        {
-                                            "key": "Accept",
-                                            "value": "application/json",
-                                            "disabled": false
-                                        }
-                                    ],
-                                    "body": {
-                                        "mode": "raw",
-                                        "raw": "{\n  \"id\" : 777,\n  \"firstName\" : \"Alotta\",\n  \"lastName\" : \"Rotta\",\n  \"email\" : \"alotta.rotta@gmail.com\",\n  \"dateOfBirth\" : \"1997-10-31\",\n  \"emailVerified\" : true,\n  \"createDate\" : \"2019-08-24\"\n}",
-                                        "options": {
-                                            "raw": {
-                                                "language": "json"
-                                            }
-                                        }
-                                    },
-                                    "url": {
-                                        "raw": "{{baseUrl}}/user",
-                                        "host": [
-                                            "{{baseUrl}}"
-                                        ],
-                                        "path": [
-                                            "user"
-                                        ],
-                                        "variable": [
-                                        ],
-                                        "query": [
-                                        ]
-                                    },
-                                    "description": "Create a new user."
                                 }
                             }
                             ]


### PR DESCRIPTION
The generated Postman collection presents the requests in a random order.

This PR fixes the generator to sort the requests by path to make sure Postman displays all requests for a given endpoint together.

Fixes #16982 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 
