### PR TITLE
Dereference parameters in OpenAPI 3.1 spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -109,7 +109,6 @@ public class OpenAPINormalizer {
         this.inputRules = inputRules;
 
         if (Boolean.parseBoolean(inputRules.get(DISABLE_ALL))) {
-            LOGGER.info("Disabled all rules in OpenAPI Normalizer (DISABLE_ALL=true)");
             this.disableAll = true;
             return; // skip the rest
         }
@@ -306,6 +305,11 @@ public class OpenAPINormalizer {
         }
 
         for (Parameter parameter : parameters) {
+            // dereference parameter
+            if (StringUtils.isNotEmpty(parameter.get$ref())) {
+                parameter = ModelUtils.getReferencedParameter(openAPI, parameter);
+            }
+
             if (parameter.getSchema() == null) {
                 continue;
             } else {

--- a/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
@@ -599,10 +599,30 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ref'
+  /ref/ref_to_parameter:
+    get:
+      operationId: ref_to_ref_parameter
+      tags:
+        - fake
+      responses:
+        '200':
+          $ref: '#/components/responses/ref'
+    parameters:
+      - $ref: '#/components/parameters/ref_to_uuid'
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
 components:
+  parameters:
+    ref_to_uuid:
+      description: to test ref to parameter (uuid)
+      name: ref_to_uuid
+      in: header
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: 61864654-6e6b-4152-a62f-795fdd606bc2
   requestBodies:
     UserArray:
       content:

--- a/samples/client/petstore/java/okhttp-gson-3.1/README.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/README.md
@@ -91,11 +91,12 @@ public class Example {
     defaultClient.setBasePath("http://petstore.swagger.io/v2");
 
     FakeApi apiInstance = new FakeApi(defaultClient);
+    UUID refToUuid = UUID.fromString("61864654-6e6b-4152-a62f-795fdd606bc2"); // UUID | to test ref to parameter (uuid)
     try {
-      String result = apiInstance.responseNoRef();
+      String result = apiInstance.refToRefParameter(refToUuid);
       System.out.println(result);
     } catch (ApiException e) {
-      System.err.println("Exception when calling FakeApi#responseNoRef");
+      System.err.println("Exception when calling FakeApi#refToRefParameter");
       System.err.println("Status code: " + e.getCode());
       System.err.println("Reason: " + e.getResponseBody());
       System.err.println("Response headers: " + e.getResponseHeaders());
@@ -112,6 +113,7 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*FakeApi* | [**refToRefParameter**](docs/FakeApi.md#refToRefParameter) | **GET** /ref/ref_to_parameter | 
 *FakeApi* | [**responseNoRef**](docs/FakeApi.md#responseNoRef) | **GET** /no_ref | 
 *FakeApi* | [**responseRefToNoRef**](docs/FakeApi.md#responseRefToNoRef) | **GET** /ref/no_ref | 
 *FakeApi* | [**responseRefToRef**](docs/FakeApi.md#responseRefToRef) | **GET** /ref/ref | 

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -641,7 +641,32 @@ paths:
       tags:
       - fake
       x-accepts: text/plain
+  /ref/ref_to_parameter:
+    get:
+      operationId: ref_to_ref_parameter
+      parameters:
+      - $ref: '#/components/parameters/ref_to_uuid'
+      responses:
+        "200":
+          $ref: '#/components/responses/ref'
+      tags:
+      - fake
+      x-accepts: text/plain
+    parameters:
+    - $ref: '#/components/parameters/ref_to_uuid'
 components:
+  parameters:
+    ref_to_uuid:
+      description: to test ref to parameter (uuid)
+      explode: false
+      in: header
+      name: ref_to_uuid
+      required: true
+      schema:
+        example: 61864654-6e6b-4152-a62f-795fdd606bc2
+        format: uuid
+        type: string
+      style: simple
   requestBodies:
     UserArray:
       content:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/FakeApi.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/FakeApi.md
@@ -4,10 +4,71 @@ All URIs are relative to *http://petstore.swagger.io/v2*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**refToRefParameter**](FakeApi.md#refToRefParameter) | **GET** /ref/ref_to_parameter |  |
 | [**responseNoRef**](FakeApi.md#responseNoRef) | **GET** /no_ref |  |
 | [**responseRefToNoRef**](FakeApi.md#responseRefToNoRef) | **GET** /ref/no_ref |  |
 | [**responseRefToRef**](FakeApi.md#responseRefToRef) | **GET** /ref/ref |  |
 
+
+<a id="refToRefParameter"></a>
+# **refToRefParameter**
+> String refToRefParameter(refToUuid)
+
+
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.FakeApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://petstore.swagger.io/v2");
+
+    FakeApi apiInstance = new FakeApi(defaultClient);
+    UUID refToUuid = UUID.fromString("61864654-6e6b-4152-a62f-795fdd606bc2"); // UUID | to test ref to parameter (uuid)
+    try {
+      String result = apiInstance.refToRefParameter(refToUuid);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling FakeApi#refToRefParameter");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **refToUuid** | **UUID**| to test ref to parameter (uuid) | |
+
+### Return type
+
+**String**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** |  |  -  |
 
 <a id="responseNoRef"></a>
 # **responseNoRef**

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/api/FakeApi.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/api/FakeApi.java
@@ -27,6 +27,7 @@ import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 
 
+import java.util.UUID;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -71,6 +72,132 @@ public class FakeApi {
         this.localCustomBaseUrl = customBaseUrl;
     }
 
+    /**
+     * Build call for refToRefParameter
+     * @param refToUuid to test ref to parameter (uuid) (required)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call refToRefParameterCall(UUID refToUuid, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/ref/ref_to_parameter";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (refToUuid != null) {
+            localVarHeaderParams.put("ref_to_uuid", localVarApiClient.parameterToString(refToUuid));
+        }
+
+        final String[] localVarAccepts = {
+            "text/plain"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call refToRefParameterValidateBeforeCall(UUID refToUuid, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'refToUuid' is set
+        if (refToUuid == null) {
+            throw new ApiException("Missing the required parameter 'refToUuid' when calling refToRefParameter(Async)");
+        }
+
+        return refToRefParameterCall(refToUuid, _callback);
+
+    }
+
+    /**
+     * 
+     * 
+     * @param refToUuid to test ref to parameter (uuid) (required)
+     * @return String
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public String refToRefParameter(UUID refToUuid) throws ApiException {
+        ApiResponse<String> localVarResp = refToRefParameterWithHttpInfo(refToUuid);
+        return localVarResp.getData();
+    }
+
+    /**
+     * 
+     * 
+     * @param refToUuid to test ref to parameter (uuid) (required)
+     * @return ApiResponse&lt;String&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<String> refToRefParameterWithHttpInfo(UUID refToUuid) throws ApiException {
+        okhttp3.Call localVarCall = refToRefParameterValidateBeforeCall(refToUuid, null);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     *  (asynchronously)
+     * 
+     * @param refToUuid to test ref to parameter (uuid) (required)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td>  </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call refToRefParameterAsync(UUID refToUuid, final ApiCallback<String> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = refToRefParameterValidateBeforeCall(refToUuid, _callback);
+        Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
     /**
      * Build call for responseNoRef
      * @param _callback Callback for upload/download progress


### PR DESCRIPTION
- dereference parameters in OpenAPI 3.1 spec
- add tests

to fix https://github.com/OpenAPITools/openapi-generator/issues/17160

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 