### PR TITLE
Use $Response.Content for deserializing response

### DIFF
--- a/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/powershell/api_client.mustache
@@ -188,7 +188,7 @@ function Invoke-{{{apiNamePrefix}}}ApiClient {
     }
 
     return @{
-        Response = DeserializeResponse -Response $Response -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
+        Response = DeserializeResponse -Response $Response.Content -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
         StatusCode = $Response.StatusCode
         Headers = $Response.Headers
     }

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Private/ApiClient.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Private/ApiClient.ps1
@@ -176,7 +176,7 @@ function Invoke-ApiClient {
     }
 
     return @{
-        Response = DeserializeResponse -Response $Response -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
+        Response = DeserializeResponse -Response $Response.Content -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
         StatusCode = $Response.StatusCode
         Headers = $Response.Headers
     }

--- a/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
+++ b/samples/client/petstore/powershell/src/PSPetstore/Private/PSApiClient.ps1
@@ -192,7 +192,7 @@ function Invoke-PSApiClient {
     }
 
     return @{
-        Response = DeserializeResponse -Response $Response -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
+        Response = DeserializeResponse -Response $Response.Content -ReturnType $ReturnType -ContentTypes $Response.Headers["Content-Type"]
         StatusCode = $Response.StatusCode
         Headers = $Response.Headers
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Powershell client should use $Response.Content for deserializing response. Converting $Response to string as is replaces non-ascii characters with `?`
fix #17340 

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
