### PR TITLE
Fix typescript-fetch to support nullable enum properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGenericInterfaces.mustache
@@ -16,7 +16,7 @@ export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
      * @deprecated
     {{/deprecated}}
      */
-    {{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
+    {{#isReadOnly}}readonly {{/isReadOnly}}{{name}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}{{^isEnum}}{{{datatype}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}};
 {{/vars}}
 }{{#hasEnums}}
 


### PR DESCRIPTION
The typescript-fetch templates for models currently don't support nullable enums. This PR copies the `nullable` segment for non-enum properties to fix that.

<details>
<summary>Example OpenAPI spec</summary>

```json
{
  "openapi": "3.0.0",
  "paths": {
    "/": {
      "get": {
        "operationId": "GetRoot",
        "summary": "GET /",
        "description": "foo",
        "parameters": [],
        "responses": {
          "200": {
            "description": "",
            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaymentCard" } } }
          }
        }
      }
    }
  },
  "info": {
    "title": "API",
    "description": "Some API with a nullable enum",
    "version": "v1",
    "contact": {}
  },
  "tags": [],
  "servers": [],
  "components": {
    "schemas": {
      "PaymentCard": {
        "type": "object",
        "properties": {
          "cardIssuer": { "nullable": true, "enum": ["visa", "mastercard"], "type": "string" }
        },
        "required": ["cardIssuer"]
      }
    }
  }
}
```

</details>

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka