### PR TITLE
[kotlin] Enum should match spec

### DIFF
--- a/docs/generators/kotlin-server.md
+++ b/docs/generators/kotlin-server.md
@@ -22,7 +22,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |kotlin-server|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
-|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
+|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |original|
 |featureAutoHead|Automatically provide responses to HEAD requests for existing routes that have the GET verb defined.| |true|
 |featureCORS|Ktor by default provides an interceptor for implementing proper support for Cross-Origin Resource Sharing (CORS). See enable-cors.org.| |false|
 |featureCompression|Adds ability to compress outgoing content using gzip, deflate or custom encoder and thus reduce size of the response.| |true|

--- a/docs/generators/kotlin-spring.md
+++ b/docs/generators/kotlin-spring.md
@@ -30,7 +30,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |configPackage|configuration package for generated code| |org.openapitools.configuration|
 |delegatePattern|Whether to generate the server files using the delegate pattern| |false|
 |documentationProvider|Select the OpenAPI documentation provider.|<dl><dt>**none**</dt><dd>Do not publish an OpenAPI specification.</dd><dt>**source**</dt><dd>Publish the original input OpenAPI specification.</dd><dt>**springfox**</dt><dd>Generate an OpenAPI 2 (fka Swagger RESTful API Documentation Specification) specification using SpringFox 2.x. Deprecated (for removal); use springdoc instead.</dd><dt>**springdoc**</dt><dd>Generate an OpenAPI 3 specification using SpringDoc.</dd></dl>|springdoc|
-|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
+|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |original|
 |exceptionHandler|generate default global exception handlers (not compatible with reactive. enabling reactive will disable exceptionHandler )| |true|
 |gradleBuildFile|generate a gradle build file using the Kotlin DSL| |true|
 |groupId|Generated artifact package's organization (i.e. maven groupId).| |org.openapitools|

--- a/docs/generators/kotlin-vertx.md
+++ b/docs/generators/kotlin-vertx.md
@@ -22,7 +22,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |apiSuffix|suffix for api classes| |Api|
 |artifactId|Generated artifact id (name of jar).| |null|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
-|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
+|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |original|
 |groupId|Generated artifact package's organization (i.e. maven groupId).| |org.openapitools|
 |modelMutable|Create mutable models| |false|
 |packageName|Generated artifact package name.| |org.openapitools|

--- a/docs/generators/kotlin.md
+++ b/docs/generators/kotlin.md
@@ -24,7 +24,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |collectionType|Option. Collection type to use|<dl><dt>**array**</dt><dd>kotlin.Array</dd><dt>**list**</dt><dd>kotlin.collections.List</dd></dl>|list|
 |dateLibrary|Option. Date library to use|<dl><dt>**threetenbp-localdatetime**</dt><dd>Threetenbp - Backport of JSR310 (jvm only, for legacy app only)</dd><dt>**kotlinx-datetime**</dt><dd>kotlinx-datetime (preferred for multiplatform)</dd><dt>**string**</dt><dd>String</dd><dt>**java8-localdatetime**</dt><dd>Java 8 native JSR310 (jvm only, for legacy app only)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (jvm only, preferred for jdk 1.8+)</dd><dt>**threetenbp**</dt><dd>Threetenbp - Backport of JSR310 (jvm only, preferred for jdk &lt; 1.8)</dd></dl>|java8|
-|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
+|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |original|
 |generateRoomModels|Generate Android Room database models in addition to API models (JVM Volley library only)| |false|
 |groupId|Generated artifact package's organization (i.e. maven groupId).| |org.openapitools|
 |idea|Add IntellJ Idea plugin and mark Kotlin main and test folders as source folders.| |false|

--- a/docs/generators/ktorm-schema.md
+++ b/docs/generators/ktorm-schema.md
@@ -23,7 +23,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |artifactId|Generated artifact id (name of jar).| |ktorm|
 |artifactVersion|Generated artifact's package version.| |1.0.0|
 |defaultDatabaseName|Default database name for all queries| |sqlite.db|
-|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |camelCase|
+|enumPropertyNaming|Naming convention for enum properties: 'camelCase', 'PascalCase', 'snake_case', 'UPPERCASE', and 'original'| |original|
 |groupId|Generated artifact package's organization (i.e. maven groupId).| |org.openapitools|
 |identifierNamingConvention|Naming convention of Ktorm identifiers(table names and column names). This is not related to database name which is defined by defaultDatabaseName option|<dl><dt>**original**</dt><dd>Do not transform original names</dd><dt>**snake_case**</dt><dd>Use snake_case names</dd></dl>|original|
 |importModelPackageName|Package name of the imported models| |org.openapitools.database.models|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -76,7 +76,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
 
     protected boolean nonPublicApi = false;
 
-    protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.camelCase;
+    protected CodegenConstants.ENUM_PROPERTY_NAMING_TYPE enumPropertyNaming = CodegenConstants.ENUM_PROPERTY_NAMING_TYPE.original;
 
     // model classes cannot use the same property names defined in HashMap
     // ref: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-hash-map/

--- a/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
+++ b/modules/openapi-generator/src/main/resources/asciidoc-documentation/model.mustache
@@ -9,20 +9,38 @@
 
 {{unescapedDescription}}
 
+
+{{^allowableValues}}
 [.fields-{{classname}}]
-[cols="2,1,2,4,1"]
+[cols="2,1,1,2,4,1"]
 |===
-| Field Name| Required| Type| Description| Format
+| Field Name| Required| Nullable | Type| Description | Format
 
 {{#vars}}
 | {{baseName}}
 | {{#required}}X{{/required}}
-| {{dataType}} {{#isContainer}} of <<{{complexType}}>>{{/isContainer}}
+| {{#isNullable}}X{{/isNullable}}
+| {{#isModel}}<<{{ dataType }}>>{{/isModel}} {{^container}}{{^allowableValues}} {{^isModel}}{{ dataType }}{{/isModel}}{{/allowableValues}}{{#allowableValues}}{{^allowableValues.empty}}<<{{ dataType }}>>{{/allowableValues.empty}}{{/allowableValues}} {{/container}} {{#isContainer}} of <<{{complexType}}>>{{/isContainer}}
 | {{description}}
-| {{{dataFormat}}} {{#isEnum}}_Enum:_ {{#_enum}}{{this}}, {{/_enum}}{{/isEnum}}
+| {{{dataFormat}}} {{#isEnum}}_Enum:_ {{#_enum}}{{this}}, {{/_enum}}{{/isEnum}} {{^isEnum}}{{^container}}{{^allowableValues.empty}} {{#allowableValues.values}}{{this}}, {{/allowableValues.values}} {{/allowableValues.empty}}{{/container}}{{/isEnum}}
 
 {{/vars}}
 |===
+{{/allowableValues}}
+
+{{#allowableValues}}
+
+[.fields-{{classname}}]
+[cols="1"]
+|===
+| Enum Values
+
+{{#allowableValues.values}}
+| {{this}}
+{{/allowableValues.values}}
+
+|===
+{{/allowableValues}}
 
     {{/model}}
 {{/models}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/AbstractKotlinCodegenTest.java
@@ -16,6 +16,9 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -278,8 +281,69 @@ public class AbstractKotlinCodegenTest {
         // Assert the enum default value is properly generated
         CodegenProperty cp1 = cm1.vars.get(0);
         Assert.assertEquals(cp1.getEnumName(), "PropertyName");
-        Assert.assertEquals(cp1.getDefaultValue(), "PropertyName.vALUE");
+        Assert.assertEquals(cp1.getDefaultValue(), "PropertyName.VALUE");
     }
+
+    @Test(description = "Issue #3804")
+    public void testEnumPropertyWithCapitalization() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/issue3804-enum-enum-capitalization.yaml");
+        final AbstractKotlinCodegen codegen = new P_AbstractKotlinCodegen();
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("ModelWithEnumPropertyHavingDefault");
+        CodegenModel cm1 = codegen.fromModel("ModelWithEnumPropertyHavingDefault", test1);
+
+        // We need to postProcess the model for enums to be processed
+        codegen.postProcessModels(createCodegenModelWrapper(cm1));
+
+        // Assert the enums are generated without changing capitalization
+        CodegenProperty cp0 = cm1.vars.get(0);
+        Assert.assertEquals(cp0.getEnumName(), "PropertyName");
+        Assert.assertEquals(((HashMap)((ArrayList) cp0.getAllowableValues().get("enumVars")).get(0)).get("name"), "VALUE");
+        CodegenProperty cp1 = cm1.vars.get(1);
+        Assert.assertEquals(cp1.getEnumName(), "PropertyName2");
+        Assert.assertEquals(((HashMap)((ArrayList) cp1.getAllowableValues().get("enumVars")).get(0)).get("name"), "Value");
+        CodegenProperty cp2 = cm1.vars.get(2);
+        Assert.assertEquals(cp2.getEnumName(), "PropertyName3");
+        Assert.assertEquals(((HashMap)((ArrayList) cp2.getAllowableValues().get("enumVars")).get(0)).get("name"), "nonkeywordvalue");
+    }
+
+    @Test(description = "Issue #3804")
+    public void testEnumPropertyDefaultWithCapitalization() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/issue3804-enum-enum-capitalization.yaml");
+        final AbstractKotlinCodegen codegen = new P_AbstractKotlinCodegen();
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("ModelWithEnumPropertyHavingDefault");
+        CodegenModel cm1 = codegen.fromModel("ModelWithEnumPropertyHavingDefault", test1);
+
+        // We need to postProcess the model for enums to be processed
+        codegen.postProcessModels(createCodegenModelWrapper(cm1));
+
+        // Assert the enum default value is properly generated
+        CodegenProperty cp0 = cm1.vars.get(0);
+        Assert.assertEquals(cp0.getDefaultValue(), "PropertyName.VALUE");
+        CodegenProperty cp1 = cm1.vars.get(1);
+        Assert.assertEquals(cp1.getDefaultValue(), "PropertyName2.Value");
+        CodegenProperty cp2 = cm1.vars.get(2);
+        Assert.assertEquals(cp2.getDefaultValue(), "PropertyName3.nonkeywordvalue");
+    }
+
+    @Test(description = "Issue #3804")
+    public void testEnumPropertyWithKeyword() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/kotlin/issue3804-enum-enum-capitalization.yaml");
+        final AbstractKotlinCodegen codegen = new P_AbstractKotlinCodegen();
+
+        Schema test1 = openAPI.getComponents().getSchemas().get("ModelWithEnumPropertyHavingDefault");
+        CodegenModel cm1 = codegen.fromModel("ModelWithEnumPropertyHavingDefault", test1);
+
+        // We need to postProcess the model for enums to be processed
+        codegen.postProcessModels(createCodegenModelWrapper(cm1));
+
+        // Assert the enum default value is properly generated
+        CodegenProperty cp3 = cm1.vars.get(3);
+        Assert.assertEquals(cp3.getEnumName(), "PropertyName4");
+        Assert.assertEquals(cp3.getDefaultValue(), "PropertyName4.`value`");
+    }
+
 
     @Test(description = "Issue #10792")
     public void handleInheritanceWithObjectTypeShouldNotBeAMap() {

--- a/modules/openapi-generator/src/test/resources/3_0/asciidoc/api-docs.json
+++ b/modules/openapi-generator/src/test/resources/3_0/asciidoc/api-docs.json
@@ -1399,9 +1399,21 @@
                         "items": {
                             "$ref": "#/components/schemas/TaskWeek"
                         }
+                    },
+                    "pricingModelType":{
+                        "$ref": "#/components/schemas/PricingModelType"
                     }
                 },
                 "description": "week, holds all work and working assignments."
+            },
+            "PricingModelType": {
+                "type": "string",
+                "enum": [
+                    "Unsupported",
+                    "Flex",
+                    "Community",
+                    "Freedom"
+                ]
             }
         },
         "securitySchemes": {

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/issue3804-enum-enum-capitalization.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/issue3804-enum-enum-capitalization.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: 'Issue 10591 Enum default value'
+  version: latest
+paths:
+  '/':
+    get:
+      operationId: operation
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelWithEnumPropertyHavingDefault'
+components:
+  schemas:
+    ModelWithEnumPropertyHavingDefault:
+      required:
+        - propertyName
+      properties:
+        propertyName:
+          type: string
+          default: VALUE
+          enum:
+            - VALUE
+        propertyName2:
+          type: string
+          default: Value
+          enum:
+            - Value
+        propertyName3:
+          type: string
+          default: nonkeywordvalue
+          enum:
+            - nonkeywordvalue
+        propertyName4:
+          type: string
+          default: value
+          enum:
+            - value

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/apis/DefaultApi.kt
@@ -48,27 +48,27 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient
      * enum for parameter queryDefaultEnum
      */
      enum class QueryDefaultEnumFindPetsByStatus(val value: kotlin.String) {
-         @Json(name = "A") a("A"),
-         @Json(name = "B") b("B"),
-         @Json(name = "C") c("C")
+         @Json(name = "A") A("A"),
+         @Json(name = "B") B("B"),
+         @Json(name = "C") C("C")
      }
 
     /**
      * enum for parameter headerDefaultEnum
      */
      enum class HeaderDefaultEnumFindPetsByStatus(val value: kotlin.String) {
-         @Json(name = "A") a("A"),
-         @Json(name = "B") b("B"),
-         @Json(name = "C") c("C")
+         @Json(name = "A") A("A"),
+         @Json(name = "B") B("B"),
+         @Json(name = "C") C("C")
      }
 
     /**
      * enum for parameter cookieDefaultEnum
      */
      enum class CookieDefaultEnumFindPetsByStatus(val value: kotlin.String) {
-         @Json(name = "A") a("A"),
-         @Json(name = "B") b("B"),
-         @Json(name = "C") c("C")
+         @Json(name = "A") A("A"),
+         @Json(name = "B") B("B"),
+         @Json(name = "C") C("C")
      }
 
     /**
@@ -97,7 +97,7 @@ class DefaultApi(basePath: kotlin.String = defaultBasePath, client: OkHttpClient
      * @throws ServerException If the API returns a server error response
      */
     @Throws(IllegalStateException::class, IOException::class, UnsupportedOperationException::class, ClientException::class, ServerException::class)
-    fun findPetsByStatus(pathDefault: kotlin.String, pathNullable: kotlin.String, queryDefault: kotlin.String? = "available", queryDefaultEnum: QueryDefaultEnumFindPetsByStatus? = QueryDefaultEnumFindPetsByStatus.b, queryDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), headerDefault: kotlin.String? = "available", headerDefaultEnum: HeaderDefaultEnumFindPetsByStatus? = HeaderDefaultEnumFindPetsByStatus.b, headerDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), cookieDefault: kotlin.String? = "available", cookieDefaultEnum: CookieDefaultEnumFindPetsByStatus? = CookieDefaultEnumFindPetsByStatus.b, cookieDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), queryNullable: kotlin.String? = null, headerNullable: kotlin.String? = null, cookieNullable: kotlin.String? = null, dollarQueryDollarDollarSign: kotlin.String? = null) : Unit {
+    fun findPetsByStatus(pathDefault: kotlin.String, pathNullable: kotlin.String, queryDefault: kotlin.String? = "available", queryDefaultEnum: QueryDefaultEnumFindPetsByStatus? = QueryDefaultEnumFindPetsByStatus.B, queryDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), headerDefault: kotlin.String? = "available", headerDefaultEnum: HeaderDefaultEnumFindPetsByStatus? = HeaderDefaultEnumFindPetsByStatus.B, headerDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), cookieDefault: kotlin.String? = "available", cookieDefaultEnum: CookieDefaultEnumFindPetsByStatus? = CookieDefaultEnumFindPetsByStatus.B, cookieDefaultInt: java.math.BigDecimal? = java.math.BigDecimal("3"), queryNullable: kotlin.String? = null, headerNullable: kotlin.String? = null, cookieNullable: kotlin.String? = null, dollarQueryDollarDollarSign: kotlin.String? = null) : Unit {
         val localVarResponse = findPetsByStatusWithHttpInfo(pathDefault = pathDefault, pathNullable = pathNullable, queryDefault = queryDefault, queryDefaultEnum = queryDefaultEnum, queryDefaultInt = queryDefaultInt, headerDefault = headerDefault, headerDefaultEnum = headerDefaultEnum, headerDefaultInt = headerDefaultInt, cookieDefault = cookieDefault, cookieDefaultEnum = cookieDefaultEnum, cookieDefaultInt = cookieDefaultInt, queryNullable = queryNullable, headerNullable = headerNullable, cookieNullable = cookieNullable, dollarQueryDollarDollarSign = dollarQueryDollarDollarSign)
 
         return when (localVarResponse.responseType) {

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
@@ -7,12 +7,12 @@ object SerializerHelper {
     fun addEnumUnknownDefaultCase(moshiBuilder: Moshi.Builder): Moshi.Builder {
         return moshiBuilder
             .add(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName::class.java, EnumJsonAdapter.create(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName::class.java)
-                .withUnknownFallback(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.ModelWithEnumPropertyHavingDefault.PropertyName.unknown_default_open_api))
             .add(org.openapitools.client.models.PropertyOfDay.DaysOfWeek::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.DaysOfWeek::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.DaysOfWeek.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.DaysOfWeek.unknown_default_open_api))
             .add(org.openapitools.client.models.PropertyOfDay.MonthOfYear::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.MonthOfYear::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.MonthOfYear.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.MonthOfYear.unknown_default_open_api))
             .add(org.openapitools.client.models.PropertyOfDay.HolidayTypes::class.java, EnumJsonAdapter.create(org.openapitools.client.models.PropertyOfDay.HolidayTypes::class.java)
-                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.HolidayTypes.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.PropertyOfDay.HolidayTypes.unknown_default_open_api))
     }
 }

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/models/ModelWithEnumPropertyHavingDefault.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/models/ModelWithEnumPropertyHavingDefault.kt
@@ -30,7 +30,7 @@ import java.io.Serializable
 data class ModelWithEnumPropertyHavingDefault (
 
     @Json(name = "propertyName")
-    val propertyName: ModelWithEnumPropertyHavingDefault.PropertyName = PropertyName.vALUE
+    val propertyName: ModelWithEnumPropertyHavingDefault.PropertyName = PropertyName.VALUE
 
 ) : Serializable {
     companion object {
@@ -40,12 +40,12 @@ data class ModelWithEnumPropertyHavingDefault (
     /**
      * 
      *
-     * Values: vALUE,unknownDefaultOpenApi
+     * Values: VALUE,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class PropertyName(val value: kotlin.String) {
-        @Json(name = "VALUE") vALUE("VALUE"),
-        @Json(name = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @Json(name = "VALUE") VALUE("VALUE"),
+        @Json(name = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 }
 

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/models/PropertyOfDay.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/models/PropertyOfDay.kt
@@ -66,26 +66,26 @@ data class PropertyOfDay (
     /**
      * Days of week
      *
-     * Values: mONDAY,tUESDAY,wEDNESDAY,tHURSDAY,fRIDAY,sATURDAY,sUNDAY,wEEKDAYS,wEEKEND,eVERYDAY,unknownDefaultOpenApi
+     * Values: MONDAY,TUESDAY,WEDNESDAY,THURSDAY,FRIDAY,SATURDAY,SUNDAY,WEEKDAYS,WEEKEND,EVERYDAY,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class DaysOfWeek(val value: kotlin.Any) {
-        @Json(name = "MONDAY") mONDAY("MONDAY"),
-        @Json(name = "TUESDAY") tUESDAY("TUESDAY"),
-        @Json(name = "WEDNESDAY") wEDNESDAY("WEDNESDAY"),
-        @Json(name = "THURSDAY") tHURSDAY("THURSDAY"),
-        @Json(name = "FRIDAY") fRIDAY("FRIDAY"),
-        @Json(name = "SATURDAY") sATURDAY("SATURDAY"),
-        @Json(name = "SUNDAY") sUNDAY("SUNDAY"),
-        @Json(name = "WEEKDAYS") wEEKDAYS("WEEKDAYS"),
-        @Json(name = "WEEKEND") wEEKEND("WEEKEND"),
-        @Json(name = "EVERYDAY") eVERYDAY("EVERYDAY"),
-        @Json(name = "11184809") unknownDefaultOpenApi("11184809");
+        @Json(name = "MONDAY") MONDAY("MONDAY"),
+        @Json(name = "TUESDAY") TUESDAY("TUESDAY"),
+        @Json(name = "WEDNESDAY") WEDNESDAY("WEDNESDAY"),
+        @Json(name = "THURSDAY") THURSDAY("THURSDAY"),
+        @Json(name = "FRIDAY") FRIDAY("FRIDAY"),
+        @Json(name = "SATURDAY") SATURDAY("SATURDAY"),
+        @Json(name = "SUNDAY") SUNDAY("SUNDAY"),
+        @Json(name = "WEEKDAYS") WEEKDAYS("WEEKDAYS"),
+        @Json(name = "WEEKEND") WEEKEND("WEEKEND"),
+        @Json(name = "EVERYDAY") EVERYDAY("EVERYDAY"),
+        @Json(name = "11184809") unknown_default_open_api("11184809");
     }
     /**
      * Month of year
      *
-     * Values: _1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,unknownDefaultOpenApi
+     * Values: _1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class MonthOfYear(val value: kotlin.Int) {
@@ -101,35 +101,35 @@ data class PropertyOfDay (
         @Json(name = "10") _10(10),
         @Json(name = "11") _11(11),
         @Json(name = "12") _12(12),
-        @Json(name = "11184809") unknownDefaultOpenApi(11184809);
+        @Json(name = "11184809") unknown_default_open_api(11184809);
     }
     /**
      * Holiday types
      *
-     * Values: nOTHOLIDAY,lOCALHOLIDAY,nATIONALHOLIDAY,aNYHOLIDAY,wORKINGDAY,aNYDAY,nEWYEARSDAY,pALMSUNDAY,mAUNDYTHURSDAY,gOODFRIDAY,eASTERSUNDAY,eASTERMONDAY,lABOURDAY,cONSTITUTIONDAY,aSCENSIONDAY,wHITSUNDAY,wHITMONDAY,XMAS_DAY,bOXINGDAY,unknownDefaultOpenApi
+     * Values: NOT_HOLIDAY,LOCAL_HOLIDAY,NATIONAL_HOLIDAY,ANY_HOLIDAY,WORKING_DAY,ANY_DAY,NEW_YEARS_DAY,PALM_SUNDAY,MAUNDY_THURSDAY,GOOD_FRIDAY,EASTER_SUNDAY,EASTER_MONDAY,LABOUR_DAY,CONSTITUTION_DAY,ASCENSION_DAY,WHIT_SUNDAY,WHIT_MONDAY,XMAS_DAY,BOXING_DAY,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class HolidayTypes(val value: kotlin.Any) {
-        @Json(name = "NOT_HOLIDAY") nOTHOLIDAY("NOT_HOLIDAY"),
-        @Json(name = "LOCAL_HOLIDAY") lOCALHOLIDAY("LOCAL_HOLIDAY"),
-        @Json(name = "NATIONAL_HOLIDAY") nATIONALHOLIDAY("NATIONAL_HOLIDAY"),
-        @Json(name = "ANY_HOLIDAY") aNYHOLIDAY("ANY_HOLIDAY"),
-        @Json(name = "WORKING_DAY") wORKINGDAY("WORKING_DAY"),
-        @Json(name = "ANY_DAY") aNYDAY("ANY_DAY"),
-        @Json(name = "NEW_YEARS_DAY") nEWYEARSDAY("NEW_YEARS_DAY"),
-        @Json(name = "PALM_SUNDAY") pALMSUNDAY("PALM_SUNDAY"),
-        @Json(name = "MAUNDY_THURSDAY") mAUNDYTHURSDAY("MAUNDY_THURSDAY"),
-        @Json(name = "GOOD_FRIDAY") gOODFRIDAY("GOOD_FRIDAY"),
-        @Json(name = "EASTER_SUNDAY") eASTERSUNDAY("EASTER_SUNDAY"),
-        @Json(name = "EASTER_MONDAY") eASTERMONDAY("EASTER_MONDAY"),
-        @Json(name = "LABOUR_DAY") lABOURDAY("LABOUR_DAY"),
-        @Json(name = "CONSTITUTION_DAY") cONSTITUTIONDAY("CONSTITUTION_DAY"),
-        @Json(name = "ASCENSION_DAY") aSCENSIONDAY("ASCENSION_DAY"),
-        @Json(name = "WHIT_SUNDAY") wHITSUNDAY("WHIT_SUNDAY"),
-        @Json(name = "WHIT_MONDAY") wHITMONDAY("WHIT_MONDAY"),
+        @Json(name = "NOT_HOLIDAY") NOT_HOLIDAY("NOT_HOLIDAY"),
+        @Json(name = "LOCAL_HOLIDAY") LOCAL_HOLIDAY("LOCAL_HOLIDAY"),
+        @Json(name = "NATIONAL_HOLIDAY") NATIONAL_HOLIDAY("NATIONAL_HOLIDAY"),
+        @Json(name = "ANY_HOLIDAY") ANY_HOLIDAY("ANY_HOLIDAY"),
+        @Json(name = "WORKING_DAY") WORKING_DAY("WORKING_DAY"),
+        @Json(name = "ANY_DAY") ANY_DAY("ANY_DAY"),
+        @Json(name = "NEW_YEARS_DAY") NEW_YEARS_DAY("NEW_YEARS_DAY"),
+        @Json(name = "PALM_SUNDAY") PALM_SUNDAY("PALM_SUNDAY"),
+        @Json(name = "MAUNDY_THURSDAY") MAUNDY_THURSDAY("MAUNDY_THURSDAY"),
+        @Json(name = "GOOD_FRIDAY") GOOD_FRIDAY("GOOD_FRIDAY"),
+        @Json(name = "EASTER_SUNDAY") EASTER_SUNDAY("EASTER_SUNDAY"),
+        @Json(name = "EASTER_MONDAY") EASTER_MONDAY("EASTER_MONDAY"),
+        @Json(name = "LABOUR_DAY") LABOUR_DAY("LABOUR_DAY"),
+        @Json(name = "CONSTITUTION_DAY") CONSTITUTION_DAY("CONSTITUTION_DAY"),
+        @Json(name = "ASCENSION_DAY") ASCENSION_DAY("ASCENSION_DAY"),
+        @Json(name = "WHIT_SUNDAY") WHIT_SUNDAY("WHIT_SUNDAY"),
+        @Json(name = "WHIT_MONDAY") WHIT_MONDAY("WHIT_MONDAY"),
         @Json(name = "CHRISTMAS_DAY") XMAS_DAY("CHRISTMAS_DAY"),
-        @Json(name = "BOXING_DAY") bOXINGDAY("BOXING_DAY"),
-        @Json(name = "11184809") unknownDefaultOpenApi("11184809");
+        @Json(name = "BOXING_DAY") BOXING_DAY("BOXING_DAY"),
+        @Json(name = "11184809") unknown_default_open_api("11184809");
     }
 }
 

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -66,14 +66,14 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     @Serializable(with = OrderSerializer::class)
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "placed") placed("placed"),
         @SerialName(value = "approved") approved("approved"),
         @SerialName(value = "delivered") delivered("delivered"),
-        @SerialName(value = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @SerialName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 
     @Serializer(forClass = Status::class)
@@ -83,7 +83,7 @@ data class Order (
         override fun deserialize(decoder: Decoder): Status {
             val value = decoder.decodeSerializableValue(kotlin.String.serializer())
             return Status.values().firstOrNull { it.value == value }
-                ?: Status.unknownDefaultOpenApi
+                ?: Status.unknown_default_open_api
         }
 
         override fun serialize(encoder: Encoder, value: Status) {

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -68,14 +68,14 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     @Serializable(with = PetSerializer::class)
     enum class Status(val value: kotlin.String) {
         @SerialName(value = "available") available("available"),
         @SerialName(value = "pending") pending("pending"),
         @SerialName(value = "sold") sold("sold"),
-        @SerialName(value = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @SerialName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 
     @Serializer(forClass = Status::class)
@@ -85,7 +85,7 @@ data class Pet (
         override fun deserialize(decoder: Decoder): Status {
             val value = decoder.decodeSerializableValue(kotlin.String.serializer())
             return Status.values().firstOrNull { it.value == value }
-                ?: Status.unknownDefaultOpenApi
+                ?: Status.unknown_default_open_api
         }
 
         override fun serialize(encoder: Encoder, value: Status) {

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,7 +57,7 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),

--- a/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -60,7 +60,7 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -56,13 +56,13 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @SerializedName(value = "placed") placed("placed"),
         @SerializedName(value = "approved") approved("approved"),
         @SerializedName(value = "delivered") delivered("delivered"),
-        @SerializedName(value = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @SerializedName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -58,13 +58,13 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @SerializedName(value = "available") available("available"),
         @SerializedName(value = "pending") pending("pending"),
         @SerializedName(value = "sold") sold("sold"),
-        @SerializedName(value = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @SerializedName(value = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 }
 

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,7 +57,7 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -59,7 +59,7 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,7 +57,7 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -60,7 +60,7 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,7 +57,7 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -60,7 +60,7 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,7 +57,7 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "placed") placed("placed"),

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -60,7 +60,7 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     enum class Status(val value: kotlin.String) {
         @JsonProperty(value = "available") available("available"),

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/SerializerHelper.kt
@@ -7,8 +7,8 @@ object SerializerHelper {
     fun addEnumUnknownDefaultCase(moshiBuilder: Moshi.Builder): Moshi.Builder {
         return moshiBuilder
             .add(org.openapitools.client.models.Order.Status::class.java, EnumJsonAdapter.create(org.openapitools.client.models.Order.Status::class.java)
-                .withUnknownFallback(org.openapitools.client.models.Order.Status.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.Order.Status.unknown_default_open_api))
             .add(org.openapitools.client.models.Pet.Status::class.java, EnumJsonAdapter.create(org.openapitools.client.models.Pet.Status::class.java)
-                .withUnknownFallback(org.openapitools.client.models.Pet.Status.unknownDefaultOpenApi))
+                .withUnknownFallback(org.openapitools.client.models.Pet.Status.unknown_default_open_api))
     }
 }

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Order.kt
@@ -57,14 +57,14 @@ data class Order (
     /**
      * Order Status
      *
-     * Values: placed,approved,delivered,unknownDefaultOpenApi
+     * Values: placed,approved,delivered,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class Status(val value: kotlin.String) {
         @Json(name = "placed") placed("placed"),
         @Json(name = "approved") approved("approved"),
         @Json(name = "delivered") delivered("delivered"),
-        @Json(name = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @Json(name = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 }
 

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/models/Pet.kt
@@ -59,14 +59,14 @@ data class Pet (
     /**
      * pet status in the store
      *
-     * Values: available,pending,sold,unknownDefaultOpenApi
+     * Values: available,pending,sold,unknown_default_open_api
      */
     @JsonClass(generateAdapter = false)
     enum class Status(val value: kotlin.String) {
         @Json(name = "available") available("available"),
         @Json(name = "pending") pending("pending"),
         @Json(name = "sold") sold("sold"),
-        @Json(name = "unknown_default_open_api") unknownDefaultOpenApi("unknown_default_open_api");
+        @Json(name = "unknown_default_open_api") unknown_default_open_api("unknown_default_open_api");
     }
 }
 


### PR DESCRIPTION
Fixing the merge conflicts on #16333 

- [kotlin] Enum should match spec
- [kotlin] export docs generators for enum change
- [kotlin] export docs generators for enum change
- fix conflicts

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
