### PR TITLE
Replace stray TAB characters with spaces

### DIFF
--- a/bin/meta-codegen-kotlin.sh
+++ b/bin/meta-codegen-kotlin.sh
@@ -7,8 +7,8 @@ declare cwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 declare root="$(cd "$cwd" && cd ../ && pwd)"
 
 if ! command -v gradle > /dev/null; then
-		echo "[WARN] This script requires a system gradle to be installed. Not treating this as an error."
-		exit 0
+  echo "[WARN] This script requires a system gradle to be installed. Not treating this as an error."
+  exit 0
 fi
 
 executable="${root}/modules/openapi-generator-cli/target/openapi-generator-cli.jar"

--- a/docs/faq-generators.md
+++ b/docs/faq-generators.md
@@ -110,6 +110,6 @@ No, please use `swift3` or `swift4` generator instead as we want to focus on Swi
 Yes, please use the following option when generating TypeScript clients:
 
 ```
-	modelPropertyNaming
-	    Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name (Default: camelCase)
+    modelPropertyNaming
+        Naming convention for the property: 'camelCase', 'PascalCase', 'snake_case' and 'original', which keeps the original name (Default: camelCase)
 ```

--- a/modules/openapi-generator/src/main/resources/Ada/config.gpr
+++ b/modules/openapi-generator/src/main/resources/Ada/config.gpr
@@ -45,7 +45,7 @@ abstract project Config is
          when "debug" =>
             for Default_Switches ("Ada") use ("-E");
 
-	 when others =>
+         when others =>
             for Default_Switches ("Ada") use ("-E");
 
       end case;
@@ -64,12 +64,12 @@ abstract project Config is
 
          when "coverage" =>
             for Default_Switches ("ada") use ("-fprofile-arcs");
-	 
-	 when others =>
-	    null;
+
+         when others =>
+            null;
       end case;
 
-   end linker;        
+   end linker;
  
    package Ide is
       for VCS_Kind use "git";

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -243,7 +243,7 @@ end:
         {{/isBoolean}}
         {{/isInteger}}
         keyPairQuery_{{paramName}} = keyValuePair_create(keyQuery_{{{paramName}}}, {{#isEnum}}(void *)strdup({{{operationId}}}_{{enumName}}_ToString(
-		{{/isEnum}}{{^isString}}{{^isInteger}}{{^isBoolean}}&{{/isBoolean}}{{/isInteger}}{{/isString}}valueQuery_{{{paramName}}}{{#isEnum}})){{/isEnum}});
+        {{/isEnum}}{{^isString}}{{^isInteger}}{{^isBoolean}}&{{/isBoolean}}{{/isInteger}}{{/isString}}valueQuery_{{{paramName}}}{{#isEnum}})){{/isEnum}});
         list_addElement(localVarQueryParameters,keyPairQuery_{{paramName}});
         {{/isArray}}
     }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/apiKey.c.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/apiKey.c.mustache
@@ -10,9 +10,9 @@ keyValuePair_t *keyValuePair_create(char *key, void *value) {
 }
 
 keyValuePair_t* keyValuePair_create_allocate(char* key, double value) {
-	double* boolpointer = malloc(sizeof(value));
-	memcpy(boolpointer, &value, sizeof(value));
-	return keyValuePair_create(key, boolpointer);
+    double* boolpointer = malloc(sizeof(value));
+    memcpy(boolpointer, &value, sizeof(value));
+    return keyValuePair_create(key, boolpointer);
 }
 
 void keyValuePair_free(keyValuePair_t *keyValuePair) {

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api_test.mustache
@@ -11,5 +11,5 @@
 #include "keyValuePair.h"
 
 int main() {
-	printf("Hello world1\n");
+    printf("Hello world1\n");
 }

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -79,7 +79,7 @@ end:
     {{#isEnum}}
 char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
     char* {{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
-	return {{name}}Array[{{name}}];
+    return {{name}}Array[{{name}}];
 }
 
 {{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}{{classname}}_FromString(char* {{name}}){
@@ -102,8 +102,8 @@ char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName
     {{^isModel}}
     {{#isEnum}}
 char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
-	char *{{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
-	return {{name}}Array[{{name}} - 1];
+    char *{{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
+    return {{name}}Array[{{name}} - 1];
 }
 
 {{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}{{classname}}_FromString(char* {{name}}) {
@@ -821,7 +821,7 @@ fail:
             }
             localMapKeyPair = keyValuePair_create(strdup(localMapObject->string),&localMapObject->valuedouble );
             {{/isNumeric}}
-		    {{/items}}
+            {{/items}}
             list_addElement({{{name}}}List , localMapKeyPair);
         }
     }

--- a/modules/openapi-generator/src/main/resources/Eiffel/model.mustache
+++ b/modules/openapi-generator/src/main/resources/Eiffel/model.mustache
@@ -24,14 +24,14 @@ feature --Access
     {{^isInherited}}
     {{#isPrimitiveType}}
     {{^isContainer}}
- 	{{name}}: {{{dataType}}}
-    	 {{#description}}-- {{{.}}}{{/description}}
-     {{/isContainer}}
+    {{name}}: {{{dataType}}}
+      {{#description}}-- {{{.}}}{{/description}}
+    {{/isContainer}}
     {{/isPrimitiveType}}
     {{#isPrimitiveType}}
     {{#isContainer}}
- 	{{name}}: detachable {{{datatypeWithEnum}}}
-    	 {{#description}}-- {{{.}}}{{/description}}
+    {{name}}: detachable {{{datatypeWithEnum}}}
+      {{#description}}-- {{{.}}}{{/description}}
     {{/isContainer}}
     {{/isPrimitiveType}}
     {{^isPrimitiveType}}
@@ -45,7 +45,7 @@ feature --Access
     {{/isContainer}}
     {{/isPrimitiveType}}
     {{/isInherited}}
-  {{/vars}}
+{{/vars}}
 
 feature -- Change Element
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumClass.mustache
@@ -25,7 +25,7 @@
      * Convert a String into {{dataType}}, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static {{datatypeWithEnum}} fromString(String s) {
+    public static {{datatypeWithEnum}} fromString(String s) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -34,8 +34,8 @@
             }
         }
         {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
-	}
-	
+    }
+
     @JsonCreator
     public static {{datatypeWithEnum}} fromValue({{dataType}} value) {
         for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/enumOuterClass.mustache
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
      * Convert a String into {{dataType}}, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
+    public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
       for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -38,8 +38,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
         }
       }
       {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/modules/openapi-generator/src/main/resources/apache2/authConf.mustache
+++ b/modules/openapi-generator/src/main/resources/apache2/authConf.mustache
@@ -1,5 +1,5 @@
 AuthBasicProvider file
-	AuthUserFile "{{vendorExtensions.x-codegen-user-info-path}}htpwd"
-	AuthGroupFile "{{vendorExtensions.x-codegen-user-info-path}}groups"
-	AuthType basic
-	AuthName "api"
+    AuthUserFile "{{vendorExtensions.x-codegen-user-info-path}}htpwd"
+    AuthGroupFile "{{vendorExtensions.x-codegen-user-info-path}}groups"
+    AuthType basic
+    AuthName "api"

--- a/modules/openapi-generator/src/main/resources/cpp-restbed-server-deprecated/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-restbed-server-deprecated/api-header.mustache
@@ -174,7 +174,7 @@ class {{declspec}} {{classname}}
 {
 public:
     explicit {{classname}}(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~{{classname}}();
+    virtual ~{{classname}}();
 
     {{#operation}}
     virtual void set{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource(std::shared_ptr<{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource> sp{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource);
@@ -185,9 +185,9 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	{{#operation}}
-	std::shared_ptr<{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource> m_sp{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource;
-	{{/operation}}
+    {{#operation}}
+    std::shared_ptr<{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource> m_sp{{classname}}{{vendorExtensions.x-codegen-resource-name}}Resource;
+    {{/operation}}
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/modules/openapi-generator/src/main/resources/cpp-restbed-server/api-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-restbed-server/api-header.mustache
@@ -137,7 +137,7 @@ class {{declspec}} {{classname}}
 {
 public:
     explicit {{classname}}(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~{{classname}}();
+    virtual ~{{classname}}();
 
     {{#operation}}
     std::shared_ptr<{{classname}}Resources::{{vendorExtensions.x-codegen-resource-name}}Resource> get{{vendorExtensions.x-codegen-resource-name}}Resource();
@@ -156,9 +156,9 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	{{#operation}}
-	std::shared_ptr<{{classname}}Resources::{{vendorExtensions.x-codegen-resource-name}}Resource> m_sp{{vendorExtensions.x-codegen-resource-name}}Resource;
-	{{/operation}}
+    {{#operation}}
+    std::shared_ptr<{{classname}}Resources::{{vendorExtensions.x-codegen-resource-name}}Resource> m_sp{{vendorExtensions.x-codegen-resource-name}}Resource;
+    {{/operation}}
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/enumClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/enumClass.mustache
@@ -25,7 +25,7 @@
      * Convert a String into {{dataType}}, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static {{datatypeWithEnum}} fromString(String s) {
+    public static {{datatypeWithEnum}} fromString(String s) {
         for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -34,8 +34,8 @@
             }
         }
         {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
-	}
-	
+    }
+
     {{#jackson}}@JsonCreator{{/jackson}}
     public static {{datatypeWithEnum}} fromValue({{dataType}} value) {
         for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {

--- a/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/enumOuterClass.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/server/libraries/mp/enumOuterClass.mustache
@@ -32,7 +32,7 @@ import {{rootJavaEEPackage}}.json.bind.annotation.JsonbCreator;
      * Convert a String into {{dataType}}, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
+    public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromString(String s) {
       for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -41,8 +41,8 @@ import {{rootJavaEEPackage}}.json.bind.annotation.JsonbCreator;
         }
       }
       {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected string value '" + s + "'");{{/isNullable}}
-	}
-	
+    }
+
   @Override
   {{#jackson}}@JsonValue{{/jackson}}
   public String toString() {

--- a/modules/openapi-generator/src/main/resources/java-micronaut/client/api.mustache
+++ b/modules/openapi-generator/src/main/resources/java-micronaut/client/api.mustache
@@ -41,7 +41,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 {{/generateSwagger2Annotations}}
 
 {{#additionalClientTypeAnnotations}}
-	{{{.}}}
+    {{{.}}}
 {{/additionalClientTypeAnnotations}}
 {{>common/generatedAnnotation}}
 @Client({{#configureClientId}}

--- a/modules/openapi-generator/src/main/resources/java-pkmst/gatling/application.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/gatling/application.mustache
@@ -9,6 +9,6 @@ akka {
 }
 
 url="http://localhost:8081"
-noOfUsers=10 		#Number of Users
-deleteProductId=4		#Delete the Product by using productID
-getProduct=2     	#Get the Product
+noOfUsers=10        #Number of Users
+deleteProductId=4   #Delete the Product by using productID
+getProduct=2        #Get the Product

--- a/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
+++ b/modules/openapi-generator/src/main/resources/java-pkmst/logging/httpLoggingFilter.mustache
@@ -80,7 +80,7 @@ public class HttpLoggingFilter implements Filter {
                 .append(bufferedResponse.getStatus())
                 .append("] [Response Time(ms):").append(elapsedTime)
                 .append("]");
-		String [] nonLoggingPaths = {"/v2/api-docs","/swagger-resources","/configuration/security","/swagger-ui.html","/webjars"};
+        String [] nonLoggingPaths = {"/v2/api-docs","/swagger-resources","/configuration/security","/swagger-ui.html","/webjars"};
         String urlPath = httpServletRequest.getRequestURL().toString();
         if (! ( Arrays.stream(nonLoggingPaths).parallel().anyMatch(urlPath::contains) )){
              log.info(logMessage.toString());

--- a/modules/openapi-generator/src/main/resources/objc/QueryParamCollection-body.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/QueryParamCollection-body.mustache
@@ -10,9 +10,9 @@
 
     self = [super init];
     if (self) {
-    	_values = values;
-    	_format = format;
-	}
+        _values = values;
+        _format = format;
+    }
 
     return self;
 }

--- a/modules/openapi-generator/src/main/resources/objc/xccurrentversion.mustache
+++ b/modules/openapi-generator/src/main/resources/objc/xccurrentversion.mustache
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>_XCCurrentVersionName</key>
-	<string>{{classPrefix}}Model.xcdatamodel</string>
+    <key>_XCCurrentVersionName</key>
+    <string>{{classPrefix}}Model.xcdatamodel</string>
 </dict>
 </plist>

--- a/modules/openapi-generator/src/main/resources/openapi-static/index.mustache
+++ b/modules/openapi-generator/src/main/resources/openapi-static/index.mustache
@@ -30,14 +30,14 @@
           </ul>
         </div>
         {{#apiInfo}}
-    		{{#apis}}
+            {{#apis}}
         <div class="section-box">
           <div class="section-header">
             <a href="#!/{{classname}}">{{classname}}</a>
           </div>
           <ul>
-			      {{#operations}}
-			      {{#operation}}
+            {{#operations}}
+            {{#operation}}
             <li><a href="#!/{{classname}}#{{nickname}}">{{nickname}}</a></li>
             {{/operation}}
             {{/operations}}

--- a/modules/openapi-generator/src/main/resources/openapi-static/operation.mustache
+++ b/modules/openapi-generator/src/main/resources/openapi-static/operation.mustache
@@ -16,8 +16,8 @@
   <div class="model" data-model="{{returnBaseType}}"><a href="">{{returnType}}</a></div>
   <h3 class="section">Parameters</h3>
   <ul>
-  	{{#allParams}}
-	  <li class="parameter">
+    {{#allParams}}
+      <li class="parameter">
       {{#isFormParam}}<span class="param-in">Form: </span>{{/isFormParam}}
       {{#isQueryParam}}<span class="param-in">Query: </span>{{/isQueryParam}}
       {{#isPathParam}}<span class="param-in">Path: </span>{{/isPathParam}}
@@ -27,7 +27,7 @@
       <span class="param-type">{{dataType}}{{#baseType}}({{.}}){{/baseType}}</span>
       {{#optional}}<span class="param-optional-flag">(optional)</span>{{/optional}}
       <p class="param-description">{{description}}</p>
-	  </li>
+      </li>
     {{/allParams}}
   </ul>
   {{/operation}}

--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -419,9 +419,9 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: {{version}}' . PHP_EOL;
-	    {{#artifactVersion}}
+        {{#artifactVersion}}
         $report .= '    SDK Package Version: {{.}}' . PHP_EOL;
-    	{{/artifactVersion}}
+        {{/artifactVersion}}
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_generic.mustache
@@ -36,7 +36,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
       */
     protected static array $openAPINullables = [
         {{#vars}}'{{name}}' => {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{^-last}},
-		{{/-last}}{{/vars}}
+        {{/-last}}{{/vars}}
     ];
 
     /**

--- a/modules/openapi-generator/src/main/resources/php/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php/Configuration.mustache
@@ -424,9 +424,9 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: {{version}}' . PHP_EOL;
-	    {{#artifactVersion}}
+        {{#artifactVersion}}
         $report .= '    SDK Package Version: {{.}}' . PHP_EOL;
-    	{{/artifactVersion}}
+        {{/artifactVersion}}
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;

--- a/modules/openapi-generator/src/main/resources/php/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_generic.mustache
@@ -38,7 +38,7 @@ class {{classname}} {{#parentSchema}}extends {{{parent}}}{{/parentSchema}}{{^par
       */
     protected static array $openAPINullables = [
         {{#vars}}'{{name}}' => {{#isNullable}}true{{/isNullable}}{{^isNullable}}false{{/isNullable}}{{^-last}},
-		{{/-last}}{{/vars}}
+        {{/-last}}{{/vars}}
     ];
 
     /**

--- a/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
+++ b/modules/openapi-generator/src/main/resources/python-aiohttp/tox.mustache
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-	 {toxinidir}
+     {toxinidir}
 
 commands=
    {{^useNose}}pytest --cov={{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}

--- a/modules/openapi-generator/src/main/resources/python-flask/tox.mustache
+++ b/modules/openapi-generator/src/main/resources/python-flask/tox.mustache
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-	 {toxinidir}
+     {toxinidir}
 
 commands=
    {{^useNose}}pytest --cov={{{pythonSrcRoot}}}{{{packageName}}}{{/useNose}}{{#useNose}}nosetests{{/useNose}}

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/api_mod.mustache
@@ -35,9 +35,9 @@ impl <T> fmt::Display for Error<T> {
             Error::Serde(e) => ("serde", e.to_string()),
             Error::Io(e) => ("IO", e.to_string()),
             Error::ResponseError(e) => ("response", format!("status code {}", e.status)),
-	    {{#withAWSV4Signature}}
+            {{#withAWSV4Signature}}
             Error::AWSV4SignatureError(e) => ("aws v4 signature", e.to_string()),
-	    {{/withAWSV4Signature}}
+            {{/withAWSV4Signature}}
         };
         write!(f, "error in {}: {}", module, e)
     }
@@ -53,9 +53,9 @@ impl <T: fmt::Debug> error::Error for Error<T> {
             Error::Serde(e) => e,
             Error::Io(e) => e,
             Error::ResponseError(_) => return None,
-	    {{#withAWSV4Signature}}
-	    Error::AWSV4SignatureError(_) => return None,
-	    {{/withAWSV4Signature}}
+            {{#withAWSV4Signature}}
+            Error::AWSV4SignatureError(_) => return None,
+            {{/withAWSV4Signature}}
         })
     }
 }

--- a/modules/openapi-generator/src/main/resources/scala-gatling/logback.xml
+++ b/modules/openapi-generator/src/main/resources/scala-gatling/logback.xml
@@ -9,10 +9,10 @@
     </appender>
 
     <!-- Uncomment for logging ALL HTTP request and responses -->
-    <!-- 	<logger name="io.gatling.http.ahc" level="TRACE" /> -->
+    <!--    <logger name="io.gatling.http.ahc" level="TRACE" /> -->
     <!--    <logger name="io.gatling.http.response" level="TRACE" /> -->
     <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
-    <!-- 	<logger name="io.gatling.http.ahc" level="DEBUG" /> -->
+    <!--    <logger name="io.gatling.http.ahc" level="DEBUG" /> -->
     <!--    <logger name="io.gatling.http.response" level="DEBUG" /> -->
 
     <root level="WARN">

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/recordGeneric.mustache
@@ -164,8 +164,8 @@ class {{classname}}RecordUtils extends ApiRecordUtils<{{classname}}, {{classname
 {{/items.isEntity}}
 {{/isArray}}
 {{/vars}}
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
 {{#vars}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -80,7 +80,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/modules/openapi-generator/src/main/resources/xojo-client/modelInlineEnumDeclaration.mustache
+++ b/modules/openapi-generator/src/main/resources/xojo-client/modelInlineEnumDeclaration.mustache
@@ -1,5 +1,5 @@
-	#tag Enum, Name = {{enumName}}, Type = Integer, Flags = &h{{^nonPublicApi}}0{{/nonPublicApi}}{{#nonPublicApi}}21{{/nonPublicApi}}
-		{{#allowableValues}}{{#enumVars}}
+    #tag Enum, Name = {{enumName}}, Type = Integer, Flags = &h{{^nonPublicApi}}0{{/nonPublicApi}}{{#nonPublicApi}}21{{/nonPublicApi}}
+        {{#allowableValues}}{{#enumVars}}
         {{{name}}}{{#isInteger}} = {{{value}}}{{/isInteger}}{{/enumVars}}{{/allowableValues}}
-		{{#enumUnknownDefaultCase}}Unknown{{#isInteger}} = {{{value}}}{{/isInteger}}{{/enumUnknownDefaultCase}}
-	#tag EndEnum
+        {{#enumUnknownDefaultCase}}Unknown{{#isInteger}} = {{{value}}}{{/isInteger}}{{/enumUnknownDefaultCase}}
+    #tag EndEnum

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/libraries/jersey2/pom.mustache
@@ -386,7 +386,7 @@
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         {{/useJakartaEe}}
 {{#useBeanValidation}}
-		<beanvalidation-version>2.0.2</beanvalidation-version>
+        <beanvalidation-version>2.0.2</beanvalidation-version>
 {{/useBeanValidation}}
         <junit-version>4.13.2</junit-version>
         {{#hasHttpSignatureMethods}}

--- a/modules/openapi-generator/src/test/resources/3_0/unit_test_spec/draft6/oneOf.json
+++ b/modules/openapi-generator/src/test/resources/3_0/unit_test_spec/draft6/oneOf.json
@@ -203,7 +203,7 @@
             }
         ]
     },
-	{
+    {
         "description": "oneOf with missing optional property",
         "schema": {
             "oneOf": [

--- a/samples/client/echo_api/php-nextgen/src/Model/Bird.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Bird.php
@@ -80,7 +80,7 @@ class Bird implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'size' => false,
-		'color' => false
+        'color' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/Category.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Category.php
@@ -80,7 +80,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DataQuery.php
@@ -76,8 +76,8 @@ class DataQuery extends Query
       */
     protected static array $openAPINullables = [
         'suffix' => false,
-		'text' => false,
-		'date' => false
+        'text' => false,
+        'date' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/DefaultValue.php
@@ -93,13 +93,13 @@ class DefaultValue implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'array_string_enum_ref_default' => false,
-		'array_string_enum_default' => false,
-		'array_string_default' => false,
-		'array_integer_default' => false,
-		'array_string' => false,
-		'array_string_nullable' => true,
-		'array_string_extension_nullable' => true,
-		'string_nullable' => true
+        'array_string_enum_default' => false,
+        'array_string_default' => false,
+        'array_integer_default' => false,
+        'array_string' => false,
+        'array_string_nullable' => true,
+        'array_string_extension_nullable' => true,
+        'string_nullable' => true
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/NumberPropertiesOnly.php
@@ -82,8 +82,8 @@ class NumberPropertiesOnly implements ModelInterface, ArrayAccess, JsonSerializa
       */
     protected static array $openAPINullables = [
         'number' => false,
-		'float' => false,
-		'double' => false
+        'float' => false,
+        'double' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/Pet.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Pet.php
@@ -88,11 +88,11 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false,
-		'category' => false,
-		'photo_urls' => false,
-		'tags' => false,
-		'status' => false
+        'name' => false,
+        'category' => false,
+        'photo_urls' => false,
+        'tags' => false,
+        'status' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/Query.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Query.php
@@ -80,7 +80,7 @@ class Query implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'outcomes' => false
+        'outcomes' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/Tag.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/Tag.php
@@ -80,7 +80,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
+++ b/samples/client/echo_api/php-nextgen/src/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter.php
@@ -84,9 +84,9 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter impleme
       */
     protected static array $openAPINullables = [
         'size' => false,
-		'color' => false,
-		'id' => false,
-		'name' => false
+        'color' => false,
+        'id' => false,
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/ada/config.gpr
+++ b/samples/client/petstore/ada/config.gpr
@@ -45,7 +45,7 @@ abstract project Config is
          when "debug" =>
             for Default_Switches ("Ada") use ("-E");
 
-	 when others =>
+         when others =>
             for Default_Switches ("Ada") use ("-E");
 
       end case;
@@ -64,12 +64,12 @@ abstract project Config is
 
          when "coverage" =>
             for Default_Switches ("ada") use ("-fprofile-arcs");
-	 
-	 when others =>
-	    null;
+
+         when others =>
+            null;
       end case;
 
-   end linker;        
+   end linker;
  
    package Ide is
       for VCS_Kind use "git";

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -6,7 +6,7 @@
 
 char* statusorder_ToString(openapi_petstore_order_STATUS_e status) {
     char* statusArray[] =  { "NULL", "placed", "approved", "delivered" };
-	return statusArray[status];
+    return statusArray[status];
 }
 
 openapi_petstore_order_STATUS_e statusorder_FromString(char* status){

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -6,7 +6,7 @@
 
 char* statuspet_ToString(openapi_petstore_pet_STATUS_e status) {
     char* statusArray[] =  { "NULL", "available", "pending", "sold" };
-	return statusArray[status];
+    return statusArray[status];
 }
 
 openapi_petstore_pet_STATUS_e statuspet_FromString(char* status){

--- a/samples/client/petstore/c/src/apiKey.c
+++ b/samples/client/petstore/c/src/apiKey.c
@@ -10,9 +10,9 @@ keyValuePair_t *keyValuePair_create(char *key, void *value) {
 }
 
 keyValuePair_t* keyValuePair_create_allocate(char* key, double value) {
-	double* boolpointer = malloc(sizeof(value));
-	memcpy(boolpointer, &value, sizeof(value));
-	return keyValuePair_create(key, boolpointer);
+    double* boolpointer = malloc(sizeof(value));
+    memcpy(boolpointer, &value, sizeof(value));
+    return keyValuePair_create(key, boolpointer);
 }
 
 void keyValuePair_free(keyValuePair_t *keyValuePair) {

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGQueryParamCollection.m
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Core/SWGQueryParamCollection.m
@@ -10,9 +10,9 @@
 
     self = [super init];
     if (self) {
-    	_values = values;
-    	_format = format;
-	}
+        _values = values;
+        _format = format;
+    }
 
     return self;
 }

--- a/samples/client/petstore/objc/core-data/SwaggerClient/Model/SWGModel.xcdatamodeld/.xccurrentversion
+++ b/samples/client/petstore/objc/core-data/SwaggerClient/Model/SWGModel.xcdatamodeld/.xccurrentversion
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>_XCCurrentVersionName</key>
-	<string>SWGModel.xcdatamodel</string>
+    <key>_XCCurrentVersionName</key>
+    <string>SWGModel.xcdatamodel</string>
 </dict>
 </plist>

--- a/samples/client/petstore/objc/default/SwaggerClient/Core/SWGQueryParamCollection.m
+++ b/samples/client/petstore/objc/default/SwaggerClient/Core/SWGQueryParamCollection.m
@@ -10,9 +10,9 @@
 
     self = [super init];
     if (self) {
-    	_values = values;
-    	_format = format;
-	}
+        _values = values;
+        _format = format;
+    }
 
     return self;
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AdditionalPropertiesClass.php
@@ -79,7 +79,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, JsonSeri
       */
     protected static array $openAPINullables = [
         'map_property' => false,
-		'map_of_map_property' => false
+        'map_of_map_property' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/AllOfWithSingleRef.php
@@ -79,7 +79,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, JsonSerializabl
       */
     protected static array $openAPINullables = [
         'username' => false,
-		'single_ref_type' => false
+        'single_ref_type' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Animal.php
@@ -79,7 +79,7 @@ class Animal implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'class_name' => false,
-		'color' => false
+        'color' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ApiResponse.php
@@ -81,8 +81,8 @@ class ApiResponse implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'code' => false,
-		'type' => false,
-		'message' => false
+        'type' => false,
+        'message' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ArrayTest.php
@@ -81,8 +81,8 @@ class ArrayTest implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'array_of_string' => false,
-		'array_array_of_integer' => false,
-		'array_array_of_model' => false
+        'array_array_of_integer' => false,
+        'array_array_of_model' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Capitalization.php
@@ -87,11 +87,11 @@ class Capitalization implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'small_camel' => false,
-		'capital_camel' => false,
-		'small_snake' => false,
-		'capital_snake' => false,
-		'sca_eth_flow_points' => false,
-		'att_name' => false
+        'capital_camel' => false,
+        'small_snake' => false,
+        'capital_snake' => false,
+        'sca_eth_flow_points' => false,
+        'att_name' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Category.php
@@ -79,7 +79,7 @@ class Category implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumArrays.php
@@ -79,7 +79,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'just_symbol' => false,
-		'array_enum' => false
+        'array_enum' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/EnumTest.php
@@ -91,13 +91,13 @@ class EnumTest implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'enum_string' => false,
-		'enum_string_required' => false,
-		'enum_integer' => false,
-		'enum_number' => false,
-		'outer_enum' => true,
-		'outer_enum_integer' => false,
-		'outer_enum_default_value' => false,
-		'outer_enum_integer_default_value' => false
+        'enum_string_required' => false,
+        'enum_integer' => false,
+        'enum_number' => false,
+        'outer_enum' => true,
+        'outer_enum_integer' => false,
+        'outer_enum_default_value' => false,
+        'outer_enum_integer_default_value' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FakeBigDecimalMap200Response.php
@@ -79,7 +79,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, JsonS
       */
     protected static array $openAPINullables = [
         'some_id' => false,
-		'some_map' => false
+        'some_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FileSchemaTestClass.php
@@ -79,7 +79,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, JsonSerializab
       */
     protected static array $openAPINullables = [
         'file' => false,
-		'files' => false
+        'files' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/FormatTest.php
@@ -107,21 +107,21 @@ class FormatTest implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer' => false,
-		'int32' => false,
-		'int64' => false,
-		'number' => false,
-		'float' => false,
-		'double' => false,
-		'decimal' => false,
-		'string' => false,
-		'byte' => false,
-		'binary' => false,
-		'date' => false,
-		'date_time' => false,
-		'uuid' => false,
-		'password' => false,
-		'pattern_with_digits' => false,
-		'pattern_with_digits_and_delimiter' => false
+        'int32' => false,
+        'int64' => false,
+        'number' => false,
+        'float' => false,
+        'double' => false,
+        'decimal' => false,
+        'string' => false,
+        'byte' => false,
+        'binary' => false,
+        'date' => false,
+        'date_time' => false,
+        'uuid' => false,
+        'password' => false,
+        'pattern_with_digits' => false,
+        'pattern_with_digits_and_delimiter' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/HasOnlyReadOnly.php
@@ -79,7 +79,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'foo' => false
+        'foo' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MapTest.php
@@ -83,9 +83,9 @@ class MapTest implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'map_map_of_string' => false,
-		'map_of_enum_string' => false,
-		'direct_map' => false,
-		'indirect_map' => false
+        'map_of_enum_string' => false,
+        'direct_map' => false,
+        'indirect_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -81,8 +81,8 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'date_time' => false,
-		'map' => false
+        'date_time' => false,
+        'map' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Model200Response.php
@@ -80,7 +80,7 @@ class Model200Response implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'class' => false
+        'class' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Name.php
@@ -84,9 +84,9 @@ class Name implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'snake_case' => false,
-		'property' => false,
-		'_123_number' => false
+        'snake_case' => false,
+        'property' => false,
+        '_123_number' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/NullableClass.php
@@ -99,17 +99,17 @@ class NullableClass implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer_prop' => true,
-		'number_prop' => true,
-		'boolean_prop' => true,
-		'string_prop' => true,
-		'date_prop' => true,
-		'datetime_prop' => true,
-		'array_nullable_prop' => true,
-		'array_and_items_nullable_prop' => true,
-		'array_items_nullable' => false,
-		'object_nullable_prop' => true,
-		'object_and_items_nullable_prop' => true,
-		'object_items_nullable' => false
+        'number_prop' => true,
+        'boolean_prop' => true,
+        'string_prop' => true,
+        'date_prop' => true,
+        'datetime_prop' => true,
+        'array_nullable_prop' => true,
+        'array_and_items_nullable_prop' => true,
+        'array_items_nullable' => false,
+        'object_nullable_prop' => true,
+        'object_and_items_nullable_prop' => true,
+        'object_items_nullable' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ObjectWithDeprecatedFields.php
@@ -83,9 +83,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, JsonSer
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'id' => false,
-		'deprecated_ref' => false,
-		'bars' => false
+        'id' => false,
+        'deprecated_ref' => false,
+        'bars' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Order.php
@@ -87,11 +87,11 @@ class Order implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'pet_id' => false,
-		'quantity' => false,
-		'ship_date' => false,
-		'status' => false,
-		'complete' => false
+        'pet_id' => false,
+        'quantity' => false,
+        'ship_date' => false,
+        'status' => false,
+        'complete' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/OuterComposite.php
@@ -81,8 +81,8 @@ class OuterComposite implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'my_number' => false,
-		'my_string' => false,
-		'my_boolean' => false
+        'my_string' => false,
+        'my_boolean' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ParentWithNullable.php
@@ -79,7 +79,7 @@ class ParentWithNullable implements ModelInterface, ArrayAccess, JsonSerializabl
       */
     protected static array $openAPINullables = [
         'type' => false,
-		'nullable_property' => true
+        'nullable_property' => true
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Pet.php
@@ -87,11 +87,11 @@ class Pet implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'category' => false,
-		'name' => false,
-		'photo_urls' => false,
-		'tags' => false,
-		'status' => false
+        'category' => false,
+        'name' => false,
+        'photo_urls' => false,
+        'tags' => false,
+        'status' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/ReadOnlyFirst.php
@@ -79,7 +79,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'baz' => false
+        'baz' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/Tag.php
@@ -79,7 +79,7 @@ class Tag implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Model/User.php
@@ -91,13 +91,13 @@ class User implements ModelInterface, ArrayAccess, JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'username' => false,
-		'first_name' => false,
-		'last_name' => false,
-		'email' => false,
-		'password' => false,
-		'phone' => false,
-		'user_status' => false
+        'username' => false,
+        'first_name' => false,
+        'last_name' => false,
+        'email' => false,
+        'password' => false,
+        'phone' => false,
+        'user_status' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AdditionalPropertiesClass.php
@@ -80,7 +80,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
       */
     protected static array $openAPINullables = [
         'map_property' => false,
-		'map_of_map_property' => false
+        'map_of_map_property' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/AllOfWithSingleRef.php
@@ -80,7 +80,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
       */
     protected static array $openAPINullables = [
         'username' => false,
-		'single_ref_type' => false
+        'single_ref_type' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Animal.php
@@ -80,7 +80,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'class_name' => false,
-		'color' => false
+        'color' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ApiResponse.php
@@ -82,8 +82,8 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'code' => false,
-		'type' => false,
-		'message' => false
+        'type' => false,
+        'message' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ArrayTest.php
@@ -82,8 +82,8 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'array_of_string' => false,
-		'array_array_of_integer' => false,
-		'array_array_of_model' => false
+        'array_array_of_integer' => false,
+        'array_array_of_model' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Capitalization.php
@@ -88,11 +88,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'small_camel' => false,
-		'capital_camel' => false,
-		'small_snake' => false,
-		'capital_snake' => false,
-		'sca_eth_flow_points' => false,
-		'att_name' => false
+        'capital_camel' => false,
+        'small_snake' => false,
+        'capital_snake' => false,
+        'sca_eth_flow_points' => false,
+        'att_name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Category.php
@@ -80,7 +80,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumArrays.php
@@ -80,7 +80,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'just_symbol' => false,
-		'array_enum' => false
+        'array_enum' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/EnumTest.php
@@ -92,13 +92,13 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'enum_string' => false,
-		'enum_string_required' => false,
-		'enum_integer' => false,
-		'enum_number' => false,
-		'outer_enum' => true,
-		'outer_enum_integer' => false,
-		'outer_enum_default_value' => false,
-		'outer_enum_integer_default_value' => false
+        'enum_string_required' => false,
+        'enum_integer' => false,
+        'enum_number' => false,
+        'outer_enum' => true,
+        'outer_enum_integer' => false,
+        'outer_enum_default_value' => false,
+        'outer_enum_integer_default_value' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FakeBigDecimalMap200Response.php
@@ -80,7 +80,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
       */
     protected static array $openAPINullables = [
         'some_id' => false,
-		'some_map' => false
+        'some_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FileSchemaTestClass.php
@@ -80,7 +80,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
       */
     protected static array $openAPINullables = [
         'file' => false,
-		'files' => false
+        'files' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/FormatTest.php
@@ -108,21 +108,21 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer' => false,
-		'int32' => false,
-		'int64' => false,
-		'number' => false,
-		'float' => false,
-		'double' => false,
-		'decimal' => false,
-		'string' => false,
-		'byte' => false,
-		'binary' => false,
-		'date' => false,
-		'date_time' => false,
-		'uuid' => false,
-		'password' => false,
-		'pattern_with_digits' => false,
-		'pattern_with_digits_and_delimiter' => false
+        'int32' => false,
+        'int64' => false,
+        'number' => false,
+        'float' => false,
+        'double' => false,
+        'decimal' => false,
+        'string' => false,
+        'byte' => false,
+        'binary' => false,
+        'date' => false,
+        'date_time' => false,
+        'uuid' => false,
+        'password' => false,
+        'pattern_with_digits' => false,
+        'pattern_with_digits_and_delimiter' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/HasOnlyReadOnly.php
@@ -80,7 +80,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'foo' => false
+        'foo' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MapTest.php
@@ -84,9 +84,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'map_map_of_string' => false,
-		'map_of_enum_string' => false,
-		'direct_map' => false,
-		'indirect_map' => false
+        'map_of_enum_string' => false,
+        'direct_map' => false,
+        'indirect_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -82,8 +82,8 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'date_time' => false,
-		'map' => false
+        'date_time' => false,
+        'map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Model200Response.php
@@ -81,7 +81,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'class' => false
+        'class' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Name.php
@@ -85,9 +85,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'snake_case' => false,
-		'property' => false,
-		'_123_number' => false
+        'snake_case' => false,
+        'property' => false,
+        '_123_number' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/NullableClass.php
@@ -100,17 +100,17 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer_prop' => true,
-		'number_prop' => true,
-		'boolean_prop' => true,
-		'string_prop' => true,
-		'date_prop' => true,
-		'datetime_prop' => true,
-		'array_nullable_prop' => true,
-		'array_and_items_nullable_prop' => true,
-		'array_items_nullable' => false,
-		'object_nullable_prop' => true,
-		'object_and_items_nullable_prop' => true,
-		'object_items_nullable' => false
+        'number_prop' => true,
+        'boolean_prop' => true,
+        'string_prop' => true,
+        'date_prop' => true,
+        'datetime_prop' => true,
+        'array_nullable_prop' => true,
+        'array_and_items_nullable_prop' => true,
+        'array_items_nullable' => false,
+        'object_nullable_prop' => true,
+        'object_and_items_nullable_prop' => true,
+        'object_items_nullable' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ObjectWithDeprecatedFields.php
@@ -84,9 +84,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'id' => false,
-		'deprecated_ref' => false,
-		'bars' => false
+        'id' => false,
+        'deprecated_ref' => false,
+        'bars' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Order.php
@@ -88,11 +88,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'pet_id' => false,
-		'quantity' => false,
-		'ship_date' => false,
-		'status' => false,
-		'complete' => false
+        'pet_id' => false,
+        'quantity' => false,
+        'ship_date' => false,
+        'status' => false,
+        'complete' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/OuterComposite.php
@@ -82,8 +82,8 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'my_number' => false,
-		'my_string' => false,
-		'my_boolean' => false
+        'my_string' => false,
+        'my_boolean' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Pet.php
@@ -88,11 +88,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'category' => false,
-		'name' => false,
-		'photo_urls' => false,
-		'tags' => false,
-		'status' => false
+        'category' => false,
+        'name' => false,
+        'photo_urls' => false,
+        'tags' => false,
+        'status' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/PropertyNameMapping.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/PropertyNameMapping.php
@@ -84,9 +84,9 @@ class PropertyNameMapping implements ModelInterface, ArrayAccess, \JsonSerializa
       */
     protected static array $openAPINullables = [
         'http_debug_operation' => false,
-		'underscore_type' => false,
-		'type' => false,
-		'type_with_underscore' => false
+        'underscore_type' => false,
+        'type' => false,
+        'type_with_underscore' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/ReadOnlyFirst.php
@@ -80,7 +80,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'baz' => false
+        'baz' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/Tag.php
@@ -80,7 +80,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Model/User.php
@@ -92,13 +92,13 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'username' => false,
-		'first_name' => false,
-		'last_name' => false,
-		'email' => false,
-		'password' => false,
-		'phone' => false,
-		'user_status' => false
+        'username' => false,
+        'first_name' => false,
+        'last_name' => false,
+        'email' => false,
+        'password' => false,
+        'phone' => false,
+        'user_status' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/AdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/AdditionalPropertiesClass.php
@@ -80,7 +80,7 @@ class AdditionalPropertiesClass implements ModelInterface, ArrayAccess, \JsonSer
       */
     protected static array $openAPINullables = [
         'map_property' => false,
-		'map_of_map_property' => false
+        'map_of_map_property' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/AllOfWithSingleRef.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/AllOfWithSingleRef.php
@@ -80,7 +80,7 @@ class AllOfWithSingleRef implements ModelInterface, ArrayAccess, \JsonSerializab
       */
     protected static array $openAPINullables = [
         'username' => false,
-		'single_ref_type' => false
+        'single_ref_type' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Animal.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Animal.php
@@ -80,7 +80,7 @@ class Animal implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'class_name' => false,
-		'color' => false
+        'color' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/ApiResponse.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/ApiResponse.php
@@ -82,8 +82,8 @@ class ApiResponse implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'code' => false,
-		'type' => false,
-		'message' => false
+        'type' => false,
+        'message' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/ArrayTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/ArrayTest.php
@@ -82,8 +82,8 @@ class ArrayTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'array_of_string' => false,
-		'array_array_of_integer' => false,
-		'array_array_of_model' => false
+        'array_array_of_integer' => false,
+        'array_array_of_model' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Capitalization.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Capitalization.php
@@ -88,11 +88,11 @@ class Capitalization implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'small_camel' => false,
-		'capital_camel' => false,
-		'small_snake' => false,
-		'capital_snake' => false,
-		'sca_eth_flow_points' => false,
-		'att_name' => false
+        'capital_camel' => false,
+        'small_snake' => false,
+        'capital_snake' => false,
+        'sca_eth_flow_points' => false,
+        'att_name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Category.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Category.php
@@ -80,7 +80,7 @@ class Category implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/EnumArrays.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/EnumArrays.php
@@ -80,7 +80,7 @@ class EnumArrays implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'just_symbol' => false,
-		'array_enum' => false
+        'array_enum' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/EnumTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/EnumTest.php
@@ -92,13 +92,13 @@ class EnumTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'enum_string' => false,
-		'enum_string_required' => false,
-		'enum_integer' => false,
-		'enum_number' => false,
-		'outer_enum' => true,
-		'outer_enum_integer' => false,
-		'outer_enum_default_value' => false,
-		'outer_enum_integer_default_value' => false
+        'enum_string_required' => false,
+        'enum_integer' => false,
+        'enum_number' => false,
+        'outer_enum' => true,
+        'outer_enum_integer' => false,
+        'outer_enum_default_value' => false,
+        'outer_enum_integer_default_value' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/FakeBigDecimalMap200Response.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/FakeBigDecimalMap200Response.php
@@ -80,7 +80,7 @@ class FakeBigDecimalMap200Response implements ModelInterface, ArrayAccess, \Json
       */
     protected static array $openAPINullables = [
         'some_id' => false,
-		'some_map' => false
+        'some_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/FileSchemaTestClass.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/FileSchemaTestClass.php
@@ -80,7 +80,7 @@ class FileSchemaTestClass implements ModelInterface, ArrayAccess, \JsonSerializa
       */
     protected static array $openAPINullables = [
         'file' => false,
-		'files' => false
+        'files' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/FormatTest.php
@@ -108,21 +108,21 @@ class FormatTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer' => false,
-		'int32' => false,
-		'int64' => false,
-		'number' => false,
-		'float' => false,
-		'double' => false,
-		'decimal' => false,
-		'string' => false,
-		'byte' => false,
-		'binary' => false,
-		'date' => false,
-		'date_time' => false,
-		'uuid' => false,
-		'password' => false,
-		'pattern_with_digits' => false,
-		'pattern_with_digits_and_delimiter' => false
+        'int32' => false,
+        'int64' => false,
+        'number' => false,
+        'float' => false,
+        'double' => false,
+        'decimal' => false,
+        'string' => false,
+        'byte' => false,
+        'binary' => false,
+        'date' => false,
+        'date_time' => false,
+        'uuid' => false,
+        'password' => false,
+        'pattern_with_digits' => false,
+        'pattern_with_digits_and_delimiter' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/HasOnlyReadOnly.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/HasOnlyReadOnly.php
@@ -80,7 +80,7 @@ class HasOnlyReadOnly implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'foo' => false
+        'foo' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/MapTest.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/MapTest.php
@@ -84,9 +84,9 @@ class MapTest implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'map_map_of_string' => false,
-		'map_of_enum_string' => false,
-		'direct_map' => false,
-		'indirect_map' => false
+        'map_of_enum_string' => false,
+        'direct_map' => false,
+        'indirect_map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/MixedPropertiesAndAdditionalPropertiesClass.php
@@ -82,8 +82,8 @@ class MixedPropertiesAndAdditionalPropertiesClass implements ModelInterface, Arr
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'date_time' => false,
-		'map' => false
+        'date_time' => false,
+        'map' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Model200Response.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Model200Response.php
@@ -81,7 +81,7 @@ class Model200Response implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'class' => false
+        'class' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Name.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Name.php
@@ -85,9 +85,9 @@ class Name implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'name' => false,
-		'snake_case' => false,
-		'property' => false,
-		'_123_number' => false
+        'snake_case' => false,
+        'property' => false,
+        '_123_number' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/NullableClass.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/NullableClass.php
@@ -100,17 +100,17 @@ class NullableClass implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'integer_prop' => true,
-		'number_prop' => true,
-		'boolean_prop' => true,
-		'string_prop' => true,
-		'date_prop' => true,
-		'datetime_prop' => true,
-		'array_nullable_prop' => true,
-		'array_and_items_nullable_prop' => true,
-		'array_items_nullable' => false,
-		'object_nullable_prop' => true,
-		'object_and_items_nullable_prop' => true,
-		'object_items_nullable' => false
+        'number_prop' => true,
+        'boolean_prop' => true,
+        'string_prop' => true,
+        'date_prop' => true,
+        'datetime_prop' => true,
+        'array_nullable_prop' => true,
+        'array_and_items_nullable_prop' => true,
+        'array_items_nullable' => false,
+        'object_nullable_prop' => true,
+        'object_and_items_nullable_prop' => true,
+        'object_items_nullable' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/ObjectWithDeprecatedFields.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/ObjectWithDeprecatedFields.php
@@ -84,9 +84,9 @@ class ObjectWithDeprecatedFields implements ModelInterface, ArrayAccess, \JsonSe
       */
     protected static array $openAPINullables = [
         'uuid' => false,
-		'id' => false,
-		'deprecated_ref' => false,
-		'bars' => false
+        'id' => false,
+        'deprecated_ref' => false,
+        'bars' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Order.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Order.php
@@ -88,11 +88,11 @@ class Order implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'pet_id' => false,
-		'quantity' => false,
-		'ship_date' => false,
-		'status' => false,
-		'complete' => false
+        'pet_id' => false,
+        'quantity' => false,
+        'ship_date' => false,
+        'status' => false,
+        'complete' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/OuterComposite.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/OuterComposite.php
@@ -82,8 +82,8 @@ class OuterComposite implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'my_number' => false,
-		'my_string' => false,
-		'my_boolean' => false
+        'my_string' => false,
+        'my_boolean' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Pet.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Pet.php
@@ -88,11 +88,11 @@ class Pet implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'category' => false,
-		'name' => false,
-		'photo_urls' => false,
-		'tags' => false,
-		'status' => false
+        'category' => false,
+        'name' => false,
+        'photo_urls' => false,
+        'tags' => false,
+        'status' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/PropertyNameMapping.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/PropertyNameMapping.php
@@ -84,9 +84,9 @@ class PropertyNameMapping implements ModelInterface, ArrayAccess, \JsonSerializa
       */
     protected static array $openAPINullables = [
         'http_debug_operation' => false,
-		'underscore_type' => false,
-		'type' => false,
-		'type_with_underscore' => false
+        'underscore_type' => false,
+        'type' => false,
+        'type_with_underscore' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/ReadOnlyFirst.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/ReadOnlyFirst.php
@@ -80,7 +80,7 @@ class ReadOnlyFirst implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'bar' => false,
-		'baz' => false
+        'baz' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/Tag.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/Tag.php
@@ -80,7 +80,7 @@ class Tag implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'name' => false
+        'name' => false
     ];
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Model/User.php
+++ b/samples/client/petstore/php/psr-18/lib/Model/User.php
@@ -92,13 +92,13 @@ class User implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static array $openAPINullables = [
         'id' => false,
-		'username' => false,
-		'first_name' => false,
-		'last_name' => false,
-		'email' => false,
-		'password' => false,
-		'phone' => false,
-		'user_status' => false
+        'username' => false,
+        'first_name' => false,
+        'last_name' => false,
+        'email' => false,
+        'password' => false,
+        'phone' => false,
+        'user_status' => false
     ];
 
     /**

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/mod.rs
@@ -38,7 +38,7 @@ impl <T: fmt::Debug> error::Error for Error<T> {
             Error::Serde(e) => e,
             Error::Io(e) => e,
             Error::ResponseError(_) => return None,
-	    Error::AWSV4SignatureError(_) => return None,
+            Error::AWSV4SignatureError(_) => return None,
         })
     }
 }

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/CategoryRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/CategoryRecord.ts
@@ -67,8 +67,8 @@ class CategoryRecordUtils extends ApiRecordUtils<Category, CategoryRecord> {
 
         const {
             recType,
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/OrderRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/OrderRecord.ts
@@ -72,8 +72,8 @@ class OrderRecordUtils extends ApiRecordUtils<Order, OrderRecord> {
 
         const {
             recType,
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRecord.ts
@@ -130,8 +130,8 @@ class PetRecordUtils extends ApiRecordUtils<Pet, PetRecord> {
             _entries: _entries_original,
             tags: tags_original,
             optionalTags: optionalTags_original,
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
             // @ts-ignore

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/TagRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/TagRecord.ts
@@ -67,8 +67,8 @@ class TagRecordUtils extends ApiRecordUtils<Tag, TagRecord> {
 
         const {
             recType,
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/UserRecord.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/UserRecord.ts
@@ -75,8 +75,8 @@ class UserRecordUtils extends ApiRecordUtils<User, UserRecord> {
 
         const {
             recType,
-		    ...unchangedProperties
-		} = entity;
+            ...unchangedProperties
+        } = entity;
 
         const entityProperties = {
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -91,7 +91,7 @@ export const DefaultConfig = new Configuration();
  */
 export class BaseAPI {
 
-	 private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
+    private static readonly jsonRegex = new RegExp('^(:?application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(:?;.*)?$', 'i');
     private middleware: Middleware[];
 
     constructor(protected configuration = DefaultConfig) {

--- a/samples/client/petstore/xojo/client-synchronous/XojoOpenAPIClientSynchronous/Models/Order.xojo_code
+++ b/samples/client/petstore/xojo/client-synchronous/XojoOpenAPIClientSynchronous/Models/Order.xojo_code
@@ -34,13 +34,13 @@ Protected Class Order
 	#tag EndProperty
 
 
-	#tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
-		
+    #tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
+        
         Placed
         Approved
         Delivered
-		
-	#tag EndEnum
+        
+    #tag EndEnum
 
 
 	#tag Method, Flags = &h0

--- a/samples/client/petstore/xojo/client-synchronous/XojoOpenAPIClientSynchronous/Models/Pet.xojo_code
+++ b/samples/client/petstore/xojo/client-synchronous/XojoOpenAPIClientSynchronous/Models/Pet.xojo_code
@@ -34,13 +34,13 @@ Protected Class Pet
 	#tag EndProperty
 
 
-	#tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
-		
+    #tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
+        
         Available
         Pending
         Sold
-		
-	#tag EndEnum
+        
+    #tag EndEnum
 
 
 	#tag Method, Flags = &h0

--- a/samples/client/petstore/xojo/client/OpenAPIClient/Models/Order.xojo_code
+++ b/samples/client/petstore/xojo/client/OpenAPIClient/Models/Order.xojo_code
@@ -34,13 +34,13 @@ Protected Class Order
 	#tag EndProperty
 
 
-	#tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
-		
+    #tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
+        
         Placed
         Approved
         Delivered
-		
-	#tag EndEnum
+        
+    #tag EndEnum
 
 
 	#tag Method, Flags = &h0

--- a/samples/client/petstore/xojo/client/OpenAPIClient/Models/Pet.xojo_code
+++ b/samples/client/petstore/xojo/client/OpenAPIClient/Models/Pet.xojo_code
@@ -34,13 +34,13 @@ Protected Class Pet
 	#tag EndProperty
 
 
-	#tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
-		
+    #tag Enum, Name = StatusEnum, Type = Integer, Flags = &h0
+        
         Available
         Pending
         Sold
-		
-	#tag EndEnum
+        
+    #tag EndEnum
 
 
 	#tag Method, Flags = &h0

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/AnotherFakeApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/AnotherFakeApi.h
@@ -130,7 +130,7 @@ class  AnotherFakeApi
 {
 public:
     explicit AnotherFakeApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~AnotherFakeApi();
+    virtual ~AnotherFakeApi();
 
     std::shared_ptr<AnotherFakeApiResources::Another_fakeDummyResource> getAnother_fakeDummyResource();
 
@@ -143,7 +143,7 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<AnotherFakeApiResources::Another_fakeDummyResource> m_spAnother_fakeDummyResource;
+    std::shared_ptr<AnotherFakeApiResources::Another_fakeDummyResource> m_spAnother_fakeDummyResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/DefaultApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/DefaultApi.h
@@ -130,7 +130,7 @@ class  DefaultApi
 {
 public:
     explicit DefaultApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~DefaultApi();
+    virtual ~DefaultApi();
 
     std::shared_ptr<DefaultApiResources::FooResource> getFooResource();
 
@@ -143,7 +143,7 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<DefaultApiResources::FooResource> m_spFooResource;
+    std::shared_ptr<DefaultApiResources::FooResource> m_spFooResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/FakeApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/FakeApi.h
@@ -1175,7 +1175,7 @@ class  FakeApi
 {
 public:
     explicit FakeApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~FakeApi();
+    virtual ~FakeApi();
 
     std::shared_ptr<FakeApiResources::FakeBigDecimalMapResource> getFakeBigDecimalMapResource();
     std::shared_ptr<FakeApiResources::FakeHealthResource> getFakeHealthResource();
@@ -1252,23 +1252,23 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<FakeApiResources::FakeBigDecimalMapResource> m_spFakeBigDecimalMapResource;
-	std::shared_ptr<FakeApiResources::FakeHealthResource> m_spFakeHealthResource;
-	std::shared_ptr<FakeApiResources::FakeHttp_signature_testResource> m_spFakeHttp_signature_testResource;
-	std::shared_ptr<FakeApiResources::FakeOuterBooleanResource> m_spFakeOuterBooleanResource;
-	std::shared_ptr<FakeApiResources::FakeOuterCompositeResource> m_spFakeOuterCompositeResource;
-	std::shared_ptr<FakeApiResources::FakeOuterNumberResource> m_spFakeOuterNumberResource;
-	std::shared_ptr<FakeApiResources::FakeOuterStringResource> m_spFakeOuterStringResource;
-	std::shared_ptr<FakeApiResources::FakePropertyEnum_intResource> m_spFakePropertyEnum_intResource;
-	std::shared_ptr<FakeApiResources::FakeBody_with_binaryResource> m_spFakeBody_with_binaryResource;
-	std::shared_ptr<FakeApiResources::FakeBody_with_file_schemaResource> m_spFakeBody_with_file_schemaResource;
-	std::shared_ptr<FakeApiResources::FakeBody_with_query_paramsResource> m_spFakeBody_with_query_paramsResource;
-	std::shared_ptr<FakeApiResources::FakeResource> m_spFakeResource;
-	std::shared_ptr<FakeApiResources::FakeInline_additionalPropertiesResource> m_spFakeInline_additionalPropertiesResource;
-	std::shared_ptr<FakeApiResources::FakeInline_freeform_additionalPropertiesResource> m_spFakeInline_freeform_additionalPropertiesResource;
-	std::shared_ptr<FakeApiResources::FakeJsonFormDataResource> m_spFakeJsonFormDataResource;
-	std::shared_ptr<FakeApiResources::FakeNullableResource> m_spFakeNullableResource;
-	std::shared_ptr<FakeApiResources::FakeTest_query_parametersResource> m_spFakeTest_query_parametersResource;
+    std::shared_ptr<FakeApiResources::FakeBigDecimalMapResource> m_spFakeBigDecimalMapResource;
+    std::shared_ptr<FakeApiResources::FakeHealthResource> m_spFakeHealthResource;
+    std::shared_ptr<FakeApiResources::FakeHttp_signature_testResource> m_spFakeHttp_signature_testResource;
+    std::shared_ptr<FakeApiResources::FakeOuterBooleanResource> m_spFakeOuterBooleanResource;
+    std::shared_ptr<FakeApiResources::FakeOuterCompositeResource> m_spFakeOuterCompositeResource;
+    std::shared_ptr<FakeApiResources::FakeOuterNumberResource> m_spFakeOuterNumberResource;
+    std::shared_ptr<FakeApiResources::FakeOuterStringResource> m_spFakeOuterStringResource;
+    std::shared_ptr<FakeApiResources::FakePropertyEnum_intResource> m_spFakePropertyEnum_intResource;
+    std::shared_ptr<FakeApiResources::FakeBody_with_binaryResource> m_spFakeBody_with_binaryResource;
+    std::shared_ptr<FakeApiResources::FakeBody_with_file_schemaResource> m_spFakeBody_with_file_schemaResource;
+    std::shared_ptr<FakeApiResources::FakeBody_with_query_paramsResource> m_spFakeBody_with_query_paramsResource;
+    std::shared_ptr<FakeApiResources::FakeResource> m_spFakeResource;
+    std::shared_ptr<FakeApiResources::FakeInline_additionalPropertiesResource> m_spFakeInline_additionalPropertiesResource;
+    std::shared_ptr<FakeApiResources::FakeInline_freeform_additionalPropertiesResource> m_spFakeInline_freeform_additionalPropertiesResource;
+    std::shared_ptr<FakeApiResources::FakeJsonFormDataResource> m_spFakeJsonFormDataResource;
+    std::shared_ptr<FakeApiResources::FakeNullableResource> m_spFakeNullableResource;
+    std::shared_ptr<FakeApiResources::FakeTest_query_parametersResource> m_spFakeTest_query_parametersResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/FakeClassnameTags123Api.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/FakeClassnameTags123Api.h
@@ -130,7 +130,7 @@ class  FakeClassnameTags123Api
 {
 public:
     explicit FakeClassnameTags123Api(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~FakeClassnameTags123Api();
+    virtual ~FakeClassnameTags123Api();
 
     std::shared_ptr<FakeClassnameTags123ApiResources::Fake_classname_testResource> getFake_classname_testResource();
 
@@ -143,7 +143,7 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<FakeClassnameTags123ApiResources::Fake_classname_testResource> m_spFake_classname_testResource;
+    std::shared_ptr<FakeClassnameTags123ApiResources::Fake_classname_testResource> m_spFake_classname_testResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/PetApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/PetApi.h
@@ -473,7 +473,7 @@ class  PetApi
 {
 public:
     explicit PetApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~PetApi();
+    virtual ~PetApi();
 
     std::shared_ptr<PetApiResources::PetResource> getPetResource();
     std::shared_ptr<PetApiResources::PetPetIdResource> getPetPetIdResource();
@@ -506,12 +506,12 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<PetApiResources::PetResource> m_spPetResource;
-	std::shared_ptr<PetApiResources::PetPetIdResource> m_spPetPetIdResource;
-	std::shared_ptr<PetApiResources::PetFindByStatusResource> m_spPetFindByStatusResource;
-	std::shared_ptr<PetApiResources::PetFindByTagsResource> m_spPetFindByTagsResource;
-	std::shared_ptr<PetApiResources::PetPetIdUploadImageResource> m_spPetPetIdUploadImageResource;
-	std::shared_ptr<PetApiResources::FakePetIdUploadImageWithRequiredFileResource> m_spFakePetIdUploadImageWithRequiredFileResource;
+    std::shared_ptr<PetApiResources::PetResource> m_spPetResource;
+    std::shared_ptr<PetApiResources::PetPetIdResource> m_spPetPetIdResource;
+    std::shared_ptr<PetApiResources::PetFindByStatusResource> m_spPetFindByStatusResource;
+    std::shared_ptr<PetApiResources::PetFindByTagsResource> m_spPetFindByTagsResource;
+    std::shared_ptr<PetApiResources::PetPetIdUploadImageResource> m_spPetPetIdUploadImageResource;
+    std::shared_ptr<PetApiResources::FakePetIdUploadImageWithRequiredFileResource> m_spFakePetIdUploadImageWithRequiredFileResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/StoreApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/StoreApi.h
@@ -266,7 +266,7 @@ class  StoreApi
 {
 public:
     explicit StoreApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~StoreApi();
+    virtual ~StoreApi();
 
     std::shared_ptr<StoreApiResources::StoreOrderOrder_idResource> getStoreOrderOrder_idResource();
     std::shared_ptr<StoreApiResources::StoreInventoryResource> getStoreInventoryResource();
@@ -287,9 +287,9 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<StoreApiResources::StoreOrderOrder_idResource> m_spStoreOrderOrder_idResource;
-	std::shared_ptr<StoreApiResources::StoreInventoryResource> m_spStoreInventoryResource;
-	std::shared_ptr<StoreApiResources::StoreOrderResource> m_spStoreOrderResource;
+    std::shared_ptr<StoreApiResources::StoreOrderOrder_idResource> m_spStoreOrderOrder_idResource;
+    std::shared_ptr<StoreApiResources::StoreInventoryResource> m_spStoreInventoryResource;
+    std::shared_ptr<StoreApiResources::StoreOrderResource> m_spStoreOrderResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/cpp-restbed/generated/3_0/api/UserApi.h
+++ b/samples/server/petstore/cpp-restbed/generated/3_0/api/UserApi.h
@@ -463,7 +463,7 @@ class  UserApi
 {
 public:
     explicit UserApi(std::shared_ptr<restbed::Service> const& restbedService);
-	virtual ~UserApi();
+    virtual ~UserApi();
 
     std::shared_ptr<UserApiResources::UserResource> getUserResource();
     std::shared_ptr<UserApiResources::UserCreateWithArrayResource> getUserCreateWithArrayResource();
@@ -496,12 +496,12 @@ public:
     virtual std::shared_ptr<restbed::Service> service();
 
 protected:
-	std::shared_ptr<UserApiResources::UserResource> m_spUserResource;
-	std::shared_ptr<UserApiResources::UserCreateWithArrayResource> m_spUserCreateWithArrayResource;
-	std::shared_ptr<UserApiResources::UserCreateWithListResource> m_spUserCreateWithListResource;
-	std::shared_ptr<UserApiResources::UserUsernameResource> m_spUserUsernameResource;
-	std::shared_ptr<UserApiResources::UserLoginResource> m_spUserLoginResource;
-	std::shared_ptr<UserApiResources::UserLogoutResource> m_spUserLogoutResource;
+    std::shared_ptr<UserApiResources::UserResource> m_spUserResource;
+    std::shared_ptr<UserApiResources::UserCreateWithArrayResource> m_spUserCreateWithArrayResource;
+    std::shared_ptr<UserApiResources::UserCreateWithListResource> m_spUserCreateWithListResource;
+    std::shared_ptr<UserApiResources::UserUsernameResource> m_spUserUsernameResource;
+    std::shared_ptr<UserApiResources::UserLoginResource> m_spUserLoginResource;
+    std::shared_ptr<UserApiResources::UserLogoutResource> m_spUserLogoutResource;
 
 private:
     std::shared_ptr<restbed::Service> m_service;

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumArrays.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumArrays.java
@@ -53,7 +53,7 @@ public enum JustSymbolEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -62,8 +62,8 @@ public enum JustSymbolEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -102,7 +102,7 @@ public enum ArrayEnumEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -111,8 +111,8 @@ public enum ArrayEnumEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumClass.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumClass.java
@@ -39,7 +39,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -48,8 +48,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumTest.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/EnumTest.java
@@ -56,7 +56,7 @@ public enum EnumStringEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -65,8 +65,8 @@ public enum EnumStringEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -105,7 +105,7 @@ public enum EnumStringRequiredEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -114,8 +114,8 @@ public enum EnumStringRequiredEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -154,7 +154,7 @@ public enum EnumIntegerEnum {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -163,8 +163,8 @@ public enum EnumIntegerEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -203,7 +203,7 @@ public enum EnumNumberEnum {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -212,8 +212,8 @@ public enum EnumNumberEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/MapTest.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/MapTest.java
@@ -54,7 +54,7 @@ public enum InnerEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -63,8 +63,8 @@ public enum InnerEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/Order.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/Order.java
@@ -59,7 +59,7 @@ public enum StatusEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -68,8 +68,8 @@ public enum StatusEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnum.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnum.java
@@ -39,7 +39,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -48,8 +48,8 @@ public enum OuterEnum {
         }
       }
       return null;
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumDefaultValue.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumDefaultValue.java
@@ -39,7 +39,7 @@ public enum OuterEnumDefaultValue {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnumDefaultValue fromString(String s) {
+    public static OuterEnumDefaultValue fromString(String s) {
       for (OuterEnumDefaultValue b : OuterEnumDefaultValue.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -48,8 +48,8 @@ public enum OuterEnumDefaultValue {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumInteger.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumInteger.java
@@ -39,7 +39,7 @@ public enum OuterEnumInteger {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnumInteger fromString(String s) {
+    public static OuterEnumInteger fromString(String s) {
       for (OuterEnumInteger b : OuterEnumInteger.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -48,8 +48,8 @@ public enum OuterEnumInteger {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumIntegerDefaultValue.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/OuterEnumIntegerDefaultValue.java
@@ -39,7 +39,7 @@ public enum OuterEnumIntegerDefaultValue {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnumIntegerDefaultValue fromString(String s) {
+    public static OuterEnumIntegerDefaultValue fromString(String s) {
       for (OuterEnumIntegerDefaultValue b : OuterEnumIntegerDefaultValue.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -48,8 +48,8 @@ public enum OuterEnumIntegerDefaultValue {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
@@ -54,7 +54,7 @@ public enum TypeEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static TypeEnum fromString(String s) {
+    public static TypeEnum fromString(String s) {
         for (TypeEnum b : TypeEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -63,8 +63,8 @@ public enum TypeEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static TypeEnum fromValue(String value) {
         for (TypeEnum b : TypeEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/Pet.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/Pet.java
@@ -68,7 +68,7 @@ public enum StatusEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -77,8 +77,8 @@ public enum StatusEnum {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/SingleRefType.java
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/java/org/openapitools/server/model/SingleRefType.java
@@ -37,7 +37,7 @@ public enum SingleRefType {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static SingleRefType fromString(String s) {
+    public static SingleRefType fromString(String s) {
       for (SingleRefType b : SingleRefType.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -46,8 +46,8 @@ public enum SingleRefType {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
@@ -44,7 +44,7 @@ public class BigCat extends Cat implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static KindEnum fromString(String s) {
+    public static KindEnum fromString(String s) {
         for (KindEnum b : KindEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class BigCat extends Cat implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static KindEnum fromValue(String value) {
         for (KindEnum b : KindEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -46,7 +46,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -94,7 +94,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -103,8 +103,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumClass.java
@@ -28,7 +28,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
@@ -45,7 +45,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -54,8 +54,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -93,7 +93,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -102,8 +102,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -141,7 +141,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -150,8 +150,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -189,7 +189,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -198,8 +198,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public class MapTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class MapTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
@@ -48,7 +48,7 @@ public class Order  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -57,8 +57,8 @@ public class Order  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -28,7 +28,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum OuterEnum {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
@@ -56,7 +56,7 @@ public class Pet  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -65,8 +65,8 @@ public class Pet  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
@@ -44,7 +44,7 @@ public class BigCat extends Cat implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static KindEnum fromString(String s) {
+    public static KindEnum fromString(String s) {
         for (KindEnum b : KindEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class BigCat extends Cat implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static KindEnum fromValue(String value) {
         for (KindEnum b : KindEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -46,7 +46,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -94,7 +94,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -103,8 +103,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumClass.java
@@ -28,7 +28,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -45,7 +45,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -54,8 +54,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -93,7 +93,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -102,8 +102,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -141,7 +141,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -150,8 +150,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -189,7 +189,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -198,8 +198,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public class MapTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class MapTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -48,7 +48,7 @@ public class Order  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -57,8 +57,8 @@ public class Order  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -28,7 +28,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum OuterEnum {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -56,7 +56,7 @@ public class Pet  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -65,8 +65,8 @@ public class Pet  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
@@ -44,7 +44,7 @@ public class BigCat extends Cat implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static KindEnum fromString(String s) {
+    public static KindEnum fromString(String s) {
         for (KindEnum b : KindEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class BigCat extends Cat implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static KindEnum fromValue(String value) {
         for (KindEnum b : KindEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -46,7 +46,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -94,7 +94,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -103,8 +103,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumClass.java
@@ -28,7 +28,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
@@ -45,7 +45,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -54,8 +54,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -93,7 +93,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -102,8 +102,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -141,7 +141,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -150,8 +150,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -189,7 +189,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -198,8 +198,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public class MapTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class MapTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
@@ -48,7 +48,7 @@ public class Order  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -57,8 +57,8 @@ public class Order  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -28,7 +28,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum OuterEnum {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
@@ -56,7 +56,7 @@ public class Pet  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -65,8 +65,8 @@ public class Pet  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
@@ -42,7 +42,7 @@ public class BigCat extends Cat implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static KindEnum fromString(String s) {
+    public static KindEnum fromString(String s) {
         for (KindEnum b : KindEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -51,8 +51,8 @@ public class BigCat extends Cat implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static KindEnum fromValue(String value) {
         for (KindEnum b : KindEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -44,7 +44,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -92,7 +92,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -101,8 +101,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumClass.java
@@ -28,7 +28,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
@@ -43,7 +43,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -52,8 +52,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -91,7 +91,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -100,8 +100,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -139,7 +139,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -148,8 +148,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -187,7 +187,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -196,8 +196,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
@@ -44,7 +44,7 @@ public class MapTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class MapTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
@@ -46,7 +46,7 @@ public class Order  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class Order  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -28,7 +28,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum OuterEnum {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
@@ -54,7 +54,7 @@ public class Pet  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -63,8 +63,8 @@ public class Pet  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
@@ -44,7 +44,7 @@ public class BigCat extends Cat implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static KindEnum fromString(String s) {
+    public static KindEnum fromString(String s) {
         for (KindEnum b : KindEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -53,8 +53,8 @@ public class BigCat extends Cat implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static KindEnum fromValue(String value) {
         for (KindEnum b : KindEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -46,7 +46,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static JustSymbolEnum fromString(String s) {
+    public static JustSymbolEnum fromString(String s) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static JustSymbolEnum fromValue(String value) {
         for (JustSymbolEnum b : JustSymbolEnum.values()) {
@@ -94,7 +94,7 @@ public class EnumArrays  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static ArrayEnumEnum fromString(String s) {
+    public static ArrayEnumEnum fromString(String s) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -103,8 +103,8 @@ public class EnumArrays  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static ArrayEnumEnum fromValue(String value) {
         for (ArrayEnumEnum b : ArrayEnumEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumClass.java
@@ -28,7 +28,7 @@ public enum EnumClass {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumClass fromString(String s) {
+    public static EnumClass fromString(String s) {
       for (EnumClass b : EnumClass.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum EnumClass {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -45,7 +45,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringEnum fromString(String s) {
+    public static EnumStringEnum fromString(String s) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -54,8 +54,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringEnum fromValue(String value) {
         for (EnumStringEnum b : EnumStringEnum.values()) {
@@ -93,7 +93,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumStringRequiredEnum fromString(String s) {
+    public static EnumStringRequiredEnum fromString(String s) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -102,8 +102,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumStringRequiredEnum fromValue(String value) {
         for (EnumStringRequiredEnum b : EnumStringRequiredEnum.values()) {
@@ -141,7 +141,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Integer, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumIntegerEnum fromString(String s) {
+    public static EnumIntegerEnum fromString(String s) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -150,8 +150,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumIntegerEnum fromValue(Integer value) {
         for (EnumIntegerEnum b : EnumIntegerEnum.values()) {
@@ -189,7 +189,7 @@ public class EnumTest  implements Serializable {
      * Convert a String into Double, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static EnumNumberEnum fromString(String s) {
+    public static EnumNumberEnum fromString(String s) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -198,8 +198,8 @@ public class EnumTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static EnumNumberEnum fromValue(Double value) {
         for (EnumNumberEnum b : EnumNumberEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -46,7 +46,7 @@ public class MapTest  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static InnerEnum fromString(String s) {
+    public static InnerEnum fromString(String s) {
         for (InnerEnum b : InnerEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -55,8 +55,8 @@ public class MapTest  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static InnerEnum fromValue(String value) {
         for (InnerEnum b : InnerEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -48,7 +48,7 @@ public class Order  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -57,8 +57,8 @@ public class Order  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterEnum.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterEnum.java
@@ -28,7 +28,7 @@ public enum OuterEnum {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static OuterEnum fromString(String s) {
+    public static OuterEnum fromString(String s) {
       for (OuterEnum b : OuterEnum.values()) {
         // using Objects.toString() to be safe if value type non-object type
         // because types like 'int' etc. will be auto-boxed
@@ -37,8 +37,8 @@ public enum OuterEnum {
         }
       }
       throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
   @Override
   @JsonValue
   public String toString() {

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -56,7 +56,7 @@ public class Pet  implements Serializable {
      * Convert a String into String, as specified in the
      * <a href="https://download.oracle.com/otndocs/jcp/jaxrs-2_0-fr-eval-spec/index.html">See JAX RS 2.0 Specification, section 3.2, p. 12</a>
      */
-	public static StatusEnum fromString(String s) {
+    public static StatusEnum fromString(String s) {
         for (StatusEnum b : StatusEnum.values()) {
             // using Objects.toString() to be safe if value type non-object type
             // because types like 'int' etc. will be auto-boxed
@@ -65,8 +65,8 @@ public class Pet  implements Serializable {
             }
         }
         throw new IllegalArgumentException("Unexpected string value '" + s + "'");
-	}
-	
+    }
+
     @JsonCreator
     public static StatusEnum fromValue(String value) {
         for (StatusEnum b : StatusEnum.values()) {

--- a/samples/server/petstore/python-aiohttp-srclayout/tox.ini
+++ b/samples/server/petstore/python-aiohttp-srclayout/tox.ini
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-	 {toxinidir}
+     {toxinidir}
 
 commands=
    pytest --cov=openapi_server

--- a/samples/server/petstore/python-flask/tox.ini
+++ b/samples/server/petstore/python-flask/tox.ini
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-	 {toxinidir}
+     {toxinidir}
 
 commands=
    pytest --cov=openapi_server


### PR DESCRIPTION
Although there are `bin/utils/detect_tab*` scripts I've found TAB characters.
Only indentation changes!

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
