### PR TITLE
Ruby Client for Faraday: fix file downloading

### DIFF
--- a/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
+++ b/modules/openapi-generator/src/main/resources/ruby-client/api_client_faraday_partial.mustache
@@ -6,7 +6,7 @@
       stream = nil
       begin
         response = connection(opts).public_send(http_method.to_sym.downcase) do |req|
-          build_request(http_method, path, req, opts)
+          request = build_request(http_method, path, req, opts)
           stream = download_file(request) if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
         end
 
@@ -33,7 +33,7 @@
       end
 
       if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
-        data = deserialize_file(stream)
+        data = deserialize_file(response, stream)
       elsif opts[:return_type]
         data = deserialize(response, opts[:return_type])
       else

--- a/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
+++ b/samples/client/petstore/ruby-faraday/lib/petstore/api_client.rb
@@ -52,7 +52,7 @@ module Petstore
       stream = nil
       begin
         response = connection(opts).public_send(http_method.to_sym.downcase) do |req|
-          build_request(http_method, path, req, opts)
+          request = build_request(http_method, path, req, opts)
           stream = download_file(request) if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
         end
 
@@ -79,7 +79,7 @@ module Petstore
       end
 
       if opts[:return_type] == 'File' || opts[:return_type] == 'Binary'
-        data = deserialize_file(stream)
+        data = deserialize_file(response, stream)
       elsif opts[:return_type]
         data = deserialize(response, opts[:return_type])
       else


### PR DESCRIPTION
In MR #16876, a bug was introduced that causes file downloading to fail for the Faraday adapter.

@meganemura @dkliban

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This commit fixes the obvious missing parameter for the method call to `download_file()` and the missing variable `request` for saving the response value of the call to `build_request()`.

Tested so far only locally, but would like to add an appropriate test case for binary data download but need some feedback, how to integrate this kind of tests into this MR.

There is an appropriate test scenario for the Python client that could be used as reference:

https://github.com/OpenAPITools/openapi-generator/blob/master/samples/client/echo_api/python/test/test_manual.py#L110

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
