### PR TITLE
[C][Client] Fix enum function names not matching headers in the model…

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model-body.mustache
@@ -77,12 +77,12 @@ end:
     {{^isContainer}}
     {{^isModel}}
     {{#isEnum}}
-char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
+char* {{classname}}_{{name}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
     char* {{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
     return {{name}}Array[{{name}}];
 }
 
-{{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}{{classname}}_FromString(char* {{name}}){
+{{projectName}}_{{classVarName}}_{{enumName}}_e {{classname}}_{{name}}_FromString(char* {{name}}){
     int stringToReturn = 0;
     char *{{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
     size_t sizeofArray = sizeof({{name}}Array) / sizeof({{name}}Array[0]);
@@ -101,12 +101,12 @@ char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName
     {{#items}}
     {{^isModel}}
     {{#isEnum}}
-char* {{name}}{{classname}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
+char* {{classname}}_{{name}}_ToString({{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}) {
     char *{{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
     return {{name}}Array[{{name}} - 1];
 }
 
-{{projectName}}_{{classVarName}}_{{enumName}}_e {{name}}{{classname}}_FromString(char* {{name}}) {
+{{projectName}}_{{classVarName}}_{{enumName}}_e {{classname}}_{{name}}_FromString(char* {{name}}) {
     int stringToReturn = 0;
     char *{{name}}Array[] =  { "NULL"{{#allowableValues}}{{#values}}, "{{.}}"{{/values}}{{/allowableValues}} };
     size_t sizeofArray = sizeof({{name}}Array) / sizeof({{name}}Array[0]);
@@ -629,7 +629,7 @@ fail:
     {
     goto end; //Enum
     }
-    {{name}}Variable = {{name}}{{classname}}_FromString({{{name}}}->valuestring);
+    {{name}}Variable = {{classname}}_{{name}}_FromString({{{name}}}->valuestring);
     {{/isString}}
     {{/isEnum}}
     {{^isEnum}}

--- a/samples/client/petstore/c/model/order.c
+++ b/samples/client/petstore/c/model/order.c
@@ -4,12 +4,12 @@
 #include "order.h"
 
 
-char* statusorder_ToString(openapi_petstore_order_STATUS_e status) {
+char* order_status_ToString(openapi_petstore_order_STATUS_e status) {
     char* statusArray[] =  { "NULL", "placed", "approved", "delivered" };
     return statusArray[status];
 }
 
-openapi_petstore_order_STATUS_e statusorder_FromString(char* status){
+openapi_petstore_order_STATUS_e order_status_FromString(char* status){
     int stringToReturn = 0;
     char *statusArray[] =  { "NULL", "placed", "approved", "delivered" };
     size_t sizeofArray = sizeof(statusArray) / sizeof(statusArray[0]);
@@ -164,7 +164,7 @@ order_t *order_parseFromJSON(cJSON *orderJSON){
     {
     goto end; //Enum
     }
-    statusVariable = statusorder_FromString(status->valuestring);
+    statusVariable = order_status_FromString(status->valuestring);
     }
 
     // order->complete

--- a/samples/client/petstore/c/model/pet.c
+++ b/samples/client/petstore/c/model/pet.c
@@ -4,12 +4,12 @@
 #include "pet.h"
 
 
-char* statuspet_ToString(openapi_petstore_pet_STATUS_e status) {
+char* pet_status_ToString(openapi_petstore_pet_STATUS_e status) {
     char* statusArray[] =  { "NULL", "available", "pending", "sold" };
     return statusArray[status];
 }
 
-openapi_petstore_pet_STATUS_e statuspet_FromString(char* status){
+openapi_petstore_pet_STATUS_e pet_status_FromString(char* status){
     int stringToReturn = 0;
     char *statusArray[] =  { "NULL", "available", "pending", "sold" };
     size_t sizeofArray = sizeof(statusArray) / sizeof(statusArray[0]);
@@ -253,7 +253,7 @@ pet_t *pet_parseFromJSON(cJSON *petJSON){
     {
     goto end; //Enum
     }
-    statusVariable = statuspet_FromString(status->valuestring);
+    statusVariable = pet_status_FromString(status->valuestring);
     }
 
 


### PR DESCRIPTION
… template

- fixes #17510

This changes the template for the body to match the template for the header. I have also regenerated the sample code.
I don't know where to begin with testing this but I'm willing to learn if I could be pointed in the right direction!

@zhemant 
@ityuhui
@michelealbano

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
