### PR TITLE
include {min|max}Items validation in rust-server models

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/models.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/models.mustache
@@ -296,6 +296,19 @@ pub struct {{{classname}}} {
             range(min = {{minimum}}),
             {{/maximum}}
         {{/minimum}}
+        {{#maxItems}}
+            {{#minItems}}
+            length(min = {{minItems}}, max = {{maxLength}}),
+            {{/minItems}}
+            {{^minItems}}
+            length(max = {{maxItems}}),
+            {{/minItems}}
+        {{/maxItems}}
+        {{^maxItems}}
+            {{#minItems}}
+            length(min = {{minItems}}),
+            {{/minItems}}
+        {{/maxItems}}
         )]
 {{/hasValidation}}
 {{#required}}


### PR DESCRIPTION
The JSON Schema Array validation keywords `minItems` and `maxItems` were missing in the template for `model.rs`. 

Fixes #17136 


