### PR TITLE
Generalized mime type support

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -22,16 +22,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     {{#models}}
         {{#model}}
@@ -58,6 +48,45 @@ let typeMap: {[index: string]: any} = {
         {{/model}}
     {{/models}}
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -204,14 +233,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -224,11 +254,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -243,16 +273,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript/model/ObjectSerializer.mustache
@@ -55,6 +55,15 @@ type MimeTypeDescriptor = {
     subtypeTokens: string[];
 };
 
+/**
+ * Every mime-type consists of a type, subtype, and optional parameters.
+ * The subtype can be composite, including information about the content format.
+ * For example: `application/json-patch+json`, `application/merge-patch+json`.
+ *
+ * This helper transforms a string mime-type into an internal representation.
+ * This simplifies the implementation of predicates that in turn define common rules for parsing or stringifying
+ * the payload.
+ */
 const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
     const [type, subtype] = mimeType.split('/');
     return {
@@ -66,20 +75,24 @@ const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
 
 type MimeTypePredicate = (mimeType: string) => boolean;
 
+// This factory creates a predicate function that checks a string mime-type against defined rules.
 const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
 
+// Use this factory when you need to define a simple predicate based only on type and, if applicable, subtype.
 const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
     if (descriptor.type !== type) return false;
     if (subtype != null && descriptor.subtype !== subtype) return false;
     return true;
 });
 
+// Creating a set of named predicates that will help us determine how to handle different mime-types
 const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
 const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
-const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.some((item) => item === 'json'));
 const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
 const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
 
+// Defining a list of mime-types in the order of prioritization for handling.
 const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
     isJsonMimeType,
     isJsonLikeMimeType,
@@ -234,20 +247,15 @@ export class ObjectSerializer {
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
 
-        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
-            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
-                return mediaType != null && predicate(mediaType);
-            });
-            return result.concat(filteredMediaTypes);
-        }, []);
-
-        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
-
-        if (selectedMediaType === undefined) {
-            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        for (const predicate of supportedMimeTypePredicatesWithPriority) {
+            for (const mediaType of normalMediaTypes) {
+                if (mediaType != null && predicate(mediaType)) {
+                    return mediaType;
+                }
+            }
         }
 
-        return selectedMediaType!;
+        throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
     }
 
     /**

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -14,22 +14,51 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
 ]);
 
 let typeMap: {[index: string]: any} = {
     "Response": Response,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -176,14 +205,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -196,11 +226,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -215,16 +245,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
+++ b/samples/client/others/typescript/builds/with-unique-items/models/ObjectSerializer.ts
@@ -27,6 +27,15 @@ type MimeTypeDescriptor = {
     subtypeTokens: string[];
 };
 
+/**
+ * Every mime-type consists of a type, subtype, and optional parameters.
+ * The subtype can be composite, including information about the content format.
+ * For example: `application/json-patch+json`, `application/merge-patch+json`.
+ *
+ * This helper transforms a string mime-type into an internal representation.
+ * This simplifies the implementation of predicates that in turn define common rules for parsing or stringifying
+ * the payload.
+ */
 const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
     const [type, subtype] = mimeType.split('/');
     return {
@@ -38,20 +47,24 @@ const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
 
 type MimeTypePredicate = (mimeType: string) => boolean;
 
+// This factory creates a predicate function that checks a string mime-type against defined rules.
 const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
 
+// Use this factory when you need to define a simple predicate based only on type and, if applicable, subtype.
 const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
     if (descriptor.type !== type) return false;
     if (subtype != null && descriptor.subtype !== subtype) return false;
     return true;
 });
 
+// Creating a set of named predicates that will help us determine how to handle different mime-types
 const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
 const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
-const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.some((item) => item === 'json'));
 const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
 const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
 
+// Defining a list of mime-types in the order of prioritization for handling.
 const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
     isJsonMimeType,
     isJsonLikeMimeType,
@@ -206,20 +219,15 @@ export class ObjectSerializer {
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
 
-        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
-            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
-                return mediaType != null && predicate(mediaType);
-            });
-            return result.concat(filteredMediaTypes);
-        }, []);
-
-        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
-
-        if (selectedMediaType === undefined) {
-            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        for (const predicate of supportedMimeTypePredicatesWithPriority) {
+            for (const mediaType of normalMediaTypes) {
+                if (mediaType != null && predicate(mediaType)) {
+                    return mediaType;
+                }
+            }
         }
 
-        return selectedMediaType!;
+        throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/browser/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -26,16 +26,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "DogBreedEnum",
     "PetByTypePetTypeEnum",
@@ -52,6 +42,45 @@ let typeMap: {[index: string]: any} = {
     "PetsFilteredPatchRequest": PetsFilteredPatchRequest,
     "PetsPatchRequest": PetsPatchRequest,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -198,14 +227,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -218,11 +248,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -237,16 +267,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/composed-schemas/models/ObjectSerializer.ts
@@ -49,6 +49,15 @@ type MimeTypeDescriptor = {
     subtypeTokens: string[];
 };
 
+/**
+ * Every mime-type consists of a type, subtype, and optional parameters.
+ * The subtype can be composite, including information about the content format.
+ * For example: `application/json-patch+json`, `application/merge-patch+json`.
+ *
+ * This helper transforms a string mime-type into an internal representation.
+ * This simplifies the implementation of predicates that in turn define common rules for parsing or stringifying
+ * the payload.
+ */
 const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
     const [type, subtype] = mimeType.split('/');
     return {
@@ -60,20 +69,24 @@ const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
 
 type MimeTypePredicate = (mimeType: string) => boolean;
 
+// This factory creates a predicate function that checks a string mime-type against defined rules.
 const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
 
+// Use this factory when you need to define a simple predicate based only on type and, if applicable, subtype.
 const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
     if (descriptor.type !== type) return false;
     if (subtype != null && descriptor.subtype !== subtype) return false;
     return true;
 });
 
+// Creating a set of named predicates that will help us determine how to handle different mime-types
 const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
 const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
-const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.some((item) => item === 'json'));
 const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
 const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
 
+// Defining a list of mime-types in the order of prioritization for handling.
 const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
     isJsonMimeType,
     isJsonLikeMimeType,
@@ -228,20 +241,15 @@ export class ObjectSerializer {
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
 
-        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
-            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
-                return mediaType != null && predicate(mediaType);
-            });
-            return result.concat(filteredMediaTypes);
-        }, []);
-
-        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
-
-        if (selectedMediaType === undefined) {
-            throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
+        for (const predicate of supportedMimeTypePredicatesWithPriority) {
+            for (const mediaType of normalMediaTypes) {
+                if (mediaType != null && predicate(mediaType)) {
+                    return mediaType;
+                }
+            }
         }
 
-        return selectedMediaType!;
+        throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
     }
 
     /**

--- a/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/default/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/deno/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/inversify/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/jquery/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
+++ b/samples/openapi3/client/petstore/typescript/builds/object_params/models/ObjectSerializer.ts
@@ -24,16 +24,6 @@ let primitives = [
                     "any"
                  ];
 
-const supportedMediaTypes: { [mediaType: string]: number } = {
-  "application/json": Infinity,
-  "application/json-patch+json": 1,
-  "application/merge-patch+json": 1,
-  "application/strategic-merge-patch+json": 1,
-  "application/octet-stream": 0,
-  "application/x-www-form-urlencoded": 0
-}
-
-
 let enumsMap: Set<string> = new Set<string>([
     "OrderStatusEnum",
     "PetStatusEnum",
@@ -47,6 +37,45 @@ let typeMap: {[index: string]: any} = {
     "Tag": Tag,
     "User": User,
 }
+
+type MimeTypeDescriptor = {
+    type: string;
+    subtype: string;
+    subtypeTokens: string[];
+};
+
+const parseMimeType = (mimeType: string): MimeTypeDescriptor => {
+    const [type, subtype] = mimeType.split('/');
+    return {
+        type,
+        subtype,
+        subtypeTokens: subtype.split('+'),
+    };
+};
+
+type MimeTypePredicate = (mimeType: string) => boolean;
+
+const mimeTypePredicateFactory = (predicate: (descriptor: MimeTypeDescriptor) => boolean): MimeTypePredicate => (mimeType) => predicate(parseMimeType(mimeType));
+
+const mimeTypeSimplePredicateFactory = (type: string, subtype?: string): MimeTypePredicate => mimeTypePredicateFactory((descriptor) => {
+    if (descriptor.type !== type) return false;
+    if (subtype != null && descriptor.subtype !== subtype) return false;
+    return true;
+});
+
+const isTextLikeMimeType = mimeTypeSimplePredicateFactory('text');
+const isJsonMimeType = mimeTypeSimplePredicateFactory('application', 'json');
+const isJsonLikeMimeType = mimeTypePredicateFactory((descriptor) => descriptor.type === 'application' && descriptor.subtypeTokens.includes('json'));
+const isOctetStreamMimeType = mimeTypeSimplePredicateFactory('application', 'octet-stream');
+const isFormUrlencodedMimeType = mimeTypeSimplePredicateFactory('application', 'x-www-form-urlencoded');
+
+const supportedMimeTypePredicatesWithPriority: MimeTypePredicate[] = [
+    isJsonMimeType,
+    isJsonLikeMimeType,
+    isTextLikeMimeType,
+    isOctetStreamMimeType,
+    isFormUrlencodedMimeType,
+];
 
 export class ObjectSerializer {
     public static findCorrectType(data: any, expectedType: string) {
@@ -193,14 +222,15 @@ export class ObjectSerializer {
         }
 
         const normalMediaTypes = mediaTypes.map(this.normalizeMediaType);
-        let selectedMediaType: string | undefined = undefined;
-        let selectedRank: number = -Infinity;
-        for (const mediaType of normalMediaTypes) {
-            if (supportedMediaTypes[mediaType!] > selectedRank) {
-                selectedMediaType = mediaType;
-                selectedRank = supportedMediaTypes[mediaType!];
-            }
-        }
+
+        const supportedAndOrderedMediaTypes = supportedMimeTypePredicatesWithPriority.reduce<string[]>((result, predicate) => {
+            const filteredMediaTypes = normalMediaTypes.filter((mediaType): mediaType is Exclude<typeof mediaType, undefined> => {
+                return mediaType != null && predicate(mediaType);
+            });
+            return result.concat(filteredMediaTypes);
+        }, []);
+
+        const selectedMediaType: string | undefined = supportedAndOrderedMediaTypes[0];
 
         if (selectedMediaType === undefined) {
             throw new Error("None of the given media types are supported: " + mediaTypes.join(", "));
@@ -213,11 +243,11 @@ export class ObjectSerializer {
      * Convert data to a string according the given media type
      */
     public static stringify(data: any, mediaType: string): string {
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return String(data);
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.stringify(data);
         }
 
@@ -232,16 +262,12 @@ export class ObjectSerializer {
             throw new Error("Cannot parse content. No Content-Type defined.");
         }
 
-        if (mediaType === "text/plain") {
+        if (isTextLikeMimeType(mediaType)) {
             return rawData;
         }
 
-        if (mediaType === "application/json" || mediaType === "application/json-patch+json" || mediaType === "application/merge-patch+json" || mediaType === "application/strategic-merge-patch+json") {
+        if (isJsonLikeMimeType(mediaType)) {
             return JSON.parse(rawData);
-        }
-
-        if (mediaType === "text/html") {
-            return rawData;
         }
 
         throw new Error("The mediaType " + mediaType + " is not supported by ObjectSerializer.parse.");

--- a/samples/openapi3/client/petstore/typescript/tests/default/test/models/ObjectSerializer.test.ts
+++ b/samples/openapi3/client/petstore/typescript/tests/default/test/models/ObjectSerializer.test.ts
@@ -7,6 +7,18 @@ const objectSerializerFile = rewire(__dirname + "/../../node_modules/ts-petstore
 
 const ObjectSerializer = objectSerializerFile.__get__("ObjectSerializer")
 
+const htmlContent = `
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+    <title>Error 404 Not Found</title>
+  </head>
+  <body>
+    <h2>HTTP ERROR 404</h2>
+    <p>Resource not found</p>
+  </body>
+</html>
+`;
 
 describe("ObjectSerializer", () => {
     describe("Serialize", () => {
@@ -229,12 +241,54 @@ describe("ObjectSerializer", () => {
                 expect(deserialized[i].constructor.name).to.equal("Category")
             }
             expect(deserialized).to.deep.equal(categories)
-        })        
+        })
     })
+
     describe("Parse", () => {
-        it("text/html", () => {
-            const input = "<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\"/>\n<title>Error 404 Not Found</title>\n</head>\n<body><h2>HTTP ERROR 404</h2>\n<p>Resource not found</p>\n</body>\n</html>\n"
-            expect(ObjectSerializer.parse(input, "text/html")).to.equal(input)
+        it("Text", () => {
+            expect(ObjectSerializer.parse("test", "text/plain")).to.equal("test")
+            expect(ObjectSerializer.parse(htmlContent, "text/html")).to.equal(htmlContent)
+        });
+
+        it("JSON", () => {
+            const jsonContent = { foo: "bar"};
+
+            expect(ObjectSerializer.parse(JSON.stringify(jsonContent), "application/json")).to.deep.equal(jsonContent)
+            expect(ObjectSerializer.parse(JSON.stringify(jsonContent), "application/json-patch+json")).to.deep.equal(jsonContent)
+            expect(ObjectSerializer.parse(JSON.stringify(jsonContent), "application/merge-patch+json")).to.deep.equal(jsonContent)
+        });
+    })
+
+    describe("Stringify", () => {
+        it("Text", () => {
+            expect(ObjectSerializer.stringify("test", "text/plain")).to.equal("test")
+            expect(ObjectSerializer.stringify(htmlContent, "text/html")).to.equal(htmlContent)
+        });
+
+        it("JSON", () => {
+            const jsonContent = { foo: "bar"};
+
+            expect(ObjectSerializer.stringify(jsonContent, "application/json")).to.equal(JSON.stringify(jsonContent))
+            expect(ObjectSerializer.stringify(jsonContent, "application/json-patch+json")).to.equal(JSON.stringify(jsonContent))
+            expect(ObjectSerializer.stringify(jsonContent, "application/merge-patch+json")).to.equal(JSON.stringify(jsonContent))
+        });
+    })
+
+    describe("GetPreferredMediaType", () => {
+        it("Empty media-type", () => {
+            expect(ObjectSerializer.getPreferredMediaType([])).to.equal("application/json")
+        });
+
+        it("JSON media-type", () => {
+            expect(ObjectSerializer.getPreferredMediaType(["application/json"])).to.equal("application/json")
+        });
+
+        it("Multiple media-types", () => {
+            expect(ObjectSerializer.getPreferredMediaType(["text/plain", "application/x-www-form-urlencoded", "application/json"])).to.equal("application/json")
+        });
+
+        it("Unsupported media-type", () => {
+            expect(() => ObjectSerializer.getPreferredMediaType(["foo/bar"])).to.throw('None of the given media types are supported: foo/bar')
         });
     })
 })


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Address https://github.com/OpenAPITools/openapi-generator/issues/17282

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

---
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)