### PR TITLE
Add enum name mapping support to Ruby generators

### DIFF
--- a/bin/configs/ruby.yaml
+++ b/bin/configs/ruby.yaml
@@ -15,3 +15,5 @@ nameMappings:
 parameterNameMappings:
   _type: underscore_type
   type_: type_with_underscore
+enumNameMappings:
+  delivered: SHIPPED

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RubyClientCodegen.java
@@ -508,6 +508,10 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
     @Override
     public String toEnumVarName(String name, String datatype) {
+        if (enumNameMapping.containsKey(name)) {
+            return enumNameMapping.get(name);
+        }
+
         if (name.length() == 0) {
             return "EMPTY";
         }
@@ -535,6 +539,10 @@ public class RubyClientCodegen extends AbstractRubyCodegen {
 
     @Override
     public String toEnumName(CodegenProperty property) {
+        if (enumNameMapping.containsKey(property.name)) {
+            return enumNameMapping.get(property.name);
+        }
+
         String enumName = underscore(toModelName(property.name)).toUpperCase(Locale.ROOT);
         enumName = enumName.replaceFirst("^_", "");
         enumName = enumName.replaceFirst("_$", "");

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_enum.rb
@@ -17,10 +17,10 @@ module Petstore
   class OuterEnum
     PLACED = "placed".freeze
     APPROVED = "approved".freeze
-    DELIVERED = "delivered".freeze
+    SHIPPED = "delivered".freeze
 
     def self.all_vars
-      @all_vars ||= [PLACED, APPROVED, DELIVERED].freeze
+      @all_vars ||= [PLACED, APPROVED, SHIPPED].freeze
     end
 
     # Builds the enum from string

--- a/samples/client/petstore/ruby/lib/petstore/models/outer_enum_default_value.rb
+++ b/samples/client/petstore/ruby/lib/petstore/models/outer_enum_default_value.rb
@@ -17,10 +17,10 @@ module Petstore
   class OuterEnumDefaultValue
     PLACED = "placed".freeze
     APPROVED = "approved".freeze
-    DELIVERED = "delivered".freeze
+    SHIPPED = "delivered".freeze
 
     def self.all_vars
-      @all_vars ||= [PLACED, APPROVED, DELIVERED].freeze
+      @all_vars ||= [PLACED, APPROVED, SHIPPED].freeze
     end
 
     # Builds the enum from string


### PR DESCRIPTION
Add enum name mapping support to Ruby generators

To close https://github.com/OpenAPITools/openapi-generator/issues/11350


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

cc 
@cliffano (2017/07) @zlx (2017/09) @autopp (2019/02)
