### PR TITLE
Fix rust client test

### DIFF
--- a/samples/client/petstore/rust/reqwest/petstore/tests/type_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/tests/type_testing.rs
@@ -1,10 +1,19 @@
 extern crate petstore_reqwest;
 
 use petstore_reqwest::models::TypeTesting;
+use uuid::Uuid;
 
 #[test]
 fn test_types() {
-    let tt = TypeTesting::default();
+    let tt = TypeTesting {
+        int32: 123,
+        int64: 456,
+        float: 12.34,
+        double: 45.56,
+        string: String::from("something"),
+        boolean: true,
+        uuid: Uuid::new_v4()
+    };
     assert_eq!(type_of(tt.int32), "i32");
     assert_eq!(type_of(tt.int64), "i64");
     assert_eq!(type_of(tt.float), "f32");


### PR DESCRIPTION
Fix rust client test by properly  creating the object.

tests passed locally:

```

running 1 test
test test_types ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests petstore-reqwest

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
