### PR TITLE
Fix powershell client Build.ps1 and *.psm1 error when there is a missing Model folder

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/Build.ps1.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/Build.ps1.mustache
@@ -39,7 +39,9 @@ function Get-FunctionsToExport {
 }
 
 $ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
-$FunctionPath = 'Api', 'Model', 'Client' | ForEach-Object {Join-Path "$ScriptDir\src\{{{packageName}}}\" $_}
+$FunctionPath = 'Api', 'Model', 'Client' | Where-Object {
+    Join-Path "$ScriptDir\src\{{{packageName}}}\" $_ | Test-Path
+} | ForEach-Object { Join-Path "$ScriptDir\src\{{{packageName}}}\" $_ }
 
 $Manifest = @{
     Path = "$ScriptDir\src\{{{packageName}}}\{{{packageName}}}.psd1"

--- a/modules/openapi-generator/src/main/resources/powershell/Org.OpenAPITools.psm1.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/Org.OpenAPITools.psm1.mustache
@@ -17,7 +17,9 @@ $Script:Configuration = [System.Collections.HashTable]@{}
 
 $Script:CmdletBindingParameters = @('Verbose','Debug','ErrorAction','WarningAction','InformationAction','ErrorVariable','WarningVariable','InformationVariable','OutVariable','OutBuffer','PipelineVariable')
 
-'Api', 'Model', 'Client', 'Private' | Get-ChildItem -Path {
+'Api', 'Model', 'Client', 'Private' | Where-Object {
+    Join-Path $PSScriptRoot $_ | Test-Path
+} | Get-ChildItem -Path {
     Join-Path $PSScriptRoot $_
 } -Filter '*.ps1' | ForEach-Object {
     Write-Debug "Importing file: $($_.BaseName)"

--- a/samples/client/petstore/powershell/Build.ps1
+++ b/samples/client/petstore/powershell/Build.ps1
@@ -45,7 +45,9 @@ function Get-FunctionsToExport {
 }
 
 $ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
-$FunctionPath = 'Api', 'Model', 'Client' | ForEach-Object {Join-Path "$ScriptDir\src\PSPetstore\" $_}
+$FunctionPath = 'Api', 'Model', 'Client' | Where-Object {
+    Join-Path "$ScriptDir\src\PSPetstore\" $_ | Test-Path
+} | ForEach-Object { Join-Path "$ScriptDir\src\PSPetstore\" $_ }
 
 $Manifest = @{
     Path = "$ScriptDir\src\PSPetstore\PSPetstore.psd1"

--- a/samples/client/petstore/powershell/src/PSPetstore/PSPetstore.psm1
+++ b/samples/client/petstore/powershell/src/PSPetstore/PSPetstore.psm1
@@ -23,7 +23,9 @@ $Script:Configuration = [System.Collections.HashTable]@{}
 
 $Script:CmdletBindingParameters = @('Verbose','Debug','ErrorAction','WarningAction','InformationAction','ErrorVariable','WarningVariable','InformationVariable','OutVariable','OutBuffer','PipelineVariable')
 
-'Api', 'Model', 'Client', 'Private' | Get-ChildItem -Path {
+'Api', 'Model', 'Client', 'Private' | Where-Object {
+    Join-Path $PSScriptRoot $_ | Test-Path
+} | Get-ChildItem -Path {
     Join-Path $PSScriptRoot $_
 } -Filter '*.ps1' | ForEach-Object {
     Write-Debug "Importing file: $($_.BaseName)"


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR fixes #17024 which says that Build.ps1 and *.psm1 fails to run when your openapi spec doesn't have any Models because there is no Model folder then.

@wing328 Could you have a look at this PR please.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
