### PR TITLE
Add enum name mapping support to Go generators

### DIFF
--- a/bin/configs/go-petstore.yaml
+++ b/bin/configs/go-petstore.yaml
@@ -15,4 +15,6 @@ additionalProperties:
   packageName: petstore
   disallowAdditionalPropertiesIfNotPresent: false
   generateInterfaces: true
+enumNameMappings:
+  delivered: SHIPPED
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -750,6 +750,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (enumNameMapping.containsKey(name)) {
+            return enumNameMapping.get(name);
+        }
+
         if (name.length() == 0) {
             return "EMPTY";
         }
@@ -784,6 +788,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
 
     @Override
     public String toEnumName(CodegenProperty property) {
+        if (enumNameMapping.containsKey(property.name)) {
+            return enumNameMapping.get(property.name);
+        }
+
         String enumName = underscore(toModelName(property.name)).toUpperCase(Locale.ROOT);
 
         // remove [] for array or map of enum

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/OuterEnum.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/OuterEnum.md
@@ -7,7 +7,7 @@
 
 * `APPROVED` (value: `"approved"`)
 
-* `DELIVERED` (value: `"delivered"`)
+* `SHIPPED` (value: `"delivered"`)
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go/go-petstore/docs/OuterEnumDefaultValue.md
+++ b/samples/openapi3/client/petstore/go/go-petstore/docs/OuterEnumDefaultValue.md
@@ -7,7 +7,7 @@
 
 * `APPROVED` (value: `"approved"`)
 
-* `DELIVERED` (value: `"delivered"`)
+* `SHIPPED` (value: `"delivered"`)
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum.go
@@ -22,7 +22,7 @@ type OuterEnum string
 const (
 	OUTERENUM_PLACED OuterEnum = "placed"
 	OUTERENUM_APPROVED OuterEnum = "approved"
-	OUTERENUM_DELIVERED OuterEnum = "delivered"
+	OUTERENUM_SHIPPED OuterEnum = "delivered"
 )
 
 // All allowed values of OuterEnum enum

--- a/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_default_value.go
+++ b/samples/openapi3/client/petstore/go/go-petstore/model_outer_enum_default_value.go
@@ -22,7 +22,7 @@ type OuterEnumDefaultValue string
 const (
 	OUTERENUMDEFAULTVALUE_PLACED OuterEnumDefaultValue = "placed"
 	OUTERENUMDEFAULTVALUE_APPROVED OuterEnumDefaultValue = "approved"
-	OUTERENUMDEFAULTVALUE_DELIVERED OuterEnumDefaultValue = "delivered"
+	OUTERENUMDEFAULTVALUE_SHIPPED OuterEnumDefaultValue = "delivered"
 )
 
 // All allowed values of OuterEnumDefaultValue enum


### PR DESCRIPTION
- Add enum name mapping support to Go generators
- add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc 
@antihax (2017/11) @grokify (2018/07) @kemokemo (2018/09) @jirikuncar (2021/01) @ph4r5h4d (2021/04) @lwj5 (2023/04)
