### PR TITLE
[python]fix: Configure python urllib3 connection pool size

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -4,6 +4,9 @@
 
 import copy
 import logging
+{{^asyncio}}
+import multiprocessing
+{{/asyncio}}
 import sys
 import urllib3
 
@@ -237,6 +240,15 @@ conf = {{{packageName}}}.Configuration(
         self.connection_pool_maxsize = 100
         """This value is passed to the aiohttp to limit simultaneous connections.
            Default values is 100, None means no-limit.
+        """
+        {{/asyncio}}
+        {{^asyncio}}
+        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        """urllib3 connection pool's maximum number of connections saved
+           per pool. urllib3 uses 1 connection as default value, but this is
+           not the best value when you are making a lot of possibly parallel
+           requests to the same host, which is often the case here.
+           cpu_count * 5 is used as default value to increase performance.
         """
         {{/asyncio}}
 

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -77,6 +77,9 @@ class RESTClientObject:
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 
+        if configuration.connection_pool_maxsize is not None:
+            addition_pool_args['maxsize'] = configuration.connection_pool_maxsize
+
         # https pool manager
         if configuration.proxy:
             if is_socks_proxy_url(configuration.proxy):

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/configuration.py
@@ -15,6 +15,7 @@
 
 import copy
 import logging
+import multiprocessing
 import sys
 import urllib3
 
@@ -164,6 +165,13 @@ conf = openapi_client.Configuration(
            Set this to the SNI value expected by the server.
         """
 
+        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        """urllib3 connection pool's maximum number of connections saved
+           per pool. urllib3 uses 1 connection as default value, but this is
+           not the best value when you are making a lot of possibly parallel
+           requests to the same host, which is often the case here.
+           cpu_count * 5 is used as default value to increase performance.
+        """
 
         self.proxy = None
         """Proxy URL

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
@@ -88,6 +88,9 @@ class RESTClientObject:
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 
+        if configuration.connection_pool_maxsize is not None:
+            addition_pool_args['maxsize'] = configuration.connection_pool_maxsize
+
         # https pool manager
         if configuration.proxy:
             if is_socks_proxy_url(configuration.proxy):

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -15,6 +15,7 @@
 
 import copy
 import logging
+import multiprocessing
 import sys
 import urllib3
 
@@ -164,6 +165,13 @@ conf = openapi_client.Configuration(
            Set this to the SNI value expected by the server.
         """
 
+        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        """urllib3 connection pool's maximum number of connections saved
+           per pool. urllib3 uses 1 connection as default value, but this is
+           not the best value when you are making a lot of possibly parallel
+           requests to the same host, which is often the case here.
+           cpu_count * 5 is used as default value to increase performance.
+        """
 
         self.proxy = None
         """Proxy URL

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -88,6 +88,9 @@ class RESTClientObject:
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 
+        if configuration.connection_pool_maxsize is not None:
+            addition_pool_args['maxsize'] = configuration.connection_pool_maxsize
+
         # https pool manager
         if configuration.proxy:
             if is_socks_proxy_url(configuration.proxy):

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -14,6 +14,7 @@
 
 import copy
 import logging
+import multiprocessing
 import sys
 import urllib3
 
@@ -229,6 +230,13 @@ conf = petstore_api.Configuration(
            Set this to the SNI value expected by the server.
         """
 
+        self.connection_pool_maxsize = multiprocessing.cpu_count() * 5
+        """urllib3 connection pool's maximum number of connections saved
+           per pool. urllib3 uses 1 connection as default value, but this is
+           not the best value when you are making a lot of possibly parallel
+           requests to the same host, which is often the case here.
+           cpu_count * 5 is used as default value to increase performance.
+        """
 
         self.proxy = None
         """Proxy URL

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -87,6 +87,9 @@ class RESTClientObject:
         if configuration.socket_options is not None:
             addition_pool_args['socket_options'] = configuration.socket_options
 
+        if configuration.connection_pool_maxsize is not None:
+            addition_pool_args['maxsize'] = configuration.connection_pool_maxsize
+
         # https pool manager
         if configuration.proxy:
             if is_socks_proxy_url(configuration.proxy):


### PR DESCRIPTION
This was removed in #16802, but using a higher value than 1, or at least making this configurable makes complete sense.

Without this, we get a lot of these log messages:

[ WARNING] Connection pool is full, discarding connection:

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10) @wing328 