### PR TITLE
fix oneOf merging, upgrade dependencies

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Mustache.Compiler;
 import com.samskivert.mustache.Mustache.Lambda;
+import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -924,12 +925,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
     }
 
-    /**
-     * Set the OpenAPI document.
-     * This method is invoked when the input OpenAPI document has been parsed and validated.
-     */
-    @Override
-    public void setOpenAPI(OpenAPI openAPI) {
+    public boolean specVersionGreaterThanOrEqualTo310(OpenAPI openAPI) {
         String originalSpecVersion;
         String xOriginalSwaggerVersion = "x-original-swagger-version";
         if (openAPI.getExtensions() != null && !openAPI.getExtensions().isEmpty() && openAPI.getExtensions().containsValue(xOriginalSwaggerVersion)) {
@@ -939,8 +935,16 @@ public class DefaultCodegen implements CodegenConfig {
         }
         Integer specMajorVersion = Integer.parseInt(originalSpecVersion.substring(0, 1));
         Integer specMinorVersion = Integer.parseInt(originalSpecVersion.substring(2, 3));
-        boolean specVersionGreaterThanOrEqualTo310 = (specMajorVersion == 3 && specMinorVersion >= 1);
-        if (specVersionGreaterThanOrEqualTo310) {
+        return specMajorVersion == 3 && specMinorVersion >= 1;
+    }
+
+    /**
+     * Set the OpenAPI document.
+     * This method is invoked when the input OpenAPI document has been parsed and validated.
+     */
+    @Override
+    public void setOpenAPI(OpenAPI openAPI) {
+        if (specVersionGreaterThanOrEqualTo310(openAPI)) {
             LOGGER.warn(UNSUPPORTED_V310_SPEC_MSG);
         }
         this.openAPI = openAPI;
@@ -2894,7 +2898,11 @@ public class DefaultCodegen implements CodegenConfig {
         if (null != existingProperties && null != newProperties) {
             Schema existingType = existingProperties.get("type");
             Schema newType = newProperties.get("type");
-            existingProperties.putAll(newProperties);
+            newProperties.forEach((key, value) ->
+                    existingProperties.put(
+                            key,
+                            AnnotationsUtils.clone(value, specVersionGreaterThanOrEqualTo310(openAPI))
+                    ));
             if (null != existingType && null != newType && null != newType.getEnum() && !newType.getEnum().isEmpty()) {
                 for (Object e : newType.getEnum()) {
                     // ensure all interface enum types are added to schema

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -671,6 +671,15 @@ public class DefaultCodegenTest {
         }
         Assert.assertTrue(typeSeen);
         Assert.assertTrue(typeContainsEnums);
+
+        Assert.assertEquals(
+                ((StringSchema) openAPI.getComponents().getSchemas().get("Dog").getProperties().get("type")).getEnum().size(),
+                1
+        );
+        Assert.assertEquals(
+                ((StringSchema) openAPI.getComponents().getSchemas().get("Cat").getProperties().get("type")).getEnum().size(),
+                1
+        );
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -1469,7 +1469,7 @@
         <maven-site-plugin.version>4.0.0-M8</maven-site-plugin.version>
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <mockito.version>4.10.0</mockito.version>
-        <openrewrite.version>7.39.1</openrewrite.version>
+        <openrewrite.version>8.8.3</openrewrite.version>
         <pmd-plugin.version>3.12.0</pmd-plugin.version>
         <reflections.version>0.10.2</reflections.version>
         <rxgen.version>1.4</rxgen.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1477,7 +1477,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <spotbugs-plugin.version>3.1.12.2</spotbugs-plugin.version>
         <swagger-parser-groupid.version>io.swagger.parser.v3</swagger-parser-groupid.version>
-        <swagger-parser.version>2.1.14</swagger-parser.version>
+        <swagger-parser.version>2.1.18</swagger-parser.version>
         <testng.version>7.5</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
         <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1451,9 +1451,9 @@
         <groovy.version>3.0.9</groovy.version>
         <guava.version>32.1.3-jre</guava.version>
         <handlebars-java.version>4.3.1</handlebars-java.version>
-        <jackson-threetenbp.version>2.14.3</jackson-threetenbp.version>
-        <jackson-databind.version>2.14.0</jackson-databind.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson-threetenbp.version>2.15.2</jackson-threetenbp.version>
+        <jackson-databind.version>2.15.3</jackson-databind.version>
+        <jackson.version>2.15.3</jackson.version>
         <jacoco.version>0.8.10</jacoco.version>
         <jmustache.version>1.15</jmustache.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
fix #16710

The problem was that in `mergeProperties`, instances of `Schema` were copied by reference. So later changes to a sub-schema of one of the models affected other models as well.

I had to upgrade swagger-parser so that I could use `AnnotationsUtils.clone`. The new swagger-parser version included a newer jackson-related dependency, so I further had to upgrade some other dependencies so that the transitive jackson-related dependencies were again compatible with each other.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)