### PR TITLE
[cpp-qt-client] Add cpp-qt-client technical committee to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,14 @@ modules/openapi-generator-cli/**/* @jimschubert
 modules/openapi-generator-gradle-plugin/**/* @jimschubert
 modules/openapi-generator-maven-plugin/**/* @jimschubert
 
-# Martin Delille
+# cpp-qt-client technical committee
+modules/openapi-generator/src/main/resources/cpp-qt-client/**/* @ravinikam
+samples/client/petstore/cpp-qt/**/* @ravinikam
+modules/openapi-generator/src/main/resources/cpp-qt-client/**/* @stkrwork
+samples/client/petstore/cpp-qt/**/* @stkrwork
+modules/openapi-generator/src/main/resources/cpp-qt-client/**/* @etherealjoy
+samples/client/petstore/cpp-qt/**/* @etherealjoy
 modules/openapi-generator/src/main/resources/cpp-qt-client/**/* @martindelille
 samples/client/petstore/cpp-qt/**/* @martindelille
+modules/openapi-generator/src/main/resources/cpp-qt-client/**/* @muttleyxd
+samples/client/petstore/cpp-qt/**/* @muttleyxd


### PR DESCRIPTION
Adding the technical committee manually each time is boring. Adding the technical committee to the .github/CODEOWNERS
allow automatic notification.

Maybe someone could create on these file without pinging me to check it works well on this repo (this is the case on another repo I contribute to: https://github.com/conan-io/conan-center-index/)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@ravinikam @stkrwork @etherealjoy @muttleyxd

