### PR TITLE
Python-server workflow fixes + pytest

### DIFF
--- a/.github/workflows/samples-python-server.yaml
+++ b/.github/workflows/samples-python-server.yaml
@@ -3,10 +3,10 @@ name: Python Server
 on:
   push:
     paths:
-      - samples/server/petstore/python-aiohttp/**
+      - samples/server/petstore/python-aiohttp-srclayout/**
   pull_request:
     paths:
-      - samples/server/petstore/python-aiohttp/**
+      - samples/server/petstore/python-aiohttp-srclayout/**
 jobs:
   build:
     name: Test Python server
@@ -16,7 +16,7 @@ jobs:
       matrix:
         sample:
           # servers
-          - samples/server/petstore/python-aiohttp/
+          - samples/server/petstore/python-aiohttp-srclayout/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/controller_test.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/controller_test.mustache
@@ -17,6 +17,8 @@ from aiohttp import FormData
 {{#operations}}
 {{#operation}}
 
+pytestmark = pytest.mark.asyncio
+
 {{#vendorExtensions.x-skip-test}}
 @pytest.mark.skip("{{reason}}")
 {{/vendorExtensions.x-skip-test}}

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/requirements.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/requirements.mustache
@@ -1,4 +1,4 @@
-connexion[aiohttp,swagger-ui] >= 2.6.0; python_version>="3.6"
+connexion[aiohttp,swagger-ui] >= 2.6.0, <3; python_version>="3.6"
 # 2.3 is the last version that supports python 3.5
 connexion[aiohttp,swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=="3.4"
 # connexion requires werkzeug but connexion < 2.4.0 does not install werkzeug
@@ -10,3 +10,4 @@ aiohttp_jinja2 == 1.5.0
 {{#featureCORS}}
 aiohttp_cors >= 0.7.0
 {{/featureCORS}}
+Flask < 2.3

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
@@ -8,4 +8,4 @@ deps=-r{toxinidir}/requirements.txt
 	 {toxinidir}
 
 commands=
-   {{^useNose}}pytest --cov={{#lambda.forwardslash}}{{{pythonSrcRoot}}}{{/lambda.forwardslash}}{{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}
+   {{^useNose}}pytest --cov={{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}

--- a/samples/server/petstore/python-aiohttp-srclayout/requirements.txt
+++ b/samples/server/petstore/python-aiohttp-srclayout/requirements.txt
@@ -1,4 +1,4 @@
-connexion[aiohttp,swagger-ui] >= 2.6.0; python_version>="3.6"
+connexion[aiohttp,swagger-ui] >= 2.6.0, <3; python_version>="3.6"
 # 2.3 is the last version that supports python 3.5
 connexion[aiohttp,swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=="3.4"
 # connexion requires werkzeug but connexion < 2.4.0 does not install werkzeug
@@ -7,3 +7,4 @@ connexion[aiohttp,swagger-ui] <= 2.3.0; python_version=="3.5" or python_version=
 werkzeug == 0.16.1; python_version=="3.5" or python_version=="3.4"
 swagger-ui-bundle == 0.0.9
 aiohttp_jinja2 == 1.5.0
+Flask < 2.3

--- a/samples/server/petstore/python-aiohttp-srclayout/test_python3.sh
+++ b/samples/server/petstore/python-aiohttp-srclayout/test_python3.sh
@@ -23,7 +23,7 @@ pip install -r $REQUIREMENTS_FILE | tee -a $REQUIREMENTS_OUT
 tox || exit 1
 
 ### static analysis of code
-flake8 --show-source petstore_api/
+flake8 --show-source ./src
 
 ### deactivate virtualenv
 if [ $DEACTIVE == true ]; then

--- a/samples/server/petstore/python-aiohttp-srclayout/tests/test_pet_controller.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/tests/test_pet_controller.py
@@ -8,6 +8,7 @@ from aiohttp import FormData
 from openapi_server.models.api_response import ApiResponse
 from openapi_server.models.pet import Pet
 
+pytestmark = pytest.mark.asyncio
 
 @pytest.mark.skip("Connexion does not support multiple consumes. See https://github.com/zalando/connexion/pull/760")
 async def test_add_pet(client):

--- a/samples/server/petstore/python-aiohttp-srclayout/tests/test_store_controller.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/tests/test_store_controller.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from openapi_server.models.order import Order
 
+pytestmark = pytest.mark.asyncio
 
 async def test_delete_order(client):
     """Test case for delete_order

--- a/samples/server/petstore/python-aiohttp-srclayout/tests/test_user_controller.py
+++ b/samples/server/petstore/python-aiohttp-srclayout/tests/test_user_controller.py
@@ -6,6 +6,7 @@ from aiohttp import web
 
 from openapi_server.models.user import User
 
+pytestmark = pytest.mark.asyncio
 
 @pytest.mark.skip("*/* not supported by Connexion. Use application/json instead. See https://github.com/zalando/connexion/pull/760")
 async def test_create_user(client):

--- a/samples/server/petstore/python-aiohttp-srclayout/tox.ini
+++ b/samples/server/petstore/python-aiohttp-srclayout/tox.ini
@@ -8,4 +8,4 @@ deps=-r{toxinidir}/requirements.txt
 	 {toxinidir}
 
 commands=
-   pytest --cov=src/openapi_server
+   pytest --cov=openapi_server


### PR DESCRIPTION
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

ping @cbornet @tomplus @krjakbrjak @fa0311 @multani

- The workflow was basically not working for the last 6 months: https://github.com/OpenAPITools/openapi-generator/actions/workflows/samples-python-server.yaml ; I split the PR in very small commits that each describe what they do
- Closes #17013 although this ticket was incorrect: somehow because of the other dependencies `connexion` stayed constrained at 2.x :) I made it explicit though
- I set a constraint on the Flask version to install as the current code breaks with the latest Flask
- Most notably I added a line for pytest to make it able to execute async tests