### PR TITLE
fix(go-server): ensure original filename can be deduced from tmp file

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/routers.mustache
@@ -169,7 +169,9 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 
 	defer formFile.Close()
 
-	file, err := os.CreateTemp("", fileHeader.Filename)
+	// Use .* as suffix, because the asterisk is a placeholder for the random value,
+	// and the period allows consumers of this file to remove the suffix to obtain the original file name
+	file, err := os.CreateTemp("", fileHeader.Filename+".*")
 	if err != nil {
 		return nil, err
 	}

--- a/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/routers.go
@@ -136,7 +136,9 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 
 	defer formFile.Close()
 
-	file, err := os.CreateTemp("", fileHeader.Filename)
+	// Use .* as suffix, because the asterisk is a placeholder for the random value,
+	// and the period allows consumers of this file to remove the suffix to obtain the original file name
+	file, err := os.CreateTemp("", fileHeader.Filename+".*")
 	if err != nil {
 		return nil, err
 	}

--- a/samples/server/petstore/go-api-server/go/routers.go
+++ b/samples/server/petstore/go-api-server/go/routers.go
@@ -140,7 +140,9 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 
 	defer formFile.Close()
 
-	file, err := os.CreateTemp("", fileHeader.Filename)
+	// Use .* as suffix, because the asterisk is a placeholder for the random value,
+	// and the period allows consumers of this file to remove the suffix to obtain the original file name
+	file, err := os.CreateTemp("", fileHeader.Filename+".*")
 	if err != nil {
 		return nil, err
 	}

--- a/samples/server/petstore/go-chi-server/go/routers.go
+++ b/samples/server/petstore/go-chi-server/go/routers.go
@@ -136,7 +136,9 @@ func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error
 
 	defer formFile.Close()
 
-	file, err := os.CreateTemp("", fileHeader.Filename)
+	// Use .* as suffix, because the asterisk is a placeholder for the random value,
+	// and the period allows consumers of this file to remove the suffix to obtain the original file name
+	file, err := os.CreateTemp("", fileHeader.Filename+".*")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently for the go-server, we're taking uploaded files (multipart/form-data), reading them and creating tmp files for them. There was some unexpected behaviour there, one of which was that this function returns an already closed file, so consumers will really only use the filename to manually open it from disk again, but also since it uses the default tmpfile creation with a random value suffixed, it's "impossible" to go back to the original filename (unless assuming the suffix is always fixed length, but meh).

My preferred approach would be something along these lines, but that actually changes behaviour (not putting the files on disk at all), so that could be a breaking change (especially as existing users will be taking the filename, and reopening it from disk, which won't work with this approach), so my actual proposal is in the PR:

```go
// readFileHeaderToTempFile reads multipart.FileHeader and writes it to a temporary file
func readFileHeaderToTempFile(fileHeader *multipart.FileHeader) (*os.File, error) {
	formFile, err := fileHeader.Open()
	if err != nil {
		return nil, err
	}

	defer formFile.Close()

	reader, writer, err := os.Pipe()

	if err != nil {
		return nil, err
	}

	go func() {
		if writer == nil {
			return
		}

		if _, err := io.Copy(writer, formFile); err != nil {
			// Log this? Return an error?
		}

		if err := writer.Close(); err != nil {
			// Log this? Return an error?
		}
	}()

	return os.NewFile(reader.Fd(), fileHeader.Filename), nil
}
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. /cc @lwj5
