### PR TITLE
[csharp] Mark optional fields in generated client properties as nullable

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -1513,6 +1513,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 property.isInherited = true;
             }
         }
+
+        if (!GENERICHOST.equals(getLibrary()) && !property.dataType.endsWith("?") && !property.required && (nullReferenceTypesFlag || this.getNullableTypes().contains(property.dataType))) {
+            property.dataType = property.dataType + "?";
+        }
+        // Don't attach a '?' to enums - that's already handled by the templates
+        if (!GENERICHOST.equals(getLibrary()) && !property.isEnum && !property.datatypeWithEnum.endsWith("?") && !property.required && (nullReferenceTypesFlag || this.getNullableTypes().contains(property.datatypeWithEnum))) {
+            property.datatypeWithEnum = property.datatypeWithEnum + "?";
+        }
     }
 
     @Override

--- a/samples/client/echo_api/csharp-restsharp/docs/Bird.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/Bird.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Size** | **string** |  | [optional] 
-**Color** | **string** |  | [optional] 
+**Size** | **string?** |  | [optional] 
+**Color** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/Category.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/Category.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Name** | **string** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/DataQuery.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/DataQuery.md
@@ -4,11 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** | Query | [optional] 
-**Outcomes** | **List&lt;Query.OutcomesEnum&gt;** |  | [optional] 
-**Suffix** | **string** | test suffix | [optional] 
-**Text** | **string** | Some text containing white spaces | [optional] 
-**Date** | **DateTime** | A date | [optional] 
+**Id** | **long?** | Query | [optional] 
+**Outcomes** | **List&lt;Query.OutcomesEnum&gt;?** |  | [optional] 
+**Suffix** | **string?** | test suffix | [optional] 
+**Text** | **string?** | Some text containing white spaces | [optional] 
+**Date** | **DateTime?** | A date | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/DefaultValue.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/DefaultValue.md
@@ -5,14 +5,14 @@ to test the default value of properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayStringEnumRefDefault** | [**List&lt;StringEnumRef&gt;**](StringEnumRef.md) |  | [optional] 
-**ArrayStringEnumDefault** | **List&lt;DefaultValue.ArrayStringEnumDefaultEnum&gt;** |  | [optional] 
-**ArrayStringDefault** | **List&lt;string&gt;** |  | [optional] 
-**ArrayIntegerDefault** | **List&lt;int&gt;** |  | [optional] 
-**ArrayString** | **List&lt;string&gt;** |  | [optional] 
-**ArrayStringNullable** | **List&lt;string&gt;** |  | [optional] 
-**ArrayStringExtensionNullable** | **List&lt;string&gt;** |  | [optional] 
-**StringNullable** | **string** |  | [optional] 
+**ArrayStringEnumRefDefault** | [**List&lt;StringEnumRef&gt;?**](StringEnumRef.md) |  | [optional] 
+**ArrayStringEnumDefault** | **List&lt;DefaultValue.ArrayStringEnumDefaultEnum&gt;?** |  | [optional] 
+**ArrayStringDefault** | **List&lt;string&gt;?** |  | [optional] 
+**ArrayIntegerDefault** | **List&lt;int&gt;?** |  | [optional] 
+**ArrayString** | **List&lt;string&gt;?** |  | [optional] 
+**ArrayStringNullable** | **List&lt;string&gt;?** |  | [optional] 
+**ArrayStringExtensionNullable** | **List&lt;string&gt;?** |  | [optional] 
+**StringNullable** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/NumberPropertiesOnly.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/NumberPropertiesOnly.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Number** | **decimal** |  | [optional] 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
+**Number** | **decimal?** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/Pet.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/Pet.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | 
-**Category** | [**Category**](Category.md) |  | [optional] 
+**Category** | [**Category?**](Category.md) |  | [optional] 
 **PhotoUrls** | **List&lt;string&gt;** |  | 
-**Tags** | [**List&lt;Tag&gt;**](Tag.md) |  | [optional] 
-**Status** | **string** | pet status in the store | [optional] 
+**Tags** | [**List&lt;Tag&gt;?**](Tag.md) |  | [optional] 
+**Status** | **string?** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/Query.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/Query.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** | Query | [optional] 
-**Outcomes** | **List&lt;Query.OutcomesEnum&gt;** |  | [optional] 
+**Id** | **long?** | Query | [optional] 
+**Outcomes** | **List&lt;Query.OutcomesEnum&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/Tag.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/Tag.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Name** | **string** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Size** | **string** |  | [optional] 
-**Color** | **string** |  | [optional] 
-**Id** | **long** |  | [optional] 
-**Name** | **string** |  | [optional] 
+**Size** | **string?** |  | [optional] 
+**Color** | **string?** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/docs/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Values** | **List&lt;string&gt;** |  | [optional] 
+**Values** | **List&lt;string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Bird.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Bird.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="size">size.</param>
         /// <param name="color">color.</param>
-        public Bird(string size = default(string), string color = default(string))
+        public Bird(string? size = default(string?), string? color = default(string?))
         {
             this.Size = size;
             this.Color = color;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Size
         /// </summary>
         [DataMember(Name = "size", EmitDefaultValue = false)]
-        public string Size { get; set; }
+        public string? Size { get; set; }
 
         /// <summary>
         /// Gets or Sets Color
         /// </summary>
         [DataMember(Name = "color", EmitDefaultValue = false)]
-        public string Color { get; set; }
+        public string? Color { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Category.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Category(long id = default(long), string name = default(string))
+        public Category(long? id = default(long?), string? name = default(string?))
         {
             this.Id = id;
             this.Name = name;
@@ -48,14 +48,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>1</example>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         /// <example>Dogs</example>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/DataQuery.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/DataQuery.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="date">A date.</param>
         /// <param name="id">Query.</param>
         /// <param name="outcomes">outcomes.</param>
-        public DataQuery(string suffix = default(string), string text = default(string), DateTime date = default(DateTime), long id = default(long), List<OutcomesEnum> outcomes = default(List<OutcomesEnum>)) : base(id, outcomes)
+        public DataQuery(string? suffix = default(string?), string? text = default(string?), DateTime? date = default(DateTime?), long? id = default(long?), List<OutcomesEnum> outcomes = default(List<OutcomesEnum>)) : base(id, outcomes)
         {
             this.Suffix = suffix;
             this.Text = text;
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>test suffix</value>
         [DataMember(Name = "suffix", EmitDefaultValue = false)]
-        public string Suffix { get; set; }
+        public string? Suffix { get; set; }
 
         /// <summary>
         /// Some text containing white spaces
@@ -60,14 +60,14 @@ namespace Org.OpenAPITools.Model
         /// <value>Some text containing white spaces</value>
         /// <example>Some text</example>
         [DataMember(Name = "text", EmitDefaultValue = false)]
-        public string Text { get; set; }
+        public string? Text { get; set; }
 
         /// <summary>
         /// A date
         /// </summary>
         /// <value>A date</value>
         [DataMember(Name = "date", EmitDefaultValue = false)]
-        public DateTime Date { get; set; }
+        public DateTime? Date { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/DefaultValue.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/DefaultValue.cs
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="arrayStringNullable">arrayStringNullable.</param>
         /// <param name="arrayStringExtensionNullable">arrayStringExtensionNullable.</param>
         /// <param name="stringNullable">stringNullable.</param>
-        public DefaultValue(List<StringEnumRef> arrayStringEnumRefDefault = default(List<StringEnumRef>), List<ArrayStringEnumDefaultEnum> arrayStringEnumDefault = default(List<ArrayStringEnumDefaultEnum>), List<string> arrayStringDefault = default(List<string>), List<int> arrayIntegerDefault = default(List<int>), List<string> arrayString = default(List<string>), List<string> arrayStringNullable = default(List<string>), List<string> arrayStringExtensionNullable = default(List<string>), string stringNullable = default(string))
+        public DefaultValue(List<StringEnumRef>? arrayStringEnumRefDefault = default(List<StringEnumRef>?), List<ArrayStringEnumDefaultEnum> arrayStringEnumDefault = default(List<ArrayStringEnumDefaultEnum>), List<string>? arrayStringDefault = default(List<string>?), List<int>? arrayIntegerDefault = default(List<int>?), List<string>? arrayString = default(List<string>?), List<string>? arrayStringNullable = default(List<string>?), List<string>? arrayStringExtensionNullable = default(List<string>?), string? stringNullable = default(string?))
         {
             this.ArrayStringEnumRefDefault = arrayStringEnumRefDefault;
             this.ArrayStringEnumDefault = arrayStringEnumDefault;
@@ -84,49 +84,49 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayStringEnumRefDefault
         /// </summary>
         [DataMember(Name = "array_string_enum_ref_default", EmitDefaultValue = false)]
-        public List<StringEnumRef> ArrayStringEnumRefDefault { get; set; }
+        public List<StringEnumRef>? ArrayStringEnumRefDefault { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayStringEnumDefault
         /// </summary>
         [DataMember(Name = "array_string_enum_default", EmitDefaultValue = false)]
-        public List<DefaultValue.ArrayStringEnumDefaultEnum> ArrayStringEnumDefault { get; set; }
+        public List<DefaultValue.ArrayStringEnumDefaultEnum>? ArrayStringEnumDefault { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayStringDefault
         /// </summary>
         [DataMember(Name = "array_string_default", EmitDefaultValue = false)]
-        public List<string> ArrayStringDefault { get; set; }
+        public List<string>? ArrayStringDefault { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayIntegerDefault
         /// </summary>
         [DataMember(Name = "array_integer_default", EmitDefaultValue = false)]
-        public List<int> ArrayIntegerDefault { get; set; }
+        public List<int>? ArrayIntegerDefault { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayString
         /// </summary>
         [DataMember(Name = "array_string", EmitDefaultValue = false)]
-        public List<string> ArrayString { get; set; }
+        public List<string>? ArrayString { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayStringNullable
         /// </summary>
         [DataMember(Name = "array_string_nullable", EmitDefaultValue = true)]
-        public List<string> ArrayStringNullable { get; set; }
+        public List<string>? ArrayStringNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayStringExtensionNullable
         /// </summary>
         [DataMember(Name = "array_string_extension_nullable", EmitDefaultValue = true)]
-        public List<string> ArrayStringExtensionNullable { get; set; }
+        public List<string>? ArrayStringExtensionNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets StringNullable
         /// </summary>
         [DataMember(Name = "string_nullable", EmitDefaultValue = true)]
-        public string StringNullable { get; set; }
+        public string? StringNullable { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/NumberPropertiesOnly.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/NumberPropertiesOnly.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="number">number.</param>
         /// <param name="varFloat">varFloat.</param>
         /// <param name="varDouble">varDouble.</param>
-        public NumberPropertiesOnly(decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double))
+        public NumberPropertiesOnly(decimal? number = default(decimal?), float? varFloat = default(float?), double? varDouble = default(double?))
         {
             this.Number = number;
             this.VarFloat = varFloat;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Number
         /// </summary>
         [DataMember(Name = "number", EmitDefaultValue = false)]
-        public decimal Number { get; set; }
+        public decimal? Number { get; set; }
 
         /// <summary>
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -146,14 +146,14 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)50.2)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)50.2)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 50.2.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)0.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)0.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 0.8.", new [] { "VarDouble" });
             }

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Pet.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), string name = default(string), Category category = default(Category), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), string name = default(string), Category? category = default(Category?), List<string> photoUrls = default(List<string>), List<Tag>? tags = default(List<Tag>?), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>10</example>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
@@ -117,7 +117,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Category
         /// </summary>
         [DataMember(Name = "category", EmitDefaultValue = false)]
-        public Category Category { get; set; }
+        public Category? Category { get; set; }
 
         /// <summary>
         /// Gets or Sets PhotoUrls
@@ -129,7 +129,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        public List<Tag> Tags { get; set; }
+        public List<Tag>? Tags { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Query.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Query.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">Query.</param>
         /// <param name="outcomes">outcomes.</param>
-        public Query(long id = default(long), List<OutcomesEnum> outcomes = default(List<OutcomesEnum>))
+        public Query(long? id = default(long?), List<OutcomesEnum> outcomes = default(List<OutcomesEnum>))
         {
             this.Id = id;
             this.Outcomes = outcomes;
@@ -73,13 +73,13 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Query</value>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Outcomes
         /// </summary>
         [DataMember(Name = "outcomes", EmitDefaultValue = false)]
-        public List<Query.OutcomesEnum> Outcomes { get; set; }
+        public List<Query.OutcomesEnum>? Outcomes { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string? name = default(string?))
         {
             this.Id = id;
             this.Name = name;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="color">color.</param>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(string size = default(string), string color = default(string), long id = default(long), string name = default(string))
+        public TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(string? size = default(string?), string? color = default(string?), long? id = default(long?), string? name = default(string?))
         {
             this.Size = size;
             this.Color = color;
@@ -51,27 +51,27 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Size
         /// </summary>
         [DataMember(Name = "size", EmitDefaultValue = false)]
-        public string Size { get; set; }
+        public string? Size { get; set; }
 
         /// <summary>
         /// Gets or Sets Color
         /// </summary>
         [DataMember(Name = "color", EmitDefaultValue = false)]
-        public string Color { get; set; }
+        public string? Color { get; set; }
 
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
         /// <example>1</example>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         /// <example>Dogs</example>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter" /> class.
         /// </summary>
         /// <param name="values">values.</param>
-        public TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(List<string> values = default(List<string>))
+        public TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(List<string>? values = default(List<string>?))
         {
             this.Values = values;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Values
         /// </summary>
         [DataMember(Name = "values", EmitDefaultValue = false)]
-        public List<string> Values { get; set; }
+        public List<string>? Values { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/Env.md
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/Env.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Dummy** | **string** |  | [optional] 
+**Dummy** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/PropertyNameMapping.md
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/docs/PropertyNameMapping.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HttpDebugOperation** | **string** |  | [optional] 
-**UnderscoreType** | **string** |  | [optional] 
-**Type** | **string** |  | [optional] 
-**TypeWithUnderscore** | **string** |  | [optional] 
+**HttpDebugOperation** | **string?** |  | [optional] 
+**UnderscoreType** | **string?** |  | [optional] 
+**Type** | **string?** |  | [optional] 
+**TypeWithUnderscore** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/Env.cs
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/Env.cs
@@ -35,7 +35,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Env" /> class.
         /// </summary>
         /// <param name="dummy">dummy.</param>
-        public Env(string dummy = default(string))
+        public Env(string? dummy = default(string?))
         {
             this.Dummy = dummy;
         }
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Dummy
         /// </summary>
         [DataMember(Name = "dummy", EmitDefaultValue = false)]
-        public string Dummy { get; set; }
+        public string? Dummy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/PropertyNameMapping.cs
+++ b/samples/client/petstore/csharp-restsharp-name-parameter-mappings/src/Org.OpenAPITools/Model/PropertyNameMapping.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="underscoreType">underscoreType.</param>
         /// <param name="type">type.</param>
         /// <param name="typeWithUnderscore">typeWithUnderscore.</param>
-        public PropertyNameMapping(string httpDebugOperation = default(string), string underscoreType = default(string), string type = default(string), string typeWithUnderscore = default(string))
+        public PropertyNameMapping(string? httpDebugOperation = default(string?), string? underscoreType = default(string?), string? type = default(string?), string? typeWithUnderscore = default(string?))
         {
             this.HttpDebugOperation = httpDebugOperation;
             this.UnderscoreType = underscoreType;
@@ -50,25 +50,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HttpDebugOperation
         /// </summary>
         [DataMember(Name = "http_debug_operation", EmitDefaultValue = false)]
-        public string HttpDebugOperation { get; set; }
+        public string? HttpDebugOperation { get; set; }
 
         /// <summary>
         /// Gets or Sets UnderscoreType
         /// </summary>
         [DataMember(Name = "_type", EmitDefaultValue = false)]
-        public string UnderscoreType { get; set; }
+        public string? UnderscoreType { get; set; }
 
         /// <summary>
         /// Gets or Sets Type
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
         /// Gets or Sets TypeWithUnderscore
         /// </summary>
         [DataMember(Name = "type_", EmitDefaultValue = false)]
-        public string TypeWithUnderscore { get; set; }
+        public string? TypeWithUnderscore { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this._Code = code;
             if (this.Code != null)
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code
+        public int? Code
         {
             get{ return _Code;}
             set
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
                 _flagCode = true;
             }
         }
-        private int _Code;
+        private int? _Code;
         private bool _flagCode;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -85,7 +85,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy
+        public bool? Mealy
         {
             get{ return _Mealy;}
             set
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
                 _flagMealy = true;
             }
         }
-        private bool _Mealy;
+        private bool? _Mealy;
         private bool _flagMealy;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this._LengthCm = lengthCm;
             if (this.LengthCm != null)
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm
+        public decimal? LengthCm
         {
             get{ return _LengthCm;}
             set
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
                 _flagLengthCm = true;
             }
         }
-        private decimal _LengthCm;
+        private decimal? _LengthCm;
         private bool _flagLengthCm;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this._LengthCm = lengthCm;
             this._Sweet = sweet;
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet
+        public bool? Sweet
         {
             get{ return _Sweet;}
             set
@@ -89,7 +89,7 @@ namespace Org.OpenAPITools.Model
                 _flagSweet = true;
             }
         }
-        private bool _Sweet;
+        private bool? _Sweet;
         private bool _flagSweet;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Cat.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this._Declawed = declawed;
             if (this.Declawed != null)
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed
+        public bool? Declawed
         {
             get{ return _Declawed;}
             set
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
                 _flagDeclawed = true;
             }
         }
-        private bool _Declawed;
+        private bool? _Declawed;
         private bool _flagDeclawed;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id
+        public long? Id
         {
             get{ return _Id;}
             set
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private long _Id;
+        private long? _Id;
         private bool _flagId;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this._DateOnlyProperty = dateOnlyProperty;
             if (this.DateOnlyProperty != null)
@@ -52,7 +52,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [JsonConverter(typeof(OpenAPIDateConverter))]
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
-        public DateTime DateOnlyProperty
+        public DateTime? DateOnlyProperty
         {
             get{ return _DateOnlyProperty;}
             set
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
                 _flagDateOnlyProperty = true;
             }
         }
-        private DateTime _DateOnlyProperty;
+        private DateTime? _DateOnlyProperty;
         private bool _flagDateOnlyProperty;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this._Number = number;
             // to ensure "varByte" is required (not null)
@@ -160,7 +160,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer
+        public int? Integer
         {
             get{ return _Integer;}
             set
@@ -169,7 +169,7 @@ namespace Org.OpenAPITools.Model
                 _flagInteger = true;
             }
         }
-        private int _Integer;
+        private int? _Integer;
         private bool _flagInteger;
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32
+        public int? Int32
         {
             get{ return _Int32;}
             set
@@ -193,7 +193,7 @@ namespace Org.OpenAPITools.Model
                 _flagInt32 = true;
             }
         }
-        private int _Int32;
+        private int? _Int32;
         private bool _flagInt32;
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger
+        public uint? UnsignedInteger
         {
             get{ return _UnsignedInteger;}
             set
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Model
                 _flagUnsignedInteger = true;
             }
         }
-        private uint _UnsignedInteger;
+        private uint? _UnsignedInteger;
         private bool _flagUnsignedInteger;
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64
+        public long? Int64
         {
             get{ return _Int64;}
             set
@@ -241,7 +241,7 @@ namespace Org.OpenAPITools.Model
                 _flagInt64 = true;
             }
         }
-        private long _Int64;
+        private long? _Int64;
         private bool _flagInt64;
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong
+        public ulong? UnsignedLong
         {
             get{ return _UnsignedLong;}
             set
@@ -265,7 +265,7 @@ namespace Org.OpenAPITools.Model
                 _flagUnsignedLong = true;
             }
         }
-        private ulong _UnsignedLong;
+        private ulong? _UnsignedLong;
         private bool _flagUnsignedLong;
 
         /// <summary>
@@ -304,7 +304,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat
+        public float? VarFloat
         {
             get{ return _VarFloat;}
             set
@@ -313,7 +313,7 @@ namespace Org.OpenAPITools.Model
                 _flagVarFloat = true;
             }
         }
-        private float _VarFloat;
+        private float? _VarFloat;
         private bool _flagVarFloat;
 
         /// <summary>
@@ -328,7 +328,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble
+        public double? VarDouble
         {
             get{ return _VarDouble;}
             set
@@ -337,7 +337,7 @@ namespace Org.OpenAPITools.Model
                 _flagVarDouble = true;
             }
         }
-        private double _VarDouble;
+        private double? _VarDouble;
         private bool _flagVarDouble;
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal
+        public decimal? VarDecimal
         {
             get{ return _VarDecimal;}
             set
@@ -361,7 +361,7 @@ namespace Org.OpenAPITools.Model
                 _flagVarDecimal = true;
             }
         }
-        private decimal _VarDecimal;
+        private decimal? _VarDecimal;
         private bool _flagVarDecimal;
 
         /// <summary>
@@ -475,7 +475,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime
+        public DateTime? DateTime
         {
             get{ return _DateTime;}
             set
@@ -484,7 +484,7 @@ namespace Org.OpenAPITools.Model
                 _flagDateTime = true;
             }
         }
-        private DateTime _DateTime;
+        private DateTime? _DateTime;
         private bool _flagDateTime;
 
         /// <summary>
@@ -500,7 +500,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid
+        public Guid? Uuid
         {
             get{ return _Uuid;}
             set
@@ -509,7 +509,7 @@ namespace Org.OpenAPITools.Model
                 _flagUuid = true;
             }
         }
-        private Guid _Uuid;
+        private Guid? _Uuid;
         private bool _flagUuid;
 
         /// <summary>
@@ -759,38 +759,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -807,26 +807,26 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this._UuidWithPattern = uuidWithPattern;
             if (this.UuidWithPattern != null)
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern
+        public Guid? UuidWithPattern
         {
             get{ return _UuidWithPattern;}
             set
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
                 _flagUuidWithPattern = true;
             }
         }
-        private Guid _UuidWithPattern;
+        private Guid? _UuidWithPattern;
         private bool _flagUuidWithPattern;
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid
+        public Guid? Uuid
         {
             get{ return _Uuid;}
             set
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
                 _flagUuid = true;
             }
         }
-        private Guid _Uuid;
+        private Guid? _Uuid;
         private bool _flagUuid;
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime
+        public DateTime? DateTime
         {
             get{ return _DateTime;}
             set
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
                 _flagDateTime = true;
             }
         }
-        private DateTime _DateTime;
+        private DateTime? _DateTime;
         private bool _flagDateTime;
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this._Name = name;
             if (this.Name != null)
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name
+        public int? Name
         {
             get{ return _Name;}
             set
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
                 _flagName = true;
             }
         }
-        private int _Name;
+        private int? _Name;
         private bool _flagName;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Name.cs
@@ -84,7 +84,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -122,7 +122,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this._JustNumber = justNumber;
             if (this.JustNumber != null)
@@ -53,7 +53,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber
+        public decimal? JustNumber
         {
             get{ return _JustNumber;}
             set
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
                 _flagJustNumber = true;
             }
         }
-        private decimal _JustNumber;
+        private decimal? _JustNumber;
         private bool _flagJustNumber;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this._Uuid = uuid;
             if (this.Uuid != null)
@@ -93,7 +93,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id
+        public decimal? Id
         {
             get{ return _Id;}
             set
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private decimal _Id;
+        private decimal? _Id;
         private bool _flagId;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Order.cs
@@ -94,7 +94,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this._Id = id;
             if (this.Id != null)
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id
+        public long? Id
         {
             get{ return _Id;}
             set
@@ -137,7 +137,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private long _Id;
+        private long? _Id;
         private bool _flagId;
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId
+        public long? PetId
         {
             get{ return _PetId;}
             set
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
                 _flagPetId = true;
             }
         }
-        private long _PetId;
+        private long? _PetId;
         private bool _flagPetId;
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity
+        public int? Quantity
         {
             get{ return _Quantity;}
             set
@@ -185,7 +185,7 @@ namespace Org.OpenAPITools.Model
                 _flagQuantity = true;
             }
         }
-        private int _Quantity;
+        private int? _Quantity;
         private bool _flagQuantity;
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate
+        public DateTime? ShipDate
         {
             get{ return _ShipDate;}
             set
@@ -210,7 +210,7 @@ namespace Org.OpenAPITools.Model
                 _flagShipDate = true;
             }
         }
-        private DateTime _ShipDate;
+        private DateTime? _ShipDate;
         private bool _flagShipDate;
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete
+        public bool? Complete
         {
             get{ return _Complete;}
             set
@@ -234,7 +234,7 @@ namespace Org.OpenAPITools.Model
                 _flagComplete = true;
             }
         }
-        private bool _Complete;
+        private bool? _Complete;
         private bool _flagComplete;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this._MyNumber = myNumber;
             if (this.MyNumber != null)
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber
+        public decimal? MyNumber
         {
             get{ return _MyNumber;}
             set
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
                 _flagMyNumber = true;
             }
         }
-        private decimal _MyNumber;
+        private decimal? _MyNumber;
         private bool _flagMyNumber;
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean
+        public bool? MyBoolean
         {
             get{ return _MyBoolean;}
             set
@@ -119,7 +119,7 @@ namespace Org.OpenAPITools.Model
                 _flagMyBoolean = true;
             }
         }
-        private bool _MyBoolean;
+        private bool? _MyBoolean;
         private bool _flagMyBoolean;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Pet.cs
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -143,7 +143,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id
+        public long? Id
         {
             get{ return _Id;}
             set
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private long _Id;
+        private long? _Id;
         private bool _flagId;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -853,7 +853,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -1111,7 +1111,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp
+        public int? NotRequiredNotnullableintegerProp
         {
             get{ return _NotRequiredNotnullableintegerProp;}
             set
@@ -1120,7 +1120,7 @@ namespace Org.OpenAPITools.Model
                 _flagNotRequiredNotnullableintegerProp = true;
             }
         }
-        private int _NotRequiredNotnullableintegerProp;
+        private int? _NotRequiredNotnullableintegerProp;
         private bool _flagNotRequiredNotnullableintegerProp;
 
         /// <summary>
@@ -1303,7 +1303,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp
+        public bool? NotrequiredNotnullableBooleanProp
         {
             get{ return _NotrequiredNotnullableBooleanProp;}
             set
@@ -1312,7 +1312,7 @@ namespace Org.OpenAPITools.Model
                 _flagNotrequiredNotnullableBooleanProp = true;
             }
         }
-        private bool _NotrequiredNotnullableBooleanProp;
+        private bool? _NotrequiredNotnullableBooleanProp;
         private bool _flagNotrequiredNotnullableBooleanProp;
 
         /// <summary>
@@ -1403,7 +1403,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [JsonConverter(typeof(OpenAPIDateConverter))]
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
-        public DateTime NotRequiredNotnullableDateProp
+        public DateTime? NotRequiredNotnullableDateProp
         {
             get{ return _NotRequiredNotnullableDateProp;}
             set
@@ -1412,7 +1412,7 @@ namespace Org.OpenAPITools.Model
                 _flagNotRequiredNotnullableDateProp = true;
             }
         }
-        private DateTime _NotRequiredNotnullableDateProp;
+        private DateTime? _NotRequiredNotnullableDateProp;
         private bool _flagNotRequiredNotnullableDateProp;
 
         /// <summary>
@@ -1499,7 +1499,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp
+        public DateTime? NotrequiredNotnullableDatetimeProp
         {
             get{ return _NotrequiredNotnullableDatetimeProp;}
             set
@@ -1508,7 +1508,7 @@ namespace Org.OpenAPITools.Model
                 _flagNotrequiredNotnullableDatetimeProp = true;
             }
         }
-        private DateTime _NotrequiredNotnullableDatetimeProp;
+        private DateTime? _NotrequiredNotnullableDatetimeProp;
         private bool _flagNotrequiredNotnullableDatetimeProp;
 
         /// <summary>
@@ -1599,7 +1599,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid
+        public Guid? NotrequiredNotnullableUuid
         {
             get{ return _NotrequiredNotnullableUuid;}
             set
@@ -1608,7 +1608,7 @@ namespace Org.OpenAPITools.Model
                 _flagNotrequiredNotnullableUuid = true;
             }
         }
-        private Guid _NotrequiredNotnullableUuid;
+        private Guid? _NotrequiredNotnullableUuid;
         private bool _flagNotrequiredNotnullableUuid;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this._VarReturn = varReturn;
             if (this.VarReturn != null)
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn
+        public int? VarReturn
         {
             get{ return _VarReturn;}
             set
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
                 _flagVarReturn = true;
             }
         }
-        private int _VarReturn;
+        private int? _VarReturn;
         private bool _flagVarReturn;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this._RoleUuid = roleUuid;
             if (this.RoleUuid != null)
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid
+        public Guid? RoleUuid
         {
             get{ return _RoleUuid;}
             set
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
                 _flagRoleUuid = true;
             }
         }
-        private Guid _RoleUuid;
+        private Guid? _RoleUuid;
         private bool _flagRoleUuid;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this._SpecialPropertyName = specialPropertyName;
             if (this.SpecialPropertyName != null)
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName
+        public long? SpecialPropertyName
         {
             get{ return _SpecialPropertyName;}
             set
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
                 _flagSpecialPropertyName = true;
             }
         }
-        private long _SpecialPropertyName;
+        private long? _SpecialPropertyName;
         private bool _flagSpecialPropertyName;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this._Id = id;
             if (this.Id != null)
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id
+        public long? Id
         {
             get{ return _Id;}
             set
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private long _Id;
+        private long? _Id;
         private bool _flagId;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this._Id = id;
             if (this.Id != null)
@@ -116,7 +116,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id
+        public long? Id
         {
             get{ return _Id;}
             set
@@ -125,7 +125,7 @@ namespace Org.OpenAPITools.Model
                 _flagId = true;
             }
         }
-        private long _Id;
+        private long? _Id;
         private bool _flagId;
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus
+        public int? UserStatus
         {
             get{ return _UserStatus;}
             set
@@ -294,7 +294,7 @@ namespace Org.OpenAPITools.Model
                 _flagUserStatus = true;
             }
         }
-        private int _UserStatus;
+        private int? _UserStatus;
         private bool _flagUserStatus;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-ConditionalSerialization/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -71,7 +71,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen
+        public bool? HasBaleen
         {
             get{ return _HasBaleen;}
             set
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
                 _flagHasBaleen = true;
             }
         }
-        private bool _HasBaleen;
+        private bool? _HasBaleen;
         private bool _flagHasBaleen;
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth
+        public bool? HasTeeth
         {
             get{ return _HasTeeth;}
             set
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
                 _flagHasTeeth = true;
             }
         }
-        private bool _HasTeeth;
+        private bool? _HasTeeth;
         private bool _flagHasTeeth;
 
         /// <summary>

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | [**FileParameter**](FileParameter.md) |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -51,7 +51,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -64,7 +64,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Banana.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Cat.cs
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Category.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), FileParameter binary = default(FileParameter), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), FileParameter binary = default(FileParameter), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -101,31 +101,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -137,19 +137,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -182,14 +182,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -358,38 +358,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -406,26 +406,26 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -53,19 +53,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Name.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Order.cs
@@ -75,7 +75,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -90,32 +90,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -51,7 +51,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Pet.cs
@@ -83,7 +83,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -534,7 +534,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -650,7 +650,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -698,7 +698,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -726,7 +726,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -750,7 +750,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -778,7 +778,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Return.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Tag.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/User.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this.Id = id;
             this.Username = username;
@@ -69,7 +69,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -112,7 +112,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.

--- a/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-httpclient/src/Org.OpenAPITools/Model/Whale.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -64,13 +64,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Cat.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -100,31 +100,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -136,19 +136,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -181,14 +181,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -357,38 +357,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -405,26 +405,26 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -52,19 +52,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Name.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -89,32 +89,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -649,7 +649,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -697,7 +697,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -725,7 +725,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -749,7 +749,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -777,7 +777,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this.Id = id;
             this.Username = username;
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -111,7 +111,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.

--- a/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net47/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -63,13 +63,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Cat.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -100,31 +100,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -136,19 +136,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -181,14 +181,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -357,38 +357,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -405,26 +405,26 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -52,19 +52,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Name.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -89,32 +89,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -649,7 +649,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -697,7 +697,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -725,7 +725,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -749,7 +749,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -777,7 +777,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this.Id = id;
             this.Username = username;
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -111,7 +111,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.

--- a/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net48/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -63,13 +63,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Activity.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Activity.md
@@ -5,7 +5,7 @@ test map of maps
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ActivityOutputs** | **Dictionary&lt;string, List&lt;ActivityOutputElementRepresentation&gt;&gt;** |  | [optional] 
+**ActivityOutputs** | **Dictionary&lt;string, List&lt;ActivityOutputElementRepresentation&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ActivityOutputElementRepresentation.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ActivityOutputElementRepresentation.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Prop1** | **string** |  | [optional] 
-**Prop2** | **Object** |  | [optional] 
+**Prop1** | **string?** |  | [optional] 
+**Prop2** | **Object?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AdditionalPropertiesClass.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MapProperty** | **Dictionary&lt;string, string&gt;** |  | [optional] 
-**MapOfMapProperty** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**Anytype1** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype1** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype2** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype3** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**EmptyMap** | **Object** | an object with no declared properties and no undeclared properties, hence it&#39;s an empty map. | [optional] 
-**MapWithUndeclaredPropertiesString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapProperty** | **Dictionary&lt;string, string&gt;?** |  | [optional] 
+**MapOfMapProperty** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;?** |  | [optional] 
+**Anytype1** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype1** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype2** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype3** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**EmptyMap** | **Object?** | an object with no declared properties and no undeclared properties, hence it&#39;s an empty map. | [optional] 
+**MapWithUndeclaredPropertiesString** | **Dictionary&lt;string, string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Animal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Animal.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
+**Color** | **string?** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ApiResponse.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
-**Type** | **string** |  | [optional] 
-**Message** | **string** |  | [optional] 
+**Code** | **int?** |  | [optional] 
+**Type** | **string?** |  | [optional] 
+**Message** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Apple.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayOfArrayOfNumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayArrayNumber** | **List&lt;List&lt;decimal&gt;&gt;** |  | [optional] 
+**ArrayArrayNumber** | **List&lt;List&lt;decimal&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayOfNumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayNumber** | **List&lt;decimal&gt;** |  | [optional] 
+**ArrayNumber** | **List&lt;decimal&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ArrayTest.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayOfString** | **List&lt;string&gt;** |  | [optional] 
-**ArrayArrayOfInteger** | **List&lt;List&lt;long&gt;&gt;** |  | [optional] 
-**ArrayArrayOfModel** | **List&lt;List&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] 
+**ArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
+**ArrayArrayOfInteger** | **List&lt;List&lt;long&gt;&gt;?** |  | [optional] 
+**ArrayArrayOfModel** | **List&lt;List&lt;ReadOnlyFirst&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Capitalization.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Capitalization.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SmallCamel** | **string** |  | [optional] 
-**CapitalCamel** | **string** |  | [optional] 
-**SmallSnake** | **string** |  | [optional] 
-**CapitalSnake** | **string** |  | [optional] 
-**SCAETHFlowPoints** | **string** |  | [optional] 
-**ATT_NAME** | **string** | Name of the pet  | [optional] 
+**SmallCamel** | **string?** |  | [optional] 
+**CapitalCamel** | **string?** |  | [optional] 
+**SmallSnake** | **string?** |  | [optional] 
+**CapitalSnake** | **string?** |  | [optional] 
+**SCAETHFlowPoints** | **string?** |  | [optional] 
+**ATT_NAME** | **string?** | Name of the pet  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Cat.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Color** | **string?** |  | [optional] [default to "red"]
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ChildCat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ChildCat.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 **PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ClassModel.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ClassModel.md
@@ -5,7 +5,7 @@ Model for testing model with \"_class\" property
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarClass** | **string** |  | [optional] 
+**VarClass** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DeprecatedObject.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/DeprecatedObject.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Dog.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Dog.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
-**Breed** | **string** |  | [optional] 
+**Color** | **string?** |  | [optional] [default to "red"]
+**Breed** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Drawing.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Drawing.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MainShape** | [**Shape**](Shape.md) |  | [optional] 
-**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
-**NullableShape** | [**NullableShape**](NullableShape.md) |  | [optional] 
-**Shapes** | [**List&lt;Shape&gt;**](Shape.md) |  | [optional] 
+**MainShape** | [**Shape?**](Shape.md) |  | [optional] 
+**ShapeOrNull** | [**ShapeOrNull?**](ShapeOrNull.md) |  | [optional] 
+**NullableShape** | [**NullableShape?**](NullableShape.md) |  | [optional] 
+**Shapes** | [**List&lt;Shape&gt;?**](Shape.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/EnumArrays.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/EnumArrays.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustSymbol** | **string** |  | [optional] 
-**ArrayEnum** | **List&lt;EnumArrays.ArrayEnumEnum&gt;** |  | [optional] 
+**JustSymbol** | **string?** |  | [optional] 
+**ArrayEnum** | **List&lt;EnumArrays.ArrayEnumEnum&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/EnumTest.md
@@ -4,15 +4,15 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**EnumString** | **string** |  | [optional] 
+**EnumString** | **string?** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
-**OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
+**OuterEnum** | **OuterEnum?** |  | [optional] 
+**OuterEnumInteger** | **OuterEnumInteger?** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/File.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/File.md
@@ -5,7 +5,7 @@ Must be named `File` for test.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SourceURI** | **string** | Test capitalization | [optional] 
+**SourceURI** | **string?** | Test capitalization | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FileSchemaTestClass.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**File** | [**File**](File.md) |  | [optional] 
-**Files** | [**List&lt;File&gt;**](File.md) |  | [optional] 
+**File** | [**File?**](File.md) |  | [optional] 
+**Files** | [**List&lt;File&gt;?**](File.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Foo.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Foo.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [default to "bar"]
+**Bar** | **string?** |  | [optional] [default to "bar"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FooGetDefaultResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FooGetDefaultResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarString** | [**Foo**](Foo.md) |  | [optional] 
+**VarString** | [**Foo?**](Foo.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FormatTest.md
@@ -4,25 +4,25 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
-**VarString** | **string** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
+**VarString** | **string?** |  | [optional] 
 **VarByte** | **byte[]** |  | 
-**Binary** | **System.IO.Stream** |  | [optional] 
+**Binary** | **System.IO.Stream?** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
-**PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
-**PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
-**PatternWithBackslash** | **string** | None | [optional] 
+**PatternWithDigits** | **string?** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
+**PatternWithDigitsAndDelimiter** | **string?** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
+**PatternWithBackslash** | **string?** | None | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Fruit.md
@@ -4,11 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Color** | **string** |  | [optional] 
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**Color** | **string?** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/GmFruit.md
@@ -4,11 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Color** | **string** |  | [optional] 
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**Color** | **string?** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [readonly] 
-**Foo** | **string** |  | [optional] [readonly] 
+**Bar** | **string?** |  | [optional] [readonly] 
+**Foo** | **string?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/HealthCheckResult.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/HealthCheckResult.md
@@ -5,7 +5,7 @@ Just a string to inform instance is up and running. Make it nullable in hope to 
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**NullableMessage** | **string** |  | [optional] 
+**NullableMessage** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/List.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/List.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Var123List** | **string** |  | [optional] 
+**Var123List** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/LiteralStringClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/LiteralStringClass.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**EscapedLiteralString** | **string** |  | [optional] [default to "C:\\Users\\username"]
-**UnescapedLiteralString** | **string** |  | [optional] [default to "C:\Users\username"]
+**EscapedLiteralString** | **string?** |  | [optional] [default to "C:\\Users\\username"]
+**UnescapedLiteralString** | **string?** |  | [optional] [default to "C:\Users\username"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Mammal.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
-**Type** | **string** |  | [optional] 
+**Type** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/MapTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/MapTest.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, MapTest.InnerEnum&gt;** |  | [optional] 
-**DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
-**IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
+**MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;?** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, MapTest.InnerEnum&gt;?** |  | [optional] 
+**DirectMap** | **Dictionary&lt;string, bool&gt;?** |  | [optional] 
+**IndirectMap** | **Dictionary&lt;string, bool&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
-**Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Map** | [**Dictionary&lt;string, Animal&gt;?**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Model200Response.md
@@ -5,8 +5,8 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
-**VarClass** | **string** |  | [optional] 
+**Name** | **int?** |  | [optional] 
+**VarClass** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ModelClient.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ModelClient.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarClient** | **string** |  | [optional] 
+**VarClient** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
-**Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
+**Property** | **string?** |  | [optional] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/NullableClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/NullableClass.md
@@ -7,15 +7,15 @@ Name | Type | Description | Notes
 **IntegerProp** | **int?** |  | [optional] 
 **NumberProp** | **decimal?** |  | [optional] 
 **BooleanProp** | **bool?** |  | [optional] 
-**StringProp** | **string** |  | [optional] 
+**StringProp** | **string?** |  | [optional] 
 **DateProp** | **DateTime?** |  | [optional] 
 **DatetimeProp** | **DateTime?** |  | [optional] 
-**ArrayNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**ArrayAndItemsNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**ArrayItemsNullable** | **List&lt;Object&gt;** |  | [optional] 
-**ObjectNullableProp** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**ObjectAndItemsNullableProp** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**ObjectItemsNullable** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
+**ArrayNullableProp** | **List&lt;Object&gt;?** |  | [optional] 
+**ArrayAndItemsNullableProp** | **List&lt;Object&gt;?** |  | [optional] 
+**ArrayItemsNullable** | **List&lt;Object&gt;?** |  | [optional] 
+**ObjectNullableProp** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**ObjectAndItemsNullableProp** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**ObjectItemsNullable** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ObjectWithDeprecatedFields.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
-**DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
-**Bars** | **List&lt;string&gt;** |  | [optional] 
+**Uuid** | **string?** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
+**DeprecatedRef** | [**DeprecatedObject?**](DeprecatedObject.md) |  | [optional] 
+**Bars** | **List&lt;string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
-**Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
+**Status** | **string?** | Order Status | [optional] 
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
-**MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
+**MyString** | **string?** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Pet.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Category** | [**Category**](Category.md) |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Category** | [**Category?**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 
-**Tags** | [**List&lt;Tag&gt;**](Tag.md) |  | [optional] 
-**Status** | **string** | pet status in the store | [optional] 
+**Tags** | [**List&lt;Tag&gt;?**](Tag.md) |  | [optional] 
+**Status** | **string?** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ReadOnlyFirst.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [readonly] 
-**Baz** | **string** |  | [optional] 
+**Bar** | **string?** |  | [optional] [readonly] 
+**Baz** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RequiredClass.md
@@ -7,47 +7,47 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
-**NotrequiredNullableStringProp** | **string** |  | [optional] 
-**NotrequiredNotnullableStringProp** | **string** |  | [optional] 
+**NotrequiredNullableStringProp** | **string?** |  | [optional] 
+**NotrequiredNotnullableStringProp** | **string?** |  | [optional] 
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
-**NotrequiredNullableEnumString** | **string** |  | [optional] 
-**NotrequiredNotnullableEnumString** | **string** |  | [optional] 
+**NotrequiredNullableEnumString** | **string?** |  | [optional] 
+**NotrequiredNotnullableEnumString** | **string?** |  | [optional] 
 **RequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | 
 **RequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | 
-**NotrequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**NotrequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**NotrequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
+**NotrequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
-**NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 
-**NotrequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 
+**NotrequiredNullableArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
+**NotrequiredNotnullableArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RolesReportsHash.md
@@ -5,8 +5,8 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
-**Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
+**Role** | [**RolesReportsHashRole?**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RolesReportsHashRole.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/RolesReportsHashRole.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/SpecialModelName.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
-**VarSpecialModelName** | **string** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
+**VarSpecialModelName** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Tag.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Name** | **string** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestCollectionEndingWithWordList.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestCollectionEndingWithWordList.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Value** | **string** |  | [optional] 
+**Value** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestCollectionEndingWithWordListObject.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestCollectionEndingWithWordListObject.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**TestCollectionEndingWithWordList** | [**List&lt;TestCollectionEndingWithWordList&gt;**](TestCollectionEndingWithWordList.md) |  | [optional] 
+**TestCollectionEndingWithWordList** | [**List&lt;TestCollectionEndingWithWordList&gt;?**](TestCollectionEndingWithWordList.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestInlineFreeformAdditionalPropertiesRequest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/TestInlineFreeformAdditionalPropertiesRequest.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SomeProperty** | **string** |  | [optional] 
+**SomeProperty** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/User.md
@@ -4,18 +4,18 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Username** | **string** |  | [optional] 
-**FirstName** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
-**Email** | **string** |  | [optional] 
-**Password** | **string** |  | [optional] 
-**Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
-**ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
-**ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
-**AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 
-**AnyTypePropNullable** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values. | [optional] 
+**Id** | **long?** |  | [optional] 
+**Username** | **string?** |  | [optional] 
+**FirstName** | **string?** |  | [optional] 
+**LastName** | **string?** |  | [optional] 
+**Email** | **string?** |  | [optional] 
+**Password** | **string?** |  | [optional] 
+**Phone** | **string?** |  | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
+**ObjectWithNoDeclaredProps** | **Object?** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
+**ObjectWithNoDeclaredPropsNullable** | **Object?** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
+**AnyTypeProp** | **Object?** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 
+**AnyTypePropNullable** | **Object?** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Zebra.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/Zebra.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
+**Type** | **string?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ZeroBasedEnumClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/docs/ZeroBasedEnumClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ZeroBasedEnum** | **string** |  | [optional] 
+**ZeroBasedEnum** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Activity.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
         /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>>? activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>?))
         {
             this.ActivityOutputs = activityOutputs;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [DataMember(Name = "activity_outputs", EmitDefaultValue = false)]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get; set; }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="prop1">prop1.</param>
         /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        public ActivityOutputElementRepresentation(string? prop1 = default(string?), Object? prop2 = default(Object?))
         {
             this.Prop1 = prop1;
             this.Prop2 = prop2;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [DataMember(Name = "prop1", EmitDefaultValue = false)]
-        public string Prop1 { get; set; }
+        public string? Prop1 { get; set; }
 
         /// <summary>
         /// Gets or Sets Prop2
         /// </summary>
         [DataMember(Name = "prop2", EmitDefaultValue = false)]
-        public Object Prop2 { get; set; }
+        public Object? Prop2 { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
         /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
         /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        public AdditionalPropertiesClass(Dictionary<string, string>? mapProperty = default(Dictionary<string, string>?), Dictionary<string, Dictionary<string, string>>? mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>?), Object? anytype1 = default(Object?), Object? mapWithUndeclaredPropertiesAnytype1 = default(Object?), Object? mapWithUndeclaredPropertiesAnytype2 = default(Object?), Dictionary<string, Object>? mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>?), Object? emptyMap = default(Object?), Dictionary<string, string>? mapWithUndeclaredPropertiesString = default(Dictionary<string, string>?))
         {
             this.MapProperty = mapProperty;
             this.MapOfMapProperty = mapOfMapProperty;
@@ -60,50 +60,50 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [DataMember(Name = "map_property", EmitDefaultValue = false)]
-        public Dictionary<string, string> MapProperty { get; set; }
+        public Dictionary<string, string>? MapProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [DataMember(Name = "map_of_map_property", EmitDefaultValue = false)]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get; set; }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
         [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
-        public Object Anytype1 { get; set; }
+        public Object? Anytype1 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_1", EmitDefaultValue = false)]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get; set; }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_2", EmitDefaultValue = false)]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get; set; }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_3", EmitDefaultValue = false)]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get; set; }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get; set; }
 
         /// <summary>
         /// an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [DataMember(Name = "empty_map", EmitDefaultValue = false)]
-        public Object EmptyMap { get; set; }
+        public Object? EmptyMap { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_string", EmitDefaultValue = false)]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get; set; }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Animal.cs
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="className">className (required).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = @"red")
+        public Animal(string className = default(string), string? color = @"red")
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [DataMember(Name = "color", EmitDefaultValue = false)]
-        public string Color { get; set; }
+        public string? Color { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string? type = default(string?), string? message = default(string?))
         {
             this.Code = code;
             this.Type = type;
@@ -50,19 +50,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
         /// Gets or Sets Message
         /// </summary>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Apple.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
         /// <param name="colorCode">colorCode.</param>
-        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
+        public Apple(string? cultivar = default(string?), string? origin = default(string?), string? colorCode = default(string?))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
@@ -50,19 +50,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [DataMember(Name = "cultivar", EmitDefaultValue = false)]
-        public string Cultivar { get; set; }
+        public string? Cultivar { get; set; }
 
         /// <summary>
         /// Gets or Sets Origin
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
-        public string Origin { get; set; }
+        public string? Origin { get; set; }
 
         /// <summary>
         /// Gets or Sets ColorCode
         /// </summary>
         [DataMember(Name = "color_code", EmitDefaultValue = false)]
-        public string ColorCode { get; set; }
+        public string? ColorCode { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -152,7 +152,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.Cultivar != null) {
-                // Cultivar (string) pattern
+                // Cultivar (string?) pattern
                 Regex regexCultivar = new Regex(@"^[a-zA-Z\s]*$", RegexOptions.CultureInvariant);
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
@@ -161,7 +161,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.Origin != null) {
-                // Origin (string) pattern
+                // Origin (string?) pattern
                 Regex regexOrigin = new Regex(@"^[A-Z\s]*$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
@@ -170,7 +170,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.ColorCode != null) {
-                // ColorCode (string) pattern
+                // ColorCode (string?) pattern
                 Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
                 if (!regexColorCode.Match(this.ColorCode).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        public ArrayOfArrayOfNumberOnly(List<List<decimal>>? arrayArrayNumber = default(List<List<decimal>>?))
         {
             this.ArrayArrayNumber = arrayArrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [DataMember(Name = "ArrayArrayNumber", EmitDefaultValue = false)]
-        public List<List<decimal>> ArrayArrayNumber { get; set; }
+        public List<List<decimal>>? ArrayArrayNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        public ArrayOfNumberOnly(List<decimal>? arrayNumber = default(List<decimal>?))
         {
             this.ArrayNumber = arrayNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [DataMember(Name = "ArrayNumber", EmitDefaultValue = false)]
-        public List<decimal> ArrayNumber { get; set; }
+        public List<decimal>? ArrayNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="arrayOfString">arrayOfString.</param>
         /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
         /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        public ArrayTest(List<string>? arrayOfString = default(List<string>?), List<List<long>>? arrayArrayOfInteger = default(List<List<long>>?), List<List<ReadOnlyFirst>>? arrayArrayOfModel = default(List<List<ReadOnlyFirst>>?))
         {
             this.ArrayOfString = arrayOfString;
             this.ArrayArrayOfInteger = arrayArrayOfInteger;
@@ -50,19 +50,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [DataMember(Name = "array_of_string", EmitDefaultValue = false)]
-        public List<string> ArrayOfString { get; set; }
+        public List<string>? ArrayOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [DataMember(Name = "array_array_of_integer", EmitDefaultValue = false)]
-        public List<List<long>> ArrayArrayOfInteger { get; set; }
+        public List<List<long>>? ArrayArrayOfInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [DataMember(Name = "array_array_of_model", EmitDefaultValue = false)]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get; set; }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -41,7 +41,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="capitalSnake">capitalSnake.</param>
         /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
         /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        public Capitalization(string? smallCamel = default(string?), string? capitalCamel = default(string?), string? smallSnake = default(string?), string? capitalSnake = default(string?), string? sCAETHFlowPoints = default(string?), string? aTTNAME = default(string?))
         {
             this.SmallCamel = smallCamel;
             this.CapitalCamel = capitalCamel;
@@ -56,38 +56,38 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [DataMember(Name = "smallCamel", EmitDefaultValue = false)]
-        public string SmallCamel { get; set; }
+        public string? SmallCamel { get; set; }
 
         /// <summary>
         /// Gets or Sets CapitalCamel
         /// </summary>
         [DataMember(Name = "CapitalCamel", EmitDefaultValue = false)]
-        public string CapitalCamel { get; set; }
+        public string? CapitalCamel { get; set; }
 
         /// <summary>
         /// Gets or Sets SmallSnake
         /// </summary>
         [DataMember(Name = "small_Snake", EmitDefaultValue = false)]
-        public string SmallSnake { get; set; }
+        public string? SmallSnake { get; set; }
 
         /// <summary>
         /// Gets or Sets CapitalSnake
         /// </summary>
         [DataMember(Name = "Capital_Snake", EmitDefaultValue = false)]
-        public string CapitalSnake { get; set; }
+        public string? CapitalSnake { get; set; }
 
         /// <summary>
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [DataMember(Name = "SCA_ETH_Flow_Points", EmitDefaultValue = false)]
-        public string SCAETHFlowPoints { get; set; }
+        public string? SCAETHFlowPoints { get; set; }
 
         /// <summary>
         /// Name of the pet 
         /// </summary>
         /// <value>Name of the pet </value>
         [DataMember(Name = "ATT_NAME", EmitDefaultValue = false)]
-        public string ATT_NAME { get; set; }
+        public string? ATT_NAME { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Cat.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string? color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -66,7 +66,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        public ChildCat(string? name = default(string?), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
         {
             this.PetType = petType;
             this.Name = name;
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
         /// <param name="varClass">varClass.</param>
-        public ClassModel(string varClass = default(string))
+        public ClassModel(string? varClass = default(string?))
         {
             this.VarClass = varClass;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClass
         /// </summary>
         [DataMember(Name = "_class", EmitDefaultValue = false)]
-        public string VarClass { get; set; }
+        public string? VarClass { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        public DeprecatedObject(string? name = default(string?))
         {
             this.Name = name;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Dog.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="breed">breed.</param>
         /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = @"Dog", string color = @"red") : base(className, color)
+        public Dog(string? breed = default(string?), string className = @"Dog", string? color = @"red") : base(className, color)
         {
             this.Breed = breed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [DataMember(Name = "breed", EmitDefaultValue = false)]
-        public string Breed { get; set; }
+        public string? Breed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Drawing.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shapeOrNull">shapeOrNull.</param>
         /// <param name="nullableShape">nullableShape.</param>
         /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>))
+        public Drawing(Shape? mainShape = default(Shape?), ShapeOrNull? shapeOrNull = default(ShapeOrNull?), NullableShape? nullableShape = default(NullableShape?), List<Shape>? shapes = default(List<Shape>?))
         {
             this.MainShape = mainShape;
             this.ShapeOrNull = shapeOrNull;
@@ -52,25 +52,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [DataMember(Name = "mainShape", EmitDefaultValue = false)]
-        public Shape MainShape { get; set; }
+        public Shape? MainShape { get; set; }
 
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
-        public ShapeOrNull ShapeOrNull { get; set; }
+        public ShapeOrNull? ShapeOrNull { get; set; }
 
         /// <summary>
         /// Gets or Sets NullableShape
         /// </summary>
         [DataMember(Name = "nullableShape", EmitDefaultValue = true)]
-        public NullableShape NullableShape { get; set; }
+        public NullableShape? NullableShape { get; set; }
 
         /// <summary>
         /// Gets or Sets Shapes
         /// </summary>
         [DataMember(Name = "shapes", EmitDefaultValue = false)]
-        public List<Shape> Shapes { get; set; }
+        public List<Shape>? Shapes { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -92,7 +92,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [DataMember(Name = "array_enum", EmitDefaultValue = false)]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get; set; }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/File.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
         /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        public File(string? sourceURI = default(string?))
         {
             this.SourceURI = sourceURI;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [DataMember(Name = "sourceURI", EmitDefaultValue = false)]
-        public string SourceURI { get; set; }
+        public string? SourceURI { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="file">file.</param>
         /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        public FileSchemaTestClass(File? file = default(File?), List<File>? files = default(List<File>?))
         {
             this.File = file;
             this.Files = files;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [DataMember(Name = "file", EmitDefaultValue = false)]
-        public File File { get; set; }
+        public File? File { get; set; }
 
         /// <summary>
         /// Gets or Sets Files
         /// </summary>
         [DataMember(Name = "files", EmitDefaultValue = false)]
-        public List<File> Files { get; set; }
+        public List<File>? Files { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Foo.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
         /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = @"bar")
+        public Foo(string? bar = @"bar")
         {
             // use default value if no "bar" provided
             this.Bar = bar ?? @"bar";
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; set; }
+        public string? Bar { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
         /// <param name="varString">varString.</param>
-        public FooGetDefaultResponse(Foo varString = default(Foo))
+        public FooGetDefaultResponse(Foo? varString = default(Foo?))
         {
             this.VarString = varString;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarString
         /// </summary>
         [DataMember(Name = "string", EmitDefaultValue = false)]
-        public Foo VarString { get; set; }
+        public Foo? VarString { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string? varString = default(string?), byte[] varByte = default(byte[]), System.IO.Stream? binary = default(System.IO.Stream?), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string? patternWithDigits = default(string?), string? patternWithDigitsAndDelimiter = default(string?), string? patternWithBackslash = default(string?))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -100,31 +100,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -136,25 +136,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
         /// </summary>
         [DataMember(Name = "string", EmitDefaultValue = false)]
-        public string VarString { get; set; }
+        public string? VarString { get; set; }
 
         /// <summary>
         /// Gets or Sets VarByte
@@ -166,7 +166,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [DataMember(Name = "binary", EmitDefaultValue = false)]
-        public System.IO.Stream Binary { get; set; }
+        public System.IO.Stream? Binary { get; set; }
 
         /// <summary>
         /// Gets or Sets Date
@@ -181,14 +181,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -201,21 +201,21 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [DataMember(Name = "pattern_with_digits", EmitDefaultValue = false)]
-        public string PatternWithDigits { get; set; }
+        public string? PatternWithDigits { get; set; }
 
         /// <summary>
         /// A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [DataMember(Name = "pattern_with_digits_and_delimiter", EmitDefaultValue = false)]
-        public string PatternWithDigitsAndDelimiter { get; set; }
+        public string? PatternWithDigitsAndDelimiter { get; set; }
 
         /// <summary>
         /// None
         /// </summary>
         /// <value>None</value>
         [DataMember(Name = "pattern_with_backslash", EmitDefaultValue = false)]
-        public string PatternWithBackslash { get; set; }
+        public string? PatternWithBackslash { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -357,38 +357,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -405,32 +405,32 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }
 
             if (this.VarString != null) {
-                // VarString (string) pattern
+                // VarString (string?) pattern
                 Regex regexVarString = new Regex(@"[a-z]", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexVarString.Match(this.VarString).Success)
                 {
@@ -451,7 +451,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithDigits != null) {
-                // PatternWithDigits (string) pattern
+                // PatternWithDigits (string?) pattern
                 Regex regexPatternWithDigits = new Regex(@"^\d{10}$", RegexOptions.CultureInvariant);
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
@@ -460,7 +460,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
-                // PatternWithDigitsAndDelimiter (string) pattern
+                // PatternWithDigitsAndDelimiter (string?) pattern
                 Regex regexPatternWithDigitsAndDelimiter = new Regex(@"^image_\d{1,3}$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
@@ -469,7 +469,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithBackslash != null) {
-                // PatternWithBackslash (string) pattern
+                // PatternWithBackslash (string?) pattern
                 Regex regexPatternWithBackslash = new Regex(@"^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$", RegexOptions.CultureInvariant);
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; private set; }
+        public string? Bar { get; private set; }
 
         /// <summary>
         /// Returns false as Bar should not be serialized given that it's read-only.
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [DataMember(Name = "foo", EmitDefaultValue = false)]
-        public string Foo { get; private set; }
+        public string? Foo { get; private set; }
 
         /// <summary>
         /// Returns false as Foo should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
         /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        public HealthCheckResult(string? nullableMessage = default(string?))
         {
             this.NullableMessage = nullableMessage;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [DataMember(Name = "NullableMessage", EmitDefaultValue = true)]
-        public string NullableMessage { get; set; }
+        public string? NullableMessage { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/List.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
         /// <param name="var123List">var123List.</param>
-        public List(string var123List = default(string))
+        public List(string? var123List = default(string?))
         {
             this.Var123List = var123List;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [DataMember(Name = "123-list", EmitDefaultValue = false)]
-        public string Var123List { get; set; }
+        public string? Var123List { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="escapedLiteralString">escapedLiteralString (default to &quot;C:\\Users\\username&quot;).</param>
         /// <param name="unescapedLiteralString">unescapedLiteralString (default to &quot;C:\Users\username&quot;).</param>
-        public LiteralStringClass(string escapedLiteralString = @"C:\\Users\\username", string unescapedLiteralString = @"C:\Users\username")
+        public LiteralStringClass(string? escapedLiteralString = @"C:\\Users\\username", string? unescapedLiteralString = @"C:\Users\username")
         {
             // use default value if no "escapedLiteralString" provided
             this.EscapedLiteralString = escapedLiteralString ?? @"C:\\Users\\username";
@@ -50,13 +50,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [DataMember(Name = "escapedLiteralString", EmitDefaultValue = false)]
-        public string EscapedLiteralString { get; set; }
+        public string? EscapedLiteralString { get; set; }
 
         /// <summary>
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [DataMember(Name = "unescapedLiteralString", EmitDefaultValue = false)]
-        public string UnescapedLiteralString { get; set; }
+        public string? UnescapedLiteralString { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MapTest.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="mapOfEnumString">mapOfEnumString.</param>
         /// <param name="directMap">directMap.</param>
         /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        public MapTest(Dictionary<string, Dictionary<string, string>>? mapMapOfString = default(Dictionary<string, Dictionary<string, string>>?), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool>? directMap = default(Dictionary<string, bool>?), Dictionary<string, bool>? indirectMap = default(Dictionary<string, bool>?))
         {
             this.MapMapOfString = mapMapOfString;
             this.MapOfEnumString = mapOfEnumString;
@@ -71,25 +71,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [DataMember(Name = "map_map_of_string", EmitDefaultValue = false)]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get; set; }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [DataMember(Name = "map_of_enum_string", EmitDefaultValue = false)]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get; set; }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get; set; }
 
         /// <summary>
         /// Gets or Sets DirectMap
         /// </summary>
         [DataMember(Name = "direct_map", EmitDefaultValue = false)]
-        public Dictionary<string, bool> DirectMap { get; set; }
+        public Dictionary<string, bool>? DirectMap { get; set; }
 
         /// <summary>
         /// Gets or Sets IndirectMap
         /// </summary>
         [DataMember(Name = "indirect_map", EmitDefaultValue = false)]
-        public Dictionary<string, bool> IndirectMap { get; set; }
+        public Dictionary<string, bool>? IndirectMap { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal>? map = default(Dictionary<string, Animal>?))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -52,25 +52,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
         /// </summary>
         [DataMember(Name = "map", EmitDefaultValue = false)]
-        public Dictionary<string, Animal> Map { get; set; }
+        public Dictionary<string, Animal>? Map { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string? varClass = default(string?))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass
         /// </summary>
         [DataMember(Name = "class", EmitDefaultValue = false)]
-        public string VarClass { get; set; }
+        public string? VarClass { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
         /// <param name="varClient">varClient.</param>
-        public ModelClient(string varClient = default(string))
+        public ModelClient(string? varClient = default(string?))
         {
             this.VarClient = varClient;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [DataMember(Name = "client", EmitDefaultValue = false)]
-        public string VarClient { get; set; }
+        public string? VarClient { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Name.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="varName">varName (required).</param>
         /// <param name="property">property.</param>
-        public Name(int varName = default(int), string property = default(string))
+        public Name(int varName = default(int), string? property = default(string?))
         {
             this.VarName = varName;
             this.Property = property;
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -76,13 +76,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [DataMember(Name = "property", EmitDefaultValue = false)]
-        public string Property { get; set; }
+        public string? Property { get; set; }
 
         /// <summary>
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectNullableProp">objectNullableProp.</param>
         /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
         /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>))
+        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string? stringProp = default(string?), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object>? arrayNullableProp = default(List<Object>?), List<Object>? arrayAndItemsNullableProp = default(List<Object>?), List<Object>? arrayItemsNullable = default(List<Object>?), Dictionary<string, Object>? objectNullableProp = default(Dictionary<string, Object>?), Dictionary<string, Object>? objectAndItemsNullableProp = default(Dictionary<string, Object>?), Dictionary<string, Object>? objectItemsNullable = default(Dictionary<string, Object>?))
         {
             this.IntegerProp = integerProp;
             this.NumberProp = numberProp;
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [DataMember(Name = "string_prop", EmitDefaultValue = true)]
-        public string StringProp { get; set; }
+        public string? StringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets DateProp
@@ -105,37 +105,37 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [DataMember(Name = "array_nullable_prop", EmitDefaultValue = true)]
-        public List<Object> ArrayNullableProp { get; set; }
+        public List<Object>? ArrayNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [DataMember(Name = "array_and_items_nullable_prop", EmitDefaultValue = true)]
-        public List<Object> ArrayAndItemsNullableProp { get; set; }
+        public List<Object>? ArrayAndItemsNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [DataMember(Name = "array_items_nullable", EmitDefaultValue = false)]
-        public List<Object> ArrayItemsNullable { get; set; }
+        public List<Object>? ArrayItemsNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [DataMember(Name = "object_nullable_prop", EmitDefaultValue = true)]
-        public Dictionary<string, Object> ObjectNullableProp { get; set; }
+        public Dictionary<string, Object>? ObjectNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [DataMember(Name = "object_and_items_nullable_prop", EmitDefaultValue = true)]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get; set; }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [DataMember(Name = "object_items_nullable", EmitDefaultValue = false)]
-        public Dictionary<string, Object> ObjectItemsNullable { get; set; }
+        public Dictionary<string, Object>? ObjectItemsNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string? uuid = default(string?), decimal? id = default(decimal?), DeprecatedObject? deprecatedRef = default(DeprecatedObject?), List<string>? bars = default(List<string>?))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -52,28 +52,28 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public string Uuid { get; set; }
+        public string? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef
         /// </summary>
         [DataMember(Name = "deprecatedRef", EmitDefaultValue = false)]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get; set; }
+        public DeprecatedObject? DeprecatedRef { get; set; }
 
         /// <summary>
         /// Gets or Sets Bars
         /// </summary>
         [DataMember(Name = "bars", EmitDefaultValue = false)]
         [Obsolete]
-        public List<string> Bars { get; set; }
+        public List<string>? Bars { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -89,32 +89,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string? myString = default(string?), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -50,19 +50,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
         /// </summary>
         [DataMember(Name = "my_string", EmitDefaultValue = false)]
-        public string MyString { get; set; }
+        public string? MyString { get; set; }
 
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category? category = default(Category?), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag>? tags = default(List<Tag>?), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -107,13 +107,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category
         /// </summary>
         [DataMember(Name = "category", EmitDefaultValue = false)]
-        public Category Category { get; set; }
+        public Category? Category { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
@@ -132,7 +132,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        public List<Tag> Tags { get; set; }
+        public List<Tag>? Tags { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
         /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        public ReadOnlyFirst(string? baz = default(string?))
         {
             this.Baz = baz;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; private set; }
+        public string? Bar { get; private set; }
 
         /// <summary>
         /// Returns false as Bar should not be serialized given that it's read-only.
@@ -60,7 +60,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [DataMember(Name = "baz", EmitDefaultValue = false)]
-        public string Baz { get; set; }
+        public string? Baz { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string? notrequiredNullableStringProp = default(string?), string? notrequiredNotnullableStringProp = default(string?), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string>? notrequiredNullableArrayOfString = default(List<string>?), List<string>? notrequiredNotnullableArrayOfString = default(List<string>?))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -649,7 +649,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -667,13 +667,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [DataMember(Name = "notrequired_nullable_string_prop", EmitDefaultValue = true)]
-        public string NotrequiredNullableStringProp { get; set; }
+        public string? NotrequiredNullableStringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_string_prop", EmitDefaultValue = false)]
-        public string NotrequiredNotnullableStringProp { get; set; }
+        public string? NotrequiredNotnullableStringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableBooleanProp
@@ -697,7 +697,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -725,7 +725,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -749,7 +749,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -777,7 +777,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString
@@ -795,13 +795,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [DataMember(Name = "notrequired_nullable_array_of_string", EmitDefaultValue = true)]
-        public List<string> NotrequiredNullableArrayOfString { get; set; }
+        public List<string>? NotrequiredNullableArrayOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_array_of_string", EmitDefaultValue = false)]
-        public List<string> NotrequiredNotnullableArrayOfString { get; set; }
+        public List<string>? NotrequiredNotnullableArrayOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole? role = default(RolesReportsHashRole?))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role
         /// </summary>
         [DataMember(Name = "role", EmitDefaultValue = false)]
-        public RolesReportsHashRole Role { get; set; }
+        public RolesReportsHashRole? Role { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        public RolesReportsHashRole(string name = default(string))
+        public RolesReportsHashRole(string? name = default(string?))
         {
             this.Name = name;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string? varSpecialModelName = default(string?))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [DataMember(Name = "_special_model.name_", EmitDefaultValue = false)]
-        public string VarSpecialModelName { get; set; }
+        public string? VarSpecialModelName { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string? name = default(string?))
         {
             this.Id = id;
             this.Name = name;
@@ -48,13 +48,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
         /// </summary>
         /// <param name="value">value.</param>
-        public TestCollectionEndingWithWordList(string value = default(string))
+        public TestCollectionEndingWithWordList(string? value = default(string?))
         {
             this.Value = value;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
         /// </summary>
         /// <param name="testCollectionEndingWithWordList">testCollectionEndingWithWordList.</param>
-        public TestCollectionEndingWithWordListObject(List<TestCollectionEndingWithWordList> testCollectionEndingWithWordList = default(List<TestCollectionEndingWithWordList>))
+        public TestCollectionEndingWithWordListObject(List<TestCollectionEndingWithWordList>? testCollectionEndingWithWordList = default(List<TestCollectionEndingWithWordList>?))
         {
             this.TestCollectionEndingWithWordList = testCollectionEndingWithWordList;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [DataMember(Name = "TestCollectionEndingWithWordList", EmitDefaultValue = false)]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get; set; }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
         /// </summary>
         /// <param name="someProperty">someProperty.</param>
-        public TestInlineFreeformAdditionalPropertiesRequest(string someProperty = default(string))
+        public TestInlineFreeformAdditionalPropertiesRequest(string? someProperty = default(string?))
         {
             this.SomeProperty = someProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [DataMember(Name = "someProperty", EmitDefaultValue = false)]
-        public string SomeProperty { get; set; }
+        public string? SomeProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string? username = default(string?), string? firstName = default(string?), string? lastName = default(string?), string? email = default(string?), string? password = default(string?), string? phone = default(string?), int? userStatus = default(int?), Object? objectWithNoDeclaredProps = default(Object?), Object? objectWithNoDeclaredPropsNullable = default(Object?), Object? anyTypeProp = default(Object?), Object? anyTypePropNullable = default(Object?))
         {
             this.Id = id;
             this.Username = username;
@@ -68,78 +68,78 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
         /// </summary>
         [DataMember(Name = "username", EmitDefaultValue = false)]
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
         /// <summary>
         /// Gets or Sets FirstName
         /// </summary>
         [DataMember(Name = "firstName", EmitDefaultValue = false)]
-        public string FirstName { get; set; }
+        public string? FirstName { get; set; }
 
         /// <summary>
         /// Gets or Sets LastName
         /// </summary>
         [DataMember(Name = "lastName", EmitDefaultValue = false)]
-        public string LastName { get; set; }
+        public string? LastName { get; set; }
 
         /// <summary>
         /// Gets or Sets Email
         /// </summary>
         [DataMember(Name = "email", EmitDefaultValue = false)]
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
         /// </summary>
         [DataMember(Name = "password", EmitDefaultValue = false)]
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
         /// <summary>
         /// Gets or Sets Phone
         /// </summary>
         [DataMember(Name = "phone", EmitDefaultValue = false)]
-        public string Phone { get; set; }
+        public string? Phone { get; set; }
 
         /// <summary>
         /// User Status
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [DataMember(Name = "objectWithNoDeclaredProps", EmitDefaultValue = false)]
-        public Object ObjectWithNoDeclaredProps { get; set; }
+        public Object? ObjectWithNoDeclaredProps { get; set; }
 
         /// <summary>
         /// test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [DataMember(Name = "objectWithNoDeclaredPropsNullable", EmitDefaultValue = true)]
-        public Object ObjectWithNoDeclaredPropsNullable { get; set; }
+        public Object? ObjectWithNoDeclaredPropsNullable { get; set; }
 
         /// <summary>
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
-        public Object AnyTypeProp { get; set; }
+        public Object? AnyTypeProp { get; set; }
 
         /// <summary>
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [DataMember(Name = "anyTypePropNullable", EmitDefaultValue = true)]
-        public Object AnyTypePropNullable { get; set; }
+        public Object? AnyTypePropNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-net5.0/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -63,13 +63,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Banana.cs
@@ -34,7 +34,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
         }
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Cat.cs
@@ -41,7 +41,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
         }
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Category.cs
@@ -40,7 +40,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -55,7 +55,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -34,7 +34,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -94,31 +94,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -130,19 +130,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -175,14 +175,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -35,7 +35,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Name.cs
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -76,7 +76,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
         }
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -56,7 +56,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Order.cs
@@ -72,7 +72,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -86,32 +86,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Pet.cs
@@ -77,7 +77,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -101,7 +101,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -528,7 +528,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -643,7 +643,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -691,7 +691,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -719,7 +719,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -743,7 +743,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -771,7 +771,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Return.cs
@@ -34,7 +34,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
         }
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -35,7 +35,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -35,7 +35,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Tag.cs
@@ -35,7 +35,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/User.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this.Id = id;
             this.Username = username;
@@ -65,7 +65,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -108,7 +108,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.

--- a/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient-unityWebRequest/src/Org.OpenAPITools/Model/Whale.cs
@@ -41,7 +41,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -57,13 +57,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/ApiResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Cat.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
 **Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/EnumTest.md
@@ -6,9 +6,9 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **EnumString** | **string** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
 **OuterEnum** | **OuterEnum** |  | [optional] 
 **OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
 **OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FormatTest.md
@@ -4,21 +4,21 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
 **VarString** | **string** |  | [optional] 
 **VarByte** | **byte[]** |  | 
 **Binary** | **System.IO.Stream** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
 **PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
 **PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Fruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/GmFruit.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **Cultivar** | **string** |  | [optional] 
 **Origin** | **string** |  | [optional] 
 **ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Mammal.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 **Type** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
 **Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Model200Response.md
@@ -5,7 +5,7 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
+**Name** | **int?** |  | [optional] 
 **VarClass** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
 **Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/ObjectWithDeprecatedFields.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
 **DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
 **Bars** | **List&lt;string&gt;** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
 **MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Pet.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/RequiredClass.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
 **NotrequiredNullableStringProp** | **string** |  | [optional] 
@@ -15,23 +15,23 @@ Name | Type | Description | Notes
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
 **NotrequiredNullableEnumString** | **string** |  | [optional] 
@@ -43,7 +43,7 @@ Name | Type | Description | Notes
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
 **NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/RolesReportsHash.md
@@ -5,7 +5,7 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
 **Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/SpecialModelName.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
 **VarSpecialModelName** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Tag.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/User.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 **ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
 **ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
 **AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 

--- a/samples/client/petstore/csharp/OpenAPIClient/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClient/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Cat.cs
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Category.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -61,7 +61,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -100,31 +100,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -136,19 +136,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
@@ -181,14 +181,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -357,38 +357,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -405,26 +405,26 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -52,19 +52,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
@@ -165,7 +165,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string varClass = default(string))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Name.cs
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string uuid = default(string), decimal? id = default(decimal?), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -89,32 +89,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string myString = default(string), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -50,7 +50,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
@@ -62,7 +62,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Pet.cs
@@ -82,7 +82,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -107,7 +107,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -533,7 +533,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -649,7 +649,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -697,7 +697,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -725,7 +725,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -749,7 +749,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -777,7 +777,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole role = default(RolesReportsHashRole))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string varSpecialModelName = default(string))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
         {
             this.Id = id;
             this.Username = username;
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -111,7 +111,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.

--- a/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClient/src/Org.OpenAPITools/Model/Whale.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -63,13 +63,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Activity.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Activity.md
@@ -5,7 +5,7 @@ test map of maps
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ActivityOutputs** | **Dictionary&lt;string, List&lt;ActivityOutputElementRepresentation&gt;&gt;** |  | [optional] 
+**ActivityOutputs** | **Dictionary&lt;string, List&lt;ActivityOutputElementRepresentation&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ActivityOutputElementRepresentation.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ActivityOutputElementRepresentation.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Prop1** | **string** |  | [optional] 
-**Prop2** | **Object** |  | [optional] 
+**Prop1** | **string?** |  | [optional] 
+**Prop2** | **Object?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/AdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/AdditionalPropertiesClass.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MapProperty** | **Dictionary&lt;string, string&gt;** |  | [optional] 
-**MapOfMapProperty** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**Anytype1** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype1** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype2** | **Object** |  | [optional] 
-**MapWithUndeclaredPropertiesAnytype3** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**EmptyMap** | **Object** | an object with no declared properties and no undeclared properties, hence it&#39;s an empty map. | [optional] 
-**MapWithUndeclaredPropertiesString** | **Dictionary&lt;string, string&gt;** |  | [optional] 
+**MapProperty** | **Dictionary&lt;string, string&gt;?** |  | [optional] 
+**MapOfMapProperty** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;?** |  | [optional] 
+**Anytype1** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype1** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype2** | **Object?** |  | [optional] 
+**MapWithUndeclaredPropertiesAnytype3** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**EmptyMap** | **Object?** | an object with no declared properties and no undeclared properties, hence it&#39;s an empty map. | [optional] 
+**MapWithUndeclaredPropertiesString** | **Dictionary&lt;string, string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Animal.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Animal.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
+**Color** | **string?** |  | [optional] [default to "red"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ApiResponse.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
-**Type** | **string** |  | [optional] 
-**Message** | **string** |  | [optional] 
+**Code** | **int?** |  | [optional] 
+**Type** | **string?** |  | [optional] 
+**Message** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Apple.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Apple.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/AppleReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/AppleReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayOfArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayOfArrayOfNumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayArrayNumber** | **List&lt;List&lt;decimal&gt;&gt;** |  | [optional] 
+**ArrayArrayNumber** | **List&lt;List&lt;decimal&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayOfNumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayOfNumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayNumber** | **List&lt;decimal&gt;** |  | [optional] 
+**ArrayNumber** | **List&lt;decimal&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ArrayTest.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ArrayOfString** | **List&lt;string&gt;** |  | [optional] 
-**ArrayArrayOfInteger** | **List&lt;List&lt;long&gt;&gt;** |  | [optional] 
-**ArrayArrayOfModel** | **List&lt;List&lt;ReadOnlyFirst&gt;&gt;** |  | [optional] 
+**ArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
+**ArrayArrayOfInteger** | **List&lt;List&lt;long&gt;&gt;?** |  | [optional] 
+**ArrayArrayOfModel** | **List&lt;List&lt;ReadOnlyFirst&gt;&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Banana.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Banana.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**LengthCm** | **decimal** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/BananaReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/BananaReq.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Capitalization.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Capitalization.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SmallCamel** | **string** |  | [optional] 
-**CapitalCamel** | **string** |  | [optional] 
-**SmallSnake** | **string** |  | [optional] 
-**CapitalSnake** | **string** |  | [optional] 
-**SCAETHFlowPoints** | **string** |  | [optional] 
-**ATT_NAME** | **string** | Name of the pet  | [optional] 
+**SmallCamel** | **string?** |  | [optional] 
+**CapitalCamel** | **string?** |  | [optional] 
+**SmallSnake** | **string?** |  | [optional] 
+**CapitalSnake** | **string?** |  | [optional] 
+**SCAETHFlowPoints** | **string?** |  | [optional] 
+**ATT_NAME** | **string?** | Name of the pet  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Cat.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Cat.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
-**Declawed** | **bool** |  | [optional] 
+**Color** | **string?** |  | [optional] [default to "red"]
+**Declawed** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Category.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [default to "default-name"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ChildCat.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ChildCat.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 **PetType** | **string** |  | [default to PetTypeEnum.ChildCat]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ClassModel.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ClassModel.md
@@ -5,7 +5,7 @@ Model for testing model with \"_class\" property
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarClass** | **string** |  | [optional] 
+**VarClass** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/DateOnlyClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/DateOnlyClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**DateOnlyProperty** | **DateTime** |  | [optional] 
+**DateOnlyProperty** | **DateTime?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/DeprecatedObject.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/DeprecatedObject.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Dog.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Dog.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **ClassName** | **string** |  | 
-**Color** | **string** |  | [optional] [default to "red"]
-**Breed** | **string** |  | [optional] 
+**Color** | **string?** |  | [optional] [default to "red"]
+**Breed** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Drawing.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Drawing.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MainShape** | [**Shape**](Shape.md) |  | [optional] 
-**ShapeOrNull** | [**ShapeOrNull**](ShapeOrNull.md) |  | [optional] 
-**NullableShape** | [**NullableShape**](NullableShape.md) |  | [optional] 
-**Shapes** | [**List&lt;Shape&gt;**](Shape.md) |  | [optional] 
+**MainShape** | [**Shape?**](Shape.md) |  | [optional] 
+**ShapeOrNull** | [**ShapeOrNull?**](ShapeOrNull.md) |  | [optional] 
+**NullableShape** | [**NullableShape?**](NullableShape.md) |  | [optional] 
+**Shapes** | [**List&lt;Shape&gt;?**](Shape.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/EnumArrays.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/EnumArrays.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustSymbol** | **string** |  | [optional] 
-**ArrayEnum** | **List&lt;EnumArrays.ArrayEnumEnum&gt;** |  | [optional] 
+**JustSymbol** | **string?** |  | [optional] 
+**ArrayEnum** | **List&lt;EnumArrays.ArrayEnumEnum&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/EnumTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/EnumTest.md
@@ -4,15 +4,15 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**EnumString** | **string** |  | [optional] 
+**EnumString** | **string?** |  | [optional] 
 **EnumStringRequired** | **string** |  | 
-**EnumInteger** | **int** |  | [optional] 
-**EnumIntegerOnly** | **int** |  | [optional] 
-**EnumNumber** | **double** |  | [optional] 
-**OuterEnum** | **OuterEnum** |  | [optional] 
-**OuterEnumInteger** | **OuterEnumInteger** |  | [optional] 
-**OuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue** |  | [optional] 
+**EnumInteger** | **int?** |  | [optional] 
+**EnumIntegerOnly** | **int?** |  | [optional] 
+**EnumNumber** | **double?** |  | [optional] 
+**OuterEnum** | **OuterEnum?** |  | [optional] 
+**OuterEnumInteger** | **OuterEnumInteger?** |  | [optional] 
+**OuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
+**OuterEnumIntegerDefaultValue** | **OuterEnumIntegerDefaultValue?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/File.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/File.md
@@ -5,7 +5,7 @@ Must be named `File` for test.
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SourceURI** | **string** | Test capitalization | [optional] 
+**SourceURI** | **string?** | Test capitalization | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FileSchemaTestClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FileSchemaTestClass.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**File** | [**File**](File.md) |  | [optional] 
-**Files** | [**List&lt;File&gt;**](File.md) |  | [optional] 
+**File** | [**File?**](File.md) |  | [optional] 
+**Files** | [**List&lt;File&gt;?**](File.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Foo.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Foo.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [default to "bar"]
+**Bar** | **string?** |  | [optional] [default to "bar"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FooGetDefaultResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FooGetDefaultResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarString** | [**Foo**](Foo.md) |  | [optional] 
+**VarString** | [**Foo?**](Foo.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FormatTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FormatTest.md
@@ -4,25 +4,25 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Integer** | **int** |  | [optional] 
-**Int32** | **int** |  | [optional] 
-**UnsignedInteger** | **uint** |  | [optional] 
-**Int64** | **long** |  | [optional] 
-**UnsignedLong** | **ulong** |  | [optional] 
+**Integer** | **int?** |  | [optional] 
+**Int32** | **int?** |  | [optional] 
+**UnsignedInteger** | **uint?** |  | [optional] 
+**Int64** | **long?** |  | [optional] 
+**UnsignedLong** | **ulong?** |  | [optional] 
 **Number** | **decimal** |  | 
-**VarFloat** | **float** |  | [optional] 
-**VarDouble** | **double** |  | [optional] 
-**VarDecimal** | **decimal** |  | [optional] 
-**VarString** | **string** |  | [optional] 
+**VarFloat** | **float?** |  | [optional] 
+**VarDouble** | **double?** |  | [optional] 
+**VarDecimal** | **decimal?** |  | [optional] 
+**VarString** | **string?** |  | [optional] 
 **VarByte** | **byte[]** |  | 
-**Binary** | **System.IO.Stream** |  | [optional] 
+**Binary** | **System.IO.Stream?** |  | [optional] 
 **Date** | **DateTime** |  | 
-**DateTime** | **DateTime** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
 **Password** | **string** |  | 
-**PatternWithDigits** | **string** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
-**PatternWithDigitsAndDelimiter** | **string** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
-**PatternWithBackslash** | **string** | None | [optional] 
+**PatternWithDigits** | **string?** | A string that is a 10 digit number. Can have leading zeros. | [optional] 
+**PatternWithDigitsAndDelimiter** | **string?** | A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01. | [optional] 
+**PatternWithBackslash** | **string?** | None | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Fruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Fruit.md
@@ -4,11 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Color** | **string** |  | [optional] 
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**Color** | **string?** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/FruitReq.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/FruitReq.md
@@ -5,9 +5,9 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Cultivar** | **string** |  | 
-**Mealy** | **bool** |  | [optional] 
+**Mealy** | **bool?** |  | [optional] 
 **LengthCm** | **decimal** |  | 
-**Sweet** | **bool** |  | [optional] 
+**Sweet** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/GmFruit.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/GmFruit.md
@@ -4,11 +4,11 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Color** | **string** |  | [optional] 
-**Cultivar** | **string** |  | [optional] 
-**Origin** | **string** |  | [optional] 
-**ColorCode** | **string** |  | [optional] 
-**LengthCm** | **decimal** |  | [optional] 
+**Color** | **string?** |  | [optional] 
+**Cultivar** | **string?** |  | [optional] 
+**Origin** | **string?** |  | [optional] 
+**ColorCode** | **string?** |  | [optional] 
+**LengthCm** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/HasOnlyReadOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/HasOnlyReadOnly.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [readonly] 
-**Foo** | **string** |  | [optional] [readonly] 
+**Bar** | **string?** |  | [optional] [readonly] 
+**Foo** | **string?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/HealthCheckResult.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/HealthCheckResult.md
@@ -5,7 +5,7 @@ Just a string to inform instance is up and running. Make it nullable in hope to 
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**NullableMessage** | **string** |  | [optional] 
+**NullableMessage** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/List.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/List.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Var123List** | **string** |  | [optional] 
+**Var123List** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/LiteralStringClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/LiteralStringClass.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**EscapedLiteralString** | **string** |  | [optional] [default to "C:\\Users\\username"]
-**UnescapedLiteralString** | **string** |  | [optional] [default to "C:\Users\username"]
+**EscapedLiteralString** | **string?** |  | [optional] [default to "C:\\Users\\username"]
+**UnescapedLiteralString** | **string?** |  | [optional] [default to "C:\Users\username"]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Mammal.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Mammal.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
-**Type** | **string** |  | [optional] 
+**Type** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/MapTest.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/MapTest.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;** |  | [optional] 
-**MapOfEnumString** | **Dictionary&lt;string, MapTest.InnerEnum&gt;** |  | [optional] 
-**DirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
-**IndirectMap** | **Dictionary&lt;string, bool&gt;** |  | [optional] 
+**MapMapOfString** | **Dictionary&lt;string, Dictionary&lt;string, string&gt;&gt;?** |  | [optional] 
+**MapOfEnumString** | **Dictionary&lt;string, MapTest.InnerEnum&gt;?** |  | [optional] 
+**DirectMap** | **Dictionary&lt;string, bool&gt;?** |  | [optional] 
+**IndirectMap** | **Dictionary&lt;string, bool&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/MixedPropertiesAndAdditionalPropertiesClass.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**UuidWithPattern** | **Guid** |  | [optional] 
-**Uuid** | **Guid** |  | [optional] 
-**DateTime** | **DateTime** |  | [optional] 
-**Map** | [**Dictionary&lt;string, Animal&gt;**](Animal.md) |  | [optional] 
+**UuidWithPattern** | **Guid?** |  | [optional] 
+**Uuid** | **Guid?** |  | [optional] 
+**DateTime** | **DateTime?** |  | [optional] 
+**Map** | [**Dictionary&lt;string, Animal&gt;?**](Animal.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Model200Response.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Model200Response.md
@@ -5,8 +5,8 @@ Model for testing model name starting with number
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **int** |  | [optional] 
-**VarClass** | **string** |  | [optional] 
+**Name** | **int?** |  | [optional] 
+**VarClass** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ModelClient.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ModelClient.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarClient** | **string** |  | [optional] 
+**VarClient** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Name.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Name.md
@@ -6,9 +6,9 @@ Model for testing model name same as property name
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **VarName** | **int** |  | 
-**SnakeCase** | **int** |  | [optional] [readonly] 
-**Property** | **string** |  | [optional] 
-**Var123Number** | **int** |  | [optional] [readonly] 
+**SnakeCase** | **int?** |  | [optional] [readonly] 
+**Property** | **string?** |  | [optional] 
+**Var123Number** | **int?** |  | [optional] [readonly] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/NullableClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/NullableClass.md
@@ -7,15 +7,15 @@ Name | Type | Description | Notes
 **IntegerProp** | **int?** |  | [optional] 
 **NumberProp** | **decimal?** |  | [optional] 
 **BooleanProp** | **bool?** |  | [optional] 
-**StringProp** | **string** |  | [optional] 
+**StringProp** | **string?** |  | [optional] 
 **DateProp** | **DateTime?** |  | [optional] 
 **DatetimeProp** | **DateTime?** |  | [optional] 
-**ArrayNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**ArrayAndItemsNullableProp** | **List&lt;Object&gt;** |  | [optional] 
-**ArrayItemsNullable** | **List&lt;Object&gt;** |  | [optional] 
-**ObjectNullableProp** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**ObjectAndItemsNullableProp** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
-**ObjectItemsNullable** | **Dictionary&lt;string, Object&gt;** |  | [optional] 
+**ArrayNullableProp** | **List&lt;Object&gt;?** |  | [optional] 
+**ArrayAndItemsNullableProp** | **List&lt;Object&gt;?** |  | [optional] 
+**ArrayItemsNullable** | **List&lt;Object&gt;?** |  | [optional] 
+**ObjectNullableProp** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**ObjectAndItemsNullableProp** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
+**ObjectItemsNullable** | **Dictionary&lt;string, Object&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/NumberOnly.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/NumberOnly.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**JustNumber** | **decimal** |  | [optional] 
+**JustNumber** | **decimal?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ObjectWithDeprecatedFields.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ObjectWithDeprecatedFields.md
@@ -4,10 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Uuid** | **string** |  | [optional] 
-**Id** | **decimal** |  | [optional] 
-**DeprecatedRef** | [**DeprecatedObject**](DeprecatedObject.md) |  | [optional] 
-**Bars** | **List&lt;string&gt;** |  | [optional] 
+**Uuid** | **string?** |  | [optional] 
+**Id** | **decimal?** |  | [optional] 
+**DeprecatedRef** | [**DeprecatedObject?**](DeprecatedObject.md) |  | [optional] 
+**Bars** | **List&lt;string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Order.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
-**Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
+**Status** | **string?** | Order Status | [optional] 
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/OuterComposite.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/OuterComposite.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**MyNumber** | **decimal** |  | [optional] 
-**MyString** | **string** |  | [optional] 
-**MyBoolean** | **bool** |  | [optional] 
+**MyNumber** | **decimal?** |  | [optional] 
+**MyString** | **string?** |  | [optional] 
+**MyBoolean** | **bool?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Pet.md
@@ -4,12 +4,12 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Category** | [**Category**](Category.md) |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Category** | [**Category?**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 
-**Tags** | [**List&lt;Tag&gt;**](Tag.md) |  | [optional] 
-**Status** | **string** | pet status in the store | [optional] 
+**Tags** | [**List&lt;Tag&gt;?**](Tag.md) |  | [optional] 
+**Status** | **string?** | pet status in the store | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ReadOnlyFirst.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ReadOnlyFirst.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Bar** | **string** |  | [optional] [readonly] 
-**Baz** | **string** |  | [optional] 
+**Bar** | **string?** |  | [optional] [readonly] 
+**Baz** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/RequiredClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/RequiredClass.md
@@ -7,47 +7,47 @@ Name | Type | Description | Notes
 **RequiredNullableIntegerProp** | **int?** |  | 
 **RequiredNotnullableintegerProp** | **int** |  | 
 **NotRequiredNullableIntegerProp** | **int?** |  | [optional] 
-**NotRequiredNotnullableintegerProp** | **int** |  | [optional] 
+**NotRequiredNotnullableintegerProp** | **int?** |  | [optional] 
 **RequiredNullableStringProp** | **string** |  | 
 **RequiredNotnullableStringProp** | **string** |  | 
-**NotrequiredNullableStringProp** | **string** |  | [optional] 
-**NotrequiredNotnullableStringProp** | **string** |  | [optional] 
+**NotrequiredNullableStringProp** | **string?** |  | [optional] 
+**NotrequiredNotnullableStringProp** | **string?** |  | [optional] 
 **RequiredNullableBooleanProp** | **bool?** |  | 
 **RequiredNotnullableBooleanProp** | **bool** |  | 
 **NotrequiredNullableBooleanProp** | **bool?** |  | [optional] 
-**NotrequiredNotnullableBooleanProp** | **bool** |  | [optional] 
+**NotrequiredNotnullableBooleanProp** | **bool?** |  | [optional] 
 **RequiredNullableDateProp** | **DateTime?** |  | 
 **RequiredNotNullableDateProp** | **DateTime** |  | 
 **NotRequiredNullableDateProp** | **DateTime?** |  | [optional] 
-**NotRequiredNotnullableDateProp** | **DateTime** |  | [optional] 
+**NotRequiredNotnullableDateProp** | **DateTime?** |  | [optional] 
 **RequiredNotnullableDatetimeProp** | **DateTime** |  | 
 **RequiredNullableDatetimeProp** | **DateTime?** |  | 
 **NotrequiredNullableDatetimeProp** | **DateTime?** |  | [optional] 
-**NotrequiredNotnullableDatetimeProp** | **DateTime** |  | [optional] 
+**NotrequiredNotnullableDatetimeProp** | **DateTime?** |  | [optional] 
 **RequiredNullableEnumInteger** | **int?** |  | 
 **RequiredNotnullableEnumInteger** | **int** |  | 
 **NotrequiredNullableEnumInteger** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumInteger** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumInteger** | **int?** |  | [optional] 
 **RequiredNullableEnumIntegerOnly** | **int?** |  | 
 **RequiredNotnullableEnumIntegerOnly** | **int** |  | 
 **NotrequiredNullableEnumIntegerOnly** | **int?** |  | [optional] 
-**NotrequiredNotnullableEnumIntegerOnly** | **int** |  | [optional] 
+**NotrequiredNotnullableEnumIntegerOnly** | **int?** |  | [optional] 
 **RequiredNotnullableEnumString** | **string** |  | 
 **RequiredNullableEnumString** | **string** |  | 
-**NotrequiredNullableEnumString** | **string** |  | [optional] 
-**NotrequiredNotnullableEnumString** | **string** |  | [optional] 
+**NotrequiredNullableEnumString** | **string?** |  | [optional] 
+**NotrequiredNotnullableEnumString** | **string?** |  | [optional] 
 **RequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | 
 **RequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | 
-**NotrequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
-**NotrequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue** |  | [optional] 
+**NotrequiredNullableOuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
+**NotrequiredNotnullableOuterEnumDefaultValue** | **OuterEnumDefaultValue?** |  | [optional] 
 **RequiredNullableUuid** | **Guid?** |  | 
 **RequiredNotnullableUuid** | **Guid** |  | 
 **NotrequiredNullableUuid** | **Guid?** |  | [optional] 
-**NotrequiredNotnullableUuid** | **Guid** |  | [optional] 
+**NotrequiredNotnullableUuid** | **Guid?** |  | [optional] 
 **RequiredNullableArrayOfString** | **List&lt;string&gt;** |  | 
 **RequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | 
-**NotrequiredNullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 
-**NotrequiredNotnullableArrayOfString** | **List&lt;string&gt;** |  | [optional] 
+**NotrequiredNullableArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
+**NotrequiredNotnullableArrayOfString** | **List&lt;string&gt;?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Return.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Return.md
@@ -5,7 +5,7 @@ Model for testing reserved words
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**VarReturn** | **int** |  | [optional] 
+**VarReturn** | **int?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/RolesReportsHash.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/RolesReportsHash.md
@@ -5,8 +5,8 @@ Role report Hash
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**RoleUuid** | **Guid** |  | [optional] 
-**Role** | [**RolesReportsHashRole**](RolesReportsHashRole.md) |  | [optional] 
+**RoleUuid** | **Guid?** |  | [optional] 
+**Role** | [**RolesReportsHashRole?**](RolesReportsHashRole.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/RolesReportsHashRole.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/RolesReportsHashRole.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Name** | **string** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/SpecialModelName.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/SpecialModelName.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SpecialPropertyName** | **long** |  | [optional] 
-**VarSpecialModelName** | **string** |  | [optional] 
+**SpecialPropertyName** | **long?** |  | [optional] 
+**VarSpecialModelName** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Tag.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Name** | **string** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**Name** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestCollectionEndingWithWordList.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestCollectionEndingWithWordList.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Value** | **string** |  | [optional] 
+**Value** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestCollectionEndingWithWordListObject.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestCollectionEndingWithWordListObject.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**TestCollectionEndingWithWordList** | [**List&lt;TestCollectionEndingWithWordList&gt;**](TestCollectionEndingWithWordList.md) |  | [optional] 
+**TestCollectionEndingWithWordList** | [**List&lt;TestCollectionEndingWithWordList&gt;?**](TestCollectionEndingWithWordList.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestInlineFreeformAdditionalPropertiesRequest.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/TestInlineFreeformAdditionalPropertiesRequest.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**SomeProperty** | **string** |  | [optional] 
+**SomeProperty** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/User.md
@@ -4,18 +4,18 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**Username** | **string** |  | [optional] 
-**FirstName** | **string** |  | [optional] 
-**LastName** | **string** |  | [optional] 
-**Email** | **string** |  | [optional] 
-**Password** | **string** |  | [optional] 
-**Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
-**ObjectWithNoDeclaredProps** | **Object** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
-**ObjectWithNoDeclaredPropsNullable** | **Object** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
-**AnyTypeProp** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 
-**AnyTypePropNullable** | **Object** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values. | [optional] 
+**Id** | **long?** |  | [optional] 
+**Username** | **string?** |  | [optional] 
+**FirstName** | **string?** |  | [optional] 
+**LastName** | **string?** |  | [optional] 
+**Email** | **string?** |  | [optional] 
+**Password** | **string?** |  | [optional] 
+**Phone** | **string?** |  | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
+**ObjectWithNoDeclaredProps** | **Object?** | test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value. | [optional] 
+**ObjectWithNoDeclaredPropsNullable** | **Object?** | test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value. | [optional] 
+**AnyTypeProp** | **Object?** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389 | [optional] 
+**AnyTypePropNullable** | **Object?** | test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Whale.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Whale.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**HasBaleen** | **bool** |  | [optional] 
-**HasTeeth** | **bool** |  | [optional] 
+**HasBaleen** | **bool?** |  | [optional] 
+**HasTeeth** | **bool?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/Zebra.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/Zebra.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | **string** |  | [optional] 
+**Type** | **string?** |  | [optional] 
 **ClassName** | **string** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCore/docs/ZeroBasedEnumClass.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/docs/ZeroBasedEnumClass.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ZeroBasedEnum** | **string** |  | [optional] 
+**ZeroBasedEnum** | **string?** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Activity.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Activity.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Activity" /> class.
         /// </summary>
         /// <param name="activityOutputs">activityOutputs.</param>
-        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>> activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>))
+        public Activity(Dictionary<string, List<ActivityOutputElementRepresentation>>? activityOutputs = default(Dictionary<string, List<ActivityOutputElementRepresentation>>?))
         {
             this.ActivityOutputs = activityOutputs;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ActivityOutputs
         /// </summary>
         [DataMember(Name = "activity_outputs", EmitDefaultValue = false)]
-        public Dictionary<string, List<ActivityOutputElementRepresentation>> ActivityOutputs { get; set; }
+        public Dictionary<string, List<ActivityOutputElementRepresentation>>? ActivityOutputs { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ActivityOutputElementRepresentation.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="prop1">prop1.</param>
         /// <param name="prop2">prop2.</param>
-        public ActivityOutputElementRepresentation(string prop1 = default(string), Object prop2 = default(Object))
+        public ActivityOutputElementRepresentation(string? prop1 = default(string?), Object? prop2 = default(Object?))
         {
             this.Prop1 = prop1;
             this.Prop2 = prop2;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Prop1
         /// </summary>
         [DataMember(Name = "prop1", EmitDefaultValue = false)]
-        public string Prop1 { get; set; }
+        public string? Prop1 { get; set; }
 
         /// <summary>
         /// Gets or Sets Prop2
         /// </summary>
         [DataMember(Name = "prop2", EmitDefaultValue = false)]
-        public Object Prop2 { get; set; }
+        public Object? Prop2 { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/AdditionalPropertiesClass.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="mapWithUndeclaredPropertiesAnytype3">mapWithUndeclaredPropertiesAnytype3.</param>
         /// <param name="emptyMap">an object with no declared properties and no undeclared properties, hence it&#39;s an empty map..</param>
         /// <param name="mapWithUndeclaredPropertiesString">mapWithUndeclaredPropertiesString.</param>
-        public AdditionalPropertiesClass(Dictionary<string, string> mapProperty = default(Dictionary<string, string>), Dictionary<string, Dictionary<string, string>> mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>), Object anytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype1 = default(Object), Object mapWithUndeclaredPropertiesAnytype2 = default(Object), Dictionary<string, Object> mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>), Object emptyMap = default(Object), Dictionary<string, string> mapWithUndeclaredPropertiesString = default(Dictionary<string, string>))
+        public AdditionalPropertiesClass(Dictionary<string, string>? mapProperty = default(Dictionary<string, string>?), Dictionary<string, Dictionary<string, string>>? mapOfMapProperty = default(Dictionary<string, Dictionary<string, string>>?), Object? anytype1 = default(Object?), Object? mapWithUndeclaredPropertiesAnytype1 = default(Object?), Object? mapWithUndeclaredPropertiesAnytype2 = default(Object?), Dictionary<string, Object>? mapWithUndeclaredPropertiesAnytype3 = default(Dictionary<string, Object>?), Object? emptyMap = default(Object?), Dictionary<string, string>? mapWithUndeclaredPropertiesString = default(Dictionary<string, string>?))
         {
             this.MapProperty = mapProperty;
             this.MapOfMapProperty = mapOfMapProperty;
@@ -59,50 +59,50 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapProperty
         /// </summary>
         [DataMember(Name = "map_property", EmitDefaultValue = false)]
-        public Dictionary<string, string> MapProperty { get; set; }
+        public Dictionary<string, string>? MapProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets MapOfMapProperty
         /// </summary>
         [DataMember(Name = "map_of_map_property", EmitDefaultValue = false)]
-        public Dictionary<string, Dictionary<string, string>> MapOfMapProperty { get; set; }
+        public Dictionary<string, Dictionary<string, string>>? MapOfMapProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets Anytype1
         /// </summary>
         [DataMember(Name = "anytype_1", EmitDefaultValue = true)]
-        public Object Anytype1 { get; set; }
+        public Object? Anytype1 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype1
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_1", EmitDefaultValue = false)]
-        public Object MapWithUndeclaredPropertiesAnytype1 { get; set; }
+        public Object? MapWithUndeclaredPropertiesAnytype1 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype2
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_2", EmitDefaultValue = false)]
-        public Object MapWithUndeclaredPropertiesAnytype2 { get; set; }
+        public Object? MapWithUndeclaredPropertiesAnytype2 { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesAnytype3
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_anytype_3", EmitDefaultValue = false)]
-        public Dictionary<string, Object> MapWithUndeclaredPropertiesAnytype3 { get; set; }
+        public Dictionary<string, Object>? MapWithUndeclaredPropertiesAnytype3 { get; set; }
 
         /// <summary>
         /// an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.
         /// </summary>
         /// <value>an object with no declared properties and no undeclared properties, hence it&#39;s an empty map.</value>
         [DataMember(Name = "empty_map", EmitDefaultValue = false)]
-        public Object EmptyMap { get; set; }
+        public Object? EmptyMap { get; set; }
 
         /// <summary>
         /// Gets or Sets MapWithUndeclaredPropertiesString
         /// </summary>
         [DataMember(Name = "map_with_undeclared_properties_string", EmitDefaultValue = false)]
-        public Dictionary<string, string> MapWithUndeclaredPropertiesString { get; set; }
+        public Dictionary<string, string>? MapWithUndeclaredPropertiesString { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Animal.cs
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="className">className (required).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Animal(string className = default(string), string color = @"red")
+        public Animal(string className = default(string), string? color = @"red")
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -68,7 +68,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Color
         /// </summary>
         [DataMember(Name = "color", EmitDefaultValue = false)]
-        public string Color { get; set; }
+        public string? Color { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string? type = default(string?), string? message = default(string?))
         {
             this.Code = code;
             this.Type = type;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type
         /// </summary>
         [DataMember(Name = "type", EmitDefaultValue = false)]
-        public string Type { get; set; }
+        public string? Type { get; set; }
 
         /// <summary>
         /// Gets or Sets Message
         /// </summary>
         [DataMember(Name = "message", EmitDefaultValue = false)]
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Apple.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="cultivar">cultivar.</param>
         /// <param name="origin">origin.</param>
         /// <param name="colorCode">colorCode.</param>
-        public Apple(string cultivar = default(string), string origin = default(string), string colorCode = default(string))
+        public Apple(string? cultivar = default(string?), string? origin = default(string?), string? colorCode = default(string?))
         {
             this.Cultivar = cultivar;
             this.Origin = origin;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Cultivar
         /// </summary>
         [DataMember(Name = "cultivar", EmitDefaultValue = false)]
-        public string Cultivar { get; set; }
+        public string? Cultivar { get; set; }
 
         /// <summary>
         /// Gets or Sets Origin
         /// </summary>
         [DataMember(Name = "origin", EmitDefaultValue = false)]
-        public string Origin { get; set; }
+        public string? Origin { get; set; }
 
         /// <summary>
         /// Gets or Sets ColorCode
         /// </summary>
         [DataMember(Name = "color_code", EmitDefaultValue = false)]
-        public string ColorCode { get; set; }
+        public string? ColorCode { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -140,7 +140,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.Cultivar != null) {
-                // Cultivar (string) pattern
+                // Cultivar (string?) pattern
                 Regex regexCultivar = new Regex(@"^[a-zA-Z\s]*$", RegexOptions.CultureInvariant);
                 if (!regexCultivar.Match(this.Cultivar).Success)
                 {
@@ -149,7 +149,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.Origin != null) {
-                // Origin (string) pattern
+                // Origin (string?) pattern
                 Regex regexOrigin = new Regex(@"^[A-Z\s]*$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexOrigin.Match(this.Origin).Success)
                 {
@@ -158,7 +158,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.ColorCode != null) {
-                // ColorCode (string) pattern
+                // ColorCode (string?) pattern
                 Regex regexColorCode = new Regex(@"^#(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$", RegexOptions.CultureInvariant);
                 if (!regexColorCode.Match(this.ColorCode).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/AppleReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="cultivar">cultivar (required).</param>
         /// <param name="mealy">mealy.</param>
-        public AppleReq(string cultivar = default(string), bool mealy = default(bool))
+        public AppleReq(string cultivar = default(string), bool? mealy = default(bool?))
         {
             // to ensure "cultivar" is required (not null)
             if (cultivar == null)
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Mealy
         /// </summary>
         [DataMember(Name = "mealy", EmitDefaultValue = true)]
-        public bool Mealy { get; set; }
+        public bool? Mealy { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayArrayNumber">arrayArrayNumber.</param>
-        public ArrayOfArrayOfNumberOnly(List<List<decimal>> arrayArrayNumber = default(List<List<decimal>>))
+        public ArrayOfArrayOfNumberOnly(List<List<decimal>>? arrayArrayNumber = default(List<List<decimal>>?))
         {
             this.ArrayArrayNumber = arrayArrayNumber;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayArrayNumber
         /// </summary>
         [DataMember(Name = "ArrayArrayNumber", EmitDefaultValue = false)]
-        public List<List<decimal>> ArrayArrayNumber { get; set; }
+        public List<List<decimal>>? ArrayArrayNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayOfNumberOnly.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ArrayOfNumberOnly" /> class.
         /// </summary>
         /// <param name="arrayNumber">arrayNumber.</param>
-        public ArrayOfNumberOnly(List<decimal> arrayNumber = default(List<decimal>))
+        public ArrayOfNumberOnly(List<decimal>? arrayNumber = default(List<decimal>?))
         {
             this.ArrayNumber = arrayNumber;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNumber
         /// </summary>
         [DataMember(Name = "ArrayNumber", EmitDefaultValue = false)]
-        public List<decimal> ArrayNumber { get; set; }
+        public List<decimal>? ArrayNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ArrayTest.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="arrayOfString">arrayOfString.</param>
         /// <param name="arrayArrayOfInteger">arrayArrayOfInteger.</param>
         /// <param name="arrayArrayOfModel">arrayArrayOfModel.</param>
-        public ArrayTest(List<string> arrayOfString = default(List<string>), List<List<long>> arrayArrayOfInteger = default(List<List<long>>), List<List<ReadOnlyFirst>> arrayArrayOfModel = default(List<List<ReadOnlyFirst>>))
+        public ArrayTest(List<string>? arrayOfString = default(List<string>?), List<List<long>>? arrayArrayOfInteger = default(List<List<long>>?), List<List<ReadOnlyFirst>>? arrayArrayOfModel = default(List<List<ReadOnlyFirst>>?))
         {
             this.ArrayOfString = arrayOfString;
             this.ArrayArrayOfInteger = arrayArrayOfInteger;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayOfString
         /// </summary>
         [DataMember(Name = "array_of_string", EmitDefaultValue = false)]
-        public List<string> ArrayOfString { get; set; }
+        public List<string>? ArrayOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayArrayOfInteger
         /// </summary>
         [DataMember(Name = "array_array_of_integer", EmitDefaultValue = false)]
-        public List<List<long>> ArrayArrayOfInteger { get; set; }
+        public List<List<long>>? ArrayArrayOfInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayArrayOfModel
         /// </summary>
         [DataMember(Name = "array_array_of_model", EmitDefaultValue = false)]
-        public List<List<ReadOnlyFirst>> ArrayArrayOfModel { get; set; }
+        public List<List<ReadOnlyFirst>>? ArrayArrayOfModel { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Banana.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Banana.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Banana" /> class.
         /// </summary>
         /// <param name="lengthCm">lengthCm.</param>
-        public Banana(decimal lengthCm = default(decimal))
+        public Banana(decimal? lengthCm = default(decimal?))
         {
             this.LengthCm = lengthCm;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets LengthCm
         /// </summary>
         [DataMember(Name = "lengthCm", EmitDefaultValue = false)]
-        public decimal LengthCm { get; set; }
+        public decimal? LengthCm { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/BananaReq.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="lengthCm">lengthCm (required).</param>
         /// <param name="sweet">sweet.</param>
-        public BananaReq(decimal lengthCm = default(decimal), bool sweet = default(bool))
+        public BananaReq(decimal lengthCm = default(decimal), bool? sweet = default(bool?))
         {
             this.LengthCm = lengthCm;
             this.Sweet = sweet;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Sweet
         /// </summary>
         [DataMember(Name = "sweet", EmitDefaultValue = true)]
-        public bool Sweet { get; set; }
+        public bool? Sweet { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Capitalization.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Capitalization.cs
@@ -41,7 +41,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="capitalSnake">capitalSnake.</param>
         /// <param name="sCAETHFlowPoints">sCAETHFlowPoints.</param>
         /// <param name="aTTNAME">Name of the pet .</param>
-        public Capitalization(string smallCamel = default(string), string capitalCamel = default(string), string smallSnake = default(string), string capitalSnake = default(string), string sCAETHFlowPoints = default(string), string aTTNAME = default(string))
+        public Capitalization(string? smallCamel = default(string?), string? capitalCamel = default(string?), string? smallSnake = default(string?), string? capitalSnake = default(string?), string? sCAETHFlowPoints = default(string?), string? aTTNAME = default(string?))
         {
             this.SmallCamel = smallCamel;
             this.CapitalCamel = capitalCamel;
@@ -55,38 +55,38 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SmallCamel
         /// </summary>
         [DataMember(Name = "smallCamel", EmitDefaultValue = false)]
-        public string SmallCamel { get; set; }
+        public string? SmallCamel { get; set; }
 
         /// <summary>
         /// Gets or Sets CapitalCamel
         /// </summary>
         [DataMember(Name = "CapitalCamel", EmitDefaultValue = false)]
-        public string CapitalCamel { get; set; }
+        public string? CapitalCamel { get; set; }
 
         /// <summary>
         /// Gets or Sets SmallSnake
         /// </summary>
         [DataMember(Name = "small_Snake", EmitDefaultValue = false)]
-        public string SmallSnake { get; set; }
+        public string? SmallSnake { get; set; }
 
         /// <summary>
         /// Gets or Sets CapitalSnake
         /// </summary>
         [DataMember(Name = "Capital_Snake", EmitDefaultValue = false)]
-        public string CapitalSnake { get; set; }
+        public string? CapitalSnake { get; set; }
 
         /// <summary>
         /// Gets or Sets SCAETHFlowPoints
         /// </summary>
         [DataMember(Name = "SCA_ETH_Flow_Points", EmitDefaultValue = false)]
-        public string SCAETHFlowPoints { get; set; }
+        public string? SCAETHFlowPoints { get; set; }
 
         /// <summary>
         /// Name of the pet 
         /// </summary>
         /// <value>Name of the pet </value>
         [DataMember(Name = "ATT_NAME", EmitDefaultValue = false)]
-        public string ATT_NAME { get; set; }
+        public string? ATT_NAME { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Cat.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="declawed">declawed.</param>
         /// <param name="className">className (required) (default to &quot;Cat&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Cat(bool declawed = default(bool), string className = @"Cat", string color = @"red") : base(className, color)
+        public Cat(bool? declawed = default(bool?), string className = @"Cat", string? color = @"red") : base(className, color)
         {
             this.Declawed = declawed;
         }
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Declawed
         /// </summary>
         [DataMember(Name = "declawed", EmitDefaultValue = true)]
-        public bool Declawed { get; set; }
+        public bool? Declawed { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Category.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name (required) (default to &quot;default-name&quot;).</param>
-        public Category(long id = default(long), string name = @"default-name")
+        public Category(long? id = default(long?), string name = @"default-name")
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -57,7 +57,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ChildCat.cs
@@ -63,7 +63,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="petType">petType (required) (default to PetTypeEnum.ChildCat).</param>
-        public ChildCat(string name = default(string), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
+        public ChildCat(string? name = default(string?), PetTypeEnum petType = PetTypeEnum.ChildCat) : base()
         {
             this.PetType = petType;
             this.Name = name;
@@ -73,7 +73,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ClassModel.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ClassModel.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ClassModel" /> class.
         /// </summary>
         /// <param name="varClass">varClass.</param>
-        public ClassModel(string varClass = default(string))
+        public ClassModel(string? varClass = default(string?))
         {
             this.VarClass = varClass;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClass
         /// </summary>
         [DataMember(Name = "_class", EmitDefaultValue = false)]
-        public string VarClass { get; set; }
+        public string? VarClass { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/DateOnlyClass.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DateOnlyClass" /> class.
         /// </summary>
         /// <param name="dateOnlyProperty">dateOnlyProperty.</param>
-        public DateOnlyClass(DateTime dateOnlyProperty = default(DateTime))
+        public DateOnlyClass(DateTime? dateOnlyProperty = default(DateTime?))
         {
             this.DateOnlyProperty = dateOnlyProperty;
         }
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <example>Fri Jul 21 00:00:00 UTC 2017</example>
         [DataMember(Name = "dateOnlyProperty", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime DateOnlyProperty { get; set; }
+        public DateTime? DateOnlyProperty { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/DeprecatedObject.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="DeprecatedObject" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        public DeprecatedObject(string name = default(string))
+        public DeprecatedObject(string? name = default(string?))
         {
             this.Name = name;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Dog.cs
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="breed">breed.</param>
         /// <param name="className">className (required) (default to &quot;Dog&quot;).</param>
         /// <param name="color">color (default to &quot;red&quot;).</param>
-        public Dog(string breed = default(string), string className = @"Dog", string color = @"red") : base(className, color)
+        public Dog(string? breed = default(string?), string className = @"Dog", string? color = @"red") : base(className, color)
         {
             this.Breed = breed;
         }
@@ -54,7 +54,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Breed
         /// </summary>
         [DataMember(Name = "breed", EmitDefaultValue = false)]
-        public string Breed { get; set; }
+        public string? Breed { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Drawing.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shapeOrNull">shapeOrNull.</param>
         /// <param name="nullableShape">nullableShape.</param>
         /// <param name="shapes">shapes.</param>
-        public Drawing(Shape mainShape = default(Shape), ShapeOrNull shapeOrNull = default(ShapeOrNull), NullableShape nullableShape = default(NullableShape), List<Shape> shapes = default(List<Shape>))
+        public Drawing(Shape? mainShape = default(Shape?), ShapeOrNull? shapeOrNull = default(ShapeOrNull?), NullableShape? nullableShape = default(NullableShape?), List<Shape>? shapes = default(List<Shape>?))
         {
             this.MainShape = mainShape;
             this.ShapeOrNull = shapeOrNull;
@@ -52,25 +52,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MainShape
         /// </summary>
         [DataMember(Name = "mainShape", EmitDefaultValue = false)]
-        public Shape MainShape { get; set; }
+        public Shape? MainShape { get; set; }
 
         /// <summary>
         /// Gets or Sets ShapeOrNull
         /// </summary>
         [DataMember(Name = "shapeOrNull", EmitDefaultValue = true)]
-        public ShapeOrNull ShapeOrNull { get; set; }
+        public ShapeOrNull? ShapeOrNull { get; set; }
 
         /// <summary>
         /// Gets or Sets NullableShape
         /// </summary>
         [DataMember(Name = "nullableShape", EmitDefaultValue = true)]
-        public NullableShape NullableShape { get; set; }
+        public NullableShape? NullableShape { get; set; }
 
         /// <summary>
         /// Gets or Sets Shapes
         /// </summary>
         [DataMember(Name = "shapes", EmitDefaultValue = false)]
-        public List<Shape> Shapes { get; set; }
+        public List<Shape>? Shapes { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/EnumArrays.cs
@@ -91,7 +91,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayEnum
         /// </summary>
         [DataMember(Name = "array_enum", EmitDefaultValue = false)]
-        public List<EnumArrays.ArrayEnumEnum> ArrayEnum { get; set; }
+        public List<EnumArrays.ArrayEnumEnum>? ArrayEnum { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/File.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/File.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="File" /> class.
         /// </summary>
         /// <param name="sourceURI">Test capitalization.</param>
-        public File(string sourceURI = default(string))
+        public File(string? sourceURI = default(string?))
         {
             this.SourceURI = sourceURI;
         }
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>Test capitalization</value>
         [DataMember(Name = "sourceURI", EmitDefaultValue = false)]
-        public string SourceURI { get; set; }
+        public string? SourceURI { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FileSchemaTestClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="file">file.</param>
         /// <param name="files">files.</param>
-        public FileSchemaTestClass(File file = default(File), List<File> files = default(List<File>))
+        public FileSchemaTestClass(File? file = default(File?), List<File>? files = default(List<File>?))
         {
             this.File = file;
             this.Files = files;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets File
         /// </summary>
         [DataMember(Name = "file", EmitDefaultValue = false)]
-        public File File { get; set; }
+        public File? File { get; set; }
 
         /// <summary>
         /// Gets or Sets Files
         /// </summary>
         [DataMember(Name = "files", EmitDefaultValue = false)]
-        public List<File> Files { get; set; }
+        public List<File>? Files { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Foo.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Foo.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Foo" /> class.
         /// </summary>
         /// <param name="bar">bar (default to &quot;bar&quot;).</param>
-        public Foo(string bar = @"bar")
+        public Foo(string? bar = @"bar")
         {
             // use default value if no "bar" provided
             this.Bar = bar ?? @"bar";
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; set; }
+        public string? Bar { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FooGetDefaultResponse.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="FooGetDefaultResponse" /> class.
         /// </summary>
         /// <param name="varString">varString.</param>
-        public FooGetDefaultResponse(Foo varString = default(Foo))
+        public FooGetDefaultResponse(Foo? varString = default(Foo?))
         {
             this.VarString = varString;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarString
         /// </summary>
         [DataMember(Name = "string", EmitDefaultValue = false)]
-        public Foo VarString { get; set; }
+        public Foo? VarString { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/FormatTest.cs
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="patternWithDigits">A string that is a 10 digit number. Can have leading zeros..</param>
         /// <param name="patternWithDigitsAndDelimiter">A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01..</param>
         /// <param name="patternWithBackslash">None.</param>
-        public FormatTest(int integer = default(int), int int32 = default(int), uint unsignedInteger = default(uint), long int64 = default(long), ulong unsignedLong = default(ulong), decimal number = default(decimal), float varFloat = default(float), double varDouble = default(double), decimal varDecimal = default(decimal), string varString = default(string), byte[] varByte = default(byte[]), System.IO.Stream binary = default(System.IO.Stream), DateTime date = default(DateTime), DateTime dateTime = default(DateTime), Guid uuid = default(Guid), string password = default(string), string patternWithDigits = default(string), string patternWithDigitsAndDelimiter = default(string), string patternWithBackslash = default(string))
+        public FormatTest(int? integer = default(int?), int? int32 = default(int?), uint? unsignedInteger = default(uint?), long? int64 = default(long?), ulong? unsignedLong = default(ulong?), decimal number = default(decimal), float? varFloat = default(float?), double? varDouble = default(double?), decimal? varDecimal = default(decimal?), string? varString = default(string?), byte[] varByte = default(byte[]), System.IO.Stream? binary = default(System.IO.Stream?), DateTime date = default(DateTime), DateTime? dateTime = default(DateTime?), Guid? uuid = default(Guid?), string password = default(string), string? patternWithDigits = default(string?), string? patternWithDigitsAndDelimiter = default(string?), string? patternWithBackslash = default(string?))
         {
             this.Number = number;
             // to ensure "varByte" is required (not null)
@@ -96,31 +96,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Integer
         /// </summary>
         [DataMember(Name = "integer", EmitDefaultValue = false)]
-        public int Integer { get; set; }
+        public int? Integer { get; set; }
 
         /// <summary>
         /// Gets or Sets Int32
         /// </summary>
         [DataMember(Name = "int32", EmitDefaultValue = false)]
-        public int Int32 { get; set; }
+        public int? Int32 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedInteger
         /// </summary>
         [DataMember(Name = "unsigned_integer", EmitDefaultValue = false)]
-        public uint UnsignedInteger { get; set; }
+        public uint? UnsignedInteger { get; set; }
 
         /// <summary>
         /// Gets or Sets Int64
         /// </summary>
         [DataMember(Name = "int64", EmitDefaultValue = false)]
-        public long Int64 { get; set; }
+        public long? Int64 { get; set; }
 
         /// <summary>
         /// Gets or Sets UnsignedLong
         /// </summary>
         [DataMember(Name = "unsigned_long", EmitDefaultValue = false)]
-        public ulong UnsignedLong { get; set; }
+        public ulong? UnsignedLong { get; set; }
 
         /// <summary>
         /// Gets or Sets Number
@@ -132,25 +132,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarFloat
         /// </summary>
         [DataMember(Name = "float", EmitDefaultValue = false)]
-        public float VarFloat { get; set; }
+        public float? VarFloat { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDouble
         /// </summary>
         [DataMember(Name = "double", EmitDefaultValue = false)]
-        public double VarDouble { get; set; }
+        public double? VarDouble { get; set; }
 
         /// <summary>
         /// Gets or Sets VarDecimal
         /// </summary>
         [DataMember(Name = "decimal", EmitDefaultValue = false)]
-        public decimal VarDecimal { get; set; }
+        public decimal? VarDecimal { get; set; }
 
         /// <summary>
         /// Gets or Sets VarString
         /// </summary>
         [DataMember(Name = "string", EmitDefaultValue = false)]
-        public string VarString { get; set; }
+        public string? VarString { get; set; }
 
         /// <summary>
         /// Gets or Sets VarByte
@@ -162,7 +162,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Binary
         /// </summary>
         [DataMember(Name = "binary", EmitDefaultValue = false)]
-        public System.IO.Stream Binary { get; set; }
+        public System.IO.Stream? Binary { get; set; }
 
         /// <summary>
         /// Gets or Sets Date
@@ -177,14 +177,14 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>2007-12-03T10:15:30+01:00</example>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
@@ -197,21 +197,21 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>A string that is a 10 digit number. Can have leading zeros.</value>
         [DataMember(Name = "pattern_with_digits", EmitDefaultValue = false)]
-        public string PatternWithDigits { get; set; }
+        public string? PatternWithDigits { get; set; }
 
         /// <summary>
         /// A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.
         /// </summary>
         /// <value>A string starting with &#39;image_&#39; (case insensitive) and one to three digits following i.e. Image_01.</value>
         [DataMember(Name = "pattern_with_digits_and_delimiter", EmitDefaultValue = false)]
-        public string PatternWithDigitsAndDelimiter { get; set; }
+        public string? PatternWithDigitsAndDelimiter { get; set; }
 
         /// <summary>
         /// None
         /// </summary>
         /// <value>None</value>
         [DataMember(Name = "pattern_with_backslash", EmitDefaultValue = false)]
-        public string PatternWithBackslash { get; set; }
+        public string? PatternWithBackslash { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -342,38 +342,38 @@ namespace Org.OpenAPITools.Model
         /// <returns>Validation Result</returns>
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
-            // Integer (int) maximum
-            if (this.Integer > (int)100)
+            // Integer (int?) maximum
+            if (this.Integer > (int?)100)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value less than or equal to 100.", new [] { "Integer" });
             }
 
-            // Integer (int) minimum
-            if (this.Integer < (int)10)
+            // Integer (int?) minimum
+            if (this.Integer < (int?)10)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Integer, must be a value greater than or equal to 10.", new [] { "Integer" });
             }
 
-            // Int32 (int) maximum
-            if (this.Int32 > (int)200)
+            // Int32 (int?) maximum
+            if (this.Int32 > (int?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value less than or equal to 200.", new [] { "Int32" });
             }
 
-            // Int32 (int) minimum
-            if (this.Int32 < (int)20)
+            // Int32 (int?) minimum
+            if (this.Int32 < (int?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Int32, must be a value greater than or equal to 20.", new [] { "Int32" });
             }
 
-            // UnsignedInteger (uint) maximum
-            if (this.UnsignedInteger > (uint)200)
+            // UnsignedInteger (uint?) maximum
+            if (this.UnsignedInteger > (uint?)200)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value less than or equal to 200.", new [] { "UnsignedInteger" });
             }
 
-            // UnsignedInteger (uint) minimum
-            if (this.UnsignedInteger < (uint)20)
+            // UnsignedInteger (uint?) minimum
+            if (this.UnsignedInteger < (uint?)20)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for UnsignedInteger, must be a value greater than or equal to 20.", new [] { "UnsignedInteger" });
             }
@@ -390,32 +390,32 @@ namespace Org.OpenAPITools.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Number, must be a value greater than or equal to 32.1.", new [] { "Number" });
             }
 
-            // VarFloat (float) maximum
-            if (this.VarFloat > (float)987.6)
+            // VarFloat (float?) maximum
+            if (this.VarFloat > (float?)987.6)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value less than or equal to 987.6.", new [] { "VarFloat" });
             }
 
-            // VarFloat (float) minimum
-            if (this.VarFloat < (float)54.3)
+            // VarFloat (float?) minimum
+            if (this.VarFloat < (float?)54.3)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarFloat, must be a value greater than or equal to 54.3.", new [] { "VarFloat" });
             }
 
-            // VarDouble (double) maximum
-            if (this.VarDouble > (double)123.4)
+            // VarDouble (double?) maximum
+            if (this.VarDouble > (double?)123.4)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value less than or equal to 123.4.", new [] { "VarDouble" });
             }
 
-            // VarDouble (double) minimum
-            if (this.VarDouble < (double)67.8)
+            // VarDouble (double?) minimum
+            if (this.VarDouble < (double?)67.8)
             {
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for VarDouble, must be a value greater than or equal to 67.8.", new [] { "VarDouble" });
             }
 
             if (this.VarString != null) {
-                // VarString (string) pattern
+                // VarString (string?) pattern
                 Regex regexVarString = new Regex(@"[a-z]", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexVarString.Match(this.VarString).Success)
                 {
@@ -436,7 +436,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithDigits != null) {
-                // PatternWithDigits (string) pattern
+                // PatternWithDigits (string?) pattern
                 Regex regexPatternWithDigits = new Regex(@"^\d{10}$", RegexOptions.CultureInvariant);
                 if (!regexPatternWithDigits.Match(this.PatternWithDigits).Success)
                 {
@@ -445,7 +445,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithDigitsAndDelimiter != null) {
-                // PatternWithDigitsAndDelimiter (string) pattern
+                // PatternWithDigitsAndDelimiter (string?) pattern
                 Regex regexPatternWithDigitsAndDelimiter = new Regex(@"^image_\d{1,3}$", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
                 if (!regexPatternWithDigitsAndDelimiter.Match(this.PatternWithDigitsAndDelimiter).Success)
                 {
@@ -454,7 +454,7 @@ namespace Org.OpenAPITools.Model
             }
 
             if (this.PatternWithBackslash != null) {
-                // PatternWithBackslash (string) pattern
+                // PatternWithBackslash (string?) pattern
                 Regex regexPatternWithBackslash = new Regex(@"^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$", RegexOptions.CultureInvariant);
                 if (!regexPatternWithBackslash.Match(this.PatternWithBackslash).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/HasOnlyReadOnly.cs
@@ -44,7 +44,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; private set; }
+        public string? Bar { get; private set; }
 
         /// <summary>
         /// Returns false as Bar should not be serialized given that it's read-only.
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Foo
         /// </summary>
         [DataMember(Name = "foo", EmitDefaultValue = false)]
-        public string Foo { get; private set; }
+        public string? Foo { get; private set; }
 
         /// <summary>
         /// Returns false as Foo should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/HealthCheckResult.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="HealthCheckResult" /> class.
         /// </summary>
         /// <param name="nullableMessage">nullableMessage.</param>
-        public HealthCheckResult(string nullableMessage = default(string))
+        public HealthCheckResult(string? nullableMessage = default(string?))
         {
             this.NullableMessage = nullableMessage;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NullableMessage
         /// </summary>
         [DataMember(Name = "NullableMessage", EmitDefaultValue = true)]
-        public string NullableMessage { get; set; }
+        public string? NullableMessage { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/List.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/List.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="List" /> class.
         /// </summary>
         /// <param name="var123List">var123List.</param>
-        public List(string var123List = default(string))
+        public List(string? var123List = default(string?))
         {
             this.Var123List = var123List;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Var123List
         /// </summary>
         [DataMember(Name = "123-list", EmitDefaultValue = false)]
-        public string Var123List { get; set; }
+        public string? Var123List { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/LiteralStringClass.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="escapedLiteralString">escapedLiteralString (default to &quot;C:\\Users\\username&quot;).</param>
         /// <param name="unescapedLiteralString">unescapedLiteralString (default to &quot;C:\Users\username&quot;).</param>
-        public LiteralStringClass(string escapedLiteralString = @"C:\\Users\\username", string unescapedLiteralString = @"C:\Users\username")
+        public LiteralStringClass(string? escapedLiteralString = @"C:\\Users\\username", string? unescapedLiteralString = @"C:\Users\username")
         {
             // use default value if no "escapedLiteralString" provided
             this.EscapedLiteralString = escapedLiteralString ?? @"C:\\Users\\username";
@@ -49,13 +49,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets EscapedLiteralString
         /// </summary>
         [DataMember(Name = "escapedLiteralString", EmitDefaultValue = false)]
-        public string EscapedLiteralString { get; set; }
+        public string? EscapedLiteralString { get; set; }
 
         /// <summary>
         /// Gets or Sets UnescapedLiteralString
         /// </summary>
         [DataMember(Name = "unescapedLiteralString", EmitDefaultValue = false)]
-        public string UnescapedLiteralString { get; set; }
+        public string? UnescapedLiteralString { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MapTest.cs
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="mapOfEnumString">mapOfEnumString.</param>
         /// <param name="directMap">directMap.</param>
         /// <param name="indirectMap">indirectMap.</param>
-        public MapTest(Dictionary<string, Dictionary<string, string>> mapMapOfString = default(Dictionary<string, Dictionary<string, string>>), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool> directMap = default(Dictionary<string, bool>), Dictionary<string, bool> indirectMap = default(Dictionary<string, bool>))
+        public MapTest(Dictionary<string, Dictionary<string, string>>? mapMapOfString = default(Dictionary<string, Dictionary<string, string>>?), Dictionary<string, InnerEnum> mapOfEnumString = default(Dictionary<string, InnerEnum>), Dictionary<string, bool>? directMap = default(Dictionary<string, bool>?), Dictionary<string, bool>? indirectMap = default(Dictionary<string, bool>?))
         {
             this.MapMapOfString = mapMapOfString;
             this.MapOfEnumString = mapOfEnumString;
@@ -70,25 +70,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MapMapOfString
         /// </summary>
         [DataMember(Name = "map_map_of_string", EmitDefaultValue = false)]
-        public Dictionary<string, Dictionary<string, string>> MapMapOfString { get; set; }
+        public Dictionary<string, Dictionary<string, string>>? MapMapOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets MapOfEnumString
         /// </summary>
         [DataMember(Name = "map_of_enum_string", EmitDefaultValue = false)]
-        public Dictionary<string, MapTest.InnerEnum> MapOfEnumString { get; set; }
+        public Dictionary<string, MapTest.InnerEnum>? MapOfEnumString { get; set; }
 
         /// <summary>
         /// Gets or Sets DirectMap
         /// </summary>
         [DataMember(Name = "direct_map", EmitDefaultValue = false)]
-        public Dictionary<string, bool> DirectMap { get; set; }
+        public Dictionary<string, bool>? DirectMap { get; set; }
 
         /// <summary>
         /// Gets or Sets IndirectMap
         /// </summary>
         [DataMember(Name = "indirect_map", EmitDefaultValue = false)]
-        public Dictionary<string, bool> IndirectMap { get; set; }
+        public Dictionary<string, bool>? IndirectMap { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/MixedPropertiesAndAdditionalPropertiesClass.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="uuid">uuid.</param>
         /// <param name="dateTime">dateTime.</param>
         /// <param name="map">map.</param>
-        public MixedPropertiesAndAdditionalPropertiesClass(Guid uuidWithPattern = default(Guid), Guid uuid = default(Guid), DateTime dateTime = default(DateTime), Dictionary<string, Animal> map = default(Dictionary<string, Animal>))
+        public MixedPropertiesAndAdditionalPropertiesClass(Guid? uuidWithPattern = default(Guid?), Guid? uuid = default(Guid?), DateTime? dateTime = default(DateTime?), Dictionary<string, Animal>? map = default(Dictionary<string, Animal>?))
         {
             this.UuidWithPattern = uuidWithPattern;
             this.Uuid = uuid;
@@ -51,25 +51,25 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets UuidWithPattern
         /// </summary>
         [DataMember(Name = "uuid_with_pattern", EmitDefaultValue = false)]
-        public Guid UuidWithPattern { get; set; }
+        public Guid? UuidWithPattern { get; set; }
 
         /// <summary>
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public Guid Uuid { get; set; }
+        public Guid? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets DateTime
         /// </summary>
         [DataMember(Name = "dateTime", EmitDefaultValue = false)]
-        public DateTime DateTime { get; set; }
+        public DateTime? DateTime { get; set; }
 
         /// <summary>
         /// Gets or Sets Map
         /// </summary>
         [DataMember(Name = "map", EmitDefaultValue = false)]
-        public Dictionary<string, Animal> Map { get; set; }
+        public Dictionary<string, Animal>? Map { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -153,7 +153,7 @@ namespace Org.OpenAPITools.Model
         IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
         {
             if (this.UuidWithPattern != null) {
-                // UuidWithPattern (Guid) pattern
+                // UuidWithPattern (Guid?) pattern
                 Regex regexUuidWithPattern = new Regex(@"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", RegexOptions.CultureInvariant);
                 if (!regexUuidWithPattern.Match(this.UuidWithPattern.ToString()).Success)
                 {

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Model200Response.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Model200Response.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="name">name.</param>
         /// <param name="varClass">varClass.</param>
-        public Model200Response(int name = default(int), string varClass = default(string))
+        public Model200Response(int? name = default(int?), string? varClass = default(string?))
         {
             this.Name = name;
             this.VarClass = varClass;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public int Name { get; set; }
+        public int? Name { get; set; }
 
         /// <summary>
         /// Gets or Sets VarClass
         /// </summary>
         [DataMember(Name = "class", EmitDefaultValue = false)]
-        public string VarClass { get; set; }
+        public string? VarClass { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ModelClient.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ModelClient.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ModelClient" /> class.
         /// </summary>
         /// <param name="varClient">varClient.</param>
-        public ModelClient(string varClient = default(string))
+        public ModelClient(string? varClient = default(string?))
         {
             this.VarClient = varClient;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarClient
         /// </summary>
         [DataMember(Name = "client", EmitDefaultValue = false)]
-        public string VarClient { get; set; }
+        public string? VarClient { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Name.cs
@@ -42,7 +42,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="varName">varName (required).</param>
         /// <param name="property">property.</param>
-        public Name(int varName = default(int), string property = default(string))
+        public Name(int varName = default(int), string? property = default(string?))
         {
             this.VarName = varName;
             this.Property = property;
@@ -58,7 +58,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SnakeCase
         /// </summary>
         [DataMember(Name = "snake_case", EmitDefaultValue = false)]
-        public int SnakeCase { get; private set; }
+        public int? SnakeCase { get; private set; }
 
         /// <summary>
         /// Returns false as SnakeCase should not be serialized given that it's read-only.
@@ -72,13 +72,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Property
         /// </summary>
         [DataMember(Name = "property", EmitDefaultValue = false)]
-        public string Property { get; set; }
+        public string? Property { get; set; }
 
         /// <summary>
         /// Gets or Sets Var123Number
         /// </summary>
         [DataMember(Name = "123Number", EmitDefaultValue = false)]
-        public int Var123Number { get; private set; }
+        public int? Var123Number { get; private set; }
 
         /// <summary>
         /// Returns false as Var123Number should not be serialized given that it's read-only.

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/NullableClass.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectNullableProp">objectNullableProp.</param>
         /// <param name="objectAndItemsNullableProp">objectAndItemsNullableProp.</param>
         /// <param name="objectItemsNullable">objectItemsNullable.</param>
-        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string stringProp = default(string), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object> arrayNullableProp = default(List<Object>), List<Object> arrayAndItemsNullableProp = default(List<Object>), List<Object> arrayItemsNullable = default(List<Object>), Dictionary<string, Object> objectNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectAndItemsNullableProp = default(Dictionary<string, Object>), Dictionary<string, Object> objectItemsNullable = default(Dictionary<string, Object>))
+        public NullableClass(int? integerProp = default(int?), decimal? numberProp = default(decimal?), bool? booleanProp = default(bool?), string? stringProp = default(string?), DateTime? dateProp = default(DateTime?), DateTime? datetimeProp = default(DateTime?), List<Object>? arrayNullableProp = default(List<Object>?), List<Object>? arrayAndItemsNullableProp = default(List<Object>?), List<Object>? arrayItemsNullable = default(List<Object>?), Dictionary<string, Object>? objectNullableProp = default(Dictionary<string, Object>?), Dictionary<string, Object>? objectAndItemsNullableProp = default(Dictionary<string, Object>?), Dictionary<string, Object>? objectItemsNullable = default(Dictionary<string, Object>?))
         {
             this.IntegerProp = integerProp;
             this.NumberProp = numberProp;
@@ -86,7 +86,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets StringProp
         /// </summary>
         [DataMember(Name = "string_prop", EmitDefaultValue = true)]
-        public string StringProp { get; set; }
+        public string? StringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets DateProp
@@ -105,37 +105,37 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets ArrayNullableProp
         /// </summary>
         [DataMember(Name = "array_nullable_prop", EmitDefaultValue = true)]
-        public List<Object> ArrayNullableProp { get; set; }
+        public List<Object>? ArrayNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayAndItemsNullableProp
         /// </summary>
         [DataMember(Name = "array_and_items_nullable_prop", EmitDefaultValue = true)]
-        public List<Object> ArrayAndItemsNullableProp { get; set; }
+        public List<Object>? ArrayAndItemsNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ArrayItemsNullable
         /// </summary>
         [DataMember(Name = "array_items_nullable", EmitDefaultValue = false)]
-        public List<Object> ArrayItemsNullable { get; set; }
+        public List<Object>? ArrayItemsNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectNullableProp
         /// </summary>
         [DataMember(Name = "object_nullable_prop", EmitDefaultValue = true)]
-        public Dictionary<string, Object> ObjectNullableProp { get; set; }
+        public Dictionary<string, Object>? ObjectNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectAndItemsNullableProp
         /// </summary>
         [DataMember(Name = "object_and_items_nullable_prop", EmitDefaultValue = true)]
-        public Dictionary<string, Object> ObjectAndItemsNullableProp { get; set; }
+        public Dictionary<string, Object>? ObjectAndItemsNullableProp { get; set; }
 
         /// <summary>
         /// Gets or Sets ObjectItemsNullable
         /// </summary>
         [DataMember(Name = "object_items_nullable", EmitDefaultValue = false)]
-        public Dictionary<string, Object> ObjectItemsNullable { get; set; }
+        public Dictionary<string, Object>? ObjectItemsNullable { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/NumberOnly.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/NumberOnly.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="NumberOnly" /> class.
         /// </summary>
         /// <param name="justNumber">justNumber.</param>
-        public NumberOnly(decimal justNumber = default(decimal))
+        public NumberOnly(decimal? justNumber = default(decimal?))
         {
             this.JustNumber = justNumber;
         }
@@ -48,7 +48,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets JustNumber
         /// </summary>
         [DataMember(Name = "JustNumber", EmitDefaultValue = false)]
-        public decimal JustNumber { get; set; }
+        public decimal? JustNumber { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ObjectWithDeprecatedFields.cs
@@ -39,7 +39,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="id">id.</param>
         /// <param name="deprecatedRef">deprecatedRef.</param>
         /// <param name="bars">bars.</param>
-        public ObjectWithDeprecatedFields(string uuid = default(string), decimal id = default(decimal), DeprecatedObject deprecatedRef = default(DeprecatedObject), List<string> bars = default(List<string>))
+        public ObjectWithDeprecatedFields(string? uuid = default(string?), decimal? id = default(decimal?), DeprecatedObject? deprecatedRef = default(DeprecatedObject?), List<string>? bars = default(List<string>?))
         {
             this.Uuid = uuid;
             this.Id = id;
@@ -51,28 +51,28 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Uuid
         /// </summary>
         [DataMember(Name = "uuid", EmitDefaultValue = false)]
-        public string Uuid { get; set; }
+        public string? Uuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         [Obsolete]
-        public decimal Id { get; set; }
+        public decimal? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets DeprecatedRef
         /// </summary>
         [DataMember(Name = "deprecatedRef", EmitDefaultValue = false)]
         [Obsolete]
-        public DeprecatedObject DeprecatedRef { get; set; }
+        public DeprecatedObject? DeprecatedRef { get; set; }
 
         /// <summary>
         /// Gets or Sets Bars
         /// </summary>
         [DataMember(Name = "bars", EmitDefaultValue = false)]
         [Obsolete]
-        public List<string> Bars { get; set; }
+        public List<string>? Bars { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -88,32 +88,32 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         /// <example>2020-02-02T20:20:20.000222Z</example>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/OuterComposite.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="myNumber">myNumber.</param>
         /// <param name="myString">myString.</param>
         /// <param name="myBoolean">myBoolean.</param>
-        public OuterComposite(decimal myNumber = default(decimal), string myString = default(string), bool myBoolean = default(bool))
+        public OuterComposite(decimal? myNumber = default(decimal?), string? myString = default(string?), bool? myBoolean = default(bool?))
         {
             this.MyNumber = myNumber;
             this.MyString = myString;
@@ -49,19 +49,19 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets MyNumber
         /// </summary>
         [DataMember(Name = "my_number", EmitDefaultValue = false)]
-        public decimal MyNumber { get; set; }
+        public decimal? MyNumber { get; set; }
 
         /// <summary>
         /// Gets or Sets MyString
         /// </summary>
         [DataMember(Name = "my_string", EmitDefaultValue = false)]
-        public string MyString { get; set; }
+        public string? MyString { get; set; }
 
         /// <summary>
         /// Gets or Sets MyBoolean
         /// </summary>
         [DataMember(Name = "my_boolean", EmitDefaultValue = true)]
-        public bool MyBoolean { get; set; }
+        public bool? MyBoolean { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Pet.cs
@@ -79,7 +79,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category? category = default(Category?), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag>? tags = default(List<Tag>?), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -103,13 +103,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category
         /// </summary>
         [DataMember(Name = "category", EmitDefaultValue = false)]
-        public Category Category { get; set; }
+        public Category? Category { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
@@ -128,7 +128,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Tags
         /// </summary>
         [DataMember(Name = "tags", EmitDefaultValue = false)]
-        public List<Tag> Tags { get; set; }
+        public List<Tag>? Tags { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/ReadOnlyFirst.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="ReadOnlyFirst" /> class.
         /// </summary>
         /// <param name="baz">baz.</param>
-        public ReadOnlyFirst(string baz = default(string))
+        public ReadOnlyFirst(string? baz = default(string?))
         {
             this.Baz = baz;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Bar
         /// </summary>
         [DataMember(Name = "bar", EmitDefaultValue = false)]
-        public string Bar { get; private set; }
+        public string? Bar { get; private set; }
 
         /// <summary>
         /// Returns false as Bar should not be serialized given that it's read-only.
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Baz
         /// </summary>
         [DataMember(Name = "baz", EmitDefaultValue = false)]
-        public string Baz { get; set; }
+        public string? Baz { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RequiredClass.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RequiredClass.cs
@@ -530,7 +530,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="requiredNotnullableArrayOfString">requiredNotnullableArrayOfString (required).</param>
         /// <param name="notrequiredNullableArrayOfString">notrequiredNullableArrayOfString.</param>
         /// <param name="notrequiredNotnullableArrayOfString">notrequiredNotnullableArrayOfString.</param>
-        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int notRequiredNotnullableintegerProp = default(int), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string notrequiredNullableStringProp = default(string), string notrequiredNotnullableStringProp = default(string), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool notrequiredNotnullableBooleanProp = default(bool), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime notRequiredNotnullableDateProp = default(DateTime), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime notrequiredNotnullableDatetimeProp = default(DateTime), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid notrequiredNotnullableUuid = default(Guid), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string> notrequiredNullableArrayOfString = default(List<string>), List<string> notrequiredNotnullableArrayOfString = default(List<string>))
+        public RequiredClass(int? requiredNullableIntegerProp = default(int?), int requiredNotnullableintegerProp = default(int), int? notRequiredNullableIntegerProp = default(int?), int? notRequiredNotnullableintegerProp = default(int?), string requiredNullableStringProp = default(string), string requiredNotnullableStringProp = default(string), string? notrequiredNullableStringProp = default(string?), string? notrequiredNotnullableStringProp = default(string?), bool? requiredNullableBooleanProp = default(bool?), bool requiredNotnullableBooleanProp = default(bool), bool? notrequiredNullableBooleanProp = default(bool?), bool? notrequiredNotnullableBooleanProp = default(bool?), DateTime? requiredNullableDateProp = default(DateTime?), DateTime requiredNotNullableDateProp = default(DateTime), DateTime? notRequiredNullableDateProp = default(DateTime?), DateTime? notRequiredNotnullableDateProp = default(DateTime?), DateTime requiredNotnullableDatetimeProp = default(DateTime), DateTime? requiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNullableDatetimeProp = default(DateTime?), DateTime? notrequiredNotnullableDatetimeProp = default(DateTime?), RequiredNullableEnumIntegerEnum requiredNullableEnumInteger = default(RequiredNullableEnumIntegerEnum), RequiredNotnullableEnumIntegerEnum requiredNotnullableEnumInteger = default(RequiredNotnullableEnumIntegerEnum), NotrequiredNullableEnumIntegerEnum? notrequiredNullableEnumInteger = default(NotrequiredNullableEnumIntegerEnum?), NotrequiredNotnullableEnumIntegerEnum? notrequiredNotnullableEnumInteger = default(NotrequiredNotnullableEnumIntegerEnum?), RequiredNullableEnumIntegerOnlyEnum requiredNullableEnumIntegerOnly = default(RequiredNullableEnumIntegerOnlyEnum), RequiredNotnullableEnumIntegerOnlyEnum requiredNotnullableEnumIntegerOnly = default(RequiredNotnullableEnumIntegerOnlyEnum), NotrequiredNullableEnumIntegerOnlyEnum? notrequiredNullableEnumIntegerOnly = default(NotrequiredNullableEnumIntegerOnlyEnum?), NotrequiredNotnullableEnumIntegerOnlyEnum? notrequiredNotnullableEnumIntegerOnly = default(NotrequiredNotnullableEnumIntegerOnlyEnum?), RequiredNotnullableEnumStringEnum requiredNotnullableEnumString = default(RequiredNotnullableEnumStringEnum), RequiredNullableEnumStringEnum requiredNullableEnumString = default(RequiredNullableEnumStringEnum), NotrequiredNullableEnumStringEnum? notrequiredNullableEnumString = default(NotrequiredNullableEnumStringEnum?), NotrequiredNotnullableEnumStringEnum? notrequiredNotnullableEnumString = default(NotrequiredNotnullableEnumStringEnum?), OuterEnumDefaultValue requiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue requiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue), OuterEnumDefaultValue? notrequiredNullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), OuterEnumDefaultValue? notrequiredNotnullableOuterEnumDefaultValue = default(OuterEnumDefaultValue?), Guid? requiredNullableUuid = default(Guid?), Guid requiredNotnullableUuid = default(Guid), Guid? notrequiredNullableUuid = default(Guid?), Guid? notrequiredNotnullableUuid = default(Guid?), List<string> requiredNullableArrayOfString = default(List<string>), List<string> requiredNotnullableArrayOfString = default(List<string>), List<string>? notrequiredNullableArrayOfString = default(List<string>?), List<string>? notrequiredNotnullableArrayOfString = default(List<string>?))
         {
             // to ensure "requiredNullableIntegerProp" is required (not null)
             if (requiredNullableIntegerProp == null)
@@ -645,7 +645,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotRequiredNotnullableintegerProp
         /// </summary>
         [DataMember(Name = "not_required_notnullableinteger_prop", EmitDefaultValue = false)]
-        public int NotRequiredNotnullableintegerProp { get; set; }
+        public int? NotRequiredNotnullableintegerProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableStringProp
@@ -663,13 +663,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableStringProp
         /// </summary>
         [DataMember(Name = "notrequired_nullable_string_prop", EmitDefaultValue = true)]
-        public string NotrequiredNullableStringProp { get; set; }
+        public string? NotrequiredNullableStringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets NotrequiredNotnullableStringProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_string_prop", EmitDefaultValue = false)]
-        public string NotrequiredNotnullableStringProp { get; set; }
+        public string? NotrequiredNotnullableStringProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableBooleanProp
@@ -693,7 +693,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableBooleanProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_boolean_prop", EmitDefaultValue = true)]
-        public bool NotrequiredNotnullableBooleanProp { get; set; }
+        public bool? NotrequiredNotnullableBooleanProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableDateProp
@@ -721,7 +721,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         [DataMember(Name = "not_required_notnullable_date_prop", EmitDefaultValue = false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime NotRequiredNotnullableDateProp { get; set; }
+        public DateTime? NotRequiredNotnullableDateProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNotnullableDatetimeProp
@@ -745,7 +745,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNotnullableDatetimeProp
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_datetime_prop", EmitDefaultValue = false)]
-        public DateTime NotrequiredNotnullableDatetimeProp { get; set; }
+        public DateTime? NotrequiredNotnullableDatetimeProp { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableUuid
@@ -773,7 +773,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <example>72f98069-206d-4f12-9f12-3d1e525a8e84</example>
         [DataMember(Name = "notrequired_notnullable_uuid", EmitDefaultValue = false)]
-        public Guid NotrequiredNotnullableUuid { get; set; }
+        public Guid? NotrequiredNotnullableUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets RequiredNullableArrayOfString
@@ -791,13 +791,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets NotrequiredNullableArrayOfString
         /// </summary>
         [DataMember(Name = "notrequired_nullable_array_of_string", EmitDefaultValue = true)]
-        public List<string> NotrequiredNullableArrayOfString { get; set; }
+        public List<string>? NotrequiredNullableArrayOfString { get; set; }
 
         /// <summary>
         /// Gets or Sets NotrequiredNotnullableArrayOfString
         /// </summary>
         [DataMember(Name = "notrequired_notnullable_array_of_string", EmitDefaultValue = false)]
-        public List<string> NotrequiredNotnullableArrayOfString { get; set; }
+        public List<string>? NotrequiredNotnullableArrayOfString { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Return.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Return.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Return" /> class.
         /// </summary>
         /// <param name="varReturn">varReturn.</param>
-        public Return(int varReturn = default(int))
+        public Return(int? varReturn = default(int?))
         {
             this.VarReturn = varReturn;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets VarReturn
         /// </summary>
         [DataMember(Name = "return", EmitDefaultValue = false)]
-        public int VarReturn { get; set; }
+        public int? VarReturn { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RolesReportsHash.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="roleUuid">roleUuid.</param>
         /// <param name="role">role.</param>
-        public RolesReportsHash(Guid roleUuid = default(Guid), RolesReportsHashRole role = default(RolesReportsHashRole))
+        public RolesReportsHash(Guid? roleUuid = default(Guid?), RolesReportsHashRole? role = default(RolesReportsHashRole?))
         {
             this.RoleUuid = roleUuid;
             this.Role = role;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets RoleUuid
         /// </summary>
         [DataMember(Name = "role_uuid", EmitDefaultValue = false)]
-        public Guid RoleUuid { get; set; }
+        public Guid? RoleUuid { get; set; }
 
         /// <summary>
         /// Gets or Sets Role
         /// </summary>
         [DataMember(Name = "role", EmitDefaultValue = false)]
-        public RolesReportsHashRole Role { get; set; }
+        public RolesReportsHashRole? Role { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/RolesReportsHashRole.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="RolesReportsHashRole" /> class.
         /// </summary>
         /// <param name="name">name.</param>
-        public RolesReportsHashRole(string name = default(string))
+        public RolesReportsHashRole(string? name = default(string?))
         {
             this.Name = name;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/SpecialModelName.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/SpecialModelName.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="specialPropertyName">specialPropertyName.</param>
         /// <param name="varSpecialModelName">varSpecialModelName.</param>
-        public SpecialModelName(long specialPropertyName = default(long), string varSpecialModelName = default(string))
+        public SpecialModelName(long? specialPropertyName = default(long?), string? varSpecialModelName = default(string?))
         {
             this.SpecialPropertyName = specialPropertyName;
             this.VarSpecialModelName = varSpecialModelName;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SpecialPropertyName
         /// </summary>
         [DataMember(Name = "$special[property.name]", EmitDefaultValue = false)]
-        public long SpecialPropertyName { get; set; }
+        public long? SpecialPropertyName { get; set; }
 
         /// <summary>
         /// Gets or Sets VarSpecialModelName
         /// </summary>
         [DataMember(Name = "_special_model.name_", EmitDefaultValue = false)]
-        public string VarSpecialModelName { get; set; }
+        public string? VarSpecialModelName { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string? name = default(string?))
         {
             this.Id = id;
             this.Name = name;
@@ -47,13 +47,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name
         /// </summary>
         [DataMember(Name = "name", EmitDefaultValue = false)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordList.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordList" /> class.
         /// </summary>
         /// <param name="value">value.</param>
-        public TestCollectionEndingWithWordList(string value = default(string))
+        public TestCollectionEndingWithWordList(string? value = default(string?))
         {
             this.Value = value;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Value
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestCollectionEndingWithWordListObject.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestCollectionEndingWithWordListObject" /> class.
         /// </summary>
         /// <param name="testCollectionEndingWithWordList">testCollectionEndingWithWordList.</param>
-        public TestCollectionEndingWithWordListObject(List<TestCollectionEndingWithWordList> testCollectionEndingWithWordList = default(List<TestCollectionEndingWithWordList>))
+        public TestCollectionEndingWithWordListObject(List<TestCollectionEndingWithWordList>? testCollectionEndingWithWordList = default(List<TestCollectionEndingWithWordList>?))
         {
             this.TestCollectionEndingWithWordList = testCollectionEndingWithWordList;
         }
@@ -45,7 +45,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets TestCollectionEndingWithWordList
         /// </summary>
         [DataMember(Name = "TestCollectionEndingWithWordList", EmitDefaultValue = false)]
-        public List<TestCollectionEndingWithWordList> TestCollectionEndingWithWordList { get; set; }
+        public List<TestCollectionEndingWithWordList>? TestCollectionEndingWithWordList { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/TestInlineFreeformAdditionalPropertiesRequest.cs
@@ -36,7 +36,7 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="TestInlineFreeformAdditionalPropertiesRequest" /> class.
         /// </summary>
         /// <param name="someProperty">someProperty.</param>
-        public TestInlineFreeformAdditionalPropertiesRequest(string someProperty = default(string))
+        public TestInlineFreeformAdditionalPropertiesRequest(string? someProperty = default(string?))
         {
             this.SomeProperty = someProperty;
             this.AdditionalProperties = new Dictionary<string, object>();
@@ -46,7 +46,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets SomeProperty
         /// </summary>
         [DataMember(Name = "someProperty", EmitDefaultValue = false)]
-        public string SomeProperty { get; set; }
+        public string? SomeProperty { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/User.cs
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="objectWithNoDeclaredPropsNullable">test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value..</param>
         /// <param name="anyTypeProp">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389.</param>
         /// <param name="anyTypePropNullable">test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values..</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int), Object objectWithNoDeclaredProps = default(Object), Object objectWithNoDeclaredPropsNullable = default(Object), Object anyTypeProp = default(Object), Object anyTypePropNullable = default(Object))
+        public User(long? id = default(long?), string? username = default(string?), string? firstName = default(string?), string? lastName = default(string?), string? email = default(string?), string? password = default(string?), string? phone = default(string?), int? userStatus = default(int?), Object? objectWithNoDeclaredProps = default(Object?), Object? objectWithNoDeclaredPropsNullable = default(Object?), Object? anyTypeProp = default(Object?), Object? anyTypePropNullable = default(Object?))
         {
             this.Id = id;
             this.Username = username;
@@ -67,78 +67,78 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
         /// </summary>
         [DataMember(Name = "username", EmitDefaultValue = false)]
-        public string Username { get; set; }
+        public string? Username { get; set; }
 
         /// <summary>
         /// Gets or Sets FirstName
         /// </summary>
         [DataMember(Name = "firstName", EmitDefaultValue = false)]
-        public string FirstName { get; set; }
+        public string? FirstName { get; set; }
 
         /// <summary>
         /// Gets or Sets LastName
         /// </summary>
         [DataMember(Name = "lastName", EmitDefaultValue = false)]
-        public string LastName { get; set; }
+        public string? LastName { get; set; }
 
         /// <summary>
         /// Gets or Sets Email
         /// </summary>
         [DataMember(Name = "email", EmitDefaultValue = false)]
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// Gets or Sets Password
         /// </summary>
         [DataMember(Name = "password", EmitDefaultValue = false)]
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
         /// <summary>
         /// Gets or Sets Phone
         /// </summary>
         [DataMember(Name = "phone", EmitDefaultValue = false)]
-        public string Phone { get; set; }
+        public string? Phone { get; set; }
 
         /// <summary>
         /// User Status
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.
         /// </summary>
         /// <value>test code generation for objects Value must be a map of strings to values. It cannot be the &#39;null&#39; value.</value>
         [DataMember(Name = "objectWithNoDeclaredProps", EmitDefaultValue = false)]
-        public Object ObjectWithNoDeclaredProps { get; set; }
+        public Object? ObjectWithNoDeclaredProps { get; set; }
 
         /// <summary>
         /// test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.
         /// </summary>
         /// <value>test code generation for nullable objects. Value must be a map of strings to values or the &#39;null&#39; value.</value>
         [DataMember(Name = "objectWithNoDeclaredPropsNullable", EmitDefaultValue = true)]
-        public Object ObjectWithNoDeclaredPropsNullable { get; set; }
+        public Object? ObjectWithNoDeclaredPropsNullable { get; set; }
 
         /// <summary>
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. See https://github.com/OAI/OpenAPI-Specification/issues/1389</value>
         [DataMember(Name = "anyTypeProp", EmitDefaultValue = true)]
-        public Object AnyTypeProp { get; set; }
+        public Object? AnyTypeProp { get; set; }
 
         /// <summary>
         /// test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.
         /// </summary>
         /// <value>test code generation for any type Here the &#39;type&#39; attribute is not specified, which means the value can be anything, including the null value, string, number, boolean, array or object. The &#39;nullable&#39; attribute does not change the allowed values.</value>
         [DataMember(Name = "anyTypePropNullable", EmitDefaultValue = true)]
-        public Object AnyTypePropNullable { get; set; }
+        public Object? AnyTypePropNullable { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCore/src/Org.OpenAPITools/Model/Whale.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="hasBaleen">hasBaleen.</param>
         /// <param name="hasTeeth">hasTeeth.</param>
         /// <param name="className">className (required).</param>
-        public Whale(bool hasBaleen = default(bool), bool hasTeeth = default(bool), string className = default(string))
+        public Whale(bool? hasBaleen = default(bool?), bool? hasTeeth = default(bool?), string className = default(string))
         {
             // to ensure "className" is required (not null)
             if (className == null)
@@ -59,13 +59,13 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets HasBaleen
         /// </summary>
         [DataMember(Name = "hasBaleen", EmitDefaultValue = true)]
-        public bool HasBaleen { get; set; }
+        public bool? HasBaleen { get; set; }
 
         /// <summary>
         /// Gets or Sets HasTeeth
         /// </summary>
         [DataMember(Name = "hasTeeth", EmitDefaultValue = true)]
-        public bool HasTeeth { get; set; }
+        public bool? HasTeeth { get; set; }
 
         /// <summary>
         /// Gets or Sets ClassName

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/ApiResponse.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/ApiResponse.md
@@ -5,7 +5,7 @@ Describes the result of uploading an image resource
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Code** | **int** |  | [optional] 
+**Code** | **int?** |  | [optional] 
 **Type** | **string** |  | [optional] 
 **Message** | **string** |  | [optional] 
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Category.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Category.md
@@ -5,7 +5,7 @@ A category for a pet
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Order.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Order.md
@@ -5,12 +5,12 @@ An order for a pets from the pet store
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
-**PetId** | **long** |  | [optional] 
-**Quantity** | **int** |  | [optional] 
-**ShipDate** | **DateTime** |  | [optional] 
+**Id** | **long?** |  | [optional] 
+**PetId** | **long?** |  | [optional] 
+**Quantity** | **int?** |  | [optional] 
+**ShipDate** | **DateTime?** |  | [optional] 
 **Status** | **string** | Order Status | [optional] 
-**Complete** | **bool** |  | [optional] [default to false]
+**Complete** | **bool?** |  | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Pet.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Pet.md
@@ -5,7 +5,7 @@ A pet for sale in the pet store
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Category** | [**Category**](Category.md) |  | [optional] 
 **Name** | **string** |  | 
 **PhotoUrls** | **List&lt;string&gt;** |  | 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Tag.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/Tag.md
@@ -5,7 +5,7 @@ A tag for a pet
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Name** | **string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/User.md
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/docs/User.md
@@ -5,14 +5,14 @@ A User who is purchasing from the pet store
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **long** |  | [optional] 
+**Id** | **long?** |  | [optional] 
 **Username** | **string** |  | [optional] 
 **FirstName** | **string** |  | [optional] 
 **LastName** | **string** |  | [optional] 
 **Email** | **string** |  | [optional] 
 **Password** | **string** |  | [optional] 
 **Phone** | **string** |  | [optional] 
-**UserStatus** | **int** | User Status | [optional] 
+**UserStatus** | **int?** | User Status | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/ApiResponse.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/ApiResponse.cs
@@ -38,7 +38,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="code">code.</param>
         /// <param name="type">type.</param>
         /// <param name="message">message.</param>
-        public ApiResponse(int code = default(int), string type = default(string), string message = default(string))
+        public ApiResponse(int? code = default(int?), string type = default(string), string message = default(string))
         {
             this.Code = code;
             this.Type = type;
@@ -49,7 +49,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Code
         /// </summary>
         [DataMember(Name = "code", EmitDefaultValue = false)]
-        public int Code { get; set; }
+        public int? Code { get; set; }
 
         /// <summary>
         /// Gets or Sets Type

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Category.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Category(long id = default(long), string name = default(string))
+        public Category(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Order.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Order.cs
@@ -74,7 +74,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="shipDate">shipDate.</param>
         /// <param name="status">Order Status.</param>
         /// <param name="complete">complete (default to false).</param>
-        public Order(long id = default(long), long petId = default(long), int quantity = default(int), DateTime shipDate = default(DateTime), StatusEnum? status = default(StatusEnum?), bool complete = false)
+        public Order(long? id = default(long?), long? petId = default(long?), int? quantity = default(int?), DateTime? shipDate = default(DateTime?), StatusEnum? status = default(StatusEnum?), bool? complete = false)
         {
             this.Id = id;
             this.PetId = petId;
@@ -88,31 +88,31 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets PetId
         /// </summary>
         [DataMember(Name = "petId", EmitDefaultValue = false)]
-        public long PetId { get; set; }
+        public long? PetId { get; set; }
 
         /// <summary>
         /// Gets or Sets Quantity
         /// </summary>
         [DataMember(Name = "quantity", EmitDefaultValue = false)]
-        public int Quantity { get; set; }
+        public int? Quantity { get; set; }
 
         /// <summary>
         /// Gets or Sets ShipDate
         /// </summary>
         [DataMember(Name = "shipDate", EmitDefaultValue = false)]
-        public DateTime ShipDate { get; set; }
+        public DateTime? ShipDate { get; set; }
 
         /// <summary>
         /// Gets or Sets Complete
         /// </summary>
         [DataMember(Name = "complete", EmitDefaultValue = true)]
-        public bool Complete { get; set; }
+        public bool? Complete { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Pet.cs
@@ -80,7 +80,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="photoUrls">photoUrls (required).</param>
         /// <param name="tags">tags.</param>
         /// <param name="status">pet status in the store.</param>
-        public Pet(long id = default(long), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
+        public Pet(long? id = default(long?), Category category = default(Category), string name = default(string), List<string> photoUrls = default(List<string>), List<Tag> tags = default(List<Tag>), StatusEnum? status = default(StatusEnum?))
         {
             // to ensure "name" is required (not null)
             if (name == null)
@@ -104,7 +104,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Category

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Tag.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/Tag.cs
@@ -37,7 +37,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <param name="id">id.</param>
         /// <param name="name">name.</param>
-        public Tag(long id = default(long), string name = default(string))
+        public Tag(long? id = default(long?), string name = default(string))
         {
             this.Id = id;
             this.Name = name;
@@ -47,7 +47,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Name

--- a/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/User.cs
+++ b/samples/client/petstore/csharp/OpenAPIClientCoreAndNet47/src/Org.OpenAPITools/Model/User.cs
@@ -43,7 +43,7 @@ namespace Org.OpenAPITools.Model
         /// <param name="password">password.</param>
         /// <param name="phone">phone.</param>
         /// <param name="userStatus">User Status.</param>
-        public User(long id = default(long), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int userStatus = default(int))
+        public User(long? id = default(long?), string username = default(string), string firstName = default(string), string lastName = default(string), string email = default(string), string password = default(string), string phone = default(string), int? userStatus = default(int?))
         {
             this.Id = id;
             this.Username = username;
@@ -59,7 +59,7 @@ namespace Org.OpenAPITools.Model
         /// Gets or Sets Id
         /// </summary>
         [DataMember(Name = "id", EmitDefaultValue = false)]
-        public long Id { get; set; }
+        public long? Id { get; set; }
 
         /// <summary>
         /// Gets or Sets Username
@@ -102,7 +102,7 @@ namespace Org.OpenAPITools.Model
         /// </summary>
         /// <value>User Status</value>
         [DataMember(Name = "userStatus", EmitDefaultValue = false)]
-        public int UserStatus { get; set; }
+        public int? UserStatus { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object


### PR DESCRIPTION
Resolves #4816

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Mark all optional properties of in the generated C# client as nullable, with the `?`marker. For reference types, this enables C# 8's nullable reference types feature which is a nice bonus.

For value types, this fixes an issue with optional values. By default, an optional integer will be expressed as an `int` in C# with `EmitDefaultValue = false`. This means that a value of `0` is used to indicate the property is absent, which prevents actually indicating "set this value to 0". This PR emits an `int?`, which uses `null` to indicate absence. `0` can now be properly expressed.

This change seems like a breaking change, unless it's put behind some kind of generator flag. I'm perfectly happy to add a generator flag or try to retarget this PR to the `8.0.x` branch, whichever would be better.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean @shibayan @Blackclaws @lucamazzanti @iBicha 