### PR TITLE
Use postman notation

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -131,6 +131,7 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
     @Override
     public void postProcessParameter(CodegenParameter parameter) {
+        // create Postman variable from every path parameter
         if(pathParamsAsVariables && parameter.isPathParam) {
             variables.add(new PostmanVariable()
                     .addName(parameter.paramName)
@@ -216,13 +217,16 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
 
         for(CodegenOperation codegenOperation : opList) {
 
+            // use Postman notation for path parameter
+            codegenOperation.path = replacesBracesInPath(codegenOperation.path);
+
             if(pathParamsAsVariables) {
-                // create Postman variable from path parameter
-                codegenOperation.path = doubleCurlyBraces(codegenOperation.path);
-            } else {
-                // use Postman notation for path parameter
-                codegenOperation.path = replacesBracesInPath(codegenOperation.path);
+                // set value of path parameter with corresponding env variable
+                for(CodegenParameter codegenParameter : codegenOperation.pathParams) {
+                    codegenParameter.defaultValue = "{{" + codegenParameter.paramName + "}}";
+                }
             }
+
             codegenOperation.summary = getSummary(codegenOperation);
 
             // request headers

--- a/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
@@ -39,7 +39,7 @@
                                             {{#pathParams}}
                                             {
                                                 "key": "{{paramName}}",
-                                                "value": "",
+                                                "value": "{{defaultValue}}",
                                                 "description": "{{description}}"
                                             }{{^-last}},{{/-last}}
                                         {{/pathParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -161,7 +161,9 @@ public class PostmanCollectionCodegenTest {
                 "key\": \"groupId\", \"value\": \"1\", \"type\": \"number\"");
 
         // verify request endpoint
-        TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+        TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
+        // verify path parameter value
+        TestUtils.assertFileContains(path, "key\": \"userId\", \"value\": \"{{userId}}\",");
 
     }
 
@@ -196,7 +198,9 @@ public class PostmanCollectionCodegenTest {
         assertFileContains(path, "{{MY_VAR_NAME}}");
 
         // verify request endpoint
-        TestUtils.assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+        TestUtils.assertFileContains(path, "\"name\": \"/users/:userId\"");
+        // verify path parameter value
+        TestUtils.assertFileContains(path, "key\": \"userId\", \"value\": \"{{userId}}\",");
 
     }
 
@@ -303,7 +307,10 @@ public class PostmanCollectionCodegenTest {
         Path path = Paths.get(output + "/postman.json");
         assertFileExists(path);
         // verify request name (from path)
-        assertFileContains(path, "\"name\": \"/users/{{userId}}\"");
+        assertFileContains(path, "\"name\": \"/users/:userId\"");
+        // verify path parameter value
+        TestUtils.assertFileContains(path, "key\": \"userId\", \"value\": \"{{userId}}\",");
+
     }
 
     @Test

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -116,7 +116,7 @@
                                         "variable": [
                                             {
                                                 "key": "groupId",
-                                                "value": "",
+                                                "value": "1",
                                                 "description": "group Id"
                                             }
                                         ],


### PR DESCRIPTION
In the case of generating the Postman collection with the setting `pathParamsAsVariables=true` (where path parameters are defined as environment variables) the generation would change the operation path
```
'/users/{userId}':
```
to
```
'/users/{{userId}}':
```
Although this works, this is not the correct approach: the path parameter value should be set by applying the Postman notation.

This PR fixes this inconsistency creating the correct configuration: set the value of the parameter using the environment variable without affecting the URL.
```
 ...
"url": {
   "raw": "{{baseUrl}}/users/:userId",
   "host": [ "{{baseUrl}}" ],
    "path": [ "users", ":userId" ],
    "variable": [
    {
        "key": "userId",
        "value": "{{userId}}",
       "description": "The unique identifier of the user."
    }
  ],
  ...
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 
