### PR TITLE
fix: ExampleGenerator correctly generates allOf composed schemas

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -180,4 +180,62 @@ public class ExampleGeneratorTest {
         assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
+
+    @Test
+    public void generateFromResponseSchemaWithOneOfComposedModel() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_oneOf_composed_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
+
+    @Test
+    public void generateFromResponseSchemaWithAnyOfComposedModel() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_anyOf_composed_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -151,4 +151,33 @@ public class ExampleGeneratorTest {
         assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
+
+    @Test
+    public void generateFromResponseSchemaWithAllOfComposedModel() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_allOf_composed_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
@@ -53,7 +53,7 @@ paths:
                   example: primitive types example value
   /generate_from_response_schema_with_model:
     get:
-      operationId: generateFromResponseSchemaWithArrayOfPrimitiveTypes
+      operationId: generateFromResponseSchemaWithModel
       responses:
         '200':
           description: successful operation
@@ -61,6 +61,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExampleSchema'
+  /generate_from_response_schema_with_allOf_composed_model:
+    get:
+      operationId: generateFromResponseSchemaWithComposedModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleComposedSchema'
 components:
   schemas:
     StringSchema:
@@ -72,3 +82,12 @@ components:
         example_schema_property:
           type: string
           example: example schema property value
+    ExampleComposedSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ExampleSchema'
+        - type: object
+          properties:
+            example_schema_property_composed:
+              type: string
+              example: example schema property value composed

--- a/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
@@ -63,14 +63,34 @@ paths:
                 $ref: '#/components/schemas/ExampleSchema'
   /generate_from_response_schema_with_allOf_composed_model:
     get:
-      operationId: generateFromResponseSchemaWithComposedModel
+      operationId: generateFromResponseSchemaWithAllOfModel
       responses:
         '200':
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExampleComposedSchema'
+                $ref: '#/components/schemas/ExampleAllOfSchema'
+  /generate_from_response_schema_with_anyOf_composed_model:
+    get:
+      operationId: generateFromResponseSchemaWithAnyOfModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleAnyOfSchema'
+  /generate_from_response_schema_with_oneOf_composed_model:
+    get:
+      operationId: generateFromResponseSchemaWithOneOfModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleOneOfSchema'
 components:
   schemas:
     StringSchema:
@@ -82,9 +102,27 @@ components:
         example_schema_property:
           type: string
           example: example schema property value
-    ExampleComposedSchema:
+    ExampleAllOfSchema:
       type: object
       allOf:
+        - $ref: '#/components/schemas/ExampleSchema'
+        - type: object
+          properties:
+            example_schema_property_composed:
+              type: string
+              example: example schema property value composed
+    ExampleAnyOfSchema:
+      type: object
+      anyOf:
+        - $ref: '#/components/schemas/ExampleSchema'
+        - type: object
+          properties:
+            example_schema_property_composed:
+              type: string
+              example: example schema property value composed
+    ExampleOneOfSchema:
+      type: object
+      oneOf:
         - $ref: '#/components/schemas/ExampleSchema'
         - type: object
           properties:

--- a/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -2411,7 +2411,7 @@ components:
       description: Value object
       example:
         name: variable_1
-        value: null
+        value: Scalar
       properties:
         name:
           example: variable_1

--- a/samples/client/petstore/java/resteasy/api/openapi.yaml
+++ b/samples/client/petstore/java/resteasy/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/resttemplate/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/vertx/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/webclient-jakarta/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient-jakarta/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/webclient-swagger2/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient-swagger2/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/api/openapi.yaml
@@ -49,4 +49,7 @@ components:
         \ characters. The sanitization rules should make it possible to generate a\
         \ language-specific classname with allowed characters in that programming\
         \ language."
+      example:
+        prop2: prop2
+        objectType: objectType
 

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
@@ -71,7 +71,7 @@ public interface BarApi {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    String exampleString = "{ \"id\" : \"id\", \"fooPropB\" : \"fooPropB\", \"barPropA\" : \"barPropA\" }";
+                    String exampleString = "{ \"foo\" : { \"fooPropA\" : \"fooPropA\", \"fooPropB\" : \"fooPropB\" }, \"id\" : \"id\", \"fooPropB\" : \"fooPropB\", \"barPropA\" : \"barPropA\" }";
                     ApiUtil.setExampleResponse(request, "application/json", exampleString);
                     break;
                 }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
@@ -71,7 +71,7 @@ public interface FooApi {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    String exampleString = "null";
+                    String exampleString = "{ \"fooPropA\" : \"fooPropA\", \"fooPropB\" : \"fooPropB\" }";
                     ApiUtil.setExampleResponse(request, "application/json", exampleString);
                     break;
                 }
@@ -109,7 +109,7 @@ public interface FooApi {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json;charset=utf-8"))) {
-                    String exampleString = "[ null, null ]";
+                    String exampleString = "[ { \"fooPropA\" : \"fooPropA\", \"fooPropB\" : \"fooPropB\" }, { \"fooPropA\" : \"fooPropA\", \"fooPropB\" : \"fooPropB\" } ]";
                     ApiUtil.setExampleResponse(request, "application/json;charset=utf-8", exampleString);
                     break;
                 }

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/resources/openapi.yaml
@@ -189,7 +189,9 @@ components:
       allOf:
       - $ref: '#/components/schemas/Entity'
       example:
-        foo: null
+        foo:
+          fooPropA: fooPropA
+          fooPropB: fooPropB
         id: id
         fooPropB: fooPropB
         barPropA: barPropA

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/java-helidon-server/mp/src/main/resources/META-INF/openapi.yml
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/resources/META-INF/openapi.yml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/java-helidon-server/se/src/main/resources/META-INF/openapi.yml
+++ b/samples/server/petstore/java-helidon-server/se/src/main/resources/META-INF/openapi.yml
@@ -1942,6 +1942,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean

--- a/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
@@ -1902,6 +1902,10 @@ components:
           otherProperty:
             type: string
         type: object
+      example:
+        otherProperty: otherProperty
+        nullableProperty: nullableProperty
+        type: ChildWithNullable
     StringBooleanMap:
       additionalProperties:
         type: boolean


### PR DESCRIPTION

Changes the previous behavior of generating `null` examples for composed schemas.

Fixes #17497

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
