### PR TITLE
[python] fix: Annotate free-form object as dict in Python

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -2024,16 +2024,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
             return new PythonType(cp.getDataType());
         }
 
-        private PythonType freeFormType(IJsonSchemaValidationProperties cp) {
-            typingImports.add("Dict");
-            typingImports.add("Any");
-            typingImports.add("Union");
-            PythonType pt = new PythonType("Union");
-            pt.addTypeParam(new PythonType("str"));
-            pt.addTypeParam(new PythonType("Any"));
-            return pt;
-        }
-
         private PythonType modelType(IJsonSchemaValidationProperties cp) {
             // add model prefix
             hasModelsToImport = true;
@@ -2056,7 +2046,7 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
 
             if (cp.getIsArray()) {
                 return arrayType(cp);
-            } else if (cp.getIsMap()) {
+            } else if (cp.getIsMap() || cp.getIsFreeFormObject()) {
                 return mapType(cp);
             } else if (cp.getIsString()) {
                 return stringType(cp);
@@ -2076,8 +2066,6 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                 return dateType(cp);
             } else if (cp.getIsUuid()) {
                 return uuidType(cp);
-            } else if (cp.getIsFreeFormObject()) { // type: object
-                return freeFormType(cp);
             }
 
             return null;

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 try:
@@ -30,7 +30,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """ # noqa: E501
-    a_property: Optional[Union[str, Any]] = Field(default=None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
     __properties: ClassVar[List[str]] = ["aProperty"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import date, datetime
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictBool, StrictInt, StrictStr
 try:
     from typing import Self
@@ -36,12 +36,12 @@ class NullableClass(BaseModel):
     string_prop: Optional[StrictStr] = None
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
-    array_nullable_prop: Optional[List[Union[str, Any]]] = None
-    array_and_items_nullable_prop: Optional[List[Union[str, Any]]] = None
-    array_items_nullable: Optional[List[Union[str, Any]]] = None
-    object_nullable_prop: Optional[Dict[str, Union[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Union[str, Any]]] = None
-    object_items_nullable: Optional[Dict[str, Union[str, Any]]] = None
+    array_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_and_items_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_items_nullable: Optional[List[Dict[str, Any]]] = None
+    object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel
 from pydantic import Field
 try:
@@ -30,7 +30,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """ # noqa: E501
-    a_property: Optional[Union[str, Any]] = Field(default=None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["aProperty"]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import date, datetime
-from typing import Any, ClassVar, Dict, List, Optional, Union
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel, StrictBool, StrictFloat, StrictInt, StrictStr
 try:
     from typing import Self
@@ -36,12 +36,12 @@ class NullableClass(BaseModel):
     string_prop: Optional[StrictStr] = None
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
-    array_nullable_prop: Optional[List[Union[str, Any]]] = None
-    array_and_items_nullable_prop: Optional[List[Union[str, Any]]] = None
-    array_items_nullable: Optional[List[Union[str, Any]]] = None
-    object_nullable_prop: Optional[Dict[str, Union[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Union[str, Any]]] = None
-    object_items_nullable: Optional[Dict[str, Union[str, Any]]] = None
+    array_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_and_items_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_items_nullable: Optional[List[Dict[str, Any]]] = None
+    object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 

--- a/samples/openapi3/client/petstore/python/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python/tests/test_model.py
@@ -8,8 +8,10 @@ import time
 import unittest
 
 from pydantic import ValidationError
+import pytest
 
 import petstore_api
+from petstore_api import InnerDictWithProperty
 
 
 class ModelTests(unittest.TestCase):
@@ -507,6 +509,19 @@ class ModelTests(unittest.TestCase):
         b = petstore_api.ParentWithOptionalDict.from_dict({"optionalDict": {"key": {"aProperty": {"a": "b"}}}})
         self.assertFalse(b is None)
         self.assertEqual(b.optional_dict["key"].a_property["a"], "b")
+
+    def test_freeform_object(self):
+        # Allows dict[str, Any] and is nullable
+        a = InnerDictWithProperty.from_dict({"aProperty": {"a": 12}})
+        a = InnerDictWithProperty.from_dict({"aProperty": None})
+
+        # Allows no other values
+        with pytest.raises(ValidationError):
+            a = InnerDictWithProperty.from_dict({"aProperty": {123: 45}})
+        with pytest.raises(ValidationError):
+            a = InnerDictWithProperty.from_dict({"aProperty": "abc"})
+        with pytest.raises(ValidationError):
+            a = InnerDictWithProperty.from_dict({"aProperty": 12})
 
     def test_object_with_dict_of_dict_of_object(self):
         # for https://github.com/OpenAPITools/openapi-generator/issues/15135


### PR DESCRIPTION
Model properties annotated only with `type: object` are currently turned into `Union[str, Any]` in Python. This is wrong, since they must be dictionaries. They cannot be strings.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@multani @fa0311 @wing328 