### PR TITLE
rust: remove Default implementation for enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -28,14 +28,6 @@ impl ToString for {{{classname}}} {
         }
     }
 }
-
-impl Default for {{{classname}}} {
-    fn default() -> {{{classname}}} {
-        {{#allowableValues}}
-        Self::{{ enumVars.0.name }}
-        {{/allowableValues}}
-    }
-}
 {{/isEnum}}
 
 {{!-- for schemas that have a discriminator --}}
@@ -102,14 +94,6 @@ pub enum {{{enumName}}} {
     {{{name}}},
 {{/enumVars}}
 {{/allowableValues}}
-}
-
-impl Default for {{{enumName}}} {
-    fn default() -> {{{enumName}}} {
-        {{#allowableValues}}
-        Self::{{ enumVars.0.name }}
-        {{/allowableValues}}
-    }
 }
 {{/isEnum}}
 {{/vars}}

--- a/samples/client/petstore/rust/hyper/petstore/src/models/baz.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/baz.rs
@@ -32,12 +32,6 @@ impl ToString for Baz {
     }
 }
 
-impl Default for Baz {
-    fn default() -> Baz {
-        Self::A
-    }
-}
-
 
 
 

--- a/samples/client/petstore/rust/hyper/petstore/src/models/enum_array_testing.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/enum_array_testing.rs
@@ -38,9 +38,3 @@ pub enum RequiredEnums {
     C,
 }
 
-impl Default for RequiredEnums {
-    fn default() -> RequiredEnums {
-        Self::A
-    }
-}
-

--- a/samples/client/petstore/rust/hyper/petstore/src/models/order.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/order.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Delivered,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Placed
-    }
-}
-

--- a/samples/client/petstore/rust/hyper/petstore/src/models/pet.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/pet.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Sold,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Available
-    }
-}
-

--- a/samples/client/petstore/rust/hyper/petstore/src/models/unique_item_array_testing.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/unique_item_array_testing.rs
@@ -39,9 +39,3 @@ pub enum UniqueItemArray {
     Variant3,
 }
 
-impl Default for UniqueItemArray {
-    fn default() -> UniqueItemArray {
-        Self::Variant1
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/baz.rs
@@ -32,12 +32,6 @@ impl ToString for Baz {
     }
 }
 
-impl Default for Baz {
-    fn default() -> Baz {
-        Self::A
-    }
-}
-
 
 
 

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/enum_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/enum_array_testing.rs
@@ -38,9 +38,3 @@ pub enum RequiredEnums {
     C,
 }
 
-impl Default for RequiredEnums {
-    fn default() -> RequiredEnums {
-        Self::A
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/order.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Delivered,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Placed
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/pet.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/pet.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Sold,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Available
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/unique_item_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/unique_item_array_testing.rs
@@ -39,9 +39,3 @@ pub enum UniqueItemArray {
     Variant3,
 }
 
-impl Default for UniqueItemArray {
-    fn default() -> UniqueItemArray {
-        Self::Variant1
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/baz.rs
@@ -32,12 +32,6 @@ impl ToString for Baz {
     }
 }
 
-impl Default for Baz {
-    fn default() -> Baz {
-        Self::A
-    }
-}
-
 
 
 

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/enum_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/enum_array_testing.rs
@@ -38,9 +38,3 @@ pub enum RequiredEnums {
     C,
 }
 
-impl Default for RequiredEnums {
-    fn default() -> RequiredEnums {
-        Self::A
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/order.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Delivered,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Placed
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/pet.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/pet.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Sold,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Available
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/unique_item_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/unique_item_array_testing.rs
@@ -39,9 +39,3 @@ pub enum UniqueItemArray {
     Variant3,
 }
 
-impl Default for UniqueItemArray {
-    fn default() -> UniqueItemArray {
-        Self::Variant1
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/baz.rs
@@ -32,12 +32,6 @@ impl ToString for Baz {
     }
 }
 
-impl Default for Baz {
-    fn default() -> Baz {
-        Self::A
-    }
-}
-
 
 
 

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/enum_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/enum_array_testing.rs
@@ -38,9 +38,3 @@ pub enum RequiredEnums {
     C,
 }
 
-impl Default for RequiredEnums {
-    fn default() -> RequiredEnums {
-        Self::A
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/order.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Delivered,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Placed
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/pet.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/pet.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Sold,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Available
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/unique_item_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/unique_item_array_testing.rs
@@ -39,9 +39,3 @@ pub enum UniqueItemArray {
     Variant3,
 }
 
-impl Default for UniqueItemArray {
-    fn default() -> UniqueItemArray {
-        Self::Variant1
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/baz.rs
@@ -32,12 +32,6 @@ impl ToString for Baz {
     }
 }
 
-impl Default for Baz {
-    fn default() -> Baz {
-        Self::A
-    }
-}
-
 
 
 

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/enum_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/enum_array_testing.rs
@@ -38,9 +38,3 @@ pub enum RequiredEnums {
     C,
 }
 
-impl Default for RequiredEnums {
-    fn default() -> RequiredEnums {
-        Self::A
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Delivered,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Placed
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/pet.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/pet.rs
@@ -54,9 +54,3 @@ pub enum Status {
     Sold,
 }
 
-impl Default for Status {
-    fn default() -> Status {
-        Self::Available
-    }
-}
-

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/unique_item_array_testing.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/unique_item_array_testing.rs
@@ -39,9 +39,3 @@ pub enum UniqueItemArray {
     Variant3,
 }
 
-impl Default for UniqueItemArray {
-    fn default() -> UniqueItemArray {
-        Self::Variant1
-    }
-}
-


### PR DESCRIPTION
PR #15856 removed the derived Default implementations for structs, but left those for enums. Since enums do not have a sensible default (see #10845), they should not have the Default trait implemented either. This is technically a breaking change, but it's also a bug fix since Default itself was a breaking change intended to be removed in 7.0.0.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro