### PR TITLE
Fix python conversion "obj -> dict" for api_client

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -372,7 +372,7 @@ class ApiClient:
             # and attributes which value is not None.
             # Convert attribute name to json key in
             # model definition for request.
-            obj_dict = obj.to_dict()
+            obj_dict = obj.__dict__
 
         return {
             key: self.sanitize_for_serialization(val)


### PR DESCRIPTION
https://github.com/OpenAPITools/openapi-generator/issues/16086
proposal for fix conversion python obj -> dict

Path: <b>modules/openapi-generator/src/main/resources/python/api_client.mustache</b>
```diff
- obj_dict = obj.to_dict()
+ obj_dict = obj.__dict__
```