### PR TITLE
Remove None default and typing values from non-nullable any-of / one-of fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
@@ -32,7 +32,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{vendorExtensions.x-py-name}}: {{{vendorExtensions.x-py-typing}}}
 {{/composedSchemas.anyOf}}
     if TYPE_CHECKING:
-        actual_instance: Optional[Union[{{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}]] = None
+        actual_instance: Union[{{#anyOf}}{{{.}}}{{^-last}}, {{/-last}}{{/anyOf}}{{#isNullable}}, None{{/isNullable}}]
     else:
         actual_instance: Any = None
     any_of_schemas: List[str] = Literal[{{#lambda.uppercase}}{{{classname}}}{{/lambda.uppercase}}_ANY_OF_SCHEMAS]

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -30,7 +30,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     # data type: {{{dataType}}}
     {{vendorExtensions.x-py-name}}: {{{vendorExtensions.x-py-typing}}}
 {{/composedSchemas.oneOf}}
-    actual_instance: Optional[Union[{{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}]] = None
+    actual_instance: Union[{{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}{{#isNullable}}, None{{/isNullable}}]
     one_of_schemas: List[str] = Literal[{{#oneOf}}"{{.}}"{{^-last}}, {{/-last}}{{/oneOf}}]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
@@ -44,7 +44,7 @@ class AnyOfColor(BaseModel):
     # data type: str
     anyof_schema_3_validator: Optional[Annotated[str, Field(min_length=7, strict=True, max_length=7)]] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
-        actual_instance: Optional[Union[List[int], str]] = None
+        actual_instance: Union[List[int], str]
     else:
         actual_instance: Any = None
     any_of_schemas: List[str] = Literal[ANYOFCOLOR_ANY_OF_SCHEMAS]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
@@ -42,7 +42,7 @@ class AnyOfPig(BaseModel):
     # data type: DanishPig
     anyof_schema_2_validator: Optional[DanishPig] = None
     if TYPE_CHECKING:
-        actual_instance: Optional[Union[BasquePig, DanishPig]] = None
+        actual_instance: Union[BasquePig, DanishPig]
     else:
         actual_instance: Any = None
     any_of_schemas: List[str] = Literal[ANYOFPIG_ANY_OF_SCHEMAS]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
@@ -42,7 +42,7 @@ class Color(BaseModel):
     oneof_schema_2_validator: Optional[Annotated[List[Annotated[int, Field(le=255, strict=True, ge=0)]], Field(min_length=4, max_length=4)]] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
     oneof_schema_3_validator: Optional[Annotated[str, Field(min_length=7, strict=True, max_length=7)]] = Field(default=None, description="Hex color string, such as #00FF00.")
-    actual_instance: Optional[Union[List[int], str]] = None
+    actual_instance: Union[List[int], str, None]
     one_of_schemas: List[str] = Literal["List[int]", "str"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
@@ -40,7 +40,7 @@ class IntOrString(BaseModel):
     oneof_schema_1_validator: Optional[Annotated[int, Field(strict=True, ge=10)]] = None
     # data type: str
     oneof_schema_2_validator: Optional[StrictStr] = None
-    actual_instance: Optional[Union[int, str]] = None
+    actual_instance: Union[int, str]
     one_of_schemas: List[str] = Literal["int", "str"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
@@ -40,7 +40,7 @@ class OneOfEnumString(BaseModel):
     oneof_schema_1_validator: Optional[EnumString1] = None
     # data type: EnumString2
     oneof_schema_2_validator: Optional[EnumString2] = None
-    actual_instance: Optional[Union[EnumString1, EnumString2]] = None
+    actual_instance: Union[EnumString1, EnumString2]
     one_of_schemas: List[str] = Literal["EnumString1", "EnumString2"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
@@ -40,7 +40,7 @@ class Pig(BaseModel):
     oneof_schema_1_validator: Optional[BasquePig] = None
     # data type: DanishPig
     oneof_schema_2_validator: Optional[DanishPig] = None
-    actual_instance: Optional[Union[BasquePig, DanishPig]] = None
+    actual_instance: Union[BasquePig, DanishPig]
     one_of_schemas: List[str] = Literal["BasquePig", "DanishPig"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
@@ -44,7 +44,7 @@ class AnyOfColor(BaseModel):
     # data type: str
     anyof_schema_3_validator: Optional[Annotated[str, Field(min_length=7, strict=True, max_length=7)]] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
-        actual_instance: Optional[Union[List[int], str]] = None
+        actual_instance: Union[List[int], str]
     else:
         actual_instance: Any = None
     any_of_schemas: List[str] = Literal[ANYOFCOLOR_ANY_OF_SCHEMAS]

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
@@ -42,7 +42,7 @@ class AnyOfPig(BaseModel):
     # data type: DanishPig
     anyof_schema_2_validator: Optional[DanishPig] = None
     if TYPE_CHECKING:
-        actual_instance: Optional[Union[BasquePig, DanishPig]] = None
+        actual_instance: Union[BasquePig, DanishPig]
     else:
         actual_instance: Any = None
     any_of_schemas: List[str] = Literal[ANYOFPIG_ANY_OF_SCHEMAS]

--- a/samples/openapi3/client/petstore/python/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/color.py
@@ -42,7 +42,7 @@ class Color(BaseModel):
     oneof_schema_2_validator: Optional[Annotated[List[Annotated[int, Field(le=255, strict=True, ge=0)]], Field(min_length=4, max_length=4)]] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
     oneof_schema_3_validator: Optional[Annotated[str, Field(min_length=7, strict=True, max_length=7)]] = Field(default=None, description="Hex color string, such as #00FF00.")
-    actual_instance: Optional[Union[List[int], str]] = None
+    actual_instance: Union[List[int], str, None]
     one_of_schemas: List[str] = Literal["List[int]", "str"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
@@ -40,7 +40,7 @@ class IntOrString(BaseModel):
     oneof_schema_1_validator: Optional[Annotated[int, Field(strict=True, ge=10)]] = None
     # data type: str
     oneof_schema_2_validator: Optional[StrictStr] = None
-    actual_instance: Optional[Union[int, str]] = None
+    actual_instance: Union[int, str]
     one_of_schemas: List[str] = Literal["int", "str"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
@@ -40,7 +40,7 @@ class OneOfEnumString(BaseModel):
     oneof_schema_1_validator: Optional[EnumString1] = None
     # data type: EnumString2
     oneof_schema_2_validator: Optional[EnumString2] = None
-    actual_instance: Optional[Union[EnumString1, EnumString2]] = None
+    actual_instance: Union[EnumString1, EnumString2]
     one_of_schemas: List[str] = Literal["EnumString1", "EnumString2"]
 
     model_config = {

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
@@ -40,7 +40,7 @@ class Pig(BaseModel):
     oneof_schema_1_validator: Optional[BasquePig] = None
     # data type: DanishPig
     oneof_schema_2_validator: Optional[DanishPig] = None
-    actual_instance: Optional[Union[BasquePig, DanishPig]] = None
+    actual_instance: Union[BasquePig, DanishPig]
     one_of_schemas: List[str] = Literal["BasquePig", "DanishPig"]
 
     model_config = {


### PR DESCRIPTION
I removed default None value and added `None` to the typing only if field is nullable. It should resolve my issue.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
