### PR TITLE
[java] update rest-assured dependencies to newer versions

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/build.gradle.mustache
@@ -97,8 +97,13 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
+    {{#swagger1AnnotationLibrary}}
     swagger_annotations_version = "1.6.6"
-    rest_assured_version = "4.5.1"
+    {{/swagger1AnnotationLibrary}}
+    {{#swagger2AnnotationLibrary}}
+    swagger_annotations_version = "2.2.15"
+    {{/swagger2AnnotationLibrary}}
+    rest_assured_version = "5.3.2"
     junit_version = "4.13.2"
 {{#jackson}}
     jackson_version = "2.13.4"
@@ -109,17 +114,22 @@ ext {
     jakarta_annotation_version = "1.3.5"
 {{/jackson}}
 {{#gson}}
-    gson_version = "2.8.9"
+    gson_version = "2.10.1"
     gson_fire_version = "1.9.0"
 {{/gson}}
 {{#joda}}
     jodatime_version = "2.10.5"
 {{/joda}}
-    okio_version = "1.17.5"
+    okio_version = "3.6.0"
 }
 
 dependencies {
+    {{#swagger1AnnotationLibrary}}
     implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
+    {{/swagger1AnnotationLibrary}}
+    {{#swagger2AnnotationLibrary}}
+    implementation "io.swagger.core.v3:swagger-annotations:$swagger_annotations_version"
+    {{/swagger2AnnotationLibrary}}
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.rest-assured:rest-assured:$rest_assured_version"
 {{#jackson}}

--- a/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/rest-assured/pom.mustache
@@ -345,7 +345,7 @@
         {{#swagger2AnnotationLibrary}}
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
-        <rest-assured.version>4.5.1</rest-assured.version>
+        <rest-assured.version>5.3.2</rest-assured.version>
         <gson-version>2.10.1</gson-version>
         <gson-fire-version>1.9.0</gson-fire-version>
         {{#joda}}
@@ -365,7 +365,7 @@
 {{#useBeanValidation}}
         <beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}
-        <okio-version>1.17.5</okio-version>
+        <okio-version>3.6.0</okio-version>
         <junit-version>4.13.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/rest-assured-jackson/build.gradle
+++ b/samples/client/petstore/java/rest-assured-jackson/build.gradle
@@ -97,18 +97,16 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    swagger_annotations_version = "1.6.6"
-    rest_assured_version = "4.5.1"
+    rest_assured_version = "5.3.2"
     junit_version = "4.13.2"
     jackson_version = "2.13.4"
     jackson_databind_version = "2.13.4.2"
     jackson_databind_nullable_version = "0.2.6"
     jakarta_annotation_version = "1.3.5"
-    okio_version = "1.17.5"
+    okio_version = "3.6.0"
 }
 
 dependencies {
-    implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.rest-assured:rest-assured:$rest_assured_version"
     implementation "com.fasterxml.jackson.core:jackson-core:$jackson_version"

--- a/samples/client/petstore/java/rest-assured-jackson/pom.xml
+++ b/samples/client/petstore/java/rest-assured-jackson/pom.xml
@@ -277,7 +277,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rest-assured.version>4.5.1</rest-assured.version>
+        <rest-assured.version>5.3.2</rest-assured.version>
         <gson-version>2.10.1</gson-version>
         <gson-fire-version>1.9.0</gson-fire-version>
         <jackson-version>2.15.2</jackson-version>
@@ -285,7 +285,7 @@
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <okio-version>1.17.5</okio-version>
+        <okio-version>3.6.0</okio-version>
         <junit-version>4.13.2</junit-version>
     </properties>
 </project>

--- a/samples/client/petstore/java/rest-assured/build.gradle
+++ b/samples/client/petstore/java/rest-assured/build.gradle
@@ -97,16 +97,14 @@ if(hasProperty('target') && target == 'android') {
 }
 
 ext {
-    swagger_annotations_version = "1.6.6"
-    rest_assured_version = "4.5.1"
+    rest_assured_version = "5.3.2"
     junit_version = "4.13.2"
-    gson_version = "2.8.9"
+    gson_version = "2.10.1"
     gson_fire_version = "1.9.0"
-    okio_version = "1.17.5"
+    okio_version = "3.6.0"
 }
 
 dependencies {
-    implementation "io.swagger:swagger-annotations:$swagger_annotations_version"
     implementation "com.google.code.findbugs:jsr305:3.0.2"
     implementation "io.rest-assured:rest-assured:$rest_assured_version"
     implementation "io.gsonfire:gson-fire:$gson_fire_version"

--- a/samples/client/petstore/java/rest-assured/pom.xml
+++ b/samples/client/petstore/java/rest-assured/pom.xml
@@ -254,12 +254,12 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rest-assured.version>4.5.1</rest-assured.version>
+        <rest-assured.version>5.3.2</rest-assured.version>
         <gson-version>2.10.1</gson-version>
         <gson-fire-version>1.9.0</gson-fire-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <beanvalidation-version>2.0.2</beanvalidation-version>
-        <okio-version>1.17.5</okio-version>
+        <okio-version>3.6.0</okio-version>
         <junit-version>4.13.2</junit-version>
     </properties>
 </project>


### PR DESCRIPTION
update rest-assured dependencies to newer versions

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
