### PR TITLE
fix(powershell): use apikey name in header instead of securityDefinition spec id

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api.mustache
@@ -178,15 +178,15 @@ function {{{vendorExtensions.x-powershell-method-name}}} {
         {{#authMethods}}
         {{#isApiKey}}
         {{#isKeyInHeader}}
-        if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{name}}}"]) {
-            $LocalVarHeaderParameters['{{{name}}}'] = $Configuration["ApiKey"]["{{{name}}}"]
-            Write-Verbose ("Using API key '{{{name}}}' in the header for authentication in {0}" -f $MyInvocation.MyCommand)
+        if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{keyParamName}}}"]) {
+            $LocalVarHeaderParameters['{{{keyParamName}}}'] = $Configuration["ApiKey"]["{{{keyParamName}}}"]
+            Write-Verbose ("Using API key '{{{keyParamName}}}' in the header for authentication in {0}" -f $MyInvocation.MyCommand)
         }
         {{/isKeyInHeader}}
         {{#isKeyInQuery}}
-        if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{name}}}"]) {
-            $LocalVarQueryParameters['{{{name}}}'] = $Configuration["ApiKey"]["{{{name}}}"]
-            Write-Verbose ("Using API key `{{{name}}}` in the URL query for authentication in {0}" -f $MyInvocation.MyCommand)
+        if ($Configuration["ApiKey"] -and $Configuration["ApiKey"]["{{{keyParamName}}}"]) {
+            $LocalVarQueryParameters['{{{keyParamName}}}'] = $Configuration["ApiKey"]["{{{keyParamName}}}"]
+            Write-Verbose ("Using API key `{{{keyParamName}}}` in the URL query for authentication in {0}" -f $MyInvocation.MyCommand)
         }
         {{/isKeyInQuery}}
         {{#isKeyInCookie}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This fixes #17005 where the `id = APIKeyHeader` was used instead if the apikey `name = X-ApiKey` for apikey in header and query.
```yaml
securityDefinitions:
  APIKeyHeader:       # This was wrongly used in the header
    type: apiKey
    name: X-ApiKey    # This is now used in the header instead
    in: header
```

The docs are already correct so they don't need to be updated. Did not add any tests but tested it manually by adding my yaml from the issue and running it with the `./bin/generate-samples.sh ./bin/configs/powershell*` command.

@wing328 could you have a look at this apikey header fix in the powershell generator please.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
