### PR TITLE
fix: change to debug-logging for logging request headers in ApiClient

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -834,7 +834,7 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -740,7 +740,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -683,7 +683,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -732,7 +732,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -732,7 +732,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -732,7 +732,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -803,7 +803,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -790,7 +790,7 @@ public class ApiClient extends JavaTimeFormatter {
         private void logRequest(HttpRequest request, byte[] body) throws UnsupportedEncodingException {
             log.info("URI: " + request.getURI());
             log.info("HTTP Method: " + request.getMethod());
-            log.info("HTTP Headers: " + headersToString(request.getHeaders()));
+            log.debug("HTTP Headers: " + headersToString(request.getHeaders()));
             log.info("Request Body: " + new String(body, StandardCharsets.UTF_8));
         }
 


### PR DESCRIPTION
Switch to debug-logging for logging Request-Headers during ApiClient calls.

Fixes #17331 