### PR TITLE
Add openapi-normalizer rule to set tags to operationId

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -628,7 +628,7 @@ public class OpenAPINormalizer {
     }
 
     /**
-     * Set the tag name to operationId
+     * Set the tag name to operationId (or "default" if operationId is empty)
      *
      * @param operation Operation
      */
@@ -643,7 +643,6 @@ public class OpenAPINormalizer {
         } else { // default to "default" if operationId is empty
             operation.addTagsItem("default");
         }
-
     }
 
     /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -80,6 +80,11 @@ public class OpenAPINormalizer {
     final String SET_TAGS_FOR_ALL_OPERATIONS = "SET_TAGS_FOR_ALL_OPERATIONS";
     String setTagsForAllOperations;
 
+    // when set to true, tags in all operations will be set to operationId or "default" if operationId
+    // is empty
+    final String SET_TAGS_TO_OPERATIONID = "SET_TAGS_TO_OPERATIONID";
+    String setTagsToOperationId;
+
     // when set to true, auto fix integer with maximum value 4294967295 (2^32-1) or long with 18446744073709551615 (2^64-1)
     // by adding x-unsigned to the schema
     final String ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE = "ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE";
@@ -117,6 +122,7 @@ public class OpenAPINormalizer {
         ruleNames.add(SIMPLIFY_BOOLEAN_ENUM);
         ruleNames.add(KEEP_ONLY_FIRST_TAG_IN_OPERATION);
         ruleNames.add(SET_TAGS_FOR_ALL_OPERATIONS);
+        ruleNames.add(SET_TAGS_TO_OPERATIONID);
         ruleNames.add(ADD_UNSIGNED_TO_INTEGER_WITH_INVALID_MAX_VALUE);
         ruleNames.add(REFACTOR_ALLOF_WITH_PROPERTIES_ONLY);
         ruleNames.add(NORMALIZE_31SPEC);
@@ -233,6 +239,8 @@ public class OpenAPINormalizer {
         processKeepOnlyFirstTagInOperation(operation);
 
         processSetTagsForAllOperations(operation);
+
+        processSetTagsToOperationId(operation);
     }
 
     /**
@@ -617,6 +625,25 @@ public class OpenAPINormalizer {
 
         operation.setTags(null);
         operation.addTagsItem(setTagsForAllOperations);
+    }
+
+    /**
+     * Set the tag name to operationId
+     *
+     * @param operation Operation
+     */
+    private void processSetTagsToOperationId(Operation operation) {
+        if (!getRule(SET_TAGS_TO_OPERATIONID)) {
+            return;
+        }
+
+        operation.setTags(null);
+        if (StringUtils.isNotEmpty(operation.getOperationId())) {
+            operation.addTagsItem(operation.getOperationId());
+        } else { // default to "default" if operationId is empty
+            operation.addTagsItem("default");
+        }
+
     }
 
     /**

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -243,6 +243,24 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testOpenAPINormalizerSetTagsToOperationId() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/enableKeepOnlyFirstTagInOperation_test.yaml");
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 2);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().size(), 1);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SET_TAGS_TO_OPERATIONID", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().size(), 1);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().size(), 1);
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getGet().getTags().get(0), "list");
+        assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getTags().get(0), "delete");
+    }
+
+    @Test
     public void testAddUnsignedToIntegerWithInvalidMaxValue() {
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/addUnsignedToIntegerWithInvalidMaxValue_test.yaml");
 


### PR DESCRIPTION
- Add openapi-normalizer rule to set tags to operationId
- add tests
- to close https://github.com/OpenAPITools/openapi-generator/issues/17145

e.g.
```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g spring -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml  -o  /tmp/spring5 --openapi-normalizer SET_TAGS_TO_OPERATIONID=true --additional-properties useTags=true
```


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
