### PR TITLE
[POSTMAN] Add tests to verify generated Postman samples

### DIFF
--- a/samples/schema/postman-collection/python/test/test_auth.py
+++ b/samples/schema/postman-collection/python/test/test_auth.py
@@ -1,0 +1,34 @@
+"""
+    Testing Postman generator output
+"""
+from __future__ import absolute_import
+
+import unittest
+
+import json
+
+
+class TestParameters(unittest.TestCase):
+
+    def setUp(self):
+        with open('./postman.json', 'r') as file:
+            self.json_data = json.load(file)
+
+    def tearDown(self):
+        pass
+
+    def test_security_schemes(self):
+        # auth
+        self.assertEqual(self.json_data['auth']['type'], 'basic')
+
+        self.assertEqual(self.json_data['auth']['basic'][0]['key'], 'username')
+        self.assertEqual(self.json_data['auth']['basic'][0]['value'], '{{USERNAME}}')
+        self.assertEqual(self.json_data['auth']['basic'][0]['type'], 'string')
+
+        self.assertEqual(self.json_data['auth']['basic'][1]['key'], 'password')
+        self.assertEqual(self.json_data['auth']['basic'][1]['value'], '{{PASSWORD}}')
+        self.assertEqual(self.json_data['auth']['basic'][1]['type'], 'string')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/schema/postman-collection/python/test/test_endpoints.py
+++ b/samples/schema/postman-collection/python/test/test_endpoints.py
@@ -1,0 +1,27 @@
+"""
+    Testing Postman generator output
+"""
+from __future__ import absolute_import
+
+import unittest
+
+import json
+
+
+class TestParameters(unittest.TestCase):
+
+    def setUp(self):
+        with open('./postman.json', 'r') as file:
+            self.json_data = json.load(file)
+
+    def tearDown(self):
+        pass
+
+    def test_endpoint_deprecated(self):
+        # path
+        path = self.json_data['item'][0]['item'][0]
+        self.assertEqual(path['name'], '/users/:userId (DEPRECATED)')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/samples/schema/postman-collection/python/test/test_parameters.py
+++ b/samples/schema/postman-collection/python/test/test_parameters.py
@@ -25,7 +25,25 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(request['url']['query'][0]['key'], 'pUserId')
         self.assertEqual(request['url']['query'][0]['value'], '888')
         self.assertEqual(request['url']['query'][0]['description'], 'Query Id.')
+
+    def test_request_parameter_required(self):
+        # request url
+        request = self.json_data['item'][2]['item'][1]['item'][0]['request']
+        self.assertEqual(request['url']['raw'], '{{baseUrl}}/users/')
+        # first query parameter
         self.assertEqual(request['url']['query'][0]['disabled'], False)
+
+    def test_request_header(self):
+        # request url
+        request = self.json_data['item'][2]['item'][1]['item'][0]['request']
+        self.assertEqual(request['url']['raw'], '{{baseUrl}}/users/')
+        # headers
+        self.assertEqual(request['header'][0]['key'], 'Accept')
+        self.assertEqual(request['header'][0]['disabled'], False)
+        self.assertEqual(request['header'][1]['key'], 'Custom-Header')
+        self.assertEqual(request['header'][1]['disabled'], True)
+        self.assertEqual(request['header'][2]['key'], 'Another-Custom-Header')
+        self.assertEqual(request['header'][2]['disabled'], False)
 
 
 if __name__ == '__main__':

--- a/samples/schema/postman-collection/python/test/test_variables.py
+++ b/samples/schema/postman-collection/python/test/test_variables.py
@@ -1,0 +1,32 @@
+"""
+    Testing Postman generator output
+"""
+from __future__ import absolute_import
+
+import unittest
+
+import json
+
+
+class TestParameters(unittest.TestCase):
+
+    def setUp(self):
+        with open('./postman.json', 'r') as file:
+            self.json_data = json.load(file)
+
+    def tearDown(self):
+        pass
+
+    def test_security_schemes(self):
+        # variable
+        variable = self.json_data['variable']
+
+        self.assertEqual(len(variable), 4)
+
+        self.assertEqual(variable[0]['key'], 'baseUrl')
+        self.assertEqual(variable[0]['value'], 'http://localhost:{port}/{version}')
+        self.assertEqual(variable[0]['type'], 'string')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add more Python tests to verify the generated Postman samples

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@gcatanese @wing328 