### PR TITLE
[PHP-NG] allow 'object' type in serializer

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -417,10 +417,7 @@ class ObjectSerializer
             return $deserialized;
         }
 
-        if ($class === 'object') {
-            settype($data, 'array');
-            return $data;
-        } elseif ($class === 'mixed') {
+        if ($class === 'mixed') {
             settype($data, gettype($data));
             return $data;
         }

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -427,10 +427,7 @@ class ObjectSerializer
             return $deserialized;
         }
 
-        if ($class === 'object') {
-            settype($data, 'array');
-            return $data;
-        } elseif ($class === 'mixed') {
+        if ($class === 'mixed') {
             settype($data, gettype($data));
             return $data;
         }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -426,10 +426,7 @@ class ObjectSerializer
             return $deserialized;
         }
 
-        if ($class === 'object') {
-            settype($data, 'array');
-            return $data;
-        } elseif ($class === 'mixed') {
+        if ($class === 'mixed') {
             settype($data, gettype($data));
             return $data;
         }


### PR DESCRIPTION
We have this definition in the specs file:
```
        innererror:
          type: object
          description: The structure of this object is service-specific
```
see https://github.com/owncloud/libre-graph-api/blob/main/api/openapi-spec/v1.0.yaml#L4197C1-L4199C72

In an error case the server replies with:
```
{"error":{"code":"notAllowed","innererror":{"date":"2023-11-17T14:46:21Z","request-id":"789f1afa4e75/f0JanGCTzg-015800"},"message":"insufficient permissions to create a space."}}
```
note that the `innererror` is an object.

But the PHP code would fail with `OpenAPI\Client\Model\OdataErrorMain::setInnererror(): Argument #1 ($innererror) must be of type ?object, array given, called in /home/artur/www/libre-graph-api/out/php-nextgen/src/ObjectSerializer.php on line 537`

Maybe there is a reason, I cannot see, but I propose not to rewrite the object to an array, but just leave it as it is.

`settype` will the then run in https://github.com/OpenAPITools/openapi-generator/blob/39e790e9c0954b188b709ceb64e42de6f206ff5a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache#L478 because that section also is executed for `object` types

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @jebentier @dkarlovi @mandrean @jfastnacht @ybelenko @renepardon