### PR TITLE
fix: chsarp get file name from content disposition

### DIFF
--- a/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/ApiClient.mustache
@@ -104,12 +104,25 @@ namespace {{packageName}}.Client
                 headers.Add(responseHeader.Key + "=" +  ClientUtils.ParameterToString(responseHeader.Value));
             }
 
+            // RFC 2183 & RFC 2616
+            var fileNameRegex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$", RegexOptions.IgnoreCase);
             if (type == typeof(byte[])) // return byte array
             {
                 return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
             }
             else if (type == typeof(FileParameter))
             {
+                if (headers != null) {
+                    foreach (var header in headers)
+                    {
+                        var match = fileNameRegex.Match(header.ToString());
+                        if (match.Success)
+                        {
+                            string fileName = ClientUtils.SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));
+                            return new FileParameter(fileName, await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
+                        }
+                    }
+                }
                 return new FileParameter(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
             }
 
@@ -122,10 +135,10 @@ namespace {{packageName}}.Client
                     var filePath = string.IsNullOrEmpty(_configuration.TempFolderPath)
                         ? Path.GetTempPath()
                         : _configuration.TempFolderPath;
-                    var regex = new Regex(@"Content-Disposition=.*filename=['""]?([^'""\s]+)['""]?$");
+
                     foreach (var header in headers)
                     {
-                        var match = regex.Match(header.ToString());
+                        var match = fileNameRegex.Match(header.ToString());
                         if (match.Success)
                         {
                             string fileName = filePath + ClientUtils.SanitizeFilename(match.Groups[1].Value.Replace("\"", "").Replace("'", ""));


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

## Summary

Download a file can't get the file name from the header, content-disposition.

The generator will generate the `FileParameter` class, and the code doesn't handle this type.

And also, according to RFC 2616, the HTTP headers are case insensitive.

## OpenAPI Example
```yaml
openapi: 3.0.0
info:
  title: Swagger Petstore - OpenAPI 3.1
  description: |-
  version: 1.0.11
servers:
  - url: http://localhost:8080
tags:
  - name: file
    description: A Restful API to manage files
paths:
  /files/${fileId}:
    get:
      tags:
        - file
      description: Download an existing file by Id
      operationId: downloadFile
      parameters:  
        - in: path
          name: fileId
          schema:
            type: string
            format: uuid
          required: true
      responses:
        '200':
          description: Successful operation
          content:
            application/octet-stream:
              schema:
                type: string
                format: binary
```

### OpenAPI CLI Command
```shell
openapi-generator-cli generate -g csharp --additional-properties=library=httpclient --additional-properties=targetFramework=net6.0 -i file.yaml 
```

## Expect
Get file name: `example.txt`

## Actual
Get file name: 'no_name_provided'
![Screenshot from 2023-11-25 21-25-56](https://github.com/OpenAPITools/openapi-generator/assets/7081582/d4a55947-c219-4724-8478-a381c242ae8f)


## Server
If you want to have a quick test, you can use this Golang code:
```Golang
package main

import (
	"github.com/gin-gonic/gin"
	"log"
	"path/filepath"
)

func main() {
	r := gin.Default()
	r.GET("/files/:fileId", func(c *gin.Context) {
		fileId := c.Param("fileId")
		log.Println(fileId)
		filePath := filepath.Join("./", "example.txt")
		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT")
		c.Header("Content-Disposition", "attachment; filename=example.txt")
		c.Header("Content-Type", "application/octet-stream")
		c.File(filePath)
	})
	r.Run() // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
}
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

