### PR TITLE
Update C# dependencies to newer versions, update reserved word list

### DIFF
--- a/docs/generators/aspnetcore.md
+++ b/docs/generators/aspnetcore.md
@@ -116,6 +116,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Client</li>
 <li>Configuration</li>
+<li>Environment</li>
+<li>OperatingSystem</li>
+<li>TimeZone</li>
 <li>Version</li>
 <li>abstract</li>
 <li>as</li>

--- a/docs/generators/csharp-functions.md
+++ b/docs/generators/csharp-functions.md
@@ -109,6 +109,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Client</li>
 <li>Configuration</li>
+<li>Environment</li>
+<li>OperatingSystem</li>
+<li>TimeZone</li>
 <li>Version</li>
 <li>abstract</li>
 <li>as</li>

--- a/docs/generators/csharp.md
+++ b/docs/generators/csharp.md
@@ -115,6 +115,9 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <ul class="column-ul">
 <li>Client</li>
 <li>Configuration</li>
+<li>Environment</li>
+<li>OperatingSystem</li>
+<li>TimeZone</li>
 <li>Version</li>
 <li>abstract</li>
 <li>as</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -135,6 +135,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         // this is a workaround and can be removed if c# api client is updated to use
                         // fully qualified name
                         "Client", "client", "parameter", "Configuration", "Version", "Environment",
+                        "TimeZone", "OperatingSystem",
                         // local variable names in API methods (endpoints)
                         "localVarPath", "localVarPathParams", "localVarQueryParams", "localVarHeaderParams",
                         "localVarFormParams", "localVarFileParams", "localVarStatusCode", "localVarResponse",

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -134,7 +134,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                         // set "client" as a reserved word to avoid conflicts with Org.OpenAPITools.Client
                         // this is a workaround and can be removed if c# api client is updated to use
                         // fully qualified name
-                        "Client", "client", "parameter", "Configuration", "Version",
+                        "Client", "client", "parameter", "Configuration", "Version", "Environment",
                         // local variable names in API methods (endpoints)
                         "localVarPath", "localVarPathParams", "localVarQueryParams", "localVarHeaderParams",
                         "localVarFormParams", "localVarFileParams", "localVarStatusCode", "localVarResponse",

--- a/modules/openapi-generator/src/main/resources/csharp/netcore_project.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/netcore_project.mustache
@@ -43,7 +43,7 @@
       {{/useGenericHost}}
       {{^useGenericHost}}
       {{#supportsRetry}}
-    <PackageReference Include="Polly" Version="{{^netStandard}}7.2.3{{/netStandard}}{{#netStandard}}7.2.3{{/netStandard}}" />
+    <PackageReference Include="Polly" Version="{{^netStandard}}8.1.0{{/netStandard}}{{#netStandard}}8.1.0{{/netStandard}}" />
       {{/supportsRetry}}
       {{/useGenericHost}}
     {{#validatable}}

--- a/modules/openapi-generator/src/main/resources/csharp/netcore_testproject.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/netcore_testproject.mustache
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="{{^netStandard}}17.7.2{{/netStandard}}{{#netStandard}}15.9.2{{/netStandard}}" />
-    <PackageReference Include="xunit" Version="{{^netStandard}}2.5.1{{/netStandard}}{{#netStandard}}2.4.2{{/netStandard}}" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="{{^netStandard}}2.5.1{{/netStandard}}{{#netStandard}}2.4.5{{/netStandard}}" />
+    <PackageReference Include="xunit" Version="{{^netStandard}}2.6.1{{/netStandard}}{{#netStandard}}2.4.2{{/netStandard}}" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="{{^netStandard}}2.5.3{{/netStandard}}{{#netStandard}}2.4.5{{/netStandard}}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/openapi-generator/src/main/resources/csharp/nuspec.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/nuspec.mustache
@@ -42,7 +42,7 @@
             <dependency id="System.ComponentModel.Annotations" version="5.0.0" />
             {{/validatable}}
             {{#supportsRetry}}
-            <dependency id="Polly" version="7.2.3" />
+            <dependency id="Polly" version="8.1.0" />
             {{/supportsRetry}}
 
         </dependencies>

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/others/csharp-complex-files/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/Env.cs
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/Env.cs
@@ -28,7 +28,7 @@ namespace Org.OpenAPITools.Model
     /// <summary>
     /// Env
     /// </summary>
-    [DataContract(Name = "Environment")]
+    [DataContract(Name = "varEnvironment")]
     public partial class Env : IEquatable<Env>, IValidatableObject
     {
         /// <summary>

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/src/UseSourceGeneration.Test/UseSourceGeneration.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt-useSourceGeneration/src/UseSourceGeneration.Test/UseSourceGeneration.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0-nrt/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-net6.0/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-anyOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-generichost-netcore-latest-oneOf/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="CompareNETObjects" Version="4.82.0" />
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools.Test/Org.OpenAPITools.Test.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="xunit" Version="2.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Org.OpenAPITools.csproj
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Org.OpenAPITools.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update c# dependencies to newer versions, update reserved word list

cc @mandrean (2017/08) @shibayan (2020/02) @Blackclaws (2021/03) @lucamazzanti (2021/05) @iBicha (2023/07)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

