### PR TITLE
Adds a useObjectInitializerApproach option as proposed in #17147

### DIFF
--- a/docs/generators/csharp.md
+++ b/docs/generators/csharp.md
@@ -52,6 +52,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |useSourceGeneration|Use source generation where available (only `generichost` library supports this option).| |false|
 |validatable|Generates self-validatable models.| |true|
 |zeroBasedEnums|Enumerations with string values will start from 0 when true, 1 when false. If not set, enumerations with string values will start from 0 if the first value is 'unknown', case insensitive.| |null|
+|useObjectInitializerApproach|Adds the required keyword to required properties, the init keyword to required readonly properties and creates a parameterless constructor (only `generichost` library supports this option).| |false|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -60,6 +60,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
     protected boolean netCoreProjectFileFlag = false;
     protected boolean nullReferenceTypesFlag = false;
     protected boolean useSourceGeneration = false;
+    protected boolean useObjectInitializerApproach = false;
 
     protected String modelPropertyNaming = CodegenConstants.MODEL_PROPERTY_NAMING_TYPE.PascalCase.name();
 
@@ -1602,6 +1603,14 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
 
     public boolean getUseSourceGeneration() {
         return this.useSourceGeneration;
+    }
+
+    public void setUseObjectInitializerApproach(final Boolean useObjectInitializerApproach) {
+        this.useObjectInitializerApproach = useObjectInitializerApproach;
+    }
+
+    public boolean getUseObjectInitializerApproach() {
+        return this.useObjectInitializerApproach;
     }
 
     public void setInterfacePrefix(final String interfacePrefix) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -1512,6 +1512,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             if (model.parentModel != null && model.parentModel.allVars.stream().anyMatch(v -> v.baseName.equals(property.baseName))) {
                 property.isInherited = true;
             }
+
+            String setterKeyword;
+            if (!property.isReadOnly) {
+                setterKeyword = "set";
+            } else {
+                setterKeyword = "init";
+            }
+            property.vendorExtensions.put("x-csharp-setter-keyword", setterKeyword);
         }
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CSharpClientCodegen.java
@@ -328,6 +328,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 "Use source generation where available (only `generichost` library supports this option).",
                 this.getUseSourceGeneration());
 
+        addSwitch("useObjectInitializerApproach",
+                "Adds the required keyword to required properties, the init keyword to required readonly properties and creates a parameterless constructor (only `generichost` library supports this option).",
+                this.getUseObjectInitializerApproach());
+
         supportedLibraries.put(GENERICHOST, "HttpClient with Generic Host dependency injection (https://docs.microsoft.com/en-us/dotnet/core/extensions/generic-host) "
                 + "(Experimental. Subject to breaking changes without notice.)");
         supportedLibraries.put(HTTPCLIENT, "HttpClient (https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient) "
@@ -782,6 +786,7 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
         syncBooleanProperty(additionalProperties, CodegenConstants.USE_ONEOF_DISCRIMINATOR_LOOKUP, this::setUseOneOfDiscriminatorLookup, this.useOneOfDiscriminatorLookup);
         syncBooleanProperty(additionalProperties, "supportsFileParameters", this::setSupportsFileParameters, this.supportsFileParameters);
         syncBooleanProperty(additionalProperties, "useSourceGeneration", this::setUseSourceGeneration, this.useSourceGeneration);
+        syncBooleanProperty(additionalProperties, "useObjectInitializerApproach", this::setUseObjectInitializerApproach, this.useObjectInitializerApproach);
 
         final String testPackageName = testPackageName();
         String packageFolder = sourceFolder + File.separator + packageName;
@@ -855,6 +860,14 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
             throw new RuntimeException("Source generation is only compatible with .Net 7 or later.");
         }
         this.useSourceGeneration = useSourceGeneration;
+    }
+
+    @Override
+    public void setUseObjectInitializerApproach(final Boolean useObjectInitializerApproach) {
+        if (useObjectInitializerApproach && !this.additionalProperties.containsKey(NET_70_OR_LATER)) {
+            throw new RuntimeException("Object initializer approach is only compatible with .Net 7 or later.");
+        }
+        this.useObjectInitializerApproach = useObjectInitializerApproach;
     }
 
     public void setClientPackage(String clientPackage) {
@@ -1513,10 +1526,10 @@ public class CSharpClientCodegen extends AbstractCSharpCodegen {
                 property.isInherited = true;
             }
 
-            String setterKeyword;
+            String setterKeyword = null;
             if (!property.isReadOnly) {
                 setterKeyword = "set";
-            } else {
+            } else if (useObjectInitializerApproach) {
                 setterKeyword = "init";
             }
             property.vendorExtensions.put("x-csharp-setter-keyword", setterKeyword);

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/model.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/model.mustache
@@ -20,6 +20,7 @@ using System.Text.Json.Serialization;
 {{#validatable}}
 using System.ComponentModel.DataAnnotations;
 {{/validatable}}
+using System.Diagnostics.CodeAnalysis;
 {{#useCompareNetObjects}}
 using OpenAPIClientUtils = {{packageName}}.Client.ClientUtils;
 {{/useCompareNetObjects}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/model.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/model.mustache
@@ -20,7 +20,9 @@ using System.Text.Json.Serialization;
 {{#validatable}}
 using System.ComponentModel.DataAnnotations;
 {{/validatable}}
+{{#useObjectInitializerApproach}}
 using System.Diagnostics.CodeAnalysis;
+{{/useObjectInitializerApproach}}
 {{#useCompareNetObjects}}
 using OpenAPIClientUtils = {{packageName}}.Client.ClientUtils;
 {{/useCompareNetObjects}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -15,9 +15,11 @@
         {{#allVars}}
         /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}</param>
         {{/allVars}}
+        {{#useObjectInitializerApproach}}
         {{#hasRequired}}
         [SetsRequiredMembers]
         {{/hasRequired}}
+        {{/useObjectInitializerApproach}}
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{{dataType}}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}  {{#model.composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{dataType}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/model.composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{#parentModel.composedSchemas.oneOf}}{{#lambda.camelcase_param}}{{parent}}{{/lambda.camelcase_param}}.{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}  {{/parentModel.composedSchemas.oneOf}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}
@@ -52,9 +54,11 @@
         {{^composedSchemas.anyOf}}
         [JsonConstructor]
         {{/composedSchemas.anyOf}}
+        {{#useObjectInitializerApproach}}
         {{#hasRequired}}
         [SetsRequiredMembers]
         {{/hasRequired}}
+        {{/useObjectInitializerApproach}}
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{name}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}
@@ -74,6 +78,7 @@
         }
 
         {{/composedSchemas.oneOf}}
+        {{#useObjectInitializerApproach}}
         {{#hasRequired}}
         /// <summary>
         /// Initializes a new instance of the <see cref="{{classname}}" /> class to be used with object initializers.
@@ -81,6 +86,7 @@
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}() {}
 
         {{/hasRequired}}
+        {{/useObjectInitializerApproach}}
         partial void OnCreated();
 
         {{#vars}}
@@ -213,7 +219,7 @@
         {{#deprecated}}
         [Obsolete]
         {{/deprecated}}
-        public{{^isReadOnly}}{{#required}} required{{/required}}{{/isReadOnly}} {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{#vendorExtensions.x-csharp-setter-keyword}}{{.}}; {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}{{^required}}{ get { return this. {{name}}Option; } {{#vendorExtensions.x-csharp-setter-keyword}}{{.}} { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}
+        public{{#useObjectInitializerApproach}}{{^isReadOnly}}{{#required}} required{{/required}}{{/isReadOnly}}{{/useObjectInitializerApproach}} {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{#vendorExtensions.x-csharp-setter-keyword}}{{.}}; {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}{{^required}}{ get { return this. {{name}}Option; } {{#vendorExtensions.x-csharp-setter-keyword}}{{.}} { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}
 
         {{/isInherited}}
         {{/isEnum}}

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/modelGeneric.mustache
@@ -15,6 +15,9 @@
         {{#allVars}}
         /// <param name="{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}">{{description}}{{^description}}{{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}{{/description}}{{#defaultValue}} (default to {{.}}){{/defaultValue}}</param>
         {{/allVars}}
+        {{#hasRequired}}
+        [SetsRequiredMembers]
+        {{/hasRequired}}
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{{dataType}}} {{#lambda.camelcase_param}}{{name}}{{/lambda.camelcase_param}}  {{#model.composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{dataType}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/model.composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{#parentModel.composedSchemas.oneOf}}{{#lambda.camelcase_param}}{{parent}}{{/lambda.camelcase_param}}.{{#lambda.titlecase}}{{baseType}}{{/lambda.titlecase}}  {{/parentModel.composedSchemas.oneOf}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}
@@ -49,6 +52,9 @@
         {{^composedSchemas.anyOf}}
         [JsonConstructor]
         {{/composedSchemas.anyOf}}
+        {{#hasRequired}}
+        [SetsRequiredMembers]
+        {{/hasRequired}}
         {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}({{#lambda.joinWithComma}}{{#composedSchemas.anyOf}}{{^required}}Option<{{/required}}{{{name}}}{{>NullConditionalProperty}}{{^required}}>{{/required}} {{#lambda.camelcase_param}}{{baseType}}{{/lambda.camelcase_param}}  {{/composedSchemas.anyOf}}{{>ModelSignature}}{{/lambda.joinWithComma}}){{#parent}} : base({{#lambda.joinWithComma}}{{>ModelBaseSignature}}{{/lambda.joinWithComma}}){{/parent}}
         {
             {{#composedSchemas.anyOf}}
@@ -68,6 +74,13 @@
         }
 
         {{/composedSchemas.oneOf}}
+        {{#hasRequired}}
+        /// <summary>
+        /// Initializes a new instance of the <see cref="{{classname}}" /> class to be used with object initializers.
+        /// </summary>
+        {{#model.vendorExtensions.x-model-is-mutatable}}{{>visibility}}{{/model.vendorExtensions.x-model-is-mutatable}}{{^model.vendorExtensions.x-model-is-mutatable}}internal{{/model.vendorExtensions.x-model-is-mutatable}} {{classname}}() {}
+
+        {{/hasRequired}}
         partial void OnCreated();
 
         {{#vars}}
@@ -200,7 +213,7 @@
         {{#deprecated}}
         [Obsolete]
         {{/deprecated}}
-        public {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{^isReadOnly}}set; {{/isReadOnly}}}{{/required}}{{^required}}{ get { return this. {{name}}Option; } {{^isReadOnly}}set { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/isReadOnly}}}{{/required}}
+        public{{^isReadOnly}}{{#required}} required{{/required}}{{/isReadOnly}} {{{datatypeWithEnum}}}{{#lambda.first}}{{#isNullable}}{{>NullConditionalProperty}}  {{/isNullable}}{{^required}}{{nrt?}}{{^nrt}}{{#vendorExtensions.x-is-value-type}}?{{/vendorExtensions.x-is-value-type}}{{/nrt}}  {{/required}}{{/lambda.first}} {{name}} {{#required}}{ get; {{#vendorExtensions.x-csharp-setter-keyword}}{{.}}; {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}{{^required}}{ get { return this. {{name}}Option; } {{#vendorExtensions.x-csharp-setter-keyword}}{{.}} { this.{{name}}Option = new{{^net70OrLater}} Option<{{{datatypeWithEnum}}}{{>NullConditionalProperty}}>{{/net70OrLater}}(value); } {{/vendorExtensions.x-csharp-setter-keyword}}}{{/required}}
 
         {{/isInherited}}
         {{/isEnum}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This PR adds useObjectInitializerApproach to `additional-properties` for the csharp generator when using the `generichost` library. With this flag enabled the properties of generated model classes have the `required` keyword if they are required and use an `init` setter if they are read-only. It also generates a parameter less constructor if there are required properties in the model to allow the use of the object initializer and adds the `SetsRequiredMembers` attribute to the other constructors.

This should fix the issue #17147 at least when using the `generichost` library.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@mandrean, @shibayan, @Blackclaws, @lucamazzanti, @iBicha