### PR TITLE
[POSTMAN} Query parameter description

### DIFF
--- a/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
+++ b/modules/openapi-generator/src/main/resources/postman-collection/item.mustache
@@ -49,6 +49,7 @@
                                             {
                                                 "key": "{{paramName}}",
                                                 "value": "{{example}}",
+                                                "description": "{{{description}}}",
                                                 "disabled": {{#required}}false{{/required}}{{^required}}true{{/required}}
                                             }{{^-last}},{{/-last}}
                                             {{/queryParams}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -775,8 +775,33 @@ public class PostmanCollectionCodegenTest {
         Path path = Paths.get(output + "/postman.json");
         TestUtils.assertFileExists(path);
         // verify param pUserId is set as disabled=false
-        TestUtils.assertFileContains(path, "{ \"key\": \"pUserId\", \"value\": \"888\", \"disabled\": false");
+        TestUtils.assertFileContains(path, "{ \"key\": \"pUserId\", \"value\": \"888\", \"description\": \"Query Id.\", \"disabled\": false");
 
     }
+
+    @Test
+    public void testQueryParameterDescription() throws IOException {
+
+        File output = Files.createTempDirectory("postmantest_").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("postman-v2")
+                .setInputSpec("./src/test/resources/SampleProject.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+
+        System.out.println(files);
+        files.forEach(File::deleteOnExit);
+
+        Path path = Paths.get(output + "/postman.json");
+        TestUtils.assertFileExists(path);
+        // verify param pUserId is set as disabled=false
+        TestUtils.assertFileContains(path, "{ \"key\": \"pUserId\", \"value\": \"888\", \"description\": \"Query Id.\"");
+
+    }
+
 
 }

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -286,6 +286,7 @@
                                             {
                                                 "key": "pUserId",
                                                 "value": "888",
+                                                "description": "Query Id.",
                                                 "disabled": false
                                             }
                                         ]


### PR DESCRIPTION
The description of the query parameter is not displayed in Postman. This PR makes sure that the parameter description is included in the generated `postman.json`.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 