### PR TITLE
[Go] fix validation of property names when a model has required fields and doesn't allow additional properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/GoClientCodegen.java
@@ -499,8 +499,14 @@ public class GoClientCodegen extends AbstractGoCodegen {
                 addedFmtImport = true;
             }
 
-            if (!addedFmtImport && model.hasRequired) {
-                imports.add(createMapping("import", "fmt"));
+            if (model.hasRequired) {
+                if (!model.isAdditionalPropertiesTrue) {
+                    imports.add(createMapping("import", "bytes"));
+                }
+
+                if (!addedFmtImport) {
+                    imports.add(createMapping("import", "fmt"));
+                }
             }
 
             // additionalProperties: true and parent

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -7,11 +7,6 @@ import (
 {{#imports}}
 	"{{import}}"
 {{/imports}}
-{{^isAdditionalPropertiesTrue}}
-{{#hasRequired}}
-	"bytes"
-{{/hasRequired}}
-{{/isAdditionalPropertiesTrue}}
 )
 
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/go/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model.mustache
@@ -7,6 +7,11 @@ import (
 {{#imports}}
 	"{{import}}"
 {{/imports}}
+{{^isAdditionalPropertiesTrue}}
+{{#hasRequired}}
+	"bytes"
+{{/hasRequired}}
+{{/isAdditionalPropertiesTrue}}
 )
 
 {{#model}}

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -340,11 +340,11 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 }
 
 {{#isAdditionalPropertiesTrue}}
-func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/isAdditionalPropertiesTrue}}
 {{^isAdditionalPropertiesTrue}}
 {{#hasRequired}}
-func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/hasRequired}}
 {{/isAdditionalPropertiesTrue}}
 {{#hasRequired}}
@@ -359,7 +359,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -391,7 +391,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
 
-	err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
+	err = json.Unmarshal(data, &var{{{classname}}}WithoutEmbeddedStruct)
 	if err == nil {
 		var{{{classname}}} := _{{{classname}}}{}
 		{{#vars}}
@@ -404,7 +404,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	var{{{classname}}} := _{{{classname}}}{}
 
-	err = json.Unmarshal(bytes, &var{{{classname}}})
+	err = json.Unmarshal(data, &var{{{classname}}})
 	if err == nil {
 		o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
 	} else {
@@ -413,7 +413,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		{{#vars}}
 		delete(additionalProperties, "{{{baseName}}}")
 		{{/vars}}
@@ -444,7 +444,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#isMap}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	err = json.Unmarshal(bytes, &var{{{classname}}})
+	err = json.Unmarshal(data, &var{{{classname}}})
 
 	if err != nil {
 		return err
@@ -454,7 +454,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		{{#vars}}
 		delete(additionalProperties, "{{{baseName}}}")
 		{{/vars}}
@@ -467,7 +467,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{^parent}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	err = json.Unmarshal(bytes, &var{{{classname}}})
+	err = json.Unmarshal(data, &var{{{classname}}})
 
 	if err != nil {
 		return err
@@ -477,7 +477,7 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		{{#vars}}
 		delete(additionalProperties, "{{{baseName}}}")
 		{{/vars}}
@@ -495,7 +495,9 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#hasRequired}}
 	var{{{classname}}} := _{{{classname}}}{}
 
-	err = json.Unmarshal(bytes, &var{{{classname}}})
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&var{{{classname}}})
 
 	if err != nil {
 		return err
@@ -509,8 +511,8 @@ func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{/hasRequired}}
 {{/isAdditionalPropertiesTrue}}
 {{#isArray}}
-func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
-	return json.Unmarshal(bytes, &o.Items)
+func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
+	return json.Unmarshal(data, &o.Items)
 }
 
 {{/isArray}}

--- a/samples/client/echo_api/go/model_pet.go
+++ b/samples/client/echo_api/go/model_pet.go
@@ -13,6 +13,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/echo_api/go/model_pet.go
+++ b/samples/client/echo_api/go/model_pet.go
@@ -254,7 +254,7 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -265,7 +265,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -279,7 +279,9 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	varPet := _Pet{}
 
-	err = json.Unmarshal(bytes, &varPet)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varPet)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_any_type.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesAnyType) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesAnyType) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesAnyType) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesAnyType := _AdditionalPropertiesAnyType{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesAnyType)
+	err = json.Unmarshal(data, &varAdditionalPropertiesAnyType)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesAnyType) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_array.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesArray) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesArray) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesArray) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesArray := _AdditionalPropertiesArray{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesArray)
+	err = json.Unmarshal(data, &varAdditionalPropertiesArray)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesArray) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_boolean.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesBoolean) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesBoolean) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesBoolean) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesBoolean := _AdditionalPropertiesBoolean{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesBoolean)
+	err = json.Unmarshal(data, &varAdditionalPropertiesBoolean)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesBoolean) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_integer.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesInteger) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesInteger) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesInteger) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesInteger := _AdditionalPropertiesInteger{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesInteger)
+	err = json.Unmarshal(data, &varAdditionalPropertiesInteger)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesInteger) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_number.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesNumber) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesNumber) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesNumber) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesNumber := _AdditionalPropertiesNumber{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesNumber)
+	err = json.Unmarshal(data, &varAdditionalPropertiesNumber)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesNumber) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_object.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesObject) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesObject) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesObject) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesObject := _AdditionalPropertiesObject{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesObject)
+	err = json.Unmarshal(data, &varAdditionalPropertiesObject)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesObject) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
+++ b/samples/client/petstore/go/go-petstore/model_additional_properties_string.go
@@ -95,10 +95,10 @@ func (o AdditionalPropertiesString) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesString) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesString) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesString := _AdditionalPropertiesString{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesString)
+	err = json.Unmarshal(data, &varAdditionalPropertiesString)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *AdditionalPropertiesString) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -121,7 +121,7 @@ func (o Animal) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -131,7 +131,7 @@ func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -145,7 +145,9 @@ func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 
 	varAnimal := _Animal{}
 
-	err = json.Unmarshal(bytes, &varAnimal)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varAnimal)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/client/petstore/go/go-petstore/model_animal.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_big_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_big_cat.go
@@ -102,7 +102,7 @@ func (o BigCat) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *BigCat) UnmarshalJSON(bytes []byte) (err error) {
+func (o *BigCat) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -112,7 +112,7 @@ func (o *BigCat) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -126,7 +126,9 @@ func (o *BigCat) UnmarshalJSON(bytes []byte) (err error) {
 
 	varBigCat := _BigCat{}
 
-	err = json.Unmarshal(bytes, &varBigCat)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varBigCat)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/client/petstore/go/go-petstore/model_cat.go
@@ -102,7 +102,7 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -112,7 +112,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -126,7 +126,9 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	varCat := _Cat{}
 
-	err = json.Unmarshal(bytes, &varCat)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varCat)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -119,7 +119,7 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Category) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -129,7 +129,7 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -143,7 +143,9 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	varCategory := _Category{}
 
-	err = json.Unmarshal(bytes, &varCategory)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varCategory)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_category.go
+++ b/samples/client/petstore/go/go-petstore/model_category.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -102,7 +102,7 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -112,7 +112,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -126,7 +126,9 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDog := _Dog{}
 
-	err = json.Unmarshal(bytes, &varDog)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varDog)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/client/petstore/go/go-petstore/model_dog.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -225,7 +225,7 @@ func (o EnumTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -235,7 +235,7 @@ func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -249,7 +249,9 @@ func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	varEnumTest := _EnumTest{}
 
-	err = json.Unmarshal(bytes, &varEnumTest)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varEnumTest)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_enum_test_.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"os"
 	"time"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/client/petstore/go/go-petstore/model_format_test_.go
@@ -524,7 +524,7 @@ func (o FormatTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -537,7 +537,7 @@ func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -551,7 +551,9 @@ func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	varFormatTest := _FormatTest{}
 
-	err = json.Unmarshal(bytes, &varFormatTest)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varFormatTest)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -189,7 +189,7 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Name) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -199,7 +199,7 @@ func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -213,7 +213,9 @@ func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 
 	varName := _Name{}
 
-	err = json.Unmarshal(bytes, &varName)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varName)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_name.go
+++ b/samples/client/petstore/go/go-petstore/model_name.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/client/petstore/go/go-petstore/model_pet.go
@@ -253,7 +253,7 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -264,7 +264,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -278,7 +278,9 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	varPet := _Pet{}
 
-	err = json.Unmarshal(bytes, &varPet)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varPet)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_default.go
@@ -193,7 +193,7 @@ func (o TypeHolderDefault) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *TypeHolderDefault) UnmarshalJSON(bytes []byte) (err error) {
+func (o *TypeHolderDefault) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -207,7 +207,7 @@ func (o *TypeHolderDefault) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -221,7 +221,9 @@ func (o *TypeHolderDefault) UnmarshalJSON(bytes []byte) (err error) {
 
 	varTypeHolderDefault := _TypeHolderDefault{}
 
-	err = json.Unmarshal(bytes, &varTypeHolderDefault)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varTypeHolderDefault)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_type_holder_default.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_default.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_example.go
@@ -216,7 +216,7 @@ func (o TypeHolderExample) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *TypeHolderExample) UnmarshalJSON(bytes []byte) (err error) {
+func (o *TypeHolderExample) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -231,7 +231,7 @@ func (o *TypeHolderExample) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -245,7 +245,9 @@ func (o *TypeHolderExample) UnmarshalJSON(bytes []byte) (err error) {
 
 	varTypeHolderExample := _TypeHolderExample{}
 
-	err = json.Unmarshal(bytes, &varTypeHolderExample)
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	err = decoder.Decode(&varTypeHolderExample)
 
 	if err != nil {
 		return err

--- a/samples/client/petstore/go/go-petstore/model_type_holder_example.go
+++ b/samples/client/petstore/go/go-petstore/model_type_holder_example.go
@@ -12,6 +12,7 @@ package petstore
 
 import (
 	"encoding/json"
+	"bytes"
 	"fmt"
 )
 

--- a/samples/client/petstore/go/model_test.go
+++ b/samples/client/petstore/go/model_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	sw "github.com/OpenAPITools/openapi-generator/samples/client/petstore/go/go-petstore"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiredFieldsWithAdditionalPropertiesFalse(t *testing.T) {
+	assert := assert.New(t)
+
+	newAnimal := (sw.Animal{})
+	jsonAnimal := `{"className":"invalidAnimal","extraThing":"foo"}`
+
+	err := newAnimal.UnmarshalJSON([]byte(jsonAnimal))
+	expected := "json: unknown field \"extraThing\""
+
+	assert.ErrorContains(err, expected, "Animal should return error when missing additional fields are present")
+}

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_category.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_category.go
@@ -123,10 +123,10 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Category) UnmarshalJSON(data []byte) (err error) {
 	varCategory := _Category{}
 
-	err = json.Unmarshal(bytes, &varCategory)
+	err = json.Unmarshal(data, &varCategory)
 
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_pet.go
@@ -255,7 +255,7 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -266,7 +266,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -280,7 +280,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	varPet := _Pet{}
 
-	err = json.Unmarshal(bytes, &varPet)
+	err = json.Unmarshal(data, &varPet)
 
 	if err != nil {
 		return err
@@ -290,7 +290,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "category")
 		delete(additionalProperties, "name")

--- a/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_tag.go
+++ b/samples/openapi3/client/petstore/go-petstore-generateMarshalJSON-false/model_tag.go
@@ -123,10 +123,10 @@ func (o Tag) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Tag) UnmarshalJSON(data []byte) (err error) {
 	varTag := _Tag{}
 
-	err = json.Unmarshal(bytes, &varTag)
+	err = json.Unmarshal(data, &varTag)
 
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_200_response.go
@@ -131,10 +131,10 @@ func (o Model200Response) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Model200Response) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Model200Response) UnmarshalJSON(data []byte) (err error) {
 	varModel200Response := _Model200Response{}
 
-	err = json.Unmarshal(bytes, &varModel200Response)
+	err = json.Unmarshal(data, &varModel200Response)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *Model200Response) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "class")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__foo_get_default_response.go
@@ -95,10 +95,10 @@ func (o FooGetDefaultResponse) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *FooGetDefaultResponse) UnmarshalJSON(bytes []byte) (err error) {
+func (o *FooGetDefaultResponse) UnmarshalJSON(data []byte) (err error) {
 	varFooGetDefaultResponse := _FooGetDefaultResponse{}
 
-	err = json.Unmarshal(bytes, &varFooGetDefaultResponse)
+	err = json.Unmarshal(data, &varFooGetDefaultResponse)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *FooGetDefaultResponse) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "string")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model__special_model_name_.go
@@ -95,10 +95,10 @@ func (o SpecialModelName) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *SpecialModelName) UnmarshalJSON(bytes []byte) (err error) {
+func (o *SpecialModelName) UnmarshalJSON(data []byte) (err error) {
 	varSpecialModelName := _SpecialModelName{}
 
-	err = json.Unmarshal(bytes, &varSpecialModelName)
+	err = json.Unmarshal(data, &varSpecialModelName)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *SpecialModelName) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "$special[property.name]")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_additional_properties_class.go
@@ -131,10 +131,10 @@ func (o AdditionalPropertiesClass) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AdditionalPropertiesClass) UnmarshalJSON(data []byte) (err error) {
 	varAdditionalPropertiesClass := _AdditionalPropertiesClass{}
 
-	err = json.Unmarshal(bytes, &varAdditionalPropertiesClass)
+	err = json.Unmarshal(data, &varAdditionalPropertiesClass)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *AdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "map_property")
 		delete(additionalProperties, "map_of_map_property")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_all_of_primitive_types.go
@@ -96,10 +96,10 @@ func (o AllOfPrimitiveTypes) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AllOfPrimitiveTypes) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AllOfPrimitiveTypes) UnmarshalJSON(data []byte) (err error) {
 	varAllOfPrimitiveTypes := _AllOfPrimitiveTypes{}
 
-	err = json.Unmarshal(bytes, &varAllOfPrimitiveTypes)
+	err = json.Unmarshal(data, &varAllOfPrimitiveTypes)
 
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (o *AllOfPrimitiveTypes) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "test")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_animal.go
@@ -127,7 +127,7 @@ func (o Animal) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Animal) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -137,7 +137,7 @@ func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -151,7 +151,7 @@ func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 
 	varAnimal := _Animal{}
 
-	err = json.Unmarshal(bytes, &varAnimal)
+	err = json.Unmarshal(data, &varAnimal)
 
 	if err != nil {
 		return err
@@ -161,7 +161,7 @@ func (o *Animal) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "className")
 		delete(additionalProperties, "color")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_api_response.go
@@ -167,10 +167,10 @@ func (o ApiResponse) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ApiResponse) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ApiResponse) UnmarshalJSON(data []byte) (err error) {
 	varApiResponse := _ApiResponse{}
 
-	err = json.Unmarshal(bytes, &varApiResponse)
+	err = json.Unmarshal(data, &varApiResponse)
 
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func (o *ApiResponse) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "code")
 		delete(additionalProperties, "type")
 		delete(additionalProperties, "message")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple.go
@@ -95,10 +95,10 @@ func (o Apple) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Apple) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Apple) UnmarshalJSON(data []byte) (err error) {
 	varApple := _Apple{}
 
-	err = json.Unmarshal(bytes, &varApple)
+	err = json.Unmarshal(data, &varApple)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *Apple) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "cultivar")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_apple_req.go
@@ -123,7 +123,7 @@ func (o AppleReq) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
+func (o *AppleReq) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -133,7 +133,7 @@ func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -147,7 +147,7 @@ func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	varAppleReq := _AppleReq{}
 
-	err = json.Unmarshal(bytes, &varAppleReq)
+	err = json.Unmarshal(data, &varAppleReq)
 
 	if err != nil {
 		return err
@@ -157,7 +157,7 @@ func (o *AppleReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "cultivar")
 		delete(additionalProperties, "mealy")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_array_of_number_only.go
@@ -95,10 +95,10 @@ func (o ArrayOfArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(data []byte) (err error) {
 	varArrayOfArrayOfNumberOnly := _ArrayOfArrayOfNumberOnly{}
 
-	err = json.Unmarshal(bytes, &varArrayOfArrayOfNumberOnly)
+	err = json.Unmarshal(data, &varArrayOfArrayOfNumberOnly)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *ArrayOfArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "ArrayArrayNumber")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_of_number_only.go
@@ -95,10 +95,10 @@ func (o ArrayOfNumberOnly) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ArrayOfNumberOnly) UnmarshalJSON(data []byte) (err error) {
 	varArrayOfNumberOnly := _ArrayOfNumberOnly{}
 
-	err = json.Unmarshal(bytes, &varArrayOfNumberOnly)
+	err = json.Unmarshal(data, &varArrayOfNumberOnly)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *ArrayOfNumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "ArrayNumber")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_array_test_.go
@@ -167,10 +167,10 @@ func (o ArrayTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ArrayTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ArrayTest) UnmarshalJSON(data []byte) (err error) {
 	varArrayTest := _ArrayTest{}
 
-	err = json.Unmarshal(bytes, &varArrayTest)
+	err = json.Unmarshal(data, &varArrayTest)
 
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func (o *ArrayTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "array_of_string")
 		delete(additionalProperties, "array_array_of_integer")
 		delete(additionalProperties, "array_array_of_model")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana.go
@@ -95,10 +95,10 @@ func (o Banana) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Banana) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Banana) UnmarshalJSON(data []byte) (err error) {
 	varBanana := _Banana{}
 
-	err = json.Unmarshal(bytes, &varBanana)
+	err = json.Unmarshal(data, &varBanana)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *Banana) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "lengthCm")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_banana_req.go
@@ -123,7 +123,7 @@ func (o BananaReq) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
+func (o *BananaReq) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -133,7 +133,7 @@ func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -147,7 +147,7 @@ func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	varBananaReq := _BananaReq{}
 
-	err = json.Unmarshal(bytes, &varBananaReq)
+	err = json.Unmarshal(data, &varBananaReq)
 
 	if err != nil {
 		return err
@@ -157,7 +157,7 @@ func (o *BananaReq) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "lengthCm")
 		delete(additionalProperties, "sweet")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_capitalization.go
@@ -276,10 +276,10 @@ func (o Capitalization) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Capitalization) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Capitalization) UnmarshalJSON(data []byte) (err error) {
 	varCapitalization := _Capitalization{}
 
-	err = json.Unmarshal(bytes, &varCapitalization)
+	err = json.Unmarshal(data, &varCapitalization)
 
 	if err != nil {
 		return err
@@ -289,7 +289,7 @@ func (o *Capitalization) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "smallCamel")
 		delete(additionalProperties, "CapitalCamel")
 		delete(additionalProperties, "small_Snake")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_cat.go
@@ -110,7 +110,7 @@ func (o Cat) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Cat) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -120,7 +120,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -138,7 +138,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	varCatWithoutEmbeddedStruct := CatWithoutEmbeddedStruct{}
 
-	err = json.Unmarshal(bytes, &varCatWithoutEmbeddedStruct)
+	err = json.Unmarshal(data, &varCatWithoutEmbeddedStruct)
 	if err == nil {
 		varCat := _Cat{}
 		varCat.Declawed = varCatWithoutEmbeddedStruct.Declawed
@@ -149,7 +149,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	varCat := _Cat{}
 
-	err = json.Unmarshal(bytes, &varCat)
+	err = json.Unmarshal(data, &varCat)
 	if err == nil {
 		o.Animal = varCat.Animal
 	} else {
@@ -158,7 +158,7 @@ func (o *Cat) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "declawed")
 
 		// remove fields from embedded structs

--- a/samples/openapi3/client/petstore/go/go-petstore/model_category.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_category.go
@@ -125,7 +125,7 @@ func (o Category) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Category) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -135,7 +135,7 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -149,7 +149,7 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	varCategory := _Category{}
 
-	err = json.Unmarshal(bytes, &varCategory)
+	err = json.Unmarshal(data, &varCategory)
 
 	if err != nil {
 		return err
@@ -159,7 +159,7 @@ func (o *Category) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_class_model.go
@@ -95,10 +95,10 @@ func (o ClassModel) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ClassModel) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ClassModel) UnmarshalJSON(data []byte) (err error) {
 	varClassModel := _ClassModel{}
 
-	err = json.Unmarshal(bytes, &varClassModel)
+	err = json.Unmarshal(data, &varClassModel)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *ClassModel) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "_class")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_client.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_client.go
@@ -95,10 +95,10 @@ func (o Client) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Client) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Client) UnmarshalJSON(data []byte) (err error) {
 	varClient := _Client{}
 
-	err = json.Unmarshal(bytes, &varClient)
+	err = json.Unmarshal(data, &varClient)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *Client) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "client")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_dog.go
@@ -110,7 +110,7 @@ func (o Dog) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Dog) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -120,7 +120,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -138,7 +138,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDogWithoutEmbeddedStruct := DogWithoutEmbeddedStruct{}
 
-	err = json.Unmarshal(bytes, &varDogWithoutEmbeddedStruct)
+	err = json.Unmarshal(data, &varDogWithoutEmbeddedStruct)
 	if err == nil {
 		varDog := _Dog{}
 		varDog.Breed = varDogWithoutEmbeddedStruct.Breed
@@ -149,7 +149,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDog := _Dog{}
 
-	err = json.Unmarshal(bytes, &varDog)
+	err = json.Unmarshal(data, &varDog)
 	if err == nil {
 		o.Animal = varDog.Animal
 	} else {
@@ -158,7 +158,7 @@ func (o *Dog) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "breed")
 
 		// remove fields from embedded structs

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_child.go
@@ -107,7 +107,7 @@ func (o DuplicatedPropChild) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *DuplicatedPropChild) UnmarshalJSON(bytes []byte) (err error) {
+func (o *DuplicatedPropChild) UnmarshalJSON(data []byte) (err error) {
 	type DuplicatedPropChildWithoutEmbeddedStruct struct {
 		// A discriminator value
 		DupProp *string `json:"dup-prop,omitempty"`
@@ -115,7 +115,7 @@ func (o *DuplicatedPropChild) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDuplicatedPropChildWithoutEmbeddedStruct := DuplicatedPropChildWithoutEmbeddedStruct{}
 
-	err = json.Unmarshal(bytes, &varDuplicatedPropChildWithoutEmbeddedStruct)
+	err = json.Unmarshal(data, &varDuplicatedPropChildWithoutEmbeddedStruct)
 	if err == nil {
 		varDuplicatedPropChild := _DuplicatedPropChild{}
 		varDuplicatedPropChild.DupProp = varDuplicatedPropChildWithoutEmbeddedStruct.DupProp
@@ -126,7 +126,7 @@ func (o *DuplicatedPropChild) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDuplicatedPropChild := _DuplicatedPropChild{}
 
-	err = json.Unmarshal(bytes, &varDuplicatedPropChild)
+	err = json.Unmarshal(data, &varDuplicatedPropChild)
 	if err == nil {
 		o.DuplicatedPropParent = varDuplicatedPropChild.DuplicatedPropParent
 	} else {
@@ -135,7 +135,7 @@ func (o *DuplicatedPropChild) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "dup-prop")
 
 		// remove fields from embedded structs

--- a/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_duplicated_prop_parent.go
@@ -88,7 +88,7 @@ func (o DuplicatedPropParent) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
+func (o *DuplicatedPropParent) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -98,7 +98,7 @@ func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -112,7 +112,7 @@ func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
 
 	varDuplicatedPropParent := _DuplicatedPropParent{}
 
-	err = json.Unmarshal(bytes, &varDuplicatedPropParent)
+	err = json.Unmarshal(data, &varDuplicatedPropParent)
 
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (o *DuplicatedPropParent) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "dup-prop")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_arrays.go
@@ -131,10 +131,10 @@ func (o EnumArrays) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *EnumArrays) UnmarshalJSON(bytes []byte) (err error) {
+func (o *EnumArrays) UnmarshalJSON(data []byte) (err error) {
 	varEnumArrays := _EnumArrays{}
 
-	err = json.Unmarshal(bytes, &varEnumArrays)
+	err = json.Unmarshal(data, &varEnumArrays)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *EnumArrays) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "just_symbol")
 		delete(additionalProperties, "array_enum")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_enum_test_.go
@@ -357,7 +357,7 @@ func (o EnumTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *EnumTest) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -367,7 +367,7 @@ func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -381,7 +381,7 @@ func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	varEnumTest := _EnumTest{}
 
-	err = json.Unmarshal(bytes, &varEnumTest)
+	err = json.Unmarshal(data, &varEnumTest)
 
 	if err != nil {
 		return err
@@ -391,7 +391,7 @@ func (o *EnumTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "enum_string")
 		delete(additionalProperties, "enum_string_required")
 		delete(additionalProperties, "enum_integer")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file.go
@@ -96,10 +96,10 @@ func (o File) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *File) UnmarshalJSON(bytes []byte) (err error) {
+func (o *File) UnmarshalJSON(data []byte) (err error) {
 	varFile := _File{}
 
-	err = json.Unmarshal(bytes, &varFile)
+	err = json.Unmarshal(data, &varFile)
 
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (o *File) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "sourceURI")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_file_schema_test_class.go
@@ -131,10 +131,10 @@ func (o FileSchemaTestClass) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *FileSchemaTestClass) UnmarshalJSON(bytes []byte) (err error) {
+func (o *FileSchemaTestClass) UnmarshalJSON(data []byte) (err error) {
 	varFileSchemaTestClass := _FileSchemaTestClass{}
 
-	err = json.Unmarshal(bytes, &varFileSchemaTestClass)
+	err = json.Unmarshal(data, &varFileSchemaTestClass)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *FileSchemaTestClass) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "file")
 		delete(additionalProperties, "files")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_foo.go
@@ -99,10 +99,10 @@ func (o Foo) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Foo) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Foo) UnmarshalJSON(data []byte) (err error) {
 	varFoo := _Foo{}
 
-	err = json.Unmarshal(bytes, &varFoo)
+	err = json.Unmarshal(data, &varFoo)
 
 	if err != nil {
 		return err
@@ -112,7 +112,7 @@ func (o *Foo) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "bar")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_format_test_.go
@@ -568,7 +568,7 @@ func (o FormatTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *FormatTest) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -581,7 +581,7 @@ func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -595,7 +595,7 @@ func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	varFormatTest := _FormatTest{}
 
-	err = json.Unmarshal(bytes, &varFormatTest)
+	err = json.Unmarshal(data, &varFormatTest)
 
 	if err != nil {
 		return err
@@ -605,7 +605,7 @@ func (o *FormatTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "integer")
 		delete(additionalProperties, "int32")
 		delete(additionalProperties, "int64")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_has_only_read_only.go
@@ -131,10 +131,10 @@ func (o HasOnlyReadOnly) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *HasOnlyReadOnly) UnmarshalJSON(bytes []byte) (err error) {
+func (o *HasOnlyReadOnly) UnmarshalJSON(data []byte) (err error) {
 	varHasOnlyReadOnly := _HasOnlyReadOnly{}
 
-	err = json.Unmarshal(bytes, &varHasOnlyReadOnly)
+	err = json.Unmarshal(data, &varHasOnlyReadOnly)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *HasOnlyReadOnly) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "bar")
 		delete(additionalProperties, "foo")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_health_check_result.go
@@ -105,10 +105,10 @@ func (o HealthCheckResult) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *HealthCheckResult) UnmarshalJSON(bytes []byte) (err error) {
+func (o *HealthCheckResult) UnmarshalJSON(data []byte) (err error) {
 	varHealthCheckResult := _HealthCheckResult{}
 
-	err = json.Unmarshal(bytes, &varHealthCheckResult)
+	err = json.Unmarshal(data, &varHealthCheckResult)
 
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (o *HealthCheckResult) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "NullableMessage")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_list.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_list.go
@@ -95,10 +95,10 @@ func (o List) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *List) UnmarshalJSON(bytes []byte) (err error) {
+func (o *List) UnmarshalJSON(data []byte) (err error) {
 	varList := _List{}
 
-	err = json.Unmarshal(bytes, &varList)
+	err = json.Unmarshal(data, &varList)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *List) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "123-list")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_of_file_test_.go
@@ -97,10 +97,10 @@ func (o MapOfFileTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *MapOfFileTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *MapOfFileTest) UnmarshalJSON(data []byte) (err error) {
 	varMapOfFileTest := _MapOfFileTest{}
 
-	err = json.Unmarshal(bytes, &varMapOfFileTest)
+	err = json.Unmarshal(data, &varMapOfFileTest)
 
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (o *MapOfFileTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "prop_test")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_map_test_.go
@@ -203,10 +203,10 @@ func (o MapTest) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *MapTest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *MapTest) UnmarshalJSON(data []byte) (err error) {
 	varMapTest := _MapTest{}
 
-	err = json.Unmarshal(bytes, &varMapTest)
+	err = json.Unmarshal(data, &varMapTest)
 
 	if err != nil {
 		return err
@@ -216,7 +216,7 @@ func (o *MapTest) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "map_map_of_string")
 		delete(additionalProperties, "map_of_enum_string")
 		delete(additionalProperties, "direct_map")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_mixed_properties_and_additional_properties_class.go
@@ -168,10 +168,10 @@ func (o MixedPropertiesAndAdditionalPropertiesClass) ToMap() (map[string]interfa
 	return toSerialize, nil
 }
 
-func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(bytes []byte) (err error) {
+func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(data []byte) (err error) {
 	varMixedPropertiesAndAdditionalPropertiesClass := _MixedPropertiesAndAdditionalPropertiesClass{}
 
-	err = json.Unmarshal(bytes, &varMixedPropertiesAndAdditionalPropertiesClass)
+	err = json.Unmarshal(data, &varMixedPropertiesAndAdditionalPropertiesClass)
 
 	if err != nil {
 		return err
@@ -181,7 +181,7 @@ func (o *MixedPropertiesAndAdditionalPropertiesClass) UnmarshalJSON(bytes []byte
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "uuid")
 		delete(additionalProperties, "dateTime")
 		delete(additionalProperties, "map")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_name.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_name.go
@@ -195,7 +195,7 @@ func (o Name) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Name) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -205,7 +205,7 @@ func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -219,7 +219,7 @@ func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 
 	varName := _Name{}
 
-	err = json.Unmarshal(bytes, &varName)
+	err = json.Unmarshal(data, &varName)
 
 	if err != nil {
 		return err
@@ -229,7 +229,7 @@ func (o *Name) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		delete(additionalProperties, "snake_case")
 		delete(additionalProperties, "property")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of.go
@@ -105,10 +105,10 @@ func (o NullableAllOf) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *NullableAllOf) UnmarshalJSON(bytes []byte) (err error) {
+func (o *NullableAllOf) UnmarshalJSON(data []byte) (err error) {
 	varNullableAllOf := _NullableAllOf{}
 
-	err = json.Unmarshal(bytes, &varNullableAllOf)
+	err = json.Unmarshal(data, &varNullableAllOf)
 
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (o *NullableAllOf) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "child")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_all_of_child.go
@@ -95,10 +95,10 @@ func (o NullableAllOfChild) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *NullableAllOfChild) UnmarshalJSON(bytes []byte) (err error) {
+func (o *NullableAllOfChild) UnmarshalJSON(data []byte) (err error) {
 	varNullableAllOfChild := _NullableAllOfChild{}
 
-	err = json.Unmarshal(bytes, &varNullableAllOfChild)
+	err = json.Unmarshal(data, &varNullableAllOfChild)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *NullableAllOfChild) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_nullable_class.go
@@ -560,10 +560,10 @@ func (o NullableClass) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *NullableClass) UnmarshalJSON(bytes []byte) (err error) {
+func (o *NullableClass) UnmarshalJSON(data []byte) (err error) {
 	varNullableClass := _NullableClass{}
 
-	err = json.Unmarshal(bytes, &varNullableClass)
+	err = json.Unmarshal(data, &varNullableClass)
 
 	if err != nil {
 		return err
@@ -573,7 +573,7 @@ func (o *NullableClass) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "integer_prop")
 		delete(additionalProperties, "number_prop")
 		delete(additionalProperties, "boolean_prop")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_number_only.go
@@ -95,10 +95,10 @@ func (o NumberOnly) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *NumberOnly) UnmarshalJSON(bytes []byte) (err error) {
+func (o *NumberOnly) UnmarshalJSON(data []byte) (err error) {
 	varNumberOnly := _NumberOnly{}
 
-	err = json.Unmarshal(bytes, &varNumberOnly)
+	err = json.Unmarshal(data, &varNumberOnly)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *NumberOnly) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "JustNumber")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_one_of_primitive_type_child.go
@@ -95,10 +95,10 @@ func (o OneOfPrimitiveTypeChild) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *OneOfPrimitiveTypeChild) UnmarshalJSON(bytes []byte) (err error) {
+func (o *OneOfPrimitiveTypeChild) UnmarshalJSON(data []byte) (err error) {
 	varOneOfPrimitiveTypeChild := _OneOfPrimitiveTypeChild{}
 
-	err = json.Unmarshal(bytes, &varOneOfPrimitiveTypeChild)
+	err = json.Unmarshal(data, &varOneOfPrimitiveTypeChild)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *OneOfPrimitiveTypeChild) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_order.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_order.go
@@ -281,10 +281,10 @@ func (o Order) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Order) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Order) UnmarshalJSON(data []byte) (err error) {
 	varOrder := _Order{}
 
-	err = json.Unmarshal(bytes, &varOrder)
+	err = json.Unmarshal(data, &varOrder)
 
 	if err != nil {
 		return err
@@ -294,7 +294,7 @@ func (o *Order) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "petId")
 		delete(additionalProperties, "quantity")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_composite.go
@@ -167,10 +167,10 @@ func (o OuterComposite) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *OuterComposite) UnmarshalJSON(bytes []byte) (err error) {
+func (o *OuterComposite) UnmarshalJSON(data []byte) (err error) {
 	varOuterComposite := _OuterComposite{}
 
-	err = json.Unmarshal(bytes, &varOuterComposite)
+	err = json.Unmarshal(data, &varOuterComposite)
 
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func (o *OuterComposite) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "my_number")
 		delete(additionalProperties, "my_string")
 		delete(additionalProperties, "my_boolean")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_pet.go
@@ -263,7 +263,7 @@ func (o Pet) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Pet) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -274,7 +274,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -288,7 +288,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	varPet := _Pet{}
 
-	err = json.Unmarshal(bytes, &varPet)
+	err = json.Unmarshal(data, &varPet)
 
 	if err != nil {
 		return err
@@ -298,7 +298,7 @@ func (o *Pet) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "category")
 		delete(additionalProperties, "name")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_property_name_mapping.go
@@ -203,10 +203,10 @@ func (o PropertyNameMapping) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *PropertyNameMapping) UnmarshalJSON(bytes []byte) (err error) {
+func (o *PropertyNameMapping) UnmarshalJSON(data []byte) (err error) {
 	varPropertyNameMapping := _PropertyNameMapping{}
 
-	err = json.Unmarshal(bytes, &varPropertyNameMapping)
+	err = json.Unmarshal(data, &varPropertyNameMapping)
 
 	if err != nil {
 		return err
@@ -216,7 +216,7 @@ func (o *PropertyNameMapping) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "http_debug_operation")
 		delete(additionalProperties, "_type")
 		delete(additionalProperties, "type")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_first.go
@@ -131,10 +131,10 @@ func (o ReadOnlyFirst) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ReadOnlyFirst) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ReadOnlyFirst) UnmarshalJSON(data []byte) (err error) {
 	varReadOnlyFirst := _ReadOnlyFirst{}
 
-	err = json.Unmarshal(bytes, &varReadOnlyFirst)
+	err = json.Unmarshal(data, &varReadOnlyFirst)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *ReadOnlyFirst) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "bar")
 		delete(additionalProperties, "baz")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_read_only_with_default.go
@@ -323,10 +323,10 @@ func (o ReadOnlyWithDefault) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *ReadOnlyWithDefault) UnmarshalJSON(bytes []byte) (err error) {
+func (o *ReadOnlyWithDefault) UnmarshalJSON(data []byte) (err error) {
 	varReadOnlyWithDefault := _ReadOnlyWithDefault{}
 
-	err = json.Unmarshal(bytes, &varReadOnlyWithDefault)
+	err = json.Unmarshal(data, &varReadOnlyWithDefault)
 
 	if err != nil {
 		return err
@@ -336,7 +336,7 @@ func (o *ReadOnlyWithDefault) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "prop1")
 		delete(additionalProperties, "prop2")
 		delete(additionalProperties, "prop3")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_return.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_return.go
@@ -95,10 +95,10 @@ func (o Return) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Return) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Return) UnmarshalJSON(data []byte) (err error) {
 	varReturn := _Return{}
 
-	err = json.Unmarshal(bytes, &varReturn)
+	err = json.Unmarshal(data, &varReturn)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *Return) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "return")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_tag.go
@@ -131,10 +131,10 @@ func (o Tag) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Tag) UnmarshalJSON(data []byte) (err error) {
 	varTag := _Tag{}
 
-	err = json.Unmarshal(bytes, &varTag)
+	err = json.Unmarshal(data, &varTag)
 
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (o *Tag) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "name")
 		o.AdditionalProperties = additionalProperties

--- a/samples/openapi3/client/petstore/go/go-petstore/model_test_inline_freeform_additional_properties_request.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_test_inline_freeform_additional_properties_request.go
@@ -95,10 +95,10 @@ func (o TestInlineFreeformAdditionalPropertiesRequest) ToMap() (map[string]inter
 	return toSerialize, nil
 }
 
-func (o *TestInlineFreeformAdditionalPropertiesRequest) UnmarshalJSON(bytes []byte) (err error) {
+func (o *TestInlineFreeformAdditionalPropertiesRequest) UnmarshalJSON(data []byte) (err error) {
 	varTestInlineFreeformAdditionalPropertiesRequest := _TestInlineFreeformAdditionalPropertiesRequest{}
 
-	err = json.Unmarshal(bytes, &varTestInlineFreeformAdditionalPropertiesRequest)
+	err = json.Unmarshal(data, &varTestInlineFreeformAdditionalPropertiesRequest)
 
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (o *TestInlineFreeformAdditionalPropertiesRequest) UnmarshalJSON(bytes []by
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "someProperty")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/samples/openapi3/client/petstore/go/go-petstore/model_user.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_user.go
@@ -499,10 +499,10 @@ func (o User) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *User) UnmarshalJSON(bytes []byte) (err error) {
+func (o *User) UnmarshalJSON(data []byte) (err error) {
 	varUser := _User{}
 
-	err = json.Unmarshal(bytes, &varUser)
+	err = json.Unmarshal(data, &varUser)
 
 	if err != nil {
 		return err
@@ -512,7 +512,7 @@ func (o *User) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "id")
 		delete(additionalProperties, "username")
 		delete(additionalProperties, "firstName")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_whale.go
@@ -159,7 +159,7 @@ func (o Whale) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Whale) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -169,7 +169,7 @@ func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -183,7 +183,7 @@ func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
 
 	varWhale := _Whale{}
 
-	err = json.Unmarshal(bytes, &varWhale)
+	err = json.Unmarshal(data, &varWhale)
 
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func (o *Whale) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "hasBaleen")
 		delete(additionalProperties, "hasTeeth")
 		delete(additionalProperties, "className")

--- a/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_zebra.go
@@ -123,7 +123,7 @@ func (o Zebra) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
-func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
+func (o *Zebra) UnmarshalJSON(data []byte) (err error) {
 	// This validates that all required properties are included in the JSON object
 	// by unmarshalling the object into a generic map with string keys and checking
 	// that every required field exists as a key in the generic map.
@@ -133,7 +133,7 @@ func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
 
 	allProperties := make(map[string]interface{})
 
-	err = json.Unmarshal(bytes, &allProperties)
+	err = json.Unmarshal(data, &allProperties)
 
 	if err != nil {
 		return err;
@@ -147,7 +147,7 @@ func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
 
 	varZebra := _Zebra{}
 
-	err = json.Unmarshal(bytes, &varZebra)
+	err = json.Unmarshal(data, &varZebra)
 
 	if err != nil {
 		return err
@@ -157,7 +157,7 @@ func (o *Zebra) UnmarshalJSON(bytes []byte) (err error) {
 
 	additionalProperties := make(map[string]interface{})
 
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+	if err = json.Unmarshal(data, &additionalProperties); err == nil {
 		delete(additionalProperties, "type")
 		delete(additionalProperties, "className")
 		o.AdditionalProperties = additionalProperties


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This updates the Go client generator so that, if a model has required fields but does not allow additional properties, the custom `UnmarshalJSON` function will return an error when the input JSON includes additional properties.

Fixes #17156 

cc/ @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5 @wing328

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
