### PR TITLE
Allow strings as dates in typescript-node generator to fix error: data.toISOString() is not a function

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/models.mustache
@@ -119,6 +119,9 @@ export class ObjectSerializer {
             }
             return transformedData;
         } else if (type === "Date") {
+            if (typeof data === "string") {
+                return new Date(data).toISOString();
+            }
             return data.toISOString();
         } else {
             if (enumsMap[type]) {


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka

I was having a problem with data generated from an untyped endpoint being passed into an endpoint that did have a date type for a field.

```
    TypeError: data.toISOString is not a function

      491 |             return transformedData;
      492 |         } else if (type === "Date") {
    > 493 |             return data.toISOString();
          |                         ^
      494 |         } else {
      495 |             if (enumsMap[type]) {
      496 |                 return data;

      at Function.serialize (../openapi/spond-rest-api/model/models.ts:493:25)
      at Function.serialize (../openapi/spond-rest-api/model/models.ts:510:69)
      at Function.serialize (../openapi/spond-rest-api/model/models.ts:510:69)
      at Function.serialize (../openapi/spond-rest-api/model/models.ts:510:69)
```

The fix coerces the string into a date before getting the ISO string to ensure uniformity. I'm open to just passing along the string as is too, but throwing on reasonably valid input doesn't make sense.