### PR TITLE
Fix non-four indents in PHP templates

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -355,7 +355,7 @@ use {{invokerPackage}}\ObjectSerializer;
                             $statusCode,
                             $response->getHeaders(),
                             $content
-                         );
+                        );
                     }
                 }
             }

--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/SerializerInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/SerializerInterface.mustache
@@ -12,7 +12,7 @@ interface SerializerInterface
      *
      * @return string
      */
-     public function serialize($data, string $format): string;
+    public function serialize($data, string $format): string;
 
     /**
      * Deserializes the given data to the specified type.

--- a/modules/openapi-generator/src/main/resources/php-symfony/testing/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/testing/model_test.mustache
@@ -52,7 +52,7 @@ class {{classname}}Test extends TestCase
     public function setUp(): void
     {
         {{^isEnum}}
-         $this->object = $this->getMockBuilder({{classname}}::class)->getMockForAbstractClass();
+        $this->object = $this->getMockBuilder({{classname}}::class)->getMockForAbstractClass();
         {{/isEnum}}
     }
 

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -290,7 +290,7 @@ use {{invokerPackage}}\ObjectSerializer;
                                     $statusCode,
                                     $response->getHeaders(),
                                     $content
-                                 );
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
While generating PHP code I've noticed few lines are indented with 3 spaces not 4.
Command used: `grep -E '^(    )+ [^* ]'`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@renepardon