### PR TITLE
Update Dockerfile (cli, online) to use eclipse-temurin:17.0.3_7-jre-focal

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,6 +45,7 @@ jobs:
       - name: Build and test modules/openapi-generator-cli
         shell: bash
         run: |
+          cp docker-entrypoint.sh ./modules/openapi-generator-cli 
           docker build modules/openapi-generator-cli/ -t cli-test
           docker run --rm -v "${PWD}:/local" cli-test generate \
           -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,8 @@ on:
       - pom.xml
       - modules/openapi-generator-online/pom.xml
       - modules/openapi-generator-online/Dockerfile
+      - modules/openapi-generator-cli/pom.xml
+      - modules/openapi-generator-cli/Dockerfile
   pull_request:
     paths:
       - Dockerfile
@@ -16,6 +18,8 @@ on:
       - pom.xml
       - modules/openapi-generator-online/pom.xml
       - modules/openapi-generator-online/Dockerfile
+      - modules/openapi-generator-cli/pom.xml
+      - modules/openapi-generator-cli/Dockerfile
 jobs:
   build:
     name: 'Build: Docker'
@@ -38,3 +42,11 @@ jobs:
         shell: bash
         run: |
           docker build modules/openapi-generator-online/ -t test
+      - name: Build and test modules/openapi-generator-cli
+        shell: bash
+        run: |
+          docker build modules/openapi-generator-cli/ -t cli-test
+          docker run --rm -v "${PWD}:/local" cli-test generate \
+          -i https://raw.githubusercontent.com/openapitools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml \
+          -g go \
+          -o /local/out/go

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17.0.8-alpine3.18
+FROM openjdk:11.0-jre-buster
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0-jre-buster
+FROM amazoncorretto:17.0.8-alpine3.18
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0-jre-buster
+FROM eclipse-temurin:17.0.3_7-jre-focal
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.9_9-jre-focal
 
 ADD target/openapi-generator-cli.jar /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar
 

--- a/modules/openapi-generator-cli/pom.xml
+++ b/modules/openapi-generator-cli/pom.xml
@@ -9,12 +9,9 @@
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>openapi-generator-cli</artifactId>
     <packaging>jar</packaging>
-
     <name>openapi-generator (executable)</name>
-
     <build>
         <finalName>openapi-generator-cli</finalName>
         <resources>
@@ -82,7 +79,6 @@
             </plugin>
         </plugins>
     </build>
-
     <profiles>
         <profile>
             <id>static-analysis</id>
@@ -107,9 +103,7 @@
             </build>
         </profile>
     </profiles>
-
     <dependencies>
-
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
@@ -155,5 +149,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jre-focal
+FROM eclipse-temurin:17.0.9_9-jre-focal
 
 WORKDIR /generator
 

--- a/modules/openapi-generator-online/Dockerfile
+++ b/modules/openapi-generator-online/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin:17.0.3_7-jre-focal
 
 WORKDIR /generator
 


### PR DESCRIPTION
Update Dockerfile (cli, online) to use eclipse-temurin:17.0.3_7-jre-focal
Add tests for openapi-generator-cli Dockerfile

FYI @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

