### PR TITLE
Fix missing array description in 3.1 spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -940,6 +940,17 @@ public class OpenAPINormalizer {
             String type = String.valueOf(schema.getTypes().iterator().next());
             if ("array".equals(type)) {
                 ArraySchema as = new ArraySchema();
+                as.setDescription(schema.getDescription());
+                as.setDefault(schema.getDefault());
+                if (schema.getExample() != null) {
+                    as.setExample(schema.getExample());
+                }
+                if (schema.getExamples() != null) {
+                    as.setExamples(schema.getExamples());
+                }
+                as.setMinItems(schema.getMinItems());
+                as.setMaxItems(schema.getMaxItems());
+                as.setExtensions(schema.getExtensions());
                 as.setXml(schema.getXml());
                 // `items` is also a json schema
                 if (StringUtils.isNotEmpty(schema.getItems().get$ref())) {

--- a/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/java/petstore.yaml
@@ -842,3 +842,8 @@ components:
     any_type_test:
       properties:
         any_type_property: {}
+        array_prop:
+          type: array
+          description: test array in 3.1 spec
+          items:
+            type: string

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -907,6 +907,11 @@ components:
     any_type_test:
       properties:
         any_type_property: {}
+        array_prop:
+          description: test array in 3.1 spec
+          items:
+            type: string
+          type: array
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/AnyTypeTest.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/AnyTypeTest.md
@@ -8,6 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**anyTypeProperty** | **Object** |  |  [optional] |
+|**arrayProp** | **List&lt;String&gt;** | test array in 3.1 spec |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
@@ -20,7 +20,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
@@ -56,6 +58,10 @@ public class AnyTypeTest {
   @SerializedName(SERIALIZED_NAME_ANY_TYPE_PROPERTY)
   private Object anyTypeProperty = null;
 
+  public static final String SERIALIZED_NAME_ARRAY_PROP = "array_prop";
+  @SerializedName(SERIALIZED_NAME_ARRAY_PROP)
+  private List<String> arrayProp;
+
   public AnyTypeTest() {
   }
 
@@ -75,6 +81,33 @@ public class AnyTypeTest {
 
   public void setAnyTypeProperty(Object anyTypeProperty) {
     this.anyTypeProperty = anyTypeProperty;
+  }
+
+
+  public AnyTypeTest arrayProp(List<String> arrayProp) {
+    this.arrayProp = arrayProp;
+    return this;
+  }
+
+  public AnyTypeTest addArrayPropItem(String arrayPropItem) {
+    if (this.arrayProp == null) {
+      this.arrayProp = new ArrayList<>();
+    }
+    this.arrayProp.add(arrayPropItem);
+    return this;
+  }
+
+   /**
+   * test array in 3.1 spec
+   * @return arrayProp
+  **/
+  @javax.annotation.Nullable
+  public List<String> getArrayProp() {
+    return arrayProp;
+  }
+
+  public void setArrayProp(List<String> arrayProp) {
+    this.arrayProp = arrayProp;
   }
 
   /**
@@ -132,7 +165,8 @@ public class AnyTypeTest {
       return false;
     }
     AnyTypeTest anyTypeTest = (AnyTypeTest) o;
-    return Objects.equals(this.anyTypeProperty, anyTypeTest.anyTypeProperty)&&
+    return Objects.equals(this.anyTypeProperty, anyTypeTest.anyTypeProperty) &&
+        Objects.equals(this.arrayProp, anyTypeTest.arrayProp)&&
         Objects.equals(this.additionalProperties, anyTypeTest.additionalProperties);
   }
 
@@ -142,7 +176,7 @@ public class AnyTypeTest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(anyTypeProperty, additionalProperties);
+    return Objects.hash(anyTypeProperty, arrayProp, additionalProperties);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -157,6 +191,7 @@ public class AnyTypeTest {
     StringBuilder sb = new StringBuilder();
     sb.append("class AnyTypeTest {\n");
     sb.append("    anyTypeProperty: ").append(toIndentedString(anyTypeProperty)).append("\n");
+    sb.append("    arrayProp: ").append(toIndentedString(arrayProp)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -181,6 +216,7 @@ public class AnyTypeTest {
     // a set of all properties/fields (JSON key names)
     openapiFields = new HashSet<String>();
     openapiFields.add("any_type_property");
+    openapiFields.add("array_prop");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();
@@ -199,6 +235,10 @@ public class AnyTypeTest {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("array_prop") != null && !jsonObj.get("array_prop").isJsonNull() && !jsonObj.get("array_prop").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field `array_prop` to be an array in the JSON string but got `%s`", jsonObj.get("array_prop").toString()));
+      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {


### PR DESCRIPTION
Fix missing array description in 3.1 spec

to fix https://github.com/OpenAPITools/openapi-generator/issues/17423

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

FYI @OpenAPITools/generator-core-team 