### PR TITLE
fix  implicit conversion of symbol to string error in TypeScript-Aurelia template ts(2731)

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-aurelia/Api.ts.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-aurelia/Api.ts.mustache
@@ -59,7 +59,7 @@ export class Api {
    */
   protected ensureParamIsSet<T>(context: string, params: T, paramName: keyof T): void {
     if (null === params[paramName]) {
-      throw new Error(`Missing required parameter ${paramName} when calling ${context}`);
+      throw new Error(`Missing required parameter ${String(paramName)} when calling ${context}`);
     }
   }
 }


### PR DESCRIPTION
Very minor change to explicit conversion of symbol to string rather than implicit

This is a fix is for issue  #17253. Details of the problem and resolution all in #17253 