### PR TITLE
Fix Kotlin templates to be compatible with Kotlin K2 compiler

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/apiController.mustache
@@ -13,7 +13,7 @@ import java.util.Optional
 class {{classname}}Controller(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: {{classname}}Delegate?
 ) : {{classname}} {
-    private val delegate: {{classname}}Delegate
+    private lateinit var delegate: {{classname}}Delegate
 
     init {
         this.delegate = Optional.ofNullable(delegate).orElse(object : {{classname}}Delegate {})

--- a/modules/openapi-generator/src/main/resources/kotlin-vertx-server/apiProxy.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-vertx-server/apiProxy.mustache
@@ -20,7 +20,7 @@ import com.google.gson.Gson
 {{/imports}}
 
 class {{classname}}VertxProxyHandler(private val vertx: Vertx, private val service: {{classname}}, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/PetApiController.kt
@@ -10,7 +10,7 @@ import java.util.Optional
 class PetApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: PetApiDelegate?
 ) : PetApi {
-    private val delegate: PetApiDelegate
+    private lateinit var delegate: PetApiDelegate
 
     init {
         this.delegate = Optional.ofNullable(delegate).orElse(object : PetApiDelegate {})

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/StoreApiController.kt
@@ -10,7 +10,7 @@ import java.util.Optional
 class StoreApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: StoreApiDelegate?
 ) : StoreApi {
-    private val delegate: StoreApiDelegate
+    private lateinit var delegate: StoreApiDelegate
 
     init {
         this.delegate = Optional.ofNullable(delegate).orElse(object : StoreApiDelegate {})

--- a/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
+++ b/samples/server/petstore/kotlin-springboot-delegate/src/main/kotlin/org/openapitools/api/UserApiController.kt
@@ -10,7 +10,7 @@ import java.util.Optional
 class UserApiController(
         @org.springframework.beans.factory.annotation.Autowired(required = false) delegate: UserApiDelegate?
 ) : UserApi {
-    private val delegate: UserApiDelegate
+    private lateinit var delegate: UserApiDelegate
 
     init {
         this.delegate = Optional.ofNullable(delegate).orElse(object : UserApiDelegate {})

--- a/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt
@@ -20,7 +20,7 @@ import org.openapitools.server.api.model.ModelApiResponse
 import org.openapitools.server.api.model.Pet
 
 class PetApiVertxProxyHandler(private val vertx: Vertx, private val service: PetApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt
@@ -19,7 +19,7 @@ import com.google.gson.Gson
 import org.openapitools.server.api.model.Order
 
 class StoreApiVertxProxyHandler(private val vertx: Vertx, private val service: StoreApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin-vertx-modelMutable/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt
@@ -19,7 +19,7 @@ import com.google.gson.Gson
 import org.openapitools.server.api.model.User
 
 class UserApiVertxProxyHandler(private val vertx: Vertx, private val service: UserApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/PetApiVertxProxyHandler.kt
@@ -20,7 +20,7 @@ import org.openapitools.server.api.model.ModelApiResponse
 import org.openapitools.server.api.model.Pet
 
 class PetApiVertxProxyHandler(private val vertx: Vertx, private val service: PetApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/StoreApiVertxProxyHandler.kt
@@ -19,7 +19,7 @@ import com.google.gson.Gson
 import org.openapitools.server.api.model.Order
 
 class StoreApiVertxProxyHandler(private val vertx: Vertx, private val service: StoreApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {

--- a/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt
+++ b/samples/server/petstore/kotlin/vertx/src/main/kotlin/org/openapitools/server/api/verticle/UserApiVertxProxyHandler.kt
@@ -19,7 +19,7 @@ import com.google.gson.Gson
 import org.openapitools.server.api.model.User
 
 class UserApiVertxProxyHandler(private val vertx: Vertx, private val service: UserApi, topLevel: Boolean, private val timeoutSeconds: Long) : ProxyHandler() {
-    private val timerID: Long
+    private lateinit var timerID: Long
     private var lastAccessed: Long = 0
     init {
         try {


### PR DESCRIPTION
See https://github.com/OpenAPITools/openapi-generator/issues/17465

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)
