### PR TITLE
python docs templates minor fixes for jekyll

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc.mustache
@@ -40,6 +40,7 @@ Method | HTTP request | Description
 {{> api_doc_example }}
 
 ### Parameters
+
 {{^allParams}}This endpoint does not need any parameter.{{/allParams}}{{#allParams}}{{#-last}}
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------{{/-last}}{{/allParams}}
@@ -61,6 +62,7 @@ Name | Type | Description  | Notes
 
 {{#responses.0}}
 ### HTTP response details
+
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 {{#responses}}

--- a/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_doc_example.mustache
@@ -1,3 +1,4 @@
+
 ```python
 import time
 import os

--- a/modules/openapi-generator/src/main/resources/python/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_doc.mustache
@@ -4,6 +4,7 @@
 {{/description}}
 
 ## Properties
+
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 {{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{description}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}


### PR DESCRIPTION
Adding some whitespace to better handle markdown render by [jekyll](https://jekyllrb.com/)