### PR TITLE
feat: using Qt with 3rd Party Signals and Slots. Replace signals,slots and emit with Q_SIGNALS,Q_SLOTS and Q_EMIT

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.cpp.mustache
@@ -409,7 +409,7 @@ void {{prefix}}HttpRequestWorker::on_reply_finished(QNetworkReply *reply) {
     }
     process_response(reply);
     reply->deleteLater();
-    emit on_execution_finished(this);
+    Q_EMIT on_execution_finished(this);
 }
 
 void {{prefix}}HttpRequestWorker::on_reply_timeout(QNetworkReply *reply) {
@@ -419,7 +419,7 @@ void {{prefix}}HttpRequestWorker::on_reply_timeout(QNetworkReply *reply) {
     disconnect(reply, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
-    emit on_execution_finished(this);
+    Q_EMIT on_execution_finished(this);
 }
 
 void {{prefix}}HttpRequestWorker::process_response(QNetworkReply *reply) {

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/HttpRequest.h.mustache
@@ -72,7 +72,7 @@ public:
     void setRequestCompressionEnabled(bool enable);
     int  getHttpResponseCode() const;
 
-signals:
+Q_SIGNALS:
     void on_execution_finished({{prefix}}HttpRequestWorker *worker);
 
 private:

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/README.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/README.mustache
@@ -42,7 +42,7 @@ class Example : public QObject {
   {{#allParams}}
     {{{dataType}}} create();
   {{/allParams}}
-public slots:
+public Q_SLOTS:
    void exampleFunction1();
 };
 {{/-first}}{{/operation}}{{/operations}}{{/-first}}{{/apis}}{{/apiInfo}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -163,7 +163,7 @@ void {{classname}}::enableResponseCompression() {
 }
 
 void {{classname}}::abortRequests() {
-    emit abortRequestsSignal();
+    Q_EMIT abortRequestsSignal();
 }
 
 QString {{classname}}::getParamStylePrefix(const QString &style) {
@@ -676,7 +676,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(this, &{{classname}}::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<{{prefix}}HttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });{{#authMethods}}{{#isOAuth}}{{#isCode}}
     _OauthMethod = 2;
@@ -702,7 +702,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(this, &{{classname}}::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -732,7 +732,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(this, &{{classname}}::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -762,7 +762,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(this, &{{classname}}::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -792,7 +792,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
     connect(this, &{{classname}}::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<{{prefix}}HttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -857,8 +857,8 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit {{nickname}}Signal({{#returnType}}output{{/returnType}});
-        emit {{nickname}}SignalFull(worker{{#returnType}}, output{{/returnType}});{{#authMethods}}{{#isOAuth}}{{#isCode}}
+        Q_EMIT {{nickname}}Signal({{#returnType}}output{{/returnType}});
+        Q_EMIT {{nickname}}SignalFull(worker{{#returnType}}, output{{/returnType}});{{#authMethods}}{{#isOAuth}}{{#isCode}}
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_authFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -870,7 +870,7 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
         QString tokenUrl("{{tokenUrl}}");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _authFlow.setVariables(authorizationUrl, tokenUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId", "clientSecret");
-        emit _authFlow.authenticationNeeded();{{/isCode}}
+        Q_EMIT _authFlow.authenticationNeeded();{{/isCode}}
         {{#isImplicit}}
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
@@ -882,7 +882,7 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
         QString authorizationUrl("{{authorizationUrl}}");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();{{/isImplicit}}
+        Q_EMIT _implicitFlow.authenticationNeeded();{{/isImplicit}}
         {{#isApplication}}
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_credentialFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
@@ -894,7 +894,7 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
         QString tokenUrl("{{tokenUrl}}");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _credentialFlow.setVariables(tokenUrl , scopeStr, "clientId", "clientSecret");
-        emit _credentialFlow.authenticationNeeded();{{/isApplication}}
+        Q_EMIT _credentialFlow.authenticationNeeded();{{/isApplication}}
         {{#isPassword}}
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_passwordFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
@@ -906,7 +906,7 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
         QString tokenUrl("{{tokenUrl}}");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _passwordFlow.setVariables(tokenUrl , scopeStr ,"clientId", "clientSecret", "username", "password");
-        emit _passwordFlow.authenticationNeeded();
+        Q_EMIT _passwordFlow.authenticationNeeded();
         {{/isPassword}}{{/isOAuth}}{{/authMethods}}
     } else {
 
@@ -924,8 +924,8 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit {{nickname}}SignalE({{#returnType}}output, {{/returnType}}error_type, error_str);
-        emit {{nickname}}SignalEFull(worker, error_type, error_str);
+        Q_EMIT {{nickname}}SignalE({{#returnType}}output, {{/returnType}}error_type, error_str);
+        Q_EMIT {{nickname}}SignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -935,8 +935,8 @@ void {{classname}}::{{nickname}}Callback({{prefix}}HttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit {{nickname}}SignalError({{#returnType}}output, {{/returnType}}error_type, error_str);
-        emit {{nickname}}SignalErrorFull(worker, error_type, error_str);
+        Q_EMIT {{nickname}}SignalError({{#returnType}}output, {{/returnType}}error_type, error_str);
+        Q_EMIT {{nickname}}SignalErrorFull(worker, error_type, error_str);
     }
 }
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-header.mustache
@@ -85,7 +85,7 @@ private:
 {{#operations}}{{#operation}}
     void {{nickname}}Callback({{prefix}}HttpRequestWorker *worker);{{/operation}}{{/operations}}
 
-signals:
+Q_SIGNALS:
 {{#operations}}{{#operation}}
     void {{nickname}}Signal({{#returnType}}{{{.}}} summary{{/returnType}});{{/operation}}{{/operations}}
 {{#operations}}{{#operation}}
@@ -102,7 +102,7 @@ signals:
     void abortRequestsSignal();
     void allPendingRequestsCompleted();
 
-public slots:
+public Q_SLOTS:
     void tokenAvailable();
 };
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.cpp.mustache
@@ -31,7 +31,7 @@ oauthToken OauthBase::getToken(QString scope)
 void OauthBase::addToken(oauthToken token)
 {
     m_oauthTokenMap.insert(token.getScope(),token);
-    emit tokenReceived();
+    Q_EMIT tokenReceived();
 
 }
 
@@ -341,7 +341,7 @@ void ReplyServer::read()
     }
     socket->close();
 
-    emit dataReceived(queryParams);
+    Q_EMIT dataReceived(queryParams);
 }
 
 {{#cppNamespaceDeclarations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/oauth.h.mustache
@@ -58,10 +58,10 @@ public:
 private:
     QByteArray m_reply;
 
-signals:
+Q_SIGNALS:
     void dataReceived(QMap<QString, QString>);
 
-public slots:
+public Q_SLOTS:
     void onConnected();
     void read();
     void start();
@@ -88,11 +88,11 @@ protected:
     QString m_scope, m_accessType, m_state, m_redirectUri, m_clientId, m_clientSecret;
     bool m_linked;
 
-public slots:
+public Q_SLOTS:
     virtual void authenticationNeededCallback()=0;
     void onFinish(QNetworkReply *rep);
 
-signals:
+Q_SIGNALS:
     void authenticationNeeded();
     void tokenReceived();
 };
@@ -110,7 +110,7 @@ public:
 private:
     ReplyServer m_server;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
     void onVerificationReceived(const QMap<QString, QString> response);
 
@@ -129,7 +129,7 @@ public:
 private:
     ReplyServer m_server;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
     void ImplicitTokenReceived(const QMap<QString, QString> response);
 };
@@ -144,7 +144,7 @@ public:
     void unlink() override;
     void setVariables(QString tokenUrl, QString scope, QString clientId, QString clientSecret);
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
 
 };
@@ -162,7 +162,7 @@ public:
 private:
     QString m_username, m_password;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
 
 };

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apihandler.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apihandler.h.mustache
@@ -20,7 +20,7 @@ public:
     virtual ~{{classname}}Handler();
 
 
-public slots:
+public Q_SLOTS:
     {{#operations}}{{#operation}}virtual void {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
     {{/operation}}{{/operations}}
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirequest.cpp.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirequest.cpp.mustache
@@ -108,7 +108,7 @@ void {{classname}}Request::{{nickname}}Request({{#hasPathParams}}{{#pathParams}}
     {{/isArray}}
     {{/bodyParam}}{{/bodyParams}}
 
-    emit {{nickname}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
+    Q_EMIT {{nickname}}({{#allParams}}{{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
 }
 
 {{/operation}}{{/operations}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirequest.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirequest.h.mustache
@@ -44,7 +44,7 @@ public:
 
     void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
-signals:
+Q_SIGNALS:
     {{#operations}}{{#operation}}void {{nickname}}({{#allParams}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}});
     {{/operation}}{{/operations}}
 

--- a/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-qhttpengine-server/apirouter.h.mustache
@@ -24,7 +24,7 @@ namespace {{this}} {
 class {{prefix}}ApiRequestHandler : public  QHttpEngine::QObjectHandler
 {
     Q_OBJECT
-signals:
+Q_SIGNALS:
     void requestReceived(QHttpEngine::Socket *socket);
 
 protected:
@@ -34,10 +34,10 @@ protected:
         // If the slot requires all data to be received, check to see if this is
         // already the case, otherwise, wait until the rest of it arrives
         if (socket->bytesAvailable() >= socket->contentLength()) {
-            emit requestReceived(socket);
+            Q_EMIT requestReceived(socket);
         } else {
             connect(socket, &QHttpEngine::Socket::readChannelFinished, [this, socket]() {
-                emit requestReceived(socket);
+                Q_EMIT requestReceived(socket);
             });
         }
     }

--- a/samples/client/petstore/cpp-qt/PetStore/PetApiTests.h
+++ b/samples/client/petstore/cpp-qt/PetStore/PetApiTests.h
@@ -9,7 +9,7 @@ class PetApiTests : public QObject {
 
     PFXPet createRandomPet();
 
-private slots:
+private Q_SLOTS:
     void findPetsByStatusTest();
     void createAndGetPetTest();
     void updatePetTest();

--- a/samples/client/petstore/cpp-qt/PetStore/StoreApiTests.h
+++ b/samples/client/petstore/cpp-qt/PetStore/StoreApiTests.h
@@ -7,7 +7,7 @@ using namespace test_namespace;
 class StoreApiTests : public QObject {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void placeOrderTest();
     void getOrderByIdTest();
     void getInventoryTest();

--- a/samples/client/petstore/cpp-qt/PetStore/UserApiTests.h
+++ b/samples/client/petstore/cpp-qt/PetStore/UserApiTests.h
@@ -9,7 +9,7 @@ class UserApiTests : public QObject {
 
     PFXUser createRandomUser();
 
-private slots:
+private Q_SLOTS:
     void createUserTest();
     void createUsersWithArrayInputTest();
     void createUsersWithListInputTest();

--- a/samples/client/petstore/cpp-qt/README.md
+++ b/samples/client/petstore/cpp-qt/README.md
@@ -33,7 +33,7 @@ using namespace test_namespace;
 class Example : public QObject {
     Q_OBJECT
     PFXPet create();
-public slots:
+public Q_SLOTS:
    void exampleFunction1();
 };
 

--- a/samples/client/petstore/cpp-qt/client/PFXHttpRequest.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXHttpRequest.cpp
@@ -416,7 +416,7 @@ void PFXHttpRequestWorker::on_reply_finished(QNetworkReply *reply) {
     }
     process_response(reply);
     reply->deleteLater();
-    emit on_execution_finished(this);
+    Q_EMIT on_execution_finished(this);
 }
 
 void PFXHttpRequestWorker::on_reply_timeout(QNetworkReply *reply) {
@@ -426,7 +426,7 @@ void PFXHttpRequestWorker::on_reply_timeout(QNetworkReply *reply) {
     disconnect(reply, nullptr, nullptr, nullptr);
     reply->abort();
     reply->deleteLater();
-    emit on_execution_finished(this);
+    Q_EMIT on_execution_finished(this);
 }
 
 void PFXHttpRequestWorker::process_response(QNetworkReply *reply) {

--- a/samples/client/petstore/cpp-qt/client/PFXHttpRequest.h
+++ b/samples/client/petstore/cpp-qt/client/PFXHttpRequest.h
@@ -80,7 +80,7 @@ public:
     void setRequestCompressionEnabled(bool enable);
     int  getHttpResponseCode() const;
 
-signals:
+Q_SIGNALS:
     void on_execution_finished(PFXHttpRequestWorker *worker);
 
 private:

--- a/samples/client/petstore/cpp-qt/client/PFXOauth.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXOauth.cpp
@@ -29,7 +29,7 @@ oauthToken OauthBase::getToken(QString scope)
 void OauthBase::addToken(oauthToken token)
 {
     m_oauthTokenMap.insert(token.getScope(),token);
-    emit tokenReceived();
+    Q_EMIT tokenReceived();
 
 }
 
@@ -339,7 +339,7 @@ void ReplyServer::read()
     }
     socket->close();
 
-    emit dataReceived(queryParams);
+    Q_EMIT dataReceived(queryParams);
 }
 
 } // namespace test_namespace

--- a/samples/client/petstore/cpp-qt/client/PFXOauth.h
+++ b/samples/client/petstore/cpp-qt/client/PFXOauth.h
@@ -66,10 +66,10 @@ public:
 private:
     QByteArray m_reply;
 
-signals:
+Q_SIGNALS:
     void dataReceived(QMap<QString, QString>);
 
-public slots:
+public Q_SLOTS:
     void onConnected();
     void read();
     void start();
@@ -96,11 +96,11 @@ protected:
     QString m_scope, m_accessType, m_state, m_redirectUri, m_clientId, m_clientSecret;
     bool m_linked;
 
-public slots:
+public Q_SLOTS:
     virtual void authenticationNeededCallback()=0;
     void onFinish(QNetworkReply *rep);
 
-signals:
+Q_SIGNALS:
     void authenticationNeeded();
     void tokenReceived();
 };
@@ -118,7 +118,7 @@ public:
 private:
     ReplyServer m_server;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
     void onVerificationReceived(const QMap<QString, QString> response);
 
@@ -137,7 +137,7 @@ public:
 private:
     ReplyServer m_server;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
     void ImplicitTokenReceived(const QMap<QString, QString> response);
 };
@@ -152,7 +152,7 @@ public:
     void unlink() override;
     void setVariables(QString tokenUrl, QString scope, QString clientId, QString clientSecret);
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
 
 };
@@ -170,7 +170,7 @@ public:
 private:
     QString m_username, m_password;
 
-public slots:
+public Q_SLOTS:
     void authenticationNeededCallback() override;
 
 };

--- a/samples/client/petstore/cpp-qt/client/PFXPetApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXPetApi.cpp
@@ -162,7 +162,7 @@ void PFXPetApi::enableResponseCompression() {
 }
 
 void PFXPetApi::abortRequests() {
-    emit abortRequestsSignal();
+    Q_EMIT abortRequestsSignal();
 }
 
 QString PFXPetApi::getParamStylePrefix(const QString &style) {
@@ -256,7 +256,7 @@ void PFXPetApi::addPet(const PFXPet &pfx_pet) {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -279,7 +279,7 @@ void PFXPetApi::addPet(const PFXPet &pfx_pet) {
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -301,8 +301,8 @@ void PFXPetApi::addPetCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit addPetSignal();
-        emit addPetSignalFull(worker);
+        Q_EMIT addPetSignal();
+        Q_EMIT addPetSignalFull(worker);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -312,7 +312,7 @@ void PFXPetApi::addPetCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -331,8 +331,8 @@ void PFXPetApi::addPetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit addPetSignalE(error_type, error_str);
-        emit addPetSignalEFull(worker, error_type, error_str);
+        Q_EMIT addPetSignalE(error_type, error_str);
+        Q_EMIT addPetSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -342,8 +342,8 @@ void PFXPetApi::addPetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit addPetSignalError(error_type, error_str);
-        emit addPetSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT addPetSignalError(error_type, error_str);
+        Q_EMIT addPetSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -370,7 +370,7 @@ void PFXPetApi::allPets() {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -397,8 +397,8 @@ void PFXPetApi::allPetsCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit allPetsSignal(output);
-        emit allPetsSignalFull(worker, output);
+        Q_EMIT allPetsSignal(output);
+        Q_EMIT allPetsSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -415,8 +415,8 @@ void PFXPetApi::allPetsCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit allPetsSignalE(output, error_type, error_str);
-        emit allPetsSignalEFull(worker, error_type, error_str);
+        Q_EMIT allPetsSignalE(output, error_type, error_str);
+        Q_EMIT allPetsSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -426,8 +426,8 @@ void PFXPetApi::allPetsCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit allPetsSignalError(output, error_type, error_str);
-        emit allPetsSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT allPetsSignalError(output, error_type, error_str);
+        Q_EMIT allPetsSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -474,7 +474,7 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::Optional
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -497,7 +497,7 @@ void PFXPetApi::deletePet(const qint64 &pet_id, const ::test_namespace::Optional
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -519,8 +519,8 @@ void PFXPetApi::deletePetCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit deletePetSignal();
-        emit deletePetSignalFull(worker);
+        Q_EMIT deletePetSignal();
+        Q_EMIT deletePetSignalFull(worker);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -530,7 +530,7 @@ void PFXPetApi::deletePetCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -549,8 +549,8 @@ void PFXPetApi::deletePetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit deletePetSignalE(error_type, error_str);
-        emit deletePetSignalEFull(worker, error_type, error_str);
+        Q_EMIT deletePetSignalE(error_type, error_str);
+        Q_EMIT deletePetSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -560,8 +560,8 @@ void PFXPetApi::deletePetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit deletePetSignalError(error_type, error_str);
-        emit deletePetSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT deletePetSignalError(error_type, error_str);
+        Q_EMIT deletePetSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -674,7 +674,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -697,7 +697,7 @@ void PFXPetApi::findPetsByStatus(const QList<QString> &status) {
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -729,8 +729,8 @@ void PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit findPetsByStatusSignal(output);
-        emit findPetsByStatusSignalFull(worker, output);
+        Q_EMIT findPetsByStatusSignal(output);
+        Q_EMIT findPetsByStatusSignalFull(worker, output);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -740,7 +740,7 @@ void PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -759,8 +759,8 @@ void PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit findPetsByStatusSignalE(output, error_type, error_str);
-        emit findPetsByStatusSignalEFull(worker, error_type, error_str);
+        Q_EMIT findPetsByStatusSignalE(output, error_type, error_str);
+        Q_EMIT findPetsByStatusSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -770,8 +770,8 @@ void PFXPetApi::findPetsByStatusCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit findPetsByStatusSignalError(output, error_type, error_str);
-        emit findPetsByStatusSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT findPetsByStatusSignalError(output, error_type, error_str);
+        Q_EMIT findPetsByStatusSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -884,7 +884,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -907,7 +907,7 @@ void PFXPetApi::findPetsByTags(const QList<QString> &tags) {
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -939,8 +939,8 @@ void PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit findPetsByTagsSignal(output);
-        emit findPetsByTagsSignalFull(worker, output);
+        Q_EMIT findPetsByTagsSignal(output);
+        Q_EMIT findPetsByTagsSignalFull(worker, output);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -950,7 +950,7 @@ void PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -969,8 +969,8 @@ void PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit findPetsByTagsSignalE(output, error_type, error_str);
-        emit findPetsByTagsSignalEFull(worker, error_type, error_str);
+        Q_EMIT findPetsByTagsSignalE(output, error_type, error_str);
+        Q_EMIT findPetsByTagsSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -980,8 +980,8 @@ void PFXPetApi::findPetsByTagsCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit findPetsByTagsSignalError(output, error_type, error_str);
-        emit findPetsByTagsSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT findPetsByTagsSignalError(output, error_type, error_str);
+        Q_EMIT findPetsByTagsSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -1026,7 +1026,7 @@ void PFXPetApi::getPetById(const qint64 &pet_id) {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -1044,8 +1044,8 @@ void PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit getPetByIdSignal(output);
-        emit getPetByIdSignalFull(worker, output);
+        Q_EMIT getPetByIdSignal(output);
+        Q_EMIT getPetByIdSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -1062,8 +1062,8 @@ void PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit getPetByIdSignalE(output, error_type, error_str);
-        emit getPetByIdSignalEFull(worker, error_type, error_str);
+        Q_EMIT getPetByIdSignalE(output, error_type, error_str);
+        Q_EMIT getPetByIdSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -1073,8 +1073,8 @@ void PFXPetApi::getPetByIdCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit getPetByIdSignalError(output, error_type, error_str);
-        emit getPetByIdSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT getPetByIdSignalError(output, error_type, error_str);
+        Q_EMIT getPetByIdSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -1106,7 +1106,7 @@ void PFXPetApi::updatePet(const PFXPet &pfx_pet) {
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -1129,7 +1129,7 @@ void PFXPetApi::updatePet(const PFXPet &pfx_pet) {
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -1151,8 +1151,8 @@ void PFXPetApi::updatePetCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit updatePetSignal();
-        emit updatePetSignalFull(worker);
+        Q_EMIT updatePetSignal();
+        Q_EMIT updatePetSignalFull(worker);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -1162,7 +1162,7 @@ void PFXPetApi::updatePetCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -1181,8 +1181,8 @@ void PFXPetApi::updatePetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit updatePetSignalE(error_type, error_str);
-        emit updatePetSignalEFull(worker, error_type, error_str);
+        Q_EMIT updatePetSignalE(error_type, error_str);
+        Q_EMIT updatePetSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -1192,8 +1192,8 @@ void PFXPetApi::updatePetCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit updatePetSignalError(error_type, error_str);
-        emit updatePetSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT updatePetSignalError(error_type, error_str);
+        Q_EMIT updatePetSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -1242,7 +1242,7 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -1265,7 +1265,7 @@ void PFXPetApi::updatePetWithForm(const qint64 &pet_id, const ::test_namespace::
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -1287,8 +1287,8 @@ void PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit updatePetWithFormSignal();
-        emit updatePetWithFormSignalFull(worker);
+        Q_EMIT updatePetWithFormSignal();
+        Q_EMIT updatePetWithFormSignalFull(worker);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -1298,7 +1298,7 @@ void PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -1317,8 +1317,8 @@ void PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit updatePetWithFormSignalE(error_type, error_str);
-        emit updatePetWithFormSignalEFull(worker, error_type, error_str);
+        Q_EMIT updatePetWithFormSignalE(error_type, error_str);
+        Q_EMIT updatePetWithFormSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -1328,8 +1328,8 @@ void PFXPetApi::updatePetWithFormCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit updatePetWithFormSignalError(error_type, error_str);
-        emit updatePetWithFormSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT updatePetWithFormSignalError(error_type, error_str);
+        Q_EMIT updatePetWithFormSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -1378,7 +1378,7 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::Optiona
     connect(this, &PFXPetApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
     _OauthMethod = 1;
@@ -1401,7 +1401,7 @@ void PFXPetApi::uploadFile(const qint64 &pet_id, const ::test_namespace::Optiona
     connect(this, &PFXPetApi::abortRequestsSignal, _latestWorker, &QObject::deleteLater);
     connect(_latestWorker, &QObject::destroyed, [this](){
         if(findChildren<PFXHttpRequestWorker*>().count() == 0){
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -1424,8 +1424,8 @@ void PFXPetApi::uploadFileCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit uploadFileSignal(output);
-        emit uploadFileSignalFull(worker, output);
+        Q_EMIT uploadFileSignal(output);
+        Q_EMIT uploadFileSignalFull(worker, output);
     } else if(worker->error_type == QNetworkReply::AuthenticationRequiredError){
         connect(&_implicitFlow, SIGNAL(tokenReceived()), this, SLOT(tokenAvailable()));
         QStringList scope;
@@ -1435,7 +1435,7 @@ void PFXPetApi::uploadFileCallback(PFXHttpRequestWorker *worker) {
         QString authorizationUrl("http://petstore.swagger.io/api/oauth/dialog");
         //TODO get clientID and Secret and state in the config? https://swagger.io/docs/specification/authentication/oauth2/ states that you should do as you like
         _implicitFlow.setVariables(authorizationUrl, scopeStr, "state" , "http://127.0.0.1:9999", "clientId");
-        emit _implicitFlow.authenticationNeeded();
+        Q_EMIT _implicitFlow.authenticationNeeded();
 
 
     } else {
@@ -1454,8 +1454,8 @@ void PFXPetApi::uploadFileCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit uploadFileSignalE(output, error_type, error_str);
-        emit uploadFileSignalEFull(worker, error_type, error_str);
+        Q_EMIT uploadFileSignalE(output, error_type, error_str);
+        Q_EMIT uploadFileSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -1465,8 +1465,8 @@ void PFXPetApi::uploadFileCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit uploadFileSignalError(output, error_type, error_str);
-        emit uploadFileSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT uploadFileSignalError(output, error_type, error_str);
+        Q_EMIT uploadFileSignalErrorFull(worker, error_type, error_str);
     }
 }
 

--- a/samples/client/petstore/cpp-qt/client/PFXPetApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXPetApi.h
@@ -140,7 +140,7 @@ private:
     void updatePetWithFormCallback(PFXHttpRequestWorker *worker);
     void uploadFileCallback(PFXHttpRequestWorker *worker);
 
-signals:
+Q_SIGNALS:
 
     void addPetSignal();
     void allPetsSignal(QSet<PFXPet> summary);
@@ -221,7 +221,7 @@ signals:
     void abortRequestsSignal();
     void allPendingRequestsCompleted();
 
-public slots:
+public Q_SLOTS:
     void tokenAvailable();
 };
 

--- a/samples/client/petstore/cpp-qt/client/PFXPrimitivesApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXPrimitivesApi.cpp
@@ -148,7 +148,7 @@ void PFXPrimitivesApi::enableResponseCompression() {
 }
 
 void PFXPrimitivesApi::abortRequests() {
-    emit abortRequestsSignal();
+    Q_EMIT abortRequestsSignal();
 }
 
 QString PFXPrimitivesApi::getParamStylePrefix(const QString &style) {
@@ -241,7 +241,7 @@ void PFXPrimitivesApi::primitivesIntegerPost(const ::test_namespace::OptionalPar
     connect(this, &PFXPrimitivesApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -258,8 +258,8 @@ void PFXPrimitivesApi::primitivesIntegerPostCallback(PFXHttpRequestWorker *worke
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit primitivesIntegerPostSignal();
-        emit primitivesIntegerPostSignalFull(worker);
+        Q_EMIT primitivesIntegerPostSignal();
+        Q_EMIT primitivesIntegerPostSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -276,8 +276,8 @@ void PFXPrimitivesApi::primitivesIntegerPostCallback(PFXHttpRequestWorker *worke
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit primitivesIntegerPostSignalE(error_type, error_str);
-        emit primitivesIntegerPostSignalEFull(worker, error_type, error_str);
+        Q_EMIT primitivesIntegerPostSignalE(error_type, error_str);
+        Q_EMIT primitivesIntegerPostSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -287,8 +287,8 @@ void PFXPrimitivesApi::primitivesIntegerPostCallback(PFXHttpRequestWorker *worke
 #pragma GCC diagnostic pop
 #endif
 
-        emit primitivesIntegerPostSignalError(error_type, error_str);
-        emit primitivesIntegerPostSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT primitivesIntegerPostSignalError(error_type, error_str);
+        Q_EMIT primitivesIntegerPostSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -319,7 +319,7 @@ void PFXPrimitivesApi::primitivesNumberPut(const ::test_namespace::OptionalParam
     connect(this, &PFXPrimitivesApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -336,8 +336,8 @@ void PFXPrimitivesApi::primitivesNumberPutCallback(PFXHttpRequestWorker *worker)
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit primitivesNumberPutSignal();
-        emit primitivesNumberPutSignalFull(worker);
+        Q_EMIT primitivesNumberPutSignal();
+        Q_EMIT primitivesNumberPutSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -354,8 +354,8 @@ void PFXPrimitivesApi::primitivesNumberPutCallback(PFXHttpRequestWorker *worker)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit primitivesNumberPutSignalE(error_type, error_str);
-        emit primitivesNumberPutSignalEFull(worker, error_type, error_str);
+        Q_EMIT primitivesNumberPutSignalE(error_type, error_str);
+        Q_EMIT primitivesNumberPutSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -365,8 +365,8 @@ void PFXPrimitivesApi::primitivesNumberPutCallback(PFXHttpRequestWorker *worker)
 #pragma GCC diagnostic pop
 #endif
 
-        emit primitivesNumberPutSignalError(error_type, error_str);
-        emit primitivesNumberPutSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT primitivesNumberPutSignalError(error_type, error_str);
+        Q_EMIT primitivesNumberPutSignalErrorFull(worker, error_type, error_str);
     }
 }
 

--- a/samples/client/petstore/cpp-qt/client/PFXPrimitivesApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXPrimitivesApi.h
@@ -91,7 +91,7 @@ private:
     void primitivesIntegerPostCallback(PFXHttpRequestWorker *worker);
     void primitivesNumberPutCallback(PFXHttpRequestWorker *worker);
 
-signals:
+Q_SIGNALS:
 
     void primitivesIntegerPostSignal();
     void primitivesNumberPutSignal();
@@ -116,7 +116,7 @@ signals:
     void abortRequestsSignal();
     void allPendingRequestsCompleted();
 
-public slots:
+public Q_SLOTS:
     void tokenAvailable();
 };
 

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.cpp
@@ -152,7 +152,7 @@ void PFXStoreApi::enableResponseCompression() {
 }
 
 void PFXStoreApi::abortRequests() {
-    emit abortRequestsSignal();
+    Q_EMIT abortRequestsSignal();
 }
 
 QString PFXStoreApi::getParamStylePrefix(const QString &style) {
@@ -255,7 +255,7 @@ void PFXStoreApi::deleteOrder(const QString &order_id) {
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -272,8 +272,8 @@ void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit deleteOrderSignal();
-        emit deleteOrderSignalFull(worker);
+        Q_EMIT deleteOrderSignal();
+        Q_EMIT deleteOrderSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -290,8 +290,8 @@ void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit deleteOrderSignalE(error_type, error_str);
-        emit deleteOrderSignalEFull(worker, error_type, error_str);
+        Q_EMIT deleteOrderSignalE(error_type, error_str);
+        Q_EMIT deleteOrderSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -301,8 +301,8 @@ void PFXStoreApi::deleteOrderCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit deleteOrderSignalError(error_type, error_str);
-        emit deleteOrderSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT deleteOrderSignalError(error_type, error_str);
+        Q_EMIT deleteOrderSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -333,7 +333,7 @@ void PFXStoreApi::getInventory() {
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -360,8 +360,8 @@ void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit getInventorySignal(output);
-        emit getInventorySignalFull(worker, output);
+        Q_EMIT getInventorySignal(output);
+        Q_EMIT getInventorySignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -378,8 +378,8 @@ void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit getInventorySignalE(output, error_type, error_str);
-        emit getInventorySignalEFull(worker, error_type, error_str);
+        Q_EMIT getInventorySignalE(output, error_type, error_str);
+        Q_EMIT getInventorySignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -389,8 +389,8 @@ void PFXStoreApi::getInventoryCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit getInventorySignalError(output, error_type, error_str);
-        emit getInventorySignalErrorFull(worker, error_type, error_str);
+        Q_EMIT getInventorySignalError(output, error_type, error_str);
+        Q_EMIT getInventorySignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -431,7 +431,7 @@ void PFXStoreApi::getOrderById(const qint64 &order_id) {
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -449,8 +449,8 @@ void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit getOrderByIdSignal(output);
-        emit getOrderByIdSignalFull(worker, output);
+        Q_EMIT getOrderByIdSignal(output);
+        Q_EMIT getOrderByIdSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -467,8 +467,8 @@ void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit getOrderByIdSignalE(output, error_type, error_str);
-        emit getOrderByIdSignalEFull(worker, error_type, error_str);
+        Q_EMIT getOrderByIdSignalE(output, error_type, error_str);
+        Q_EMIT getOrderByIdSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -478,8 +478,8 @@ void PFXStoreApi::getOrderByIdCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit getOrderByIdSignalError(output, error_type, error_str);
-        emit getOrderByIdSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT getOrderByIdSignalError(output, error_type, error_str);
+        Q_EMIT getOrderByIdSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -511,7 +511,7 @@ void PFXStoreApi::placeOrder(const PFXOrder &pfx_order) {
     connect(this, &PFXStoreApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -529,8 +529,8 @@ void PFXStoreApi::placeOrderCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit placeOrderSignal(output);
-        emit placeOrderSignalFull(worker, output);
+        Q_EMIT placeOrderSignal(output);
+        Q_EMIT placeOrderSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -547,8 +547,8 @@ void PFXStoreApi::placeOrderCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit placeOrderSignalE(output, error_type, error_str);
-        emit placeOrderSignalEFull(worker, error_type, error_str);
+        Q_EMIT placeOrderSignalE(output, error_type, error_str);
+        Q_EMIT placeOrderSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -558,8 +558,8 @@ void PFXStoreApi::placeOrderCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit placeOrderSignalError(output, error_type, error_str);
-        emit placeOrderSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT placeOrderSignalError(output, error_type, error_str);
+        Q_EMIT placeOrderSignalErrorFull(worker, error_type, error_str);
     }
 }
 

--- a/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXStoreApi.h
@@ -103,7 +103,7 @@ private:
     void getOrderByIdCallback(PFXHttpRequestWorker *worker);
     void placeOrderCallback(PFXHttpRequestWorker *worker);
 
-signals:
+Q_SIGNALS:
 
     void deleteOrderSignal();
     void getInventorySignal(QMap<QString, qint32> summary);
@@ -144,7 +144,7 @@ signals:
     void abortRequestsSignal();
     void allPendingRequestsCompleted();
 
-public slots:
+public Q_SLOTS:
     void tokenAvailable();
 };
 

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.cpp
@@ -160,7 +160,7 @@ void PFXUserApi::enableResponseCompression() {
 }
 
 void PFXUserApi::abortRequests() {
-    emit abortRequestsSignal();
+    Q_EMIT abortRequestsSignal();
 }
 
 QString PFXUserApi::getParamStylePrefix(const QString &style) {
@@ -254,7 +254,7 @@ void PFXUserApi::createUser(const PFXUser &pfx_user) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -271,8 +271,8 @@ void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit createUserSignal();
-        emit createUserSignalFull(worker);
+        Q_EMIT createUserSignal();
+        Q_EMIT createUserSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -289,8 +289,8 @@ void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit createUserSignalE(error_type, error_str);
-        emit createUserSignalEFull(worker, error_type, error_str);
+        Q_EMIT createUserSignalE(error_type, error_str);
+        Q_EMIT createUserSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -300,8 +300,8 @@ void PFXUserApi::createUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit createUserSignalError(error_type, error_str);
-        emit createUserSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT createUserSignalError(error_type, error_str);
+        Q_EMIT createUserSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -332,7 +332,7 @@ void PFXUserApi::createUsersWithArrayInput(const QList<PFXUser> &pfx_user) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -349,8 +349,8 @@ void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker)
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit createUsersWithArrayInputSignal();
-        emit createUsersWithArrayInputSignalFull(worker);
+        Q_EMIT createUsersWithArrayInputSignal();
+        Q_EMIT createUsersWithArrayInputSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -367,8 +367,8 @@ void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit createUsersWithArrayInputSignalE(error_type, error_str);
-        emit createUsersWithArrayInputSignalEFull(worker, error_type, error_str);
+        Q_EMIT createUsersWithArrayInputSignalE(error_type, error_str);
+        Q_EMIT createUsersWithArrayInputSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -378,8 +378,8 @@ void PFXUserApi::createUsersWithArrayInputCallback(PFXHttpRequestWorker *worker)
 #pragma GCC diagnostic pop
 #endif
 
-        emit createUsersWithArrayInputSignalError(error_type, error_str);
-        emit createUsersWithArrayInputSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT createUsersWithArrayInputSignalError(error_type, error_str);
+        Q_EMIT createUsersWithArrayInputSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -410,7 +410,7 @@ void PFXUserApi::createUsersWithListInput(const QList<PFXUser> &pfx_user) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -427,8 +427,8 @@ void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) 
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit createUsersWithListInputSignal();
-        emit createUsersWithListInputSignalFull(worker);
+        Q_EMIT createUsersWithListInputSignal();
+        Q_EMIT createUsersWithListInputSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -445,8 +445,8 @@ void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) 
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit createUsersWithListInputSignalE(error_type, error_str);
-        emit createUsersWithListInputSignalEFull(worker, error_type, error_str);
+        Q_EMIT createUsersWithListInputSignalE(error_type, error_str);
+        Q_EMIT createUsersWithListInputSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -456,8 +456,8 @@ void PFXUserApi::createUsersWithListInputCallback(PFXHttpRequestWorker *worker) 
 #pragma GCC diagnostic pop
 #endif
 
-        emit createUsersWithListInputSignalError(error_type, error_str);
-        emit createUsersWithListInputSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT createUsersWithListInputSignalError(error_type, error_str);
+        Q_EMIT createUsersWithListInputSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -498,7 +498,7 @@ void PFXUserApi::deleteUser(const QString &username) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -515,8 +515,8 @@ void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit deleteUserSignal();
-        emit deleteUserSignalFull(worker);
+        Q_EMIT deleteUserSignal();
+        Q_EMIT deleteUserSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -533,8 +533,8 @@ void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit deleteUserSignalE(error_type, error_str);
-        emit deleteUserSignalEFull(worker, error_type, error_str);
+        Q_EMIT deleteUserSignalE(error_type, error_str);
+        Q_EMIT deleteUserSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -544,8 +544,8 @@ void PFXUserApi::deleteUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit deleteUserSignalError(error_type, error_str);
-        emit deleteUserSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT deleteUserSignalError(error_type, error_str);
+        Q_EMIT deleteUserSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -586,7 +586,7 @@ void PFXUserApi::getUserByName(const QString &username) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -604,8 +604,8 @@ void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit getUserByNameSignal(output);
-        emit getUserByNameSignalFull(worker, output);
+        Q_EMIT getUserByNameSignal(output);
+        Q_EMIT getUserByNameSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -622,8 +622,8 @@ void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit getUserByNameSignalE(output, error_type, error_str);
-        emit getUserByNameSignalEFull(worker, error_type, error_str);
+        Q_EMIT getUserByNameSignalE(output, error_type, error_str);
+        Q_EMIT getUserByNameSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -633,8 +633,8 @@ void PFXUserApi::getUserByNameCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit getUserByNameSignalError(output, error_type, error_str);
-        emit getUserByNameSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT getUserByNameSignalError(output, error_type, error_str);
+        Q_EMIT getUserByNameSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -692,7 +692,7 @@ void PFXUserApi::loginUser(const QString &username, const QString &password) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -711,8 +711,8 @@ void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit loginUserSignal(output);
-        emit loginUserSignalFull(worker, output);
+        Q_EMIT loginUserSignal(output);
+        Q_EMIT loginUserSignalFull(worker, output);
     } else {
 
 #if defined(_MSC_VER)
@@ -729,8 +729,8 @@ void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit loginUserSignalE(output, error_type, error_str);
-        emit loginUserSignalEFull(worker, error_type, error_str);
+        Q_EMIT loginUserSignalE(output, error_type, error_str);
+        Q_EMIT loginUserSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -740,8 +740,8 @@ void PFXUserApi::loginUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit loginUserSignalError(output, error_type, error_str);
-        emit loginUserSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT loginUserSignalError(output, error_type, error_str);
+        Q_EMIT loginUserSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -768,7 +768,7 @@ void PFXUserApi::logoutUser() {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -785,8 +785,8 @@ void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit logoutUserSignal();
-        emit logoutUserSignalFull(worker);
+        Q_EMIT logoutUserSignal();
+        Q_EMIT logoutUserSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -803,8 +803,8 @@ void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit logoutUserSignalE(error_type, error_str);
-        emit logoutUserSignalEFull(worker, error_type, error_str);
+        Q_EMIT logoutUserSignalE(error_type, error_str);
+        Q_EMIT logoutUserSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -814,8 +814,8 @@ void PFXUserApi::logoutUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit logoutUserSignalError(error_type, error_str);
-        emit logoutUserSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT logoutUserSignalError(error_type, error_str);
+        Q_EMIT logoutUserSignalErrorFull(worker, error_type, error_str);
     }
 }
 
@@ -861,7 +861,7 @@ void PFXUserApi::updateUser(const QString &username, const PFXUser &pfx_user) {
     connect(this, &PFXUserApi::abortRequestsSignal, worker, &QObject::deleteLater);
     connect(worker, &QObject::destroyed, this, [this]() {
         if (findChildren<PFXHttpRequestWorker*>().count() == 0) {
-            emit allPendingRequestsCompleted();
+            Q_EMIT allPendingRequestsCompleted();
         }
     });
 
@@ -878,8 +878,8 @@ void PFXUserApi::updateUserCallback(PFXHttpRequestWorker *worker) {
     worker->deleteLater();
 
     if (worker->error_type == QNetworkReply::NoError) {
-        emit updateUserSignal();
-        emit updateUserSignalFull(worker);
+        Q_EMIT updateUserSignal();
+        Q_EMIT updateUserSignalFull(worker);
     } else {
 
 #if defined(_MSC_VER)
@@ -896,8 +896,8 @@ void PFXUserApi::updateUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-        emit updateUserSignalE(error_type, error_str);
-        emit updateUserSignalEFull(worker, error_type, error_str);
+        Q_EMIT updateUserSignalE(error_type, error_str);
+        Q_EMIT updateUserSignalEFull(worker, error_type, error_str);
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -907,8 +907,8 @@ void PFXUserApi::updateUserCallback(PFXHttpRequestWorker *worker) {
 #pragma GCC diagnostic pop
 #endif
 
-        emit updateUserSignalError(error_type, error_str);
-        emit updateUserSignalErrorFull(worker, error_type, error_str);
+        Q_EMIT updateUserSignalError(error_type, error_str);
+        Q_EMIT updateUserSignalErrorFull(worker, error_type, error_str);
     }
 }
 

--- a/samples/client/petstore/cpp-qt/client/PFXUserApi.h
+++ b/samples/client/petstore/cpp-qt/client/PFXUserApi.h
@@ -128,7 +128,7 @@ private:
     void logoutUserCallback(PFXHttpRequestWorker *worker);
     void updateUserCallback(PFXHttpRequestWorker *worker);
 
-signals:
+Q_SIGNALS:
 
     void createUserSignal();
     void createUsersWithArrayInputSignal();
@@ -201,7 +201,7 @@ signals:
     void abortRequestsSignal();
     void allPendingRequestsCompleted();
 
-public slots:
+public Q_SLOTS:
     void tokenAvailable();
 };
 

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIApiRouter.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIApiRouter.h
@@ -34,7 +34,7 @@ namespace OpenAPI {
 class OAIApiRequestHandler : public  QHttpEngine::QObjectHandler
 {
     Q_OBJECT
-signals:
+Q_SIGNALS:
     void requestReceived(QHttpEngine::Socket *socket);
 
 protected:
@@ -44,10 +44,10 @@ protected:
         // If the slot requires all data to be received, check to see if this is
         // already the case, otherwise, wait until the rest of it arrives
         if (socket->bytesAvailable() >= socket->contentLength()) {
-            emit requestReceived(socket);
+            Q_EMIT requestReceived(socket);
         } else {
             connect(socket, &QHttpEngine::Socket::readChannelFinished, [this, socket]() {
-                emit requestReceived(socket);
+                Q_EMIT requestReceived(socket);
             });
         }
     }

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIPetApiHandler.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIPetApiHandler.h
@@ -31,7 +31,7 @@ public:
     virtual ~OAIPetApiHandler();
 
 
-public slots:
+public Q_SLOTS:
     virtual void addPet(OAIPet body);
     virtual void deletePet(qint64 pet_id, QString api_key);
     virtual void findPetsByStatus(QList<QString> status);

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIStoreApiHandler.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIStoreApiHandler.h
@@ -29,7 +29,7 @@ public:
     virtual ~OAIStoreApiHandler();
 
 
-public slots:
+public Q_SLOTS:
     virtual void deleteOrder(QString order_id);
     virtual void getInventory();
     virtual void getOrderById(qint64 order_id);

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIUserApiHandler.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/handlers/OAIUserApiHandler.h
@@ -29,7 +29,7 @@ public:
     virtual ~OAIUserApiHandler();
 
 
-public slots:
+public Q_SLOTS:
     virtual void createUser(OAIUser body);
     virtual void createUsersWithArrayInput(QList<OAIUser> body);
     virtual void createUsersWithListInput(QList<OAIUser> body);

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIPetApiRequest.cpp
@@ -63,7 +63,7 @@ void OAIPetApiRequest::addPetRequest(){
     ::OpenAPI::fromJsonValue(body, obj);
     
 
-    emit addPet(body);
+    Q_EMIT addPet(body);
 }
 
 
@@ -81,7 +81,7 @@ void OAIPetApiRequest::deletePetRequest(const QString& pet_idstr){
     }
     
 
-    emit deletePet(pet_id, api_key);
+    Q_EMIT deletePet(pet_id, api_key);
 }
 
 
@@ -97,7 +97,7 @@ void OAIPetApiRequest::findPetsByStatusRequest(){
     
 
 
-    emit findPetsByStatus(status);
+    Q_EMIT findPetsByStatus(status);
 }
 
 
@@ -113,7 +113,7 @@ void OAIPetApiRequest::findPetsByTagsRequest(){
     
 
 
-    emit findPetsByTags(tags);
+    Q_EMIT findPetsByTags(tags);
 }
 
 
@@ -126,7 +126,7 @@ void OAIPetApiRequest::getPetByIdRequest(const QString& pet_idstr){
     fromStringValue(pet_idstr, pet_id);
     
 
-    emit getPetById(pet_id);
+    Q_EMIT getPetById(pet_id);
 }
 
 
@@ -144,7 +144,7 @@ void OAIPetApiRequest::updatePetRequest(){
     ::OpenAPI::fromJsonValue(body, obj);
     
 
-    emit updatePet(body);
+    Q_EMIT updatePet(body);
 }
 
 
@@ -159,7 +159,7 @@ void OAIPetApiRequest::updatePetWithFormRequest(const QString& pet_idstr){
     QString name;
     QString status;
 
-    emit updatePetWithForm(pet_id, name, status);
+    Q_EMIT updatePetWithForm(pet_id, name, status);
 }
 
 
@@ -174,7 +174,7 @@ void OAIPetApiRequest::uploadFileRequest(const QString& pet_idstr){
     QString additional_metadata;
     OAIHttpFileElement file;
 
-    emit uploadFile(pet_id, additional_metadata, file);
+    Q_EMIT uploadFile(pet_id, additional_metadata, file);
 }
 
 

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIPetApiRequest.h
@@ -76,7 +76,7 @@ public:
 
     void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
-signals:
+Q_SIGNALS:
     void addPet(OAIPet body);
     void deletePet(qint64 pet_id, QString api_key);
     void findPetsByStatus(QList<QString> status);

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIStoreApiRequest.cpp
@@ -58,7 +58,7 @@ void OAIStoreApiRequest::deleteOrderRequest(const QString& order_idstr){
     fromStringValue(order_idstr, order_id);
     
 
-    emit deleteOrder(order_id);
+    Q_EMIT deleteOrder(order_id);
 }
 
 
@@ -69,7 +69,7 @@ void OAIStoreApiRequest::getInventoryRequest(){
     
 
 
-    emit getInventory();
+    Q_EMIT getInventory();
 }
 
 
@@ -82,7 +82,7 @@ void OAIStoreApiRequest::getOrderByIdRequest(const QString& order_idstr){
     fromStringValue(order_idstr, order_id);
     
 
-    emit getOrderById(order_id);
+    Q_EMIT getOrderById(order_id);
 }
 
 
@@ -100,7 +100,7 @@ void OAIStoreApiRequest::placeOrderRequest(){
     ::OpenAPI::fromJsonValue(body, obj);
     
 
-    emit placeOrder(body);
+    Q_EMIT placeOrder(body);
 }
 
 

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIStoreApiRequest.h
@@ -62,7 +62,7 @@ public:
 
     void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
-signals:
+Q_SIGNALS:
     void deleteOrder(QString order_id);
     void getInventory();
     void getOrderById(qint64 order_id);

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIUserApiRequest.cpp
@@ -63,7 +63,7 @@ void OAIUserApiRequest::createUserRequest(){
     ::OpenAPI::fromJsonValue(body, obj);
     
 
-    emit createUser(body);
+    Q_EMIT createUser(body);
 }
 
 
@@ -85,7 +85,7 @@ void OAIUserApiRequest::createUsersWithArrayInputRequest(){
     }
     
 
-    emit createUsersWithArrayInput(body);
+    Q_EMIT createUsersWithArrayInput(body);
 }
 
 
@@ -107,7 +107,7 @@ void OAIUserApiRequest::createUsersWithListInputRequest(){
     }
     
 
-    emit createUsersWithListInput(body);
+    Q_EMIT createUsersWithListInput(body);
 }
 
 
@@ -120,7 +120,7 @@ void OAIUserApiRequest::deleteUserRequest(const QString& usernamestr){
     fromStringValue(usernamestr, username);
     
 
-    emit deleteUser(username);
+    Q_EMIT deleteUser(username);
 }
 
 
@@ -133,7 +133,7 @@ void OAIUserApiRequest::getUserByNameRequest(const QString& usernamestr){
     fromStringValue(usernamestr, username);
     
 
-    emit getUserByName(username);
+    Q_EMIT getUserByName(username);
 }
 
 
@@ -154,7 +154,7 @@ void OAIUserApiRequest::loginUserRequest(){
     
 
 
-    emit loginUser(username, password);
+    Q_EMIT loginUser(username, password);
 }
 
 
@@ -165,7 +165,7 @@ void OAIUserApiRequest::logoutUserRequest(){
     
 
 
-    emit logoutUser();
+    Q_EMIT logoutUser();
 }
 
 
@@ -185,7 +185,7 @@ void OAIUserApiRequest::updateUserRequest(const QString& usernamestr){
     ::OpenAPI::fromJsonValue(body, obj);
     
 
-    emit updateUser(username, body);
+    Q_EMIT updateUser(username, body);
 }
 
 

--- a/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
+++ b/samples/server/petstore/cpp-qt-qhttpengine-server/server/src/requests/OAIUserApiRequest.h
@@ -74,7 +74,7 @@ public:
 
     void setResponseHeaders(const QMultiMap<QString,QString>& headers);
 
-signals:
+Q_SIGNALS:
     void createUser(OAIUser body);
     void createUsersWithArrayInput(QList<OAIUser> body);
     void createUsersWithListInput(QList<OAIUser> body);


### PR DESCRIPTION
Replace signals,slots and emit with Q_SIGNALS,Q_SLOTS and Q_EMIT

Because these names will be used by a 3rd party library, e.g. Boost

https://doc.qt.io/qt-6/signalsandslots.html#using-qt-with-3rd-party-signals-and-slots

@muttleyxd 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
