### PR TITLE
[Java][SSE] Replacing ApiResponse reference by the corresponding ApiResponse object

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.*;
 import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.io.FilenameUtils;
@@ -1305,6 +1306,14 @@ public class DefaultGenerator implements Generator {
         final List<SecurityRequirement> globalSecurities = openAPI.getSecurity();
         for (Tag tag : tags) {
             try {
+                // Replacing reference by corresponding ApiResponse
+                for(String key : operation.getResponses().keySet()) {
+                    ApiResponse apiResponse = operation.getResponses().get(key);
+                    if(apiResponse.get$ref() != null) {
+                        operation.getResponses().put(key, ModelUtils.getReferencedApiResponse(openAPI, apiResponse));
+                    }
+                }
+
                 CodegenOperation codegenOperation = config.fromOperation(resourcePath, httpMethod, operation, path.getServers());
                 codegenOperation.tags = new ArrayList<>(tags);
                 config.addOperationToGroup(config.sanitizeTag(tag.getName()), resourcePath, operation, codegenOperation, operations);

--- a/modules/openapi-generator/src/test/resources/3_0/sse.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/sse.yaml
@@ -53,7 +53,7 @@ paths:
                 format: event-stream
   /path/variant4:
     post:
-      operationId: nonSSE
+      operationId: sseVariant4
       tags:
         - sse
       responses:

--- a/modules/openapi-generator/src/test/resources/3_0/sse.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/sse.yaml
@@ -51,6 +51,15 @@ paths:
               schema:
                 type: string
                 format: event-stream
+  /path/variant4:
+    post:
+      operationId: nonSSE
+      tags:
+        - sse
+      responses:
+        '200':
+          $ref: '#/components/responses/EventTypeResponse'
+
 components:
   schemas:
     EventType:
@@ -58,5 +67,17 @@ components:
       properties:
         attribute1:
           type: string
+
+  responses:
+    EventTypeResponse:
+      description: acknowledged
+      content:
+        text/event-stream:
+          schema:
+            type: array
+            format: event-stream
+            items:
+              $ref: '#/components/schemas/EventType'
+
 
   


### PR DESCRIPTION
Fixes https://github.com/OpenAPITools/openapi-generator/issues/17271

This PR is adding a test case that is currently failing in the current context.

The problems come from the following line which is directly getting the content of the ApiResponse, when it can and is allowed to be a reference. Thus leading to a Null Pointer Exception

https://github.com/OpenAPITools/openapi-generator/blob/4a0ab21ba42f4895cd0497486d1fe979ac874f9d/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/SpringCodegen.java#L1285

This can be fixed, by replacing the ApiResponse reference by their corresponding ApiResponse in the `processOperation` method. 
> We *cannot* fetch the ApiResponse object from its reference in the method `fromOperation`, therefore we need to it before.
