### PR TITLE
[python][fix] Raise exceptions on non-2xx responses

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -304,23 +304,22 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        if response_type is None:
-            if not 200 <= response_data.status <= 299:
-                if response_data.status == 400:
-                    raise BadRequestException(http_resp=response_data)
+        if not 200 <= response_data.status <= 299:
+            if response_data.status == 400:
+                raise BadRequestException(http_resp=response_data)
 
-                if response_data.status == 401:
-                    raise UnauthorizedException(http_resp=response_data)
+            if response_data.status == 401:
+                raise UnauthorizedException(http_resp=response_data)
 
-                if response_data.status == 403:
-                    raise ForbiddenException(http_resp=response_data)
+            if response_data.status == 403:
+                raise ForbiddenException(http_resp=response_data)
 
-                if response_data.status == 404:
-                    raise NotFoundException(http_resp=response_data)
+            if response_data.status == 404:
+                raise NotFoundException(http_resp=response_data)
 
-                if 500 <= response_data.status <= 599:
-                    raise ServiceException(http_resp=response_data)
-                raise ApiException(http_resp=response_data)
+            if 500 <= response_data.status <= 599:
+                raise ServiceException(http_resp=response_data)
+            raise ApiException(http_resp=response_data)
 
         # deserialize response data
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
@@ -297,23 +297,22 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        if response_type is None:
-            if not 200 <= response_data.status <= 299:
-                if response_data.status == 400:
-                    raise BadRequestException(http_resp=response_data)
+        if not 200 <= response_data.status <= 299:
+            if response_data.status == 400:
+                raise BadRequestException(http_resp=response_data)
 
-                if response_data.status == 401:
-                    raise UnauthorizedException(http_resp=response_data)
+            if response_data.status == 401:
+                raise UnauthorizedException(http_resp=response_data)
 
-                if response_data.status == 403:
-                    raise ForbiddenException(http_resp=response_data)
+            if response_data.status == 403:
+                raise ForbiddenException(http_resp=response_data)
 
-                if response_data.status == 404:
-                    raise NotFoundException(http_resp=response_data)
+            if response_data.status == 404:
+                raise NotFoundException(http_resp=response_data)
 
-                if 500 <= response_data.status <= 599:
-                    raise ServiceException(http_resp=response_data)
-                raise ApiException(http_resp=response_data)
+            if 500 <= response_data.status <= 599:
+                raise ServiceException(http_resp=response_data)
+            raise ApiException(http_resp=response_data)
 
         # deserialize response data
 

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -297,23 +297,22 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        if response_type is None:
-            if not 200 <= response_data.status <= 299:
-                if response_data.status == 400:
-                    raise BadRequestException(http_resp=response_data)
+        if not 200 <= response_data.status <= 299:
+            if response_data.status == 400:
+                raise BadRequestException(http_resp=response_data)
 
-                if response_data.status == 401:
-                    raise UnauthorizedException(http_resp=response_data)
+            if response_data.status == 401:
+                raise UnauthorizedException(http_resp=response_data)
 
-                if response_data.status == 403:
-                    raise ForbiddenException(http_resp=response_data)
+            if response_data.status == 403:
+                raise ForbiddenException(http_resp=response_data)
 
-                if response_data.status == 404:
-                    raise NotFoundException(http_resp=response_data)
+            if response_data.status == 404:
+                raise NotFoundException(http_resp=response_data)
 
-                if 500 <= response_data.status <= 599:
-                    raise ServiceException(http_resp=response_data)
-                raise ApiException(http_resp=response_data)
+            if 500 <= response_data.status <= 599:
+                raise ServiceException(http_resp=response_data)
+            raise ApiException(http_resp=response_data)
 
         # deserialize response data
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -299,23 +299,22 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        if response_type is None:
-            if not 200 <= response_data.status <= 299:
-                if response_data.status == 400:
-                    raise BadRequestException(http_resp=response_data)
+        if not 200 <= response_data.status <= 299:
+            if response_data.status == 400:
+                raise BadRequestException(http_resp=response_data)
 
-                if response_data.status == 401:
-                    raise UnauthorizedException(http_resp=response_data)
+            if response_data.status == 401:
+                raise UnauthorizedException(http_resp=response_data)
 
-                if response_data.status == 403:
-                    raise ForbiddenException(http_resp=response_data)
+            if response_data.status == 403:
+                raise ForbiddenException(http_resp=response_data)
 
-                if response_data.status == 404:
-                    raise NotFoundException(http_resp=response_data)
+            if response_data.status == 404:
+                raise NotFoundException(http_resp=response_data)
 
-                if 500 <= response_data.status <= 599:
-                    raise ServiceException(http_resp=response_data)
-                raise ApiException(http_resp=response_data)
+            if 500 <= response_data.status <= 599:
+                raise ServiceException(http_resp=response_data)
+            raise ApiException(http_resp=response_data)
 
         # deserialize response data
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -296,23 +296,22 @@ class ApiClient:
             # if not found, look for '1XX', '2XX', etc.
             response_type = response_types_map.get(str(response_data.status)[0] + "XX", None)
 
-        if response_type is None:
-            if not 200 <= response_data.status <= 299:
-                if response_data.status == 400:
-                    raise BadRequestException(http_resp=response_data)
+        if not 200 <= response_data.status <= 299:
+            if response_data.status == 400:
+                raise BadRequestException(http_resp=response_data)
 
-                if response_data.status == 401:
-                    raise UnauthorizedException(http_resp=response_data)
+            if response_data.status == 401:
+                raise UnauthorizedException(http_resp=response_data)
 
-                if response_data.status == 403:
-                    raise ForbiddenException(http_resp=response_data)
+            if response_data.status == 403:
+                raise ForbiddenException(http_resp=response_data)
 
-                if response_data.status == 404:
-                    raise NotFoundException(http_resp=response_data)
+            if response_data.status == 404:
+                raise NotFoundException(http_resp=response_data)
 
-                if 500 <= response_data.status <= 599:
-                    raise ServiceException(http_resp=response_data)
-                raise ApiException(http_resp=response_data)
+            if 500 <= response_data.status <= 599:
+                raise ServiceException(http_resp=response_data)
+            raise ApiException(http_resp=response_data)
 
         # deserialize response data
 


### PR DESCRIPTION
If the schema defines a response type for error responses, the client does not raise exceptions since https://github.com/OpenAPITools/openapi-generator/pull/16802.

This PR raises exceptions on all status codes outside [200,299].

In a follow-up, it would be nice to deserialize error responses if a type is documented, and add the deserialized model class to the exception object.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 @fa0311 @multani 