### PR TITLE
fix(typescript-*): nullable additionalProperty values

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractTypeScriptClientCodegen.java
@@ -629,6 +629,9 @@ public abstract class AbstractTypeScriptClientCodegen extends DefaultCodegen imp
         } else if (ModelUtils.isMapSchema(p)) {
             Schema<?> inner = getSchemaAdditionalProperties(p);
             String nullSafeSuffix = getNullSafeAdditionalProps() ? " | undefined" : "";
+            if (Boolean.TRUE.equals(inner.getNullable())) {
+                nullSafeSuffix += " | null";
+            }
             return "{ [key: string]: " + getTypeDeclaration(unaliasSchema(inner)) + nullSafeSuffix + "; }";
         } else if (ModelUtils.isFileSchema(p)) {
             return "File";

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -1107,16 +1107,16 @@ export interface NullableClass {
     'object_nullable_prop'?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    'object_and_items_nullable_prop'?: { [key: string]: object; } | null;
+    'object_and_items_nullable_prop'?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    'object_items_nullable'?: { [key: string]: object; };
+    'object_items_nullable'?: { [key: string]: object | null; };
 }
 /**
  * @type NullableShape

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -875,16 +875,16 @@ export interface NullableClass {
     'object_nullable_prop'?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    'object_and_items_nullable_prop'?: { [key: string]: object; } | null;
+    'object_and_items_nullable_prop'?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    'object_items_nullable'?: { [key: string]: object; };
+    'object_items_nullable'?: { [key: string]: object | null; };
 }
 /**
  * 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -82,16 +82,16 @@ export interface NullableClass {
     objectNullableProp?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    objectAndItemsNullableProp?: { [key: string]: object; } | null;
+    objectAndItemsNullableProp?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    objectItemsNullable?: { [key: string]: object; };
+    objectItemsNullable?: { [key: string]: object | null; };
 }
 
 /**

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -82,16 +82,16 @@ export interface NullableClass {
     objectNullableProp?: { [key: string]: object; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    objectAndItemsNullableProp?: { [key: string]: object; } | null;
+    objectAndItemsNullableProp?: { [key: string]: object | null; } | null;
     /**
      * 
-     * @type {{ [key: string]: object; }}
+     * @type {{ [key: string]: object | null; }}
      * @memberof NullableClass
      */
-    objectItemsNullable?: { [key: string]: object; };
+    objectItemsNullable?: { [key: string]: object | null; };
 }
 
 /**


### PR DESCRIPTION
Models generated from `additionalProperties` schema with `nullable: true` are missing `null` from the type declaration.

Applies https://github.com/OpenAPITools/openapi-generator/pull/15026 to the base typescript codegen to fix other TS-based generators.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
