### PR TITLE
[Go][Server] FormParams - Generic Array Type Handling

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -495,7 +495,12 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{/isArray}}{{/isInteger}}
 	{{^isFile}}
 	{{^isLong}}
+	{{#isArray}}
+	{{paramName}}Param := strings.Split(r.FormValue("{{baseName}}"), ",")
+	{{/isArray}}
+	{{^isArray}}
 	{{paramName}}Param := r.FormValue("{{baseName}}")
+	{{/isArray}}
 	{{/isLong}}
 	{{/isFile}}
 	{{/isFormParam}}

--- a/modules/openapi-generator/src/test/resources/3_0/go-server/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go-server/petstore.yaml
@@ -346,6 +346,11 @@ paths:
                 additionalMetadata:
                   description: Additional data to pass to server
                   type: string
+                extraOptionalMetadata:
+                  description: More data to pass to server
+                  type: array
+                  items:
+                    type: string
                 file:
                   description: file to upload
                   type: string

--- a/samples/server/petstore/go-api-server/api/openapi.yaml
+++ b/samples/server/petstore/go-api-server/api/openapi.yaml
@@ -1194,6 +1194,11 @@ components:
         additionalMetadata:
           description: Additional data to pass to server
           type: string
+        extraOptionalMetadata:
+          description: More data to pass to server
+          items:
+            type: string
+          type: array
         file:
           description: file to upload
           format: binary

--- a/samples/server/petstore/go-api-server/go/api.go
+++ b/samples/server/petstore/go-api-server/go/api.go
@@ -76,7 +76,7 @@ type PetAPIServicer interface {
 	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
-	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
+	UploadFile(context.Context, int64, string, []string, *os.File) (ImplResponse, error)
 	UploadFileArrayOfFiles(context.Context, int64, string, []*os.File) (ImplResponse, error)
 }
 

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -407,6 +407,9 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	
 	
 	additionalMetadataParam := r.FormValue("additionalMetadata")
+	
+	
+	extraOptionalMetadataParam := strings.Split(r.FormValue("extraOptionalMetadata"), ",")
 	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -414,7 +417,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	
-	result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, fileParam)
+	result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, extraOptionalMetadataParam, fileParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-api-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-api-server/go/api_pet_service.go
@@ -173,7 +173,7 @@ func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name
 }
 
 // UploadFile - uploads an image
-func (s *PetAPIService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (ImplResponse, error) {
+func (s *PetAPIService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, extraOptionalMetadata []string, file *os.File) (ImplResponse, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 

--- a/samples/server/petstore/go-chi-server/api/openapi.yaml
+++ b/samples/server/petstore/go-chi-server/api/openapi.yaml
@@ -1194,6 +1194,11 @@ components:
         additionalMetadata:
           description: Additional data to pass to server
           type: string
+        extraOptionalMetadata:
+          description: More data to pass to server
+          items:
+            type: string
+          type: array
         file:
           description: file to upload
           format: binary

--- a/samples/server/petstore/go-chi-server/go/api.go
+++ b/samples/server/petstore/go-chi-server/go/api.go
@@ -76,7 +76,7 @@ type PetAPIServicer interface {
 	GetPetsUsingBooleanQueryParameters(context.Context, bool, bool, bool) (ImplResponse, error)
 	UpdatePet(context.Context, Pet) (ImplResponse, error)
 	UpdatePetWithForm(context.Context, int64, string, string) (ImplResponse, error)
-	UploadFile(context.Context, int64, string, *os.File) (ImplResponse, error)
+	UploadFile(context.Context, int64, string, []string, *os.File) (ImplResponse, error)
 	UploadFileArrayOfFiles(context.Context, int64, string, []*os.File) (ImplResponse, error)
 }
 

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -401,6 +401,9 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	
 	
 	additionalMetadataParam := r.FormValue("additionalMetadata")
+	
+	
+	extraOptionalMetadataParam := strings.Split(r.FormValue("extraOptionalMetadata"), ",")
 	fileParam, err := ReadFormFileToTempFile(r, "file")
 	if err != nil {
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
@@ -408,7 +411,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	}
 	
 	
-	result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, fileParam)
+	result, err := c.service.UploadFile(r.Context(), petIdParam, additionalMetadataParam, extraOptionalMetadataParam, fileParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/samples/server/petstore/go-chi-server/go/api_pet_service.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet_service.go
@@ -173,7 +173,7 @@ func (s *PetAPIService) UpdatePetWithForm(ctx context.Context, petId int64, name
 }
 
 // UploadFile - uploads an image
-func (s *PetAPIService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, file *os.File) (ImplResponse, error) {
+func (s *PetAPIService) UploadFile(ctx context.Context, petId int64, additionalMetadata string, extraOptionalMetadata []string, file *os.File) (ImplResponse, error) {
 	// TODO - update UploadFile with the required logic for this service method.
 	// Add api_pet_service.go to the .openapi-generator-ignore to avoid overwriting this service implementation when updating open api generation.
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
If a form param is an array and isn't caught in the previous checks, treat it as a slice of strings.
Previously it would generate code that would not compile as a `string` would get passed into a function signature that was expecting a slice of strings.


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@lwj5 @wing328 