### PR TITLE
Use JDK17 images in Dockerfile

### DIFF
--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-17
+FROM amazoncorretto:17.0.8-alpine3.18
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0-jre-buster
+FROM maven:3-eclipse-temurin-17
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM maven:3-eclipse-temurin-17
 
 WORKDIR /generator
 

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-17
+FROM amazoncorretto:17.0.8-alpine3.18
 
 WORKDIR /generator
 


### PR DESCRIPTION
Use [amazoncorretto:17.0.8-alpine3.18](https://hub.docker.com/layers/library/amazoncorretto/17.0.8-alpine3.18/images/sha256-6e6f780411eae55e8dcb59391aa09dd778f0fa2c896f9c218961fdb7da52f485?context=explore) which has 0 vulnerabilities.

a follow-up PR to https://github.com/OpenAPITools/openapi-generator/pull/17007


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
