### PR TITLE
Add enum name mapping support to PHP generators

### DIFF
--- a/bin/configs/php-nextgen.yaml
+++ b/bin/configs/php-nextgen.yaml
@@ -2,3 +2,5 @@ generatorName: php-nextgen
 outputDir: samples/client/petstore/php-nextgen/OpenAPIClient-php
 inputSpec: modules/openapi-generator/src/test/resources/3_0/php-nextgen/petstore-with-fake-endpoints-models-for-testing.yaml
 templateDir: modules/openapi-generator/src/main/resources/php-nextgen
+enumNameMappings:
+  delivered: SHIPPED

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPhpCodegen.java
@@ -742,6 +742,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (enumNameMapping.containsKey(name)) {
+            return enumNameMapping.get(name);
+        }
+
         if (name.length() == 0) {
             return "EMPTY";
         }
@@ -778,6 +782,10 @@ public abstract class AbstractPhpCodegen extends DefaultCodegen implements Codeg
 
     @Override
     public String toEnumName(CodegenProperty property) {
+        if (enumNameMapping.containsKey(property.name)) {
+            return enumNameMapping.get(property.name);
+        }
+
         String enumName = underscore(toGenericName(property.name)).toUpperCase(Locale.ROOT);
 
         // remove [] for array or map of enum

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -259,7 +259,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
 
     public const STATUS_PLACED = 'placed';
     public const STATUS_APPROVED = 'approved';
-    public const STATUS_DELIVERED = 'delivered';
+    public const STATUS_SHIPPED = 'delivered';
 
     /**
      * Gets allowable values of the enum
@@ -271,7 +271,7 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
         return [
             self::STATUS_PLACED,
             self::STATUS_APPROVED,
-            self::STATUS_DELIVERED,
+            self::STATUS_SHIPPED,
         ];
     }
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnum.php
@@ -40,7 +40,7 @@ enum OuterEnum: string
 
     case APPROVED = 'approved';
 
-    case DELIVERED = 'delivered';
+    case SHIPPED = 'delivered';
 
 }
 

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterEnumDefaultValue.php
@@ -40,7 +40,7 @@ enum OuterEnumDefaultValue: string
 
     case APPROVED = 'approved';
 
-    case DELIVERED = 'delivered';
+    case SHIPPED = 'delivered';
 
 }
 


### PR DESCRIPTION
- Add enum name mapping support to PHP generators
- add tests

cc @jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ybelenko (2018/07), @renepardon (2018/12)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

