### PR TITLE
Fix decoding OpenAPIDateWithoutTime

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/OpenAPIDateWithoutTime.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/OpenAPIDateWithoutTime.mustache
@@ -23,11 +23,21 @@ import Foundation
         case wrappedDate
         case timezone
     }
+
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} enum DecodingError: Error {
+        case notADateString
+    }
     
     /// On decoding ISO8601 timezone is assumed
     {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.wrappedDate = try container.decode(Date.self)
+
+        let dateString = try container.decode(String.self)
+        guard let date = OpenISO8601DateFormatter.withoutTime.date(from: dateString) else {
+            throw DecodingError.notADateString
+        }
+        self.wrappedDate = date
+
         self.timezone = OpenISO8601DateFormatter.withoutTime.timeZone
     }
 
@@ -59,6 +69,10 @@ import Foundation
     fileprivate func normalizedWrappedDate() -> Date {
         return wrappedDate.addingTimeInterval(
             Double(timezone.secondsFromGMT(for: wrappedDate)))
+    }
+
+    {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} static func == (lhs: Self, rhs: Self) -> Bool {
+        Calendar.current.compare(lhs.wrappedDate, to: rhs.wrappedDate, toGranularity: .day) == .orderedSame
     }
 }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
@@ -24,20 +24,10 @@ public struct OpenAPIDateWithoutTime: Codable, Hashable, Equatable {
         case timezone
     }
     
-    public enum DecodingError: Error {
-        case notADateString
-    }
-    
     /// On decoding ISO8601 timezone is assumed
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-
-        let dateString = try container.decode(String.self)
-        guard let date = OpenISO8601DateFormatter.withoutTime.date(from: dateString) else {
-            throw DecodingError.notADateString
-        }
-        self.wrappedDate = date
-
+        self.wrappedDate = try container.decode(Date.self)
         self.timezone = OpenISO8601DateFormatter.withoutTime.timeZone
     }
 
@@ -69,10 +59,6 @@ public struct OpenAPIDateWithoutTime: Codable, Hashable, Equatable {
     fileprivate func normalizedWrappedDate() -> Date {
         return wrappedDate.addingTimeInterval(
             Double(timezone.secondsFromGMT(for: wrappedDate)))
-    }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        Calendar.current.compare(lhs.wrappedDate, to: rhs.wrappedDate, toGranularity: .day) == .orderedSame
     }
 }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
@@ -24,10 +24,20 @@ public struct OpenAPIDateWithoutTime: Codable, Hashable, Equatable {
         case timezone
     }
     
+    public enum DecodingError: Error {
+        case notADateString
+    }
+    
     /// On decoding ISO8601 timezone is assumed
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.wrappedDate = try container.decode(Date.self)
+
+        let dateString = try container.decode(String.self)
+        guard let date = OpenISO8601DateFormatter.withoutTime.date(from: dateString) else {
+            throw DecodingError.notADateString
+        }
+        self.wrappedDate = date
+
         self.timezone = OpenISO8601DateFormatter.withoutTime.timeZone
     }
 
@@ -59,6 +69,10 @@ public struct OpenAPIDateWithoutTime: Codable, Hashable, Equatable {
     fileprivate func normalizedWrappedDate() -> Date {
         return wrappedDate.addingTimeInterval(
             Double(timezone.secondsFromGMT(for: wrappedDate)))
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        Calendar.current.compare(lhs.wrappedDate, to: rhs.wrappedDate, toGranularity: .day) == .orderedSame
     }
 }
 

--- a/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/DateFormatTests.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/SwaggerClientTests/SwaggerClientTests/DateFormatTests.swift
@@ -111,4 +111,11 @@ class DateFormatTests: XCTestCase {
 		XCTAssert(jsonString == exampleJSONString, "Encoded JSON String: \(jsonString) should match: \(exampleJSONString)")
 	}
 
+    func testCodableOpenAPIDateWithoutTime() throws {
+        let sut = OpenAPIDateWithoutTime(wrappedDate: Date(timeIntervalSince1970: 0))
+        let encodedDate = try JSONEncoder().encode(sut)
+        let decodedDate = try JSONDecoder().decode(OpenAPIDateWithoutTime.self, from: encodedDate)
+
+        XCTAssert(sut == decodedDate, "Decoded date: \(decodedDate) should match initially given date: \(String(describing: sut))")
+    }
 }


### PR DESCRIPTION
Fix decoding OpenAPIDateWithoutTime which in previous implementation only worked when used with CodableHelper, because it encoded to String, but tried to decode from Date afterwards

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
