### PR TITLE
[GO] Add support for model name mapping for go

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -280,6 +280,11 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     @Override
     public String toModelFilename(String name) {
+        // Obtain the model name from modelNameMapping directly if provided
+        if (modelNameMapping.containsKey(name)) {
+            // name = underscore(modelNameMapping.get(name));
+            name = modelNameMapping.get(name);
+        }
         name = toModel("model_" + name);
 
         if (isReservedFilename(name)) {
@@ -295,6 +300,11 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     }
 
     public String toModel(String name, boolean doUnderscore) {
+        // obtain the name from modelNameMapping directly if provided
+        if (modelNameMapping.containsKey(name)) {
+            return modelNameMapping.get(name);
+        }
+
         if (!StringUtils.isEmpty(modelNamePrefix)) {
             name = modelNamePrefix + "_" + name;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -282,7 +282,6 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
     public String toModelFilename(String name) {
         // Obtain the model name from modelNameMapping directly if provided
         if (modelNameMapping.containsKey(name)) {
-            // name = underscore(modelNameMapping.get(name));
             name = modelNameMapping.get(name);
         }
         name = toModel("model_" + name);

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -298,4 +298,28 @@ public class GoModelTest {
         Assert.assertEquals(cm.name, name);
         Assert.assertEquals(cm.classname, expectedName);
     }
+
+    @DataProvider(name = "modelMappedNames")
+    public static Object[][] mappedNames() {
+        return new Object[][] {
+            {"mapped", "Remapped", "/model_remapped.go"},
+            {"mapped_underscore", "RemappedUnderscore", "/model_remapped_underscore.go"},
+        };
+    }
+
+    @Test(dataProvider = "modelMappedNames", description = "map model names")
+    public void modelNameMappingsTest(String name, String expectedName, String expectedFilename) {
+        final Schema model = new Schema();
+        final DefaultCodegen codegen = new GoClientCodegen();
+        codegen.modelNameMapping().put(name, expectedName);
+        OpenAPI openAPI = TestUtils.createOpenAPIWithOneSchema(name, model);
+        codegen.setOpenAPI(openAPI);
+        final CodegenModel cm = codegen.fromModel(name, model);
+
+        final String fn = codegen.modelFilename("model.mustache", name, "");
+        Assert.assertEquals(fn, expectedFilename);
+
+        Assert.assertEquals(cm.name, name);
+        Assert.assertEquals(cm.classname, expectedName);
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoModelTest.java
@@ -30,6 +30,8 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.File;
+
 @SuppressWarnings("static-method")
 public class GoModelTest {
 
@@ -302,8 +304,8 @@ public class GoModelTest {
     @DataProvider(name = "modelMappedNames")
     public static Object[][] mappedNames() {
         return new Object[][] {
-            {"mapped", "Remapped", "/model_remapped.go"},
-            {"mapped_underscore", "RemappedUnderscore", "/model_remapped_underscore.go"},
+            {"mapped", "Remapped", "model_remapped.go"},
+            {"mapped_underscore", "RemappedUnderscore", "model_remapped_underscore.go"},
         };
     }
 
@@ -317,7 +319,7 @@ public class GoModelTest {
         final CodegenModel cm = codegen.fromModel(name, model);
 
         final String fn = codegen.modelFilename("model.mustache", name, "");
-        Assert.assertEquals(fn, expectedFilename);
+        Assert.assertEquals(fn, File.separator + expectedFilename);
 
         Assert.assertEquals(cm.name, name);
         Assert.assertEquals(cm.classname, expectedName);


### PR DESCRIPTION
Add's model name mapping support for go.

Added a new test that tests both the model name creation and model filename.

Because of the way the filenames are generated this took me a few tries to get right, but I think I ended up with the most simple implementation

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
