### PR TITLE
[kotlin-client][jvm-spring-*] Fixed URL encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/infrastructure/RequestConfig.kt.mustache
@@ -12,6 +12,7 @@ package {{packageName}}.infrastructure
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -13,6 +13,8 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 {{/jackson}}
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
 
 {{#imports}}import {{import}}
 {{/imports}}
@@ -122,9 +124,16 @@ import {{packageName}}.infrastructure.*
         {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
 {{/hasProduces}}
 
+        val params = mutableMapOf<String, Any>(
+        {{#pathParams}}
+            "{{baseName}}" to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}{{/isContainer}},
+        {{/pathParams}}
+        )
+
         return RequestConfig(
             method = RequestMethod.{{httpMethod}},
-            path = "{{path}}"{{#pathParams}}.replace("{"+"{{baseName}}"+"}", encodeURIComponent({{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}})){{/pathParams}},
+            path = "{{path}}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = {{#hasAuthMethods}}true{{/hasAuthMethods}}{{^hasAuthMethods}}false{{/hasAuthMethods}},

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -13,7 +13,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 {{/jackson}}
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-import org.springframework.util.LinkedMultiValueMap
 
 
 {{#imports}}import {{import}}

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
@@ -32,9 +32,6 @@ open class ApiClient(protected val client: RestClient) {
             }
         }
 
-    protected fun encodeURIComponent(uriComponent: kotlin.String) =
-        UriUtils.encodeFragment(uriComponent, Charsets.UTF_8)
-
     private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/infrastructure/ApiClient.kt.mustache
@@ -4,9 +4,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.util.UriUtils
 import org.springframework.web.client.RestClient
 import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
 
@@ -37,11 +37,10 @@ open class ApiClient(protected val client: RestClient) {
 
     private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
-            builder.path(requestConfig.path).apply {
-                requestConfig.query.forEach { (name, value) ->
-                    queryParam(name, value)
-                }
-            }.build()
+            builder
+                .path(requestConfig.path)
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
 
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
@@ -14,6 +14,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 {{#imports}}import {{import}}
 {{/imports}}
@@ -126,9 +127,16 @@ import {{packageName}}.infrastructure.*
         {{/consumes}}{{/hasConsumes}}{{/hasFormParams}}{{#hasProduces}}localVariableHeaders["Accept"] = "{{#produces}}{{{mediaType}}}{{^-last}}, {{/-last}}{{/produces}}"
 {{/hasProduces}}
 
+        val params = mutableMapOf<String, Any>(
+        {{#pathParams}}
+            {{baseName}} to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}}
+        {{/pathParams}}
+        )
+
         return RequestConfig(
             method = RequestMethod.{{httpMethod}},
-            path = "{{path}}"{{#pathParams}}.replace("{"+"{{baseName}}"+"}", encodeURIComponent({{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}})){{/pathParams}},
+            path = "{{path}}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = {{#hasAuthMethods}}true{{/hasAuthMethods}}{{^hasAuthMethods}}false{{/hasAuthMethods}},

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
@@ -129,13 +129,13 @@ import {{packageName}}.infrastructure.*
 
         val params = mutableMapOf<String, Any>(
         {{#pathParams}}
-            {{baseName}} to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}}
+            "{{baseName}}" to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}},
         {{/pathParams}}
         )
 
         return RequestConfig(
             method = RequestMethod.{{httpMethod}},
-            path = "{{path}}"
+            path = "{{path}}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/api.mustache
@@ -129,7 +129,7 @@ import {{packageName}}.infrastructure.*
 
         val params = mutableMapOf<String, Any>(
         {{#pathParams}}
-            "{{baseName}}" to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}.toString(){{/isContainer}},
+            "{{baseName}}" to {{#isContainer}}{{paramName}}.joinToString(","){{/isContainer}}{{^isContainer}}{{{paramName}}}{{#isEnum}}.value{{/isEnum}}{{/isContainer}},
         {{/pathParams}}
         )
 

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
@@ -4,9 +4,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.util.UriUtils
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
 open class ApiClient(protected val client: WebClient) {

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-webclient/infrastructure/ApiClient.kt.mustache
@@ -33,19 +33,15 @@ open class ApiClient(protected val client: WebClient) {
             }
         }
 
-    protected fun encodeURIComponent(uriComponent: kotlin.String) =
-        UriUtils.encodeFragment(uriComponent, Charsets.UTF_8)
-
     private fun <I> WebClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
-            builder.path(requestConfig.path).apply {
-                requestConfig.query.forEach { (name, value) ->
-                    queryParam(name, value)
-                }
-            }.build()
+            builder
+                .path(requestConfig.path)
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
 
     private fun <I> WebClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-allOff-discriminator/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-array-simple-string-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-default-values-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-enum-default-value/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-json-request-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -69,7 +69,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet"
+            path = "/pet",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -100,12 +100,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -152,7 +152,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByStatus"
+            path = "/pet/findByStatus",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -193,7 +193,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByTags"
+            path = "/pet/findByTags",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -224,12 +224,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -266,7 +266,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/pet"
+            path = "/pet",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -298,12 +298,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -336,12 +336,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/json"
 
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}/uploadImage"
+            path = "/pet/{petId}/uploadImage",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -100,7 +100,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -224,7 +224,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -298,7 +298,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -336,7 +336,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/json"
 
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.ModelApiResponse
 import org.openapitools.client.models.Pet
@@ -63,9 +64,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet",
+            path = "/pet"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -94,9 +99,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -137,9 +147,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByStatus",
+            path = "/pet/findByStatus"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -174,9 +188,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByTags",
+            path = "/pet/findByTags"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -205,9 +223,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -238,9 +261,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/pet",
+            path = "/pet"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -270,9 +297,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -303,9 +335,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}/uploadImage"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -61,12 +61,12 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            orderId to orderId.toString()
+            "orderId" to orderId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/store/order/{orderId}"
+            path = "/store/order/{orderId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -101,7 +101,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/inventory"
+            path = "/store/inventory",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -132,12 +132,12 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            orderId to orderId.toString()
+            "orderId" to orderId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/order/{orderId}"
+            path = "/store/order/{orderId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -173,7 +173,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/store/order"
+            path = "/store/order",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -61,7 +61,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            "orderId" to orderId.toString(),
+            "orderId" to orderId,
         )
 
         return RequestConfig(
@@ -132,7 +132,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "orderId" to orderId.toString(),
+            "orderId" to orderId,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.Order
 import org.openapitools.client.infrastructure.*
@@ -59,9 +60,14 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            orderId to orderId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -90,9 +96,13 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/inventory",
+            path = "/store/inventory"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -121,9 +131,14 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            orderId to orderId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -153,9 +168,13 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/store/order",
+            path = "/store/order"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -66,7 +66,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user"
+            path = "/user",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -101,7 +101,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithArray"
+            path = "/user/createWithArray",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -136,7 +136,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithList"
+            path = "/user/createWithList",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -166,12 +166,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -202,12 +202,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -246,7 +246,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/login"
+            path = "/user/login",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -280,7 +280,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/logout"
+            path = "/user/logout",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -311,12 +311,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.User
 import org.openapitools.client.infrastructure.*
@@ -60,9 +61,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user",
+            path = "/user"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -91,9 +96,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithArray",
+            path = "/user/createWithArray"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -122,9 +131,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithList",
+            path = "/user/createWithList"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -152,9 +165,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -183,9 +201,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -218,9 +241,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/login",
+            path = "/user/login"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -248,9 +275,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/logout",
+            path = "/user/logout"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -279,9 +310,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -166,7 +166,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(
@@ -202,7 +202,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(
@@ -311,7 +311,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,9 +4,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.util.UriUtils
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
 open class ApiClient(protected val client: WebClient) {

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -33,19 +33,15 @@ open class ApiClient(protected val client: WebClient) {
             }
         }
 
-    protected fun encodeURIComponent(uriComponent: kotlin.String) =
-        UriUtils.encodeFragment(uriComponent, Charsets.UTF_8)
-
     private fun <I> WebClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
-            builder.path(requestConfig.path).apply {
-                requestConfig.query.forEach { (name, value) ->
-                    queryParam(name, value)
-                }
-            }.build()
+            builder
+                .path(requestConfig.path)
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
 
     private fun <I> WebClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -23,6 +23,8 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
 
 import org.openapitools.client.models.ModelApiResponse
 import org.openapitools.client.models.Pet
@@ -59,9 +61,13 @@ class PetApi(client: RestClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/pet",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -90,9 +96,14 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
+        val params = mutableMapOf<String, Any>(
+            "petId" to petId,
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -133,9 +144,13 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByStatus",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -170,9 +185,13 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/pet/findByTags",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -201,9 +220,14 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            "petId" to petId,
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -234,9 +258,13 @@ class PetApi(client: RestClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
             path = "/pet",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -266,9 +294,14 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+        val params = mutableMapOf<String, Any>(
+            "petId" to petId,
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -299,9 +332,14 @@ class PetApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+            "petId" to petId,
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}/uploadImage",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-import org.springframework.util.LinkedMultiValueMap
 
 
 import org.openapitools.client.models.ModelApiResponse

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -23,6 +23,8 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
 
 import org.openapitools.client.models.Order
 import org.openapitools.client.infrastructure.*
@@ -55,9 +57,14 @@ class StoreApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            "orderId" to orderId,
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -86,9 +93,13 @@ class StoreApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/store/inventory",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -117,9 +128,14 @@ class StoreApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            "orderId" to orderId,
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -149,9 +165,13 @@ class StoreApi(client: RestClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/store/order",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-import org.springframework.util.LinkedMultiValueMap
 
 
 import org.openapitools.client.models.Order

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -23,6 +23,8 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
+import org.springframework.util.LinkedMultiValueMap
+
 
 import org.openapitools.client.models.User
 import org.openapitools.client.infrastructure.*
@@ -56,9 +58,13 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -87,9 +93,13 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithArray",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -118,9 +128,13 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
             path = "/user/createWithList",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -148,9 +162,14 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            "username" to username,
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -179,9 +198,14 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            "username" to username,
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -214,9 +238,13 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/login",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -244,9 +272,13 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
             path = "/user/logout",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -275,9 +307,14 @@ class UserApi(client: RestClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+            "username" to username,
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}",
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestClientResponseException
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-import org.springframework.util.LinkedMultiValueMap
 
 
 import org.openapitools.client.models.User

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -32,9 +32,6 @@ open class ApiClient(protected val client: RestClient) {
             }
         }
 
-    protected fun encodeURIComponent(uriComponent: kotlin.String) =
-        UriUtils.encodeFragment(uriComponent, Charsets.UTF_8)
-
     private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,9 +4,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.util.UriUtils
 import org.springframework.web.client.RestClient
 import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
 
 open class ApiClient(protected val client: RestClient) {
 
@@ -37,11 +37,10 @@ open class ApiClient(protected val client: RestClient) {
 
     private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
-            builder.path(requestConfig.path).apply {
-                requestConfig.query.forEach { (name, value) ->
-                    queryParam(name, value)
-                }
-            }.build()
+            builder
+                .path(requestConfig.path)
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
 
     private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -69,7 +69,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet"
+            path = "/pet",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -100,12 +100,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -152,7 +152,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByStatus"
+            path = "/pet/findByStatus",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -193,7 +193,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByTags"
+            path = "/pet/findByTags",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -224,12 +224,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -266,7 +266,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/pet"
+            path = "/pet",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -298,12 +298,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}"
+            path = "/pet/{petId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -336,12 +336,12 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/json"
 
         val params = mutableMapOf<String, Any>(
-            petId to petId.toString()
+            "petId" to petId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}/uploadImage"
+            path = "/pet/{petId}/uploadImage",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -100,7 +100,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -224,7 +224,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -298,7 +298,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(
@@ -336,7 +336,7 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/json"
 
         val params = mutableMapOf<String, Any>(
-            "petId" to petId.toString(),
+            "petId" to petId,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.ModelApiResponse
 import org.openapitools.client.models.Pet
@@ -63,9 +64,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet",
+            path = "/pet"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -94,9 +99,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         apiKey?.apply { localVariableHeaders["api_key"] = this.toString() }
         
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -137,9 +147,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByStatus",
+            path = "/pet/findByStatus"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -174,9 +188,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/findByTags",
+            path = "/pet/findByTags"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -205,9 +223,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -238,9 +261,13 @@ class PetApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/xml"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/pet",
+            path = "/pet"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -270,9 +297,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "application/x-www-form-urlencoded")
         
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -303,9 +335,14 @@ class PetApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf("Content-Type" to "multipart/form-data")
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+            petId to petId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/pet/{petId}/uploadImage".replace("{"+"petId"+"}", encodeURIComponent(petId.toString())),
+            path = "/pet/{petId}/uploadImage"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -61,12 +61,12 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            orderId to orderId.toString()
+            "orderId" to orderId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/store/order/{orderId}"
+            path = "/store/order/{orderId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -101,7 +101,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/inventory"
+            path = "/store/inventory",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -132,12 +132,12 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            orderId to orderId.toString()
+            "orderId" to orderId.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/order/{orderId}"
+            path = "/store/order/{orderId}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -173,7 +173,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/store/order"
+            path = "/store/order",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -61,7 +61,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            "orderId" to orderId.toString(),
+            "orderId" to orderId,
         )
 
         return RequestConfig(
@@ -132,7 +132,7 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "orderId" to orderId.toString(),
+            "orderId" to orderId,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.Order
 import org.openapitools.client.infrastructure.*
@@ -59,9 +60,14 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            orderId to orderId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -90,9 +96,13 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/inventory",
+            path = "/store/inventory"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -121,9 +131,14 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            orderId to orderId.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/store/order/{orderId}".replace("{"+"orderId"+"}", encodeURIComponent(orderId.toString())),
+            path = "/store/order/{orderId}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -153,9 +168,13 @@ class StoreApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/store/order",
+            path = "/store/order"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -66,7 +66,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user"
+            path = "/user",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -101,7 +101,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithArray"
+            path = "/user/createWithArray",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -136,7 +136,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithList"
+            path = "/user/createWithList",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -166,12 +166,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -202,12 +202,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -246,7 +246,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/login"
+            path = "/user/login",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -280,7 +280,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
 
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/logout"
+            path = "/user/logout",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
@@ -311,12 +311,12 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         
         val params = mutableMapOf<String, Any>(
-            username to username.toString()
+            "username" to username.toString(),
         )
 
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/user/{username}"
+            path = "/user/{username}",
             params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -24,6 +24,7 @@ import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
 import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.User
 import org.openapitools.client.infrastructure.*
@@ -60,9 +61,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user",
+            path = "/user"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -91,9 +96,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithArray",
+            path = "/user/createWithArray"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -122,9 +131,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.POST,
-            path = "/user/createWithList",
+            path = "/user/createWithList"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -152,9 +165,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.DELETE,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -183,9 +201,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -218,9 +241,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/login",
+            path = "/user/login"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,
@@ -248,9 +275,13 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableQuery = mutableMapOf<kotlin.String, kotlin.collections.List<kotlin.String>>()
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
+        val params = mutableMapOf<String, Any>(
+        )
+
         return RequestConfig(
             method = RequestMethod.GET,
-            path = "/user/logout",
+            path = "/user/logout"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,
@@ -279,9 +310,14 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         localVariableHeaders["Content-Type"] = "application/json"
         
+        val params = mutableMapOf<String, Any>(
+            username to username.toString()
+        )
+
         return RequestConfig(
             method = RequestMethod.PUT,
-            path = "/user/{username}".replace("{"+"username"+"}", encodeURIComponent(username.toString())),
+            path = "/user/{username}"
+            params = params,
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = true,

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -166,7 +166,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         val localVariableHeaders: MutableMap<String, String> = mutableMapOf()
         
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(
@@ -202,7 +202,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Accept"] = "application/xml, application/json"
 
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(
@@ -311,7 +311,7 @@ class UserApi(client: WebClient) : ApiClient(client) {
         localVariableHeaders["Content-Type"] = "application/json"
         
         val params = mutableMapOf<String, Any>(
-            "username" to username.toString(),
+            "username" to username,
         )
 
         return RequestConfig(

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,9 +4,9 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.util.UriUtils
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.http.ResponseEntity
+import org.springframework.util.LinkedMultiValueMap
 import reactor.core.publisher.Mono
 
 open class ApiClient(protected val client: WebClient) {

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -33,19 +33,15 @@ open class ApiClient(protected val client: WebClient) {
             }
         }
 
-    protected fun encodeURIComponent(uriComponent: kotlin.String) =
-        UriUtils.encodeFragment(uriComponent, Charsets.UTF_8)
-
     private fun <I> WebClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
     private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
-            builder.path(requestConfig.path).apply {
-                requestConfig.query.forEach { (name, value) ->
-                    queryParam(name, value)
-                }
-            }.build()
+            builder
+                .path(requestConfig.path)
+                .queryParams(LinkedMultiValueMap(requestConfig.query))
+                .build(requestConfig.params)
         }
 
     private fun <I> WebClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-modelMutable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-moshi-codegen/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-multiplatform-kotlinx-datetime/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-multiplatform/src/commonMain/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-nonpublic/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ internal data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-nullable/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-okhttp3/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-string/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-threetenbp/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin-uppercase-enum/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null

--- a/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
+++ b/samples/client/petstore/kotlin/src/main/kotlin/org/openapitools/client/infrastructure/RequestConfig.kt
@@ -12,6 +12,7 @@ data class RequestConfig<T>(
     val method: RequestMethod,
     val path: String,
     val headers: MutableMap<String, String> = mutableMapOf(),
+    val params: MutableMap<String, Any> = mutableMapOf(),
     val query: MutableMap<String, List<String>> = mutableMapOf(),
     val requiresAuthentication: Boolean,
     val body: T? = null


### PR DESCRIPTION
Fixes issues https://github.com/OpenAPITools/openapi-generator/issues/17491 and https://github.com/OpenAPITools/openapi-generator/issues/16923 by letting Spring apply the encoding instead of custom replacement logic.

The fix was als manually tested using a demo petstore application.