### PR TITLE
[POSTMAN] Remove tests replaced with Python sample testing

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -403,29 +403,6 @@ public class PostmanCollectionCodegenTest {
     }
 
     @Test
-    public void testDeprecatedEndpoint() throws Exception {
-
-        File output = Files.createTempDirectory("postmantest_").toFile();
-        output.deleteOnExit();
-
-        final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("postman-collection")
-                .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
-                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
-
-        DefaultGenerator generator = new DefaultGenerator();
-        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
-
-        System.out.println(files);
-        files.forEach(File::deleteOnExit);
-
-        Path path = Paths.get(output + "/postman.json");
-        assertFileExists(path);
-        // verify request name (from path)
-        assertFileContains(path, "(DEPRECATED)");
-    }
-
-    @Test
     public void testGeneratedVariables() throws Exception {
 
         File output = Files.createTempDirectory("postmantest_").toFile();
@@ -478,36 +455,6 @@ public class PostmanCollectionCodegenTest {
         assertFileNotContains(path, "\\\"dateOfBirth\\\" : \\\"{{$isoTimestamp}}\\\"");
 
     }
-
-    @Test
-    public void testHeaderParameters() throws IOException {
-
-        File output = Files.createTempDirectory("postmantest_").toFile();
-        output.deleteOnExit();
-
-        final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("postman-collection")
-                .setInputSpec("./src/test/resources/SampleProject.yaml")
-                .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
-                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
-
-        final ClientOptInput clientOptInput = configurator.toClientOptInput();
-        DefaultGenerator generator = new DefaultGenerator();
-        List<File> files = generator.opts(clientOptInput).generate();
-
-        files.forEach(File::deleteOnExit);
-
-        Path path = Paths.get(output + "/postman.json");
-        TestUtils.assertFileExists(path);
-        TestUtils.assertFileContains(path, "{ \"key\": \"Content-Type\", \"value\": \"application/json\"");
-        TestUtils.assertFileContains(path, "{ \"key\": \"Accept\", \"value\": \"application/json\"");
-        // header without default value (disabled: true)
-        TestUtils.assertFileContains(path, "{ \"key\": \"Custom-Header\", \"value\": \"\", \"description\": \"Custom HTTP header\", \"disabled\": true");
-        // header with default value (disabled: false)
-        TestUtils.assertFileContains(path, "{ \"key\": \"Another-Custom-Header\", \"value\": \"abc\", \"description\": \"Custom HTTP header with default\", \"disabled\": false");
-
-    }
-
 
     @Test
     public void testFormatDescription() {
@@ -755,27 +702,4 @@ public class PostmanCollectionCodegenTest {
         assertEquals(true, postmanV2Generator.codegenOperationsByTag.containsKey("default"));
     }
 
-    @Test
-    public void testRequiredQueryParameter() throws IOException {
-
-        File output = Files.createTempDirectory("postmantest_").toFile();
-        output.deleteOnExit();
-
-        final CodegenConfigurator configurator = new CodegenConfigurator()
-                .setGeneratorName("postman-collection")
-                .setInputSpec("src/test/resources/3_0/postman-collection/SampleProject.yaml")
-                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
-
-        DefaultGenerator generator = new DefaultGenerator();
-        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
-
-        System.out.println(files);
-        files.forEach(File::deleteOnExit);
-
-        Path path = Paths.get(output + "/postman.json");
-        TestUtils.assertFileExists(path);
-        // verify param pUserId is set as disabled=false
-        TestUtils.assertFileContains(path, "{ \"key\": \"pUserId\", \"value\": \"888\", \"description\": \"Query Id.\", \"disabled\": false");
-
-    }
 }


### PR DESCRIPTION
Remove tests that are now replaced with Python sample testing

@wing328 Sorry, forgot to push those changes

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
