### PR TITLE
[jaxrs-spec] Improve support for sub-resource locators in jaxrs-spec generartors

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
@@ -27,6 +27,7 @@ import {{javaxPackage}}.validation.Valid;{{/useBeanValidation}}
 {{>generatedAnnotation}}
 public {{#interfaceOnly}}interface{{/interfaceOnly}}{{^interfaceOnly}}class{{/interfaceOnly}} {{classname}} {
 {{#operations}}
+   {{^interfaceOnly}}public{{/interfaceOnly}} static final String PATH = "{{commonPath}}";
 {{#operation}}
 
 {{#interfaceOnly}}{{>apiInterface}}{{/interfaceOnly}}{{^interfaceOnly}}{{>apiMethod}}{{/interfaceOnly}}

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface AnotherFakeApi {
+    static final String PATH = "/another-fake/dummy";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeApi.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeApi {
+    static final String PATH = "/fake";
 
     @POST
     @Path("/create_xml_item")

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeClassnameTestApi {
+    static final String PATH = "/fake_classname_test";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import javax.validation.Valid;
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface PetApi {
+    static final String PATH = "/pet";
 
     @POST
     @Consumes({ "application/json", "application/xml" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface StoreApi {
+    static final String PATH = "/store";
 
     @DELETE
     @Path("/order/{order_id}")

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface UserApi {
+    static final String PATH = "/user";
 
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", tags={ "user" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface AnotherFakeApi {
+    static final String PATH = "/another-fake/dummy";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeApi {
+    static final String PATH = "/fake";
 
     @POST
     @Path("/create_xml_item")

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeClassnameTestApi {
+    static final String PATH = "/fake_classname_test";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import javax.validation.Valid;
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface PetApi {
+    static final String PATH = "/pet";
 
     @POST
     @Consumes({ "application/json", "application/xml" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface StoreApi {
+    static final String PATH = "/store";
 
     @DELETE
     @Path("/order/{order_id}")

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface UserApi {
+    static final String PATH = "/user";
 
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", tags={ "user" })

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 @Api(description = "the another-fake API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AnotherFakeApi {
+   public static final String PATH = "/another-fake/dummy";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeApi.java
@@ -27,6 +27,7 @@ import jakarta.validation.Valid;
 @Api(description = "the fake API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FakeApi {
+   public static final String PATH = "/fake";
 
     @POST
     @Path("/create_xml_item")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import jakarta.validation.Valid;
 @Api(description = "the fake_classname_test API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FakeClassnameTestApi {
+   public static final String PATH = "/fake_classname_test";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import jakarta.validation.Valid;
 @Api(description = "the pet API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class PetApi {
+   public static final String PATH = "/pet";
 
     @POST
     @Consumes({ "application/json", "application/xml" })

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 @Api(description = "the store API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class StoreApi {
+   public static final String PATH = "/store";
 
     @DELETE
     @Path("/order/{order_id}")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 @Api(description = "the user API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class UserApi {
+   public static final String PATH = "/user";
 
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user" })

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/api/UserApi.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class UserApi {
+   public static final String PATH = "/user";
 
     @GET
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class AnotherFakeApi {
+   public static final String PATH = "/another-fake/dummy";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FakeApi {
+   public static final String PATH = "/fake";
 
     @POST
     @Path("/create_xml_item")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class FakeClassnameTestApi {
+   public static final String PATH = "/fake_classname_test";
 
     @PATCH
     @Consumes({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import javax.validation.Valid;
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class PetApi {
+   public static final String PATH = "/pet";
 
     @POST
     @Consumes({ "application/json", "application/xml" })

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class StoreApi {
+   public static final String PATH = "/store";
 
     @DELETE
     @Path("/order/{order_id}")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import javax.validation.Valid;
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public class UserApi {
+   public static final String PATH = "/user";
 
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", response = Void.class, tags={ "user" })


### PR DESCRIPTION
Adds a public string constant by the name of PATH to generated api classes / interfaces with the content of the class level Path annotation, so the path can easily be used in sub-resource locators etc. https://github.com/OpenAPITools/openapi-generator/issues/15052#issue-1641043190

based on #15053

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
