### PR TITLE
[kotlin-client][multiplatform] fix iosSimulatorArm64 source sets

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/build.gradle.kts.mustache
@@ -71,6 +71,9 @@ kotlin {
 
         val iosSimulatorArm64Test by getting
 
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+
         val jsMain by getting {
             dependencies {
                 api("io.ktor:ktor-client-js:$ktor_version")

--- a/samples/client/petstore/kotlin-array-simple-string-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-array-simple-string-multiplatform/build.gradle.kts
@@ -71,6 +71,9 @@ kotlin {
 
         val iosSimulatorArm64Test by getting
 
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+
         val jsMain by getting {
             dependencies {
                 api("io.ktor:ktor-client-js:$ktor_version")

--- a/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/build.gradle.kts
@@ -71,6 +71,9 @@ kotlin {
 
         val iosSimulatorArm64Test by getting
 
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+
         val jsMain by getting {
             dependencies {
                 api("io.ktor:ktor-client-js:$ktor_version")

--- a/samples/client/petstore/kotlin-default-values-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/build.gradle.kts
@@ -71,6 +71,9 @@ kotlin {
 
         val iosSimulatorArm64Test by getting
 
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+
         val jsMain by getting {
             dependencies {
                 api("io.ktor:ktor-client-js:$ktor_version")

--- a/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
+++ b/samples/client/petstore/kotlin-multiplatform/build.gradle.kts
@@ -71,6 +71,9 @@ kotlin {
 
         val iosSimulatorArm64Test by getting
 
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+
         val jsMain by getting {
             dependencies {
                 api("io.ktor:ktor-client-js:$ktor_version")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier
