### PR TITLE
fix(sec): upgrade urllib3 to 2.0.7

### DIFF
--- a/samples/server/petstore/python-fastapi/requirements.txt
+++ b/samples/server/petstore/python-fastapi/requirements.txt
@@ -30,7 +30,7 @@ six==1.16.0
 starlette==0.27.0
 typing-extensions==3.10.0.0
 ujson==4.0.2
-urllib3==1.26.5
+urllib3==2.0.7
 uvicorn==0.13.4
 uvloop==0.14.0
 watchgod==0.7


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.26.5
- [CVE-2023-43804](https://www.oscs1024.com/hd/CVE-2023-43804)


### What did I do？
Upgrade urllib3 from 1.26.5 to 2.0.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS