### PR TITLE
Add enum name mapping feature to the Rust generators

### DIFF
--- a/bin/configs/rust-reqwest-petstore.yaml
+++ b/bin/configs/rust-reqwest-petstore.yaml
@@ -6,3 +6,5 @@ templateDir: modules/openapi-generator/src/main/resources/rust
 additionalProperties:
   supportAsync: false
   packageName: petstore-reqwest
+enumNameMappings:
+  delivered: shipped

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRustCodegen.java
@@ -285,9 +285,12 @@ public abstract class AbstractRustCodegen extends DefaultCodegen implements Code
     }
 
     //// Enum naming ////
-
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (enumNameMapping.containsKey(name)) {
+            return enumNameMapping.get(name);
+        }
+
         // Empty strings need to be mapped to "Empty"
         // https://github.com/OpenAPITools/openapi-generator/issues/13453
         if (Strings.isNullOrEmpty(name)) {

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
@@ -51,7 +51,7 @@ pub enum Status {
     #[serde(rename = "approved")]
     Approved,
     #[serde(rename = "delivered")]
-    Delivered,
+    shipped,
 }
 
 impl Default for Status {


### PR DESCRIPTION
- Add enum name mapping feature to the Rust generators
- add tests

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)
