### PR TITLE
[Java] Fixed some files

### DIFF
--- a/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
+++ b/modules/openapi-generator-online/src/main/java/org/openapitools/codegen/online/service/GenApiService.java
@@ -57,16 +57,27 @@ public class GenApiService implements GenApiDelegate {
     static {
         List<CodegenConfig> extensions = CodegenConfigLoader.getAll();
         for (CodegenConfig config : extensions) {
-            if (config.getTag().equals(CodegenType.CLIENT)
-                    || config.getTag().equals(CodegenType.DOCUMENTATION)) {
-                clients.add(config.getName());
-            } else if (config.getTag().equals(CodegenType.SERVER)) {
-                servers.add(config.getName());
-            }
+            processCodegenConfig(config);
         }
 
         clients.sort(String.CASE_INSENSITIVE_ORDER);
         servers.sort(String.CASE_INSENSITIVE_ORDER);
+    }
+
+    private static void processCodegenConfig(CodegenConfig config) {
+        if (isClientOrDocumentation(config)) {
+            clients.add(config.getName());
+        } else if (isServer(config)) {
+            servers.add(config.getName());
+        }
+    }
+
+    private static boolean isClientOrDocumentation(CodegenConfig config) {
+        return config.getTag().equals(CodegenType.CLIENT) || config.getTag().equals(CodegenType.DOCUMENTATION);
+    }
+
+    private static boolean isServer(CodegenConfig config) {
+        return config.getTag().equals(CodegenType.SERVER);
     }
 
     @Autowired

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/OpenAPISerializer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/serializer/OpenAPISerializer.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.swagger.v3.oas.models.OpenAPI;
-
+import java.util.Map;
 import java.io.IOException;
 import java.util.Map.Entry;
 
@@ -14,35 +14,35 @@ public class OpenAPISerializer extends JsonSerializer<OpenAPI> {
     public void serialize(OpenAPI value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         if (value != null) {
             gen.writeStartObject();
-            gen.writeStringField("openapi", value.getOpenapi());
-            if(value.getInfo() != null) {
-                gen.writeObjectField("info", value.getInfo());
-            }
-            if(value.getExternalDocs() != null) {
-                gen.writeObjectField("externalDocs", value.getExternalDocs());
-            }
-            if(value.getServers() != null) {
-                gen.writeObjectField("servers", value.getServers());
-            }
-            if(value.getSecurity() != null) {
-                gen.writeObjectField("security", value.getSecurity());
-            }
-            if(value.getTags() != null) {
-                gen.writeObjectField("tags", value.getTags());
-            }
-            if(value.getPaths() != null) {
-                gen.writeObjectField("paths", value.getPaths());
-            }
-            if(value.getComponents() != null) {
-                gen.writeObjectField("components", value.getComponents());
-            }
-            if(value.getExtensions() != null) {
-                for (Entry<String, Object> e : value.getExtensions().entrySet()) {
-                    gen.writeObjectField(e.getKey(), e.getValue());
-                }
-            }
+            writeFieldIfNotNull(gen, "openapi", value.getOpenapi());
+            writeObjectFieldIfNotNull(gen, "info", value.getInfo());
+            writeObjectFieldIfNotNull(gen, "externalDocs", value.getExternalDocs());
+            writeObjectFieldIfNotNull(gen, "servers", value.getServers());
+            writeObjectFieldIfNotNull(gen, "security", value.getSecurity());
+            writeObjectFieldIfNotNull(gen, "tags", value.getTags());
+            writeObjectFieldIfNotNull(gen, "paths", value.getPaths());
+            writeObjectFieldIfNotNull(gen, "components", value.getComponents());
+            writeExtensionsIfNotNull(gen, value.getExtensions());
             gen.writeEndObject();
         }
     }
+    private void writeFieldIfNotNull(JsonGenerator gen, String fieldName, String value) throws IOException {
+        if (value != null) {
+            gen.writeStringField(fieldName, value);
+        }
+    }
 
+    private void writeObjectFieldIfNotNull(JsonGenerator gen, String fieldName, Object value) throws IOException {
+        if (value != null) {
+            gen.writeObjectField(fieldName, value);
+        }
+    }
+
+    private void writeExtensionsIfNotNull(JsonGenerator gen, Map<String, Object> extensions) throws IOException {
+        if (extensions != null) {
+            for (Entry<String, Object> entry : extensions.entrySet()) {
+                gen.writeObjectField(entry.getKey(), entry.getValue());
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert @dr4ke616 @karismann @Zomzog @andrewemery @4brunu @yutaka0m @stefankoppier @TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka 

