### PR TITLE
[Dart] [Client] Miscellaneous bug fixes for syntax errors, runtime exceptions, and deserialization errors

### DIFF
--- a/docs/generators/dart.md
+++ b/docs/generators/dart.md
@@ -65,6 +65,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 
 <ul class="column-ul">
 <li>abstract</li>
+<li>apiclient</li>
 <li>as</li>
 <li>assert</li>
 <li>async</li>
@@ -128,6 +129,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 <li>true</li>
 <li>try</li>
 <li>typedef</li>
+<li>value</li>
 <li>var</li>
 <li>void</li>
 <li>while</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractDartCodegen.java
@@ -1,6 +1,9 @@
 package org.openapitools.codegen.languages;
 
 import com.google.common.collect.Sets;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
@@ -10,11 +13,16 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.*;
+import org.openapitools.codegen.api.TemplatePathLocator;
 import org.openapitools.codegen.meta.features.*;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
 import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
+import org.openapitools.codegen.templating.CommonTemplateContentLocator;
+import org.openapitools.codegen.templating.GeneratorTemplateContentLocator;
+import org.openapitools.codegen.templating.MustacheEngineAdapter;
+import org.openapitools.codegen.templating.TemplateManagerOptions;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,29 +84,22 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                         SecurityFeature.OAuth2_Implicit,
                         SecurityFeature.BasicAuth,
                         SecurityFeature.BearerToken,
-                        SecurityFeature.ApiKey
-                ))
+                        SecurityFeature.ApiKey))
                 .excludeGlobalFeatures(
                         GlobalFeature.XMLStructureDefinitions,
                         GlobalFeature.Callbacks,
                         GlobalFeature.LinkObjects,
-                        GlobalFeature.ParameterStyling
-                )
+                        GlobalFeature.ParameterStyling)
                 .excludeSchemaSupportFeatures(
                         SchemaSupportFeature.Polymorphism,
                         SchemaSupportFeature.Union,
-                        SchemaSupportFeature.Composite
-                )
+                        SchemaSupportFeature.Composite)
                 .includeParameterFeatures(
-                        ParameterFeature.Cookie
-                )
+                        ParameterFeature.Cookie)
                 .includeClientModificationFeatures(
-                        ClientModificationFeature.BasePath
-                )
+                        ClientModificationFeature.BasePath)
                 .excludeWireFormatFeatures(
-                        WireFormatFeature.XML
-                )
-        );
+                        WireFormatFeature.XML));
 
         outputFolder = "generated-code/dart";
         modelTemplateFiles.put("model.mustache", ".dart");
@@ -130,8 +131,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 "bool",
                 "int",
                 "num",
-                "double"
-        );
+                "double");
 
         typeMapping = new HashMap<>();
         typeMapping.put("Array", "List");
@@ -153,8 +153,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         typeMapping.put("Date", "DateTime");
         typeMapping.put("date", "DateTime");
         typeMapping.put("DateTime", "DateTime");
-        typeMapping.put("file", "MultipartFile");
-        typeMapping.put("binary", "MultipartFile");
+        typeMapping.put("file", "Uint8List");
+        typeMapping.put("binary", "Uint8List");
         typeMapping.put("UUID", "String");
         typeMapping.put("URI", "String");
         typeMapping.put("ByteArray", "String");
@@ -172,8 +172,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                 "Set",
                 "Map",
                 "DateTime",
-                "Object"
-        );
+                "Object");
 
         imports.put("String", "dart:core");
         imports.put("bool", "dart:core");
@@ -185,6 +184,7 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         imports.put("Map", "dart:core");
         imports.put("DateTime", "dart:core");
         imports.put("Object", "dart:core");
+        imports.put("Uint8List", "dart:typed_data");
         imports.put("MultipartFile", "package:http/http.dart");
 
         addOption(PUB_LIBRARY, "Library name in generated code", pubLibrary);
@@ -196,8 +196,22 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         addOption(PUB_HOMEPAGE, "Homepage in generated pubspec", pubHomepage);
         addOption(PUB_REPOSITORY, "Repository in generated pubspec", pubRepository);
         addOption(PUB_PUBLISH_TO, "Publish_to in generated pubspec", pubPublishTo);
-        addOption(USE_ENUM_EXTENSION, "Allow the 'x-enum-values' extension for enums", String.valueOf(useEnumExtension));
+        addOption(USE_ENUM_EXTENSION, "Allow the 'x-enum-values' extension for enums",
+                String.valueOf(useEnumExtension));
         addOption(CodegenConstants.SOURCE_FOLDER, CodegenConstants.SOURCE_FOLDER_DESC, sourceFolder);
+    }
+
+    private void configureSerializationLibrary(String srcFolder) {
+        additionalProperties.put("useJsonSerializable", "true");
+        configureSerializationLibraryJsonSerializable(srcFolder);
+    }
+
+    private void configureSerializationLibraryJsonSerializable(String srcFolder) {
+
+        // most of these are defined in AbstractDartCodegen, we are overriding
+        // just the binary / file handling
+        languageSpecificPrimitives.add("Object");
+        imports.put("Uint8List", "dart:typed_data");
     }
 
     @Override
@@ -227,70 +241,72 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         additionalProperties.put(CodegenConstants.API_PACKAGE, apiPackage);
 
         if (StringUtils.isEmpty(System.getenv("DART_POST_PROCESS_FILE"))) {
-            LOGGER.info("Environment variable DART_POST_PROCESS_FILE not defined so the Dart code may not be properly formatted. To define it, try `export DART_POST_PROCESS_FILE=\"/usr/local/bin/dartfmt -w\"` (Linux/Mac)");
-            LOGGER.info("NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).");
+            LOGGER.info(
+                    "Environment variable DART_POST_PROCESS_FILE not defined so the Dart code may not be properly formatted. To define it, try `export DART_POST_PROCESS_FILE=\"/usr/local/bin/dartfmt -w\"` (Linux/Mac)");
+            LOGGER.info(
+                    "NOTE: To enable file post-processing, 'enablePostProcessFile' must be set to `true` (--enable-post-process-file for CLI).");
         }
 
         if (additionalProperties.containsKey(PUB_NAME)) {
             this.setPubName((String) additionalProperties.get(PUB_NAME));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_NAME, pubName);
         }
 
         if (additionalProperties.containsKey(PUB_LIBRARY)) {
             this.setPubLibrary((String) additionalProperties.get(PUB_LIBRARY));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_LIBRARY, pubLibrary);
         }
 
         if (additionalProperties.containsKey(PUB_VERSION)) {
             this.setPubVersion((String) additionalProperties.get(PUB_VERSION));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_VERSION, pubVersion);
         }
 
         if (additionalProperties.containsKey(PUB_DESCRIPTION)) {
             this.setPubDescription((String) additionalProperties.get(PUB_DESCRIPTION));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_DESCRIPTION, pubDescription);
         }
 
         if (additionalProperties.containsKey(PUB_AUTHOR)) {
             this.setPubAuthor((String) additionalProperties.get(PUB_AUTHOR));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_AUTHOR, pubAuthor);
         }
 
         if (additionalProperties.containsKey(PUB_AUTHOR_EMAIL)) {
             this.setPubAuthorEmail((String) additionalProperties.get(PUB_AUTHOR_EMAIL));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_AUTHOR_EMAIL, pubAuthorEmail);
         }
 
         if (additionalProperties.containsKey(PUB_HOMEPAGE)) {
             this.setPubHomepage((String) additionalProperties.get(PUB_HOMEPAGE));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_HOMEPAGE, pubHomepage);
         }
 
         if (additionalProperties.containsKey(PUB_REPOSITORY)) {
             this.setPubRepository((String) additionalProperties.get(PUB_REPOSITORY));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_REPOSITORY, pubRepository);
         }
 
         if (additionalProperties.containsKey(PUB_PUBLISH_TO)) {
             this.setPubPublishTo((String) additionalProperties.get(PUB_PUBLISH_TO));
         } else {
-            //not set, use to be passed to template
+            // not set, use to be passed to template
             additionalProperties.put(PUB_PUBLISH_TO, pubPublishTo);
         }
 
@@ -315,6 +331,10 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         if (templateDir == null) {
             embeddedTemplateDir = templateDir = "dart2";
         }
+
+        final String srcFolder = libPath + sourceFolder;
+
+        configureSerializationLibrary(srcFolder);
     }
 
     @Override
@@ -329,7 +349,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         // * a keyword
         // * a word that has been mapped in the reservedWordsMappings
         // * a default included type or a type include through some library
-        return super.isReservedWord(word) || reservedWordsMappings().containsKey(word) || defaultIncludes().contains(word);
+        return super.isReservedWord(word) || reservedWordsMappings().containsKey(word)
+                || defaultIncludes().contains(word);
     }
 
     @Override
@@ -342,12 +363,14 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
 
     @Override
     public String apiFileFolder() {
-        return (outputFolder + File.separator + libPath + sourceFolder + File.separator + apiPackage()).replace('/', File.separatorChar);
+        return (outputFolder + File.separator + libPath + sourceFolder + File.separator + apiPackage()).replace('/',
+                File.separatorChar);
     }
 
     @Override
     public String modelFileFolder() {
-        return (outputFolder + File.separator + libPath + sourceFolder + File.separator + modelPackage()).replace('/', File.separatorChar);
+        return (outputFolder + File.separator + libPath + sourceFolder + File.separator + modelPackage()).replace('/',
+                File.separatorChar);
     }
 
     @Override
@@ -453,7 +476,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         // model name starts with number
         if (camelizedName.matches("^\\d.*")) {
             final String modelName = "Model" + camelizedName; // e.g. 200Response => Model200Response (after camelize)
-            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", name, modelName);
+            LOGGER.warn("{} (model name starts with number) cannot be used as model name. Renamed to {}", name,
+                    modelName);
             return modelName;
         }
 
@@ -516,11 +540,13 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
             return getSchemaType(target) + "<" + getTypeDeclaration(items) + ">";
         }
         if (ModelUtils.isMapSchema(target)) {
-            // Note: ModelUtils.isMapSchema(p) returns true when p is a composed schema that also defines
+            // Note: ModelUtils.isMapSchema(p) returns true when p is a composed schema that
+            // also defines
             // additionalproperties: true
             Schema<?> inner = ModelUtils.getAdditionalProperties(target);
             if (inner == null) {
-                LOGGER.error("`{}` (map property) does not have a proper inner type defined. Default to type:string", p.getName());
+                LOGGER.error("`{}` (map property) does not have a proper inner type defined. Default to type:string",
+                        p.getName());
                 inner = new StringSchema().description("TODO default missing map inner type to string");
                 p.setAdditionalProperties(inner);
             }
@@ -550,17 +576,22 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     public void postProcessModelProperty(CodegenModel model, CodegenProperty property) {
         super.postProcessModelProperty(model, property);
         if (!model.isEnum && property.isEnum && property.getComposedSchemas() == null) {
-            // These are inner enums, enums which do not exist as models, just as properties.
+            // These are inner enums, enums which do not exist as models, just as
+            // properties.
             // They are handled via the enum_inline template and are generated in the
-            // same file as the containing class. To prevent name clashes the inline enum classes
+            // same file as the containing class. To prevent name clashes the inline enum
+            // classes
             // are prefix with the classname of the containing class in the template.
-            // Here the datatypeWithEnum template variable gets updated to match that scheme.
-            // Also taking into account potential collection types e.g. List<JustSymbolEnum> -> List<EnumArraysJustSymbolEnum>
+            // Here the datatypeWithEnum template variable gets updated to match that
+            // scheme.
+            // Also taking into account potential collection types e.g. List<JustSymbolEnum>
+            // -> List<EnumArraysJustSymbolEnum>
             final String enumName = model.classname + property.enumName;
             if (property.items != null) {
                 // inner items e.g. enums in collections, only works for one level
                 // but same is the case for DefaultCodegen
-                property.setDatatypeWithEnum(property.datatypeWithEnum.replace(property.items.datatypeWithEnum, enumName));
+                property.setDatatypeWithEnum(
+                        property.datatypeWithEnum.replace(property.items.datatypeWithEnum, enumName));
                 property.items.setDatatypeWithEnum(enumName);
                 property.items.setEnumName(enumName);
             } else {
@@ -606,8 +637,10 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     public CodegenOperation fromOperation(String path, String httpMethod, Operation operation, List<Server> servers) {
         final CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
         for (CodegenResponse r : op.responses) {
-            // By default, only set types are automatically added to operation imports, not sure why.
-            // Add all container type imports here, by default 'dart:core' imports are skipped
+            // By default, only set types are automatically added to operation imports, not
+            // sure why.
+            // Add all container type imports here, by default 'dart:core' imports are
+            // skipped
             // but other sub-classes may require specific container type imports.
             if (r.containerType != null && typeMapping().containsKey(r.containerType)) {
                 final String value = typeMapping().get(r.containerType);
@@ -636,8 +669,29 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         super.postProcessOperationsWithModels(objs, allModels);
         OperationMap operations = objs.getOperations();
         if (operations != null) {
-            List<CodegenOperation> ops = operations.getOperation();
-            for (CodegenOperation op : ops) {
+            List<CodegenOperation> operationList = operations.getOperation();
+            for (CodegenOperation op : operationList) {
+                for (CodegenParameter param : op.allParams) {
+                    if (((op.isMultipart && param.isFormParam) || param.isBodyParam)
+                            && (param.isBinary || param.isFile)) {
+                        param.dataType = param.dataType.replace("Uint8List", "MultipartFile");
+                        param.baseType = param.baseType.replace("Uint8List", "MultipartFile");
+                        op.imports.add("MultipartFile");
+                    }
+                }
+
+                // The MultipartFile handling above changes the type of some parameters from
+                // `UInt8List`, the default for files, to `MultipartFile`.
+                //
+                // The following block removes the required import for Uint8List if it is no
+                // longer in use.
+                if (op.allParams.stream().noneMatch(param -> param.dataType.equals("Uint8List"))
+                        && op.responses.stream().filter(response -> response.dataType != null)
+                                .noneMatch(response -> response.dataType.equals("Uint8List"))) {
+                    // Remove unused imports after processing
+                    op.imports.remove("Uint8List");
+                }
+
                 if (op.hasConsumes) {
                     if (!op.formParams.isEmpty() || op.isMultipart) {
                         // DefaultCodegen only sets this if the first consumes mediaType
@@ -650,7 +704,9 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
                         op.prioritizedContentTypes = prioritizeContentTypes(op.consumes);
                         String mediaType = op.prioritizedContentTypes.get(0).get("mediaType");
                         if (!DEFAULT_SUPPORTED_CONTENT_TYPES.contains(mediaType)) {
-                            LOGGER.warn("The media-type '{}' for operation '{}' is not support in the Dart generators by default.", mediaType, op.path);
+                            LOGGER.warn(
+                                    "The media-type '{}' for operation '{}' is not support in the Dart generators by default.",
+                                    mediaType, op.path);
                         }
                     }
                 }
@@ -687,7 +743,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
     }
 
     @Override
-    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars, Map<String, Object> vendorExtensions, String dataType) {
+    protected void updateEnumVarsWithExtensions(List<Map<String, Object>> enumVars,
+            Map<String, Object> vendorExtensions, String dataType) {
         if (vendorExtensions != null && useEnumExtension && vendorExtensions.containsKey("x-enum-values")) {
             // Use the x-enum-values extension for this enum
             // Existing enumVars added by the default handling need to be removed first
@@ -757,7 +814,8 @@ public abstract class AbstractDartCodegen extends DefaultCodegen {
         // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
             String newOperationId = camelize("call_" + operationId, LOWERCASE_FIRST_LETTER);
-            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId, newOperationId);
+            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId,
+                    newOperationId);
             operationId = newOperationId;
         }
 

--- a/modules/openapi-generator/src/main/resources/dart/dart-keywords.txt
+++ b/modules/openapi-generator/src/main/resources/dart/dart-keywords.txt
@@ -67,3 +67,5 @@ void
 while
 with
 yield
+value
+apiClient

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -170,7 +170,7 @@ class {{{classname}}} {
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (_response.body.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
     {{#native_serialization}}
     {{#isArray}}
       final _responseBody = await _decodeBodyBytes(_response);

--- a/modules/openapi-generator/src/main/resources/dart2/api.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api.mustache
@@ -51,22 +51,22 @@ class {{{classname}}} {
   {{/allParams}}
   Future<Response> {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
     // ignore: prefer_const_declarations
-    final path = r'{{{path}}}'{{#pathParams}}
+    final _path = r'{{{path}}}'{{#pathParams}}
       .replaceAll({{=<% %>=}}'{<% baseName %>}'<%={{ }}=%>, {{{paramName}}}{{^isString}}.toString(){{/isString}}){{/pathParams}};
 
     // ignore: prefer_final_locals
-    Object? postBody{{#bodyParam}} = {{{paramName}}}{{/bodyParam}};
+    Object? _postBody{{#bodyParam}} = {{{paramName}}}{{/bodyParam}};
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
     {{#hasQueryParams}}
 
       {{#queryParams}}
         {{^required}}
     if ({{{paramName}}} != null) {
           {{/required}}
-      queryParams.addAll(_queryParams('{{{collectionFormat}}}', '{{{baseName}}}', {{{paramName}}}));
+      __queryParams.addAll(_queryParams('{{{collectionFormat}}}', '{{{baseName}}}', {{{paramName}}}));
           {{^required}}
     }
         {{/required}}
@@ -76,58 +76,58 @@ class {{{classname}}} {
 
       {{#headerParams}}
         {{#required}}
-    headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
+    _headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
         {{/required}}
         {{^required}}
     if ({{{paramName}}} != null) {
-      headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
+      _headerParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
     }
         {{/required}}
       {{/headerParams}}
     {{/hasHeaderParams}}
 
-    const contentTypes = <String>[{{#prioritizedContentTypes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/prioritizedContentTypes}}];
+    const _contentTypes = <String>[{{#prioritizedContentTypes}}'{{{mediaType}}}'{{^-last}}, {{/-last}}{{/prioritizedContentTypes}}];
 
     {{#isMultipart}}
-    bool hasFields = false;
-    final mp = MultipartRequest('{{{httpMethod}}}', Uri.parse(path));
+    bool _hasFields = false;
+    final _mp = MultipartRequest('{{{httpMethod}}}', Uri.parse(_path));
     {{#formParams}}
     {{^isFile}}
     if ({{{paramName}}} != null) {
-      hasFields = true;
-      mp.fields[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
+      _hasFields = true;
+      _mp.fields[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
     }
     {{/isFile}}
     {{#isFile}}
     if ({{{paramName}}} != null) {
-      hasFields = true;
-      mp.fields[r'{{{baseName}}}'] = {{{paramName}}}.field;
-      mp.files.add({{{paramName}}});
+      _hasFields = true;
+      _mp.fields[r'{{{baseName}}}'] = {{{paramName}}}.field;
+      _mp.files.add({{{paramName}}});
     }
     {{/isFile}}
     {{/formParams}}
-    if (hasFields) {
-      postBody = mp;
+    if (_hasFields) {
+      _postBody = _mp;
     }
     {{/isMultipart}}
     {{^isMultipart}}
     {{#formParams}}
     {{^isFile}}
     if ({{{paramName}}} != null) {
-      formParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
+      _formParams[r'{{{baseName}}}'] = parameterToString({{{paramName}}});
     }
     {{/isFile}}
     {{/formParams}}
     {{/isMultipart}}
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       '{{{httpMethod}}}',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -162,28 +162,28 @@ class {{{classname}}} {
     {{/-last}}
   {{/allParams}}
   Future<{{#returnType}}{{{.}}}?{{/returnType}}{{^returnType}}void{{/returnType}}> {{{nickname}}}({{#allParams}}{{#required}}{{{dataType}}} {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{ {{#allParams}}{{^required}}{{{dataType}}}? {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}) async {
-    final response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await {{{nickname}}}WithHttpInfo({{#allParams}}{{#required}}{{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}} {{#allParams}}{{^required}}{{{paramName}}}: {{{paramName}}},{{^-last}} {{/-last}}{{/required}}{{/allParams}} {{/hasOptionalParams}});
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     {{#returnType}}
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
+    if (_response.body.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
     {{#native_serialization}}
     {{#isArray}}
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, '{{{returnType}}}') as List)
+      final _responseBody = await _decodeBodyBytes(_response);
+      return (await apiClient.deserializeAsync(_responseBody, '{{{returnType}}}') as List)
         .cast<{{{returnBaseType}}}>()
         .{{#uniqueItems}}toSet(){{/uniqueItems}}{{^uniqueItems}}toList(growable: false){{/uniqueItems}};
     {{/isArray}}
     {{^isArray}}
     {{#isMap}}
-      return {{{returnType}}}.from(await apiClient.deserializeAsync(await _decodeBodyBytes(response), '{{{returnType}}}'),);
+      return {{{returnType}}}.from(await apiClient.deserializeAsync(await _decodeBodyBytes(_response), '{{{returnType}}}'),);
     {{/isMap}}
     {{^isMap}}
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), '{{{returnType}}}',) as {{{returnType}}};
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), '{{{returnType}}}',) as {{{returnType}}};
     {{/isMap}}{{/isArray}}{{/native_serialization}}
     }
     return null;

--- a/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_client.mustache
@@ -134,19 +134,21 @@ class ApiClient {
   }
 {{#native_serialization}}
 
-  Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>
+  Future<dynamic> deserializeAsync(dynamic value, String targetType, {bool growable = false,}) async =>
     // ignore: deprecated_member_use_from_same_package
     deserialize(value, targetType, growable: growable);
 
   @Deprecated('Scheduled for removal in OpenAPI Generator 6.x. Use deserializeAsync() instead.')
-  dynamic deserialize(String value, String targetType, {bool growable = false,}) {
+  dynamic deserialize(dynamic value, String targetType, {bool growable = false,}) {
     // Remove all spaces. Necessary for regular expressions as well.
     targetType = targetType.replaceAll(' ', ''); // ignore: parameter_assignments
 
-    // If the expected target type is String, nothing to do...
-    return targetType == 'String'
-      ? value
-      : fromJson(json.decode(value), targetType, growable: growable);
+    // If targetType is a known primitive, utilize it directly
+    if (targetType == 'String' || targetType == 'int' || targetType == 'double' || targetType == 'bool' || targetType == 'DateTime' || targetType == 'Uint8List') {
+      return fromJson(value, targetType, growable: growable);
+    } else {
+      return fromJson(json.decode(value), targetType, growable: growable);
+    }
   }
 {{/native_serialization}}
 
@@ -175,6 +177,8 @@ class ApiClient {
           return valueString == 'true' || valueString == '1';
         case 'DateTime':
           return value is DateTime ? value : DateTime.tryParse(value);
+        case 'Uint8List':
+          return value as Uint8List;
         {{#models}}
           {{#model}}
         case '{{{classname}}}':

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -69,6 +69,9 @@ Future<String> _decodeBodyBytes(Response response) async {
 /// Returns a valid [T] value found at the specified Map [key], null otherwise.
 T? mapValueOfType<T>(dynamic map, String key) {
   final dynamic value = map is Map ? map[key] : null;
+  if (T == double && value is int) {
+    return value.toDouble() as T;
+  }
   return value is T ? value : null;
 }
 

--- a/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/api_helper.mustache
@@ -57,13 +57,18 @@ String parameterToString(dynamic value) {
   return value.toString();
 }
 
-/// Returns the decoded body as UTF-8 if the given headers indicate an 'application/json'
-/// content type. Otherwise, returns the decoded body as decoded by dart:http package.
-Future<String> _decodeBodyBytes(Response response) async {
-  final contentType = response.headers['content-type'];
-  return contentType != null && contentType.toLowerCase().startsWith('application/json')
-    ? response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes)
-    : response.body;
+/// Decodes the body based on the content-type
+/// application/json and text/plain are decoded as utf-8
+/// all other types will be returned as Uint8List
+Future<dynamic> _decodeBodyBytes(Response response) async {
+  final contentType = response.headers['content-type']?.toLowerCase();
+  if (contentType != null) {
+    if (contentType.startsWith('application/json') || contentType.startsWith('text/plain')) {
+      return response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes);
+    }
+  }
+  /* all other responses should be returned as a raw Uint8List */
+  return response.bodyBytes;
 }
 
 /// Returns a valid [T] value found at the specified Map [key], null otherwise.

--- a/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/apilib.mustache
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:http/http.dart';

--- a/modules/openapi-generator/src/main/resources/dart2/dart_constructor.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/dart_constructor.mustache
@@ -5,6 +5,6 @@
         A field is required in Dart when it is
         required && !defaultValue in OAS
     }}
-    {{#required}}{{^defaultValue}}required {{/defaultValue}}{{/required}}this.{{{name}}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}},
+    {{#required}}{{^defaultValue}} required{{/defaultValue}}{{/required}} this.{{{name}}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}{{^isNumeric}}const {{{enumName}}}._({{/isNumeric}}{{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}{{^isNumeric}}){{/isNumeric}}{{/isContainer}}{{/isEnum}}{{/defaultValue}},
   {{/vars}}
   });

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -220,7 +220,7 @@ class {{{classname}}} {
         {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
                 {{#isEnum}}
-        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
               {{/isNumber}}
             {{/isMap}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum.mustache
@@ -40,6 +40,13 @@ class {{{classname}}} {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [{{{classname}}}] to {{{dataType}}},

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum_inline.mustache
@@ -40,6 +40,12 @@ class {{{enumName}}} {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is {{{enumName}}} && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [{{{enumName}}}] to {{{dataType}}},

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -13,6 +13,7 @@ library openapi.api;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:http/http.dart';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -28,26 +28,26 @@ class PetApi {
   ///   Pet object that needs to be added to the store
   Future<Response> addPetWithHttpInfo(Pet pet,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet';
+    final _path = r'/pet';
 
     // ignore: prefer_final_locals
-    Object? postBody = pet;
+    Object? _postBody = pet;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json', 'application/xml'];
+    const _contentTypes = <String>['application/json', 'application/xml'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,15 +60,15 @@ class PetApi {
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
   Future<Pet?> addPet(Pet pet,) async {
-    final response = await addPetWithHttpInfo(pet,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await addPetWithHttpInfo(pet,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Pet',) as Pet;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Pet',) as Pet;
     
     }
     return null;
@@ -88,31 +88,31 @@ class PetApi {
   /// * [String] apiKey:
   Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
     if (apiKey != null) {
-      headerParams[r'api_key'] = parameterToString(apiKey);
+      _headerParams[r'api_key'] = parameterToString(apiKey);
     }
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -127,9 +127,9 @@ class PetApi {
   ///
   /// * [String] apiKey:
   Future<void> deletePet(int petId, { String? apiKey, }) async {
-    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -145,28 +145,28 @@ class PetApi {
   ///   Status values that need to be considered for filter
   Future<Response> findPetsByStatusWithHttpInfo(List<String> status,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/findByStatus';
+    final _path = r'/pet/findByStatus';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('csv', 'status', status));
+      __queryParams.addAll(_queryParams('csv', 'status', status));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -179,16 +179,16 @@ class PetApi {
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
   Future<List<Pet>?> findPetsByStatus(List<String> status,) async {
-    final response = await findPetsByStatusWithHttpInfo(status,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await findPetsByStatusWithHttpInfo(status,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<Pet>') as List)
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      final _responseBody = await _decodeBodyBytes(_response);
+      return (await apiClient.deserializeAsync(_responseBody, 'List<Pet>') as List)
         .cast<Pet>()
         .toList(growable: false);
 
@@ -208,28 +208,28 @@ class PetApi {
   ///   Tags to filter by
   Future<Response> findPetsByTagsWithHttpInfo(List<String> tags,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/findByTags';
+    final _path = r'/pet/findByTags';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('csv', 'tags', tags));
+      __queryParams.addAll(_queryParams('csv', 'tags', tags));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -242,16 +242,16 @@ class PetApi {
   /// * [List<String>] tags (required):
   ///   Tags to filter by
   Future<List<Pet>?> findPetsByTags(List<String> tags,) async {
-    final response = await findPetsByTagsWithHttpInfo(tags,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await findPetsByTagsWithHttpInfo(tags,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<Pet>') as List)
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      final _responseBody = await _decodeBodyBytes(_response);
+      return (await apiClient.deserializeAsync(_responseBody, 'List<Pet>') as List)
         .cast<Pet>()
         .toList(growable: false);
 
@@ -271,27 +271,27 @@ class PetApi {
   ///   ID of pet to return
   Future<Response> getPetByIdWithHttpInfo(int petId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -304,15 +304,15 @@ class PetApi {
   /// * [int] petId (required):
   ///   ID of pet to return
   Future<Pet?> getPetById(int petId,) async {
-    final response = await getPetByIdWithHttpInfo(petId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getPetByIdWithHttpInfo(petId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Pet',) as Pet;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Pet',) as Pet;
     
     }
     return null;
@@ -330,26 +330,26 @@ class PetApi {
   ///   Pet object that needs to be added to the store
   Future<Response> updatePetWithHttpInfo(Pet pet,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet';
+    final _path = r'/pet';
 
     // ignore: prefer_final_locals
-    Object? postBody = pet;
+    Object? _postBody = pet;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json', 'application/xml'];
+    const _contentTypes = <String>['application/json', 'application/xml'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -362,15 +362,15 @@ class PetApi {
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
   Future<Pet?> updatePet(Pet pet,) async {
-    final response = await updatePetWithHttpInfo(pet,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updatePetWithHttpInfo(pet,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Pet',) as Pet;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Pet',) as Pet;
     
     }
     return null;
@@ -394,33 +394,33 @@ class PetApi {
   ///   Updated status of the pet
   Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/x-www-form-urlencoded'];
+    const _contentTypes = <String>['application/x-www-form-urlencoded'];
 
     if (name != null) {
-      formParams[r'name'] = parameterToString(name);
+      _formParams[r'name'] = parameterToString(name);
     }
     if (status != null) {
-      formParams[r'status'] = parameterToString(status);
+      _formParams[r'status'] = parameterToString(status);
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -439,9 +439,9 @@ class PetApi {
   /// * [String] status:
   ///   Updated status of the pet
   Future<void> updatePetWithForm(int petId, { String? name, String? status, }) async {
-    final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -463,41 +463,41 @@ class PetApi {
   ///   file to upload
   Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}/uploadImage'
+    final _path = r'/pet/{petId}/uploadImage'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['multipart/form-data'];
+    const _contentTypes = <String>['multipart/form-data'];
 
-    bool hasFields = false;
-    final mp = MultipartRequest('POST', Uri.parse(path));
+    bool _hasFields = false;
+    final _mp = MultipartRequest('POST', Uri.parse(_path));
     if (additionalMetadata != null) {
-      hasFields = true;
-      mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
+      _hasFields = true;
+      _mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
     }
     if (file != null) {
-      hasFields = true;
-      mp.fields[r'file'] = file.field;
-      mp.files.add(file);
+      _hasFields = true;
+      _mp.fields[r'file'] = file.field;
+      _mp.files.add(file);
     }
-    if (hasFields) {
-      postBody = mp;
+    if (_hasFields) {
+      _postBody = _mp;
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -516,15 +516,15 @@ class PetApi {
   /// * [MultipartFile] file:
   ///   file to upload
   Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
-    final response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ApiResponse',) as ApiResponse;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ApiResponse',) as ApiResponse;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -28,27 +28,27 @@ class StoreApi {
   ///   ID of the order that needs to be deleted
   Future<Response> deleteOrderWithHttpInfo(String orderId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order/{orderId}'
+    final _path = r'/store/order/{orderId}'
       .replaceAll('{orderId}', orderId);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -61,9 +61,9 @@ class StoreApi {
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
   Future<void> deleteOrder(String orderId,) async {
-    final response = await deleteOrderWithHttpInfo(orderId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deleteOrderWithHttpInfo(orderId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -74,26 +74,26 @@ class StoreApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> getInventoryWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/store/inventory';
+    final _path = r'/store/inventory';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -101,15 +101,15 @@ class StoreApi {
   ///
   /// Returns a map of status codes to quantities
   Future<Map<String, int>?> getInventory() async {
-    final response = await getInventoryWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getInventoryWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return Map<String, int>.from(await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Map<String, int>'),);
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return Map<String, int>.from(await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Map<String, int>'),);
 
     }
     return null;
@@ -127,27 +127,27 @@ class StoreApi {
   ///   ID of pet that needs to be fetched
   Future<Response> getOrderByIdWithHttpInfo(int orderId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order/{orderId}'
+    final _path = r'/store/order/{orderId}'
       .replaceAll('{orderId}', orderId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -160,15 +160,15 @@ class StoreApi {
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
   Future<Order?> getOrderById(int orderId,) async {
-    final response = await getOrderByIdWithHttpInfo(orderId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getOrderByIdWithHttpInfo(orderId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Order',) as Order;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Order',) as Order;
     
     }
     return null;
@@ -186,26 +186,26 @@ class StoreApi {
   ///   order placed for purchasing the pet
   Future<Response> placeOrderWithHttpInfo(Order order,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order';
+    final _path = r'/store/order';
 
     // ignore: prefer_final_locals
-    Object? postBody = order;
+    Object? _postBody = order;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -218,15 +218,15 @@ class StoreApi {
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
   Future<Order?> placeOrder(Order order,) async {
-    final response = await placeOrderWithHttpInfo(order,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await placeOrderWithHttpInfo(order,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Order',) as Order;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Order',) as Order;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -28,26 +28,26 @@ class UserApi {
   ///   Created user object
   Future<Response> createUserWithHttpInfo(User user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user';
+    final _path = r'/user';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,9 +60,9 @@ class UserApi {
   /// * [User] user (required):
   ///   Created user object
   Future<void> createUser(User user,) async {
-    final response = await createUserWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUserWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -78,26 +78,26 @@ class UserApi {
   ///   List of user object
   Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/createWithArray';
+    final _path = r'/user/createWithArray';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -110,9 +110,9 @@ class UserApi {
   /// * [List<User>] user (required):
   ///   List of user object
   Future<void> createUsersWithArrayInput(List<User> user,) async {
-    final response = await createUsersWithArrayInputWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUsersWithArrayInputWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -128,26 +128,26 @@ class UserApi {
   ///   List of user object
   Future<Response> createUsersWithListInputWithHttpInfo(List<User> user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/createWithList';
+    final _path = r'/user/createWithList';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -160,9 +160,9 @@ class UserApi {
   /// * [List<User>] user (required):
   ///   List of user object
   Future<void> createUsersWithListInput(List<User> user,) async {
-    final response = await createUsersWithListInputWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUsersWithListInputWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -178,27 +178,27 @@ class UserApi {
   ///   The name that needs to be deleted
   Future<Response> deleteUserWithHttpInfo(String username,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -211,9 +211,9 @@ class UserApi {
   /// * [String] username (required):
   ///   The name that needs to be deleted
   Future<void> deleteUser(String username,) async {
-    final response = await deleteUserWithHttpInfo(username,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deleteUserWithHttpInfo(username,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -229,27 +229,27 @@ class UserApi {
   ///   The name that needs to be fetched. Use user1 for testing.
   Future<Response> getUserByNameWithHttpInfo(String username,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -262,15 +262,15 @@ class UserApi {
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
   Future<User?> getUserByName(String username,) async {
-    final response = await getUserByNameWithHttpInfo(username,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getUserByNameWithHttpInfo(username,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'User',) as User;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'User',) as User;
     
     }
     return null;
@@ -291,29 +291,29 @@ class UserApi {
   ///   The password for login in clear text
   Future<Response> loginUserWithHttpInfo(String username, String password,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/login';
+    final _path = r'/user/login';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('', 'username', username));
-      queryParams.addAll(_queryParams('', 'password', password));
+      __queryParams.addAll(_queryParams('', 'username', username));
+      __queryParams.addAll(_queryParams('', 'password', password));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -329,15 +329,15 @@ class UserApi {
   /// * [String] password (required):
   ///   The password for login in clear text
   Future<String?> loginUser(String username, String password,) async {
-    final response = await loginUserWithHttpInfo(username, password,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await loginUserWithHttpInfo(username, password,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'String',) as String;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'String',) as String;
     
     }
     return null;
@@ -350,26 +350,26 @@ class UserApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> logoutUserWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/user/logout';
+    final _path = r'/user/logout';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -377,9 +377,9 @@ class UserApi {
   ///
   /// 
   Future<void> logoutUser() async {
-    final response = await logoutUserWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await logoutUserWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -398,27 +398,27 @@ class UserApi {
   ///   Updated user object
   Future<Response> updateUserWithHttpInfo(String username, User user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -434,9 +434,9 @@ class UserApi {
   /// * [User] user (required):
   ///   Updated user object
   Future<void> updateUser(String username, User user,) async {
-    final response = await updateUserWithHttpInfo(username, user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updateUserWithHttpInfo(username, user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -143,19 +143,21 @@ class ApiClient {
     );
   }
 
-  Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>
+  Future<dynamic> deserializeAsync(dynamic value, String targetType, {bool growable = false,}) async =>
     // ignore: deprecated_member_use_from_same_package
     deserialize(value, targetType, growable: growable);
 
   @Deprecated('Scheduled for removal in OpenAPI Generator 6.x. Use deserializeAsync() instead.')
-  dynamic deserialize(String value, String targetType, {bool growable = false,}) {
+  dynamic deserialize(dynamic value, String targetType, {bool growable = false,}) {
     // Remove all spaces. Necessary for regular expressions as well.
     targetType = targetType.replaceAll(' ', ''); // ignore: parameter_assignments
 
-    // If the expected target type is String, nothing to do...
-    return targetType == 'String'
-      ? value
-      : fromJson(json.decode(value), targetType, growable: growable);
+    // If targetType is a known primitive, utilize it directly
+    if (targetType == 'String' || targetType == 'int' || targetType == 'double' || targetType == 'bool' || targetType == 'DateTime' || targetType == 'Uint8List') {
+      return fromJson(value, targetType, growable: growable);
+    } else {
+      return fromJson(json.decode(value), targetType, growable: growable);
+    }
   }
 
   // ignore: deprecated_member_use_from_same_package
@@ -182,6 +184,8 @@ class ApiClient {
           return valueString == 'true' || valueString == '1';
         case 'DateTime':
           return value is DateTime ? value : DateTime.tryParse(value);
+        case 'Uint8List':
+          return value as Uint8List;
         case 'ApiResponse':
           return ApiResponse.fromJson(value);
         case 'Category':

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
@@ -58,18 +58,26 @@ String parameterToString(dynamic value) {
   return value.toString();
 }
 
-/// Returns the decoded body as UTF-8 if the given headers indicate an 'application/json'
-/// content type. Otherwise, returns the decoded body as decoded by dart:http package.
-Future<String> _decodeBodyBytes(Response response) async {
-  final contentType = response.headers['content-type'];
-  return contentType != null && contentType.toLowerCase().startsWith('application/json')
-    ? response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes)
-    : response.body;
+/// Decodes the body based on the content-type
+/// application/json and text/plain are decoded as utf-8
+/// all other types will be returned as Uint8List
+Future<dynamic> _decodeBodyBytes(Response response) async {
+  final contentType = response.headers['content-type']?.toLowerCase();
+  if (contentType != null) {
+    if (contentType.startsWith('application/json') || contentType.startsWith('text/plain')) {
+      return response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes);
+    }
+  }
+  /* all other responses should be returned as a raw Uint8List */
+  return response.bodyBytes;
 }
 
 /// Returns a valid [T] value found at the specified Map [key], null otherwise.
 T? mapValueOfType<T>(dynamic map, String key) {
   final dynamic value = map is Map ? map[key] : null;
+  if (T == double && value is int) {
+    return value.toDouble() as T;
+  }
   return value is T ? value : null;
 }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ApiResponse {
   /// Returns a new [ApiResponse] instance.
   ApiResponse({
-    this.code,
-    this.type,
-    this.message,
+     this.code,
+     this.type,
+     this.message,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Category {
   /// Returns a new [Category] instance.
   Category({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Order {
   /// Returns a new [Order] instance.
   Order({
-    this.id,
-    this.petId,
-    this.quantity,
-    this.shipDate,
-    this.status,
-    this.complete = false,
+     this.id,
+     this.petId,
+     this.quantity,
+     this.shipDate,
+     this.status,
+     this.complete = false,
   });
 
   ///
@@ -224,6 +224,12 @@ class OrderStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OrderStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OrderStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Pet {
   /// Returns a new [Pet] instance.
   Pet({
-    this.id,
-    this.category,
-    required this.name,
-    this.photoUrls = const [],
-    this.tags = const [],
-    this.status,
+     this.id,
+     this.category,
+     required this.name,
+     this.photoUrls = const [],
+     this.tags = const [],
+     this.status,
   });
 
   ///
@@ -208,6 +208,12 @@ class PetStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PetStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [PetStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Tag {
   /// Returns a new [Tag] instance.
   Tag({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class User {
   /// Returns a new [User] instance.
   User({
-    this.id,
-    this.username,
-    this.firstName,
-    this.lastName,
-    this.email,
-    this.password,
-    this.phone,
-    this.userStatus,
+     this.id,
+     this.username,
+     this.firstName,
+     this.lastName,
+     this.email,
+     this.password,
+     this.phone,
+     this.userStatus,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FakeApi.md
@@ -559,7 +559,7 @@ final int32 = 56; // int | None
 final int64 = 789; // int | None
 final float = 3.4; // double | None
 final string = string_example; // String | None
-final binary = BINARY_DATA_HERE; // MultipartFile | None
+final binary = BINARY_DATA_HERE; // Uint8List | None
 final date = 2013-10-20; // DateTime | None
 final dateTime = 2013-10-20T19:20:30+01:00; // DateTime | None
 final password = password_example; // String | None
@@ -585,7 +585,7 @@ Name | Type | Description  | Notes
  **int64** | **int**| None | [optional] 
  **float** | **double**| None | [optional] 
  **string** | **String**| None | [optional] 
- **binary** | **MultipartFile**| None | [optional] 
+ **binary** | **Uint8List**| None | [optional] 
  **date** | **DateTime**| None | [optional] 
  **dateTime** | **DateTime**| None | [optional] 
  **password** | **String**| None | [optional] 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FormatTest.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/FormatTest.md
@@ -17,7 +17,7 @@ Name | Type | Description | Notes
 **decimal** | **double** |  | [optional] 
 **string** | **String** |  | [optional] 
 **byte** | **String** |  | 
-**binary** | [**MultipartFile**](MultipartFile.md) |  | [optional] 
+**binary** | [**Uint8List**](Uint8List.md) |  | [optional] 
 **date** | [**DateTime**](DateTime.md) |  | 
 **dateTime** | [**DateTime**](DateTime.md) |  | [optional] 
 **uuid** | **String** |  | [optional] 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/NullableClass.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/NullableClass.md
@@ -14,12 +14,12 @@ Name | Type | Description | Notes
 **stringProp** | **String** |  | [optional] 
 **dateProp** | [**DateTime**](DateTime.md) |  | [optional] 
 **datetimeProp** | [**DateTime**](DateTime.md) |  | [optional] 
-**arrayNullableProp** | [**List<Object>**](Object.md) |  | [optional] [default to const []]
-**arrayAndItemsNullableProp** | [**List<Object>**](Object.md) |  | [optional] [default to const []]
-**arrayItemsNullable** | [**List<Object>**](Object.md) |  | [optional] [default to const []]
-**objectNullableProp** | [**Map<String, Object>**](Object.md) |  | [optional] [default to const {}]
-**objectAndItemsNullableProp** | [**Map<String, Object>**](Object.md) |  | [optional] [default to const {}]
-**objectItemsNullable** | [**Map<String, Object>**](Object.md) |  | [optional] [default to const {}]
+**arrayNullableProp** | **List<Object>** |  | [optional] [default to const []]
+**arrayAndItemsNullableProp** | **List<Object>** |  | [optional] [default to const []]
+**arrayItemsNullable** | **List<Object>** |  | [optional] [default to const []]
+**objectNullableProp** | **Map<String, Object>** |  | [optional] [default to const {}]
+**objectAndItemsNullableProp** | **Map<String, Object>** |  | [optional] [default to const {}]
+**objectItemsNullable** | **Map<String, Object>** |  | [optional] [default to const {}]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/OuterObjectWithEnumProperty.md
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/doc/OuterObjectWithEnumProperty.md
@@ -8,7 +8,7 @@ import 'package:openapi/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**value** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | 
+**value_** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -13,6 +13,7 @@ library openapi.api;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:http/http.dart';

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -28,26 +28,26 @@ class AnotherFakeApi {
   ///   client model
   Future<Response> call123testSpecialTagsWithHttpInfo(ModelClient modelClient,) async {
     // ignore: prefer_const_declarations
-    final path = r'/another-fake/dummy';
+    final _path = r'/another-fake/dummy';
 
     // ignore: prefer_final_locals
-    Object? postBody = modelClient;
+    Object? _postBody = modelClient;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PATCH',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,15 +60,15 @@ class AnotherFakeApi {
   /// * [ModelClient] modelClient (required):
   ///   client model
   Future<ModelClient?> call123testSpecialTags(ModelClient modelClient,) async {
-    final response = await call123testSpecialTagsWithHttpInfo(modelClient,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await call123testSpecialTagsWithHttpInfo(modelClient,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ModelClient',) as ModelClient;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ModelClient',) as ModelClient;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
@@ -19,39 +19,39 @@ class DefaultApi {
   /// Performs an HTTP 'GET /foo' operation and returns the [Response].
   Future<Response> fooGetWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/foo';
+    final _path = r'/foo';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
   Future<FooGetDefaultResponse?> fooGet() async {
-    final response = await fooGetWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fooGetWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'FooGetDefaultResponse',) as FooGetDefaultResponse;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'FooGetDefaultResponse',) as FooGetDefaultResponse;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -21,40 +21,40 @@ class FakeApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> fakeBigDecimalMapWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/BigDecimalMap';
+    final _path = r'/fake/BigDecimalMap';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
   /// for Java apache and Java native, test toUrlQueryString for maps with BegDecimal keys
   Future<FakeBigDecimalMap200Response?> fakeBigDecimalMap() async {
-    final response = await fakeBigDecimalMapWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeBigDecimalMapWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'FakeBigDecimalMap200Response',) as FakeBigDecimalMap200Response;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'FakeBigDecimalMap200Response',) as FakeBigDecimalMap200Response;
     
     }
     return null;
@@ -65,40 +65,40 @@ class FakeApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> fakeHealthGetWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/health';
+    final _path = r'/fake/health';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
   /// Health check endpoint
   Future<HealthCheckResult?> fakeHealthGet() async {
-    final response = await fakeHealthGetWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeHealthGetWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'HealthCheckResult',) as HealthCheckResult;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'HealthCheckResult',) as HealthCheckResult;
     
     }
     return null;
@@ -120,34 +120,34 @@ class FakeApi {
   ///   header parameter
   Future<Response> fakeHttpSignatureTestWithHttpInfo(Pet pet, { String? query1, String? header1, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/http-signature-test';
+    final _path = r'/fake/http-signature-test';
 
     // ignore: prefer_final_locals
-    Object? postBody = pet;
+    Object? _postBody = pet;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
     if (query1 != null) {
-      queryParams.addAll(_queryParams('', 'query_1', query1));
+      __queryParams.addAll(_queryParams('', 'query_1', query1));
     }
 
     if (header1 != null) {
-      headerParams[r'header_1'] = parameterToString(header1);
+      _headerParams[r'header_1'] = parameterToString(header1);
     }
 
-    const contentTypes = <String>['application/json', 'application/xml'];
+    const _contentTypes = <String>['application/json', 'application/xml'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -164,9 +164,9 @@ class FakeApi {
   /// * [String] header1:
   ///   header parameter
   Future<void> fakeHttpSignatureTest(Pet pet, { String? query1, String? header1, }) async {
-    final response = await fakeHttpSignatureTestWithHttpInfo(pet,  query1: query1, header1: header1, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeHttpSignatureTestWithHttpInfo(pet,  query1: query1, header1: header1, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -180,26 +180,26 @@ class FakeApi {
   ///   Input boolean as post body
   Future<Response> fakeOuterBooleanSerializeWithHttpInfo({ bool? body, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/outer/boolean';
+    final _path = r'/fake/outer/boolean';
 
     // ignore: prefer_final_locals
-    Object? postBody = body;
+    Object? _postBody = body;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -210,15 +210,15 @@ class FakeApi {
   /// * [bool] body:
   ///   Input boolean as post body
   Future<bool?> fakeOuterBooleanSerialize({ bool? body, }) async {
-    final response = await fakeOuterBooleanSerializeWithHttpInfo( body: body, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeOuterBooleanSerializeWithHttpInfo( body: body, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'bool',) as bool;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'bool',) as bool;
     
     }
     return null;
@@ -234,26 +234,26 @@ class FakeApi {
   ///   Input composite as post body
   Future<Response> fakeOuterCompositeSerializeWithHttpInfo({ OuterComposite? outerComposite, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/outer/composite';
+    final _path = r'/fake/outer/composite';
 
     // ignore: prefer_final_locals
-    Object? postBody = outerComposite;
+    Object? _postBody = outerComposite;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -264,15 +264,15 @@ class FakeApi {
   /// * [OuterComposite] outerComposite:
   ///   Input composite as post body
   Future<OuterComposite?> fakeOuterCompositeSerialize({ OuterComposite? outerComposite, }) async {
-    final response = await fakeOuterCompositeSerializeWithHttpInfo( outerComposite: outerComposite, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeOuterCompositeSerializeWithHttpInfo( outerComposite: outerComposite, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'OuterComposite',) as OuterComposite;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'OuterComposite',) as OuterComposite;
     
     }
     return null;
@@ -288,26 +288,26 @@ class FakeApi {
   ///   Input number as post body
   Future<Response> fakeOuterNumberSerializeWithHttpInfo({ num? body, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/outer/number';
+    final _path = r'/fake/outer/number';
 
     // ignore: prefer_final_locals
-    Object? postBody = body;
+    Object? _postBody = body;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -318,15 +318,15 @@ class FakeApi {
   /// * [num] body:
   ///   Input number as post body
   Future<num?> fakeOuterNumberSerialize({ num? body, }) async {
-    final response = await fakeOuterNumberSerializeWithHttpInfo( body: body, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeOuterNumberSerializeWithHttpInfo( body: body, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'num',) as num;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'num',) as num;
     
     }
     return null;
@@ -342,26 +342,26 @@ class FakeApi {
   ///   Input string as post body
   Future<Response> fakeOuterStringSerializeWithHttpInfo({ String? body, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/outer/string';
+    final _path = r'/fake/outer/string';
 
     // ignore: prefer_final_locals
-    Object? postBody = body;
+    Object? _postBody = body;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -372,15 +372,15 @@ class FakeApi {
   /// * [String] body:
   ///   Input string as post body
   Future<String?> fakeOuterStringSerialize({ String? body, }) async {
-    final response = await fakeOuterStringSerializeWithHttpInfo( body: body, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakeOuterStringSerializeWithHttpInfo( body: body, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'String',) as String;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'String',) as String;
     
     }
     return null;
@@ -396,26 +396,26 @@ class FakeApi {
   ///   Input enum (int) as post body
   Future<Response> fakePropertyEnumIntegerSerializeWithHttpInfo(OuterObjectWithEnumProperty outerObjectWithEnumProperty,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/property/enum-int';
+    final _path = r'/fake/property/enum-int';
 
     // ignore: prefer_final_locals
-    Object? postBody = outerObjectWithEnumProperty;
+    Object? _postBody = outerObjectWithEnumProperty;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -426,15 +426,15 @@ class FakeApi {
   /// * [OuterObjectWithEnumProperty] outerObjectWithEnumProperty (required):
   ///   Input enum (int) as post body
   Future<OuterObjectWithEnumProperty?> fakePropertyEnumIntegerSerialize(OuterObjectWithEnumProperty outerObjectWithEnumProperty,) async {
-    final response = await fakePropertyEnumIntegerSerializeWithHttpInfo(outerObjectWithEnumProperty,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await fakePropertyEnumIntegerSerializeWithHttpInfo(outerObjectWithEnumProperty,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'OuterObjectWithEnumProperty',) as OuterObjectWithEnumProperty;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'OuterObjectWithEnumProperty',) as OuterObjectWithEnumProperty;
     
     }
     return null;
@@ -450,26 +450,26 @@ class FakeApi {
   ///   image to upload
   Future<Response> testBodyWithBinaryWithHttpInfo(MultipartFile body,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/body-with-binary';
+    final _path = r'/fake/body-with-binary';
 
     // ignore: prefer_final_locals
-    Object? postBody = body;
+    Object? _postBody = body;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['image/png'];
+    const _contentTypes = <String>['image/png'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -480,9 +480,9 @@ class FakeApi {
   /// * [MultipartFile] body (required):
   ///   image to upload
   Future<void> testBodyWithBinary(MultipartFile body,) async {
-    final response = await testBodyWithBinaryWithHttpInfo(body,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testBodyWithBinaryWithHttpInfo(body,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -495,26 +495,26 @@ class FakeApi {
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
   Future<Response> testBodyWithFileSchemaWithHttpInfo(FileSchemaTestClass fileSchemaTestClass,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/body-with-file-schema';
+    final _path = r'/fake/body-with-file-schema';
 
     // ignore: prefer_final_locals
-    Object? postBody = fileSchemaTestClass;
+    Object? _postBody = fileSchemaTestClass;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -524,9 +524,9 @@ class FakeApi {
   ///
   /// * [FileSchemaTestClass] fileSchemaTestClass (required):
   Future<void> testBodyWithFileSchema(FileSchemaTestClass fileSchemaTestClass,) async {
-    final response = await testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testBodyWithFileSchemaWithHttpInfo(fileSchemaTestClass,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -538,28 +538,28 @@ class FakeApi {
   /// * [User] user (required):
   Future<Response> testBodyWithQueryParamsWithHttpInfo(String query, User user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/body-with-query-params';
+    final _path = r'/fake/body-with-query-params';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('', 'query', query));
+      __queryParams.addAll(_queryParams('', 'query', query));
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -569,9 +569,9 @@ class FakeApi {
   ///
   /// * [User] user (required):
   Future<void> testBodyWithQueryParams(String query, User user,) async {
-    final response = await testBodyWithQueryParamsWithHttpInfo(query, user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testBodyWithQueryParamsWithHttpInfo(query, user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -587,26 +587,26 @@ class FakeApi {
   ///   client model
   Future<Response> testClientModelWithHttpInfo(ModelClient modelClient,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake';
+    final _path = r'/fake';
 
     // ignore: prefer_final_locals
-    Object? postBody = modelClient;
+    Object? _postBody = modelClient;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PATCH',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -619,15 +619,15 @@ class FakeApi {
   /// * [ModelClient] modelClient (required):
   ///   client model
   Future<ModelClient?> testClientModel(ModelClient modelClient,) async {
-    final response = await testClientModelWithHttpInfo(modelClient,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testClientModelWithHttpInfo(modelClient,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ModelClient',) as ModelClient;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ModelClient',) as ModelClient;
     
     }
     return null;
@@ -668,7 +668,7 @@ class FakeApi {
   /// * [String] string:
   ///   None
   ///
-  /// * [MultipartFile] binary:
+  /// * [Uint8List] binary:
   ///   None
   ///
   /// * [DateTime] date:
@@ -682,67 +682,67 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future<Response> testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
+  Future<Response> testEndpointParametersWithHttpInfo(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, Uint8List? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake';
+    final _path = r'/fake';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/x-www-form-urlencoded'];
+    const _contentTypes = <String>['application/x-www-form-urlencoded'];
 
     if (integer != null) {
-      formParams[r'integer'] = parameterToString(integer);
+      _formParams[r'integer'] = parameterToString(integer);
     }
     if (int32 != null) {
-      formParams[r'int32'] = parameterToString(int32);
+      _formParams[r'int32'] = parameterToString(int32);
     }
     if (int64 != null) {
-      formParams[r'int64'] = parameterToString(int64);
+      _formParams[r'int64'] = parameterToString(int64);
     }
     if (number != null) {
-      formParams[r'number'] = parameterToString(number);
+      _formParams[r'number'] = parameterToString(number);
     }
     if (float != null) {
-      formParams[r'float'] = parameterToString(float);
+      _formParams[r'float'] = parameterToString(float);
     }
     if (double_ != null) {
-      formParams[r'double'] = parameterToString(double_);
+      _formParams[r'double'] = parameterToString(double_);
     }
     if (string != null) {
-      formParams[r'string'] = parameterToString(string);
+      _formParams[r'string'] = parameterToString(string);
     }
     if (patternWithoutDelimiter != null) {
-      formParams[r'pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
+      _formParams[r'pattern_without_delimiter'] = parameterToString(patternWithoutDelimiter);
     }
     if (byte != null) {
-      formParams[r'byte'] = parameterToString(byte);
+      _formParams[r'byte'] = parameterToString(byte);
     }
     if (date != null) {
-      formParams[r'date'] = parameterToString(date);
+      _formParams[r'date'] = parameterToString(date);
     }
     if (dateTime != null) {
-      formParams[r'dateTime'] = parameterToString(dateTime);
+      _formParams[r'dateTime'] = parameterToString(dateTime);
     }
     if (password != null) {
-      formParams[r'password'] = parameterToString(password);
+      _formParams[r'password'] = parameterToString(password);
     }
     if (callback != null) {
-      formParams[r'callback'] = parameterToString(callback);
+      _formParams[r'callback'] = parameterToString(callback);
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -779,7 +779,7 @@ class FakeApi {
   /// * [String] string:
   ///   None
   ///
-  /// * [MultipartFile] binary:
+  /// * [Uint8List] binary:
   ///   None
   ///
   /// * [DateTime] date:
@@ -793,10 +793,10 @@ class FakeApi {
   ///
   /// * [String] callback:
   ///   None
-  Future<void> testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, MultipartFile? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
-    final response = await testEndpointParametersWithHttpInfo(number, double_, patternWithoutDelimiter, byte,  integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+  Future<void> testEndpointParameters(num number, double double_, String patternWithoutDelimiter, String byte, { int? integer, int? int32, int? int64, double? float, String? string, Uint8List? binary, DateTime? date, DateTime? dateTime, String? password, String? callback, }) async {
+    final _response = await testEndpointParametersWithHttpInfo(number, double_, patternWithoutDelimiter, byte,  integer: integer, int32: int32, int64: int64, float: float, string: string, binary: binary, date: date, dateTime: dateTime, password: password, callback: callback, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -835,55 +835,55 @@ class FakeApi {
   ///   Form parameter enum test (string)
   Future<Response> testEnumParametersWithHttpInfo({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake';
+    final _path = r'/fake';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
     if (enumQueryStringArray != null) {
-      queryParams.addAll(_queryParams('multi', 'enum_query_string_array', enumQueryStringArray));
+      __queryParams.addAll(_queryParams('multi', 'enum_query_string_array', enumQueryStringArray));
     }
     if (enumQueryString != null) {
-      queryParams.addAll(_queryParams('', 'enum_query_string', enumQueryString));
+      __queryParams.addAll(_queryParams('', 'enum_query_string', enumQueryString));
     }
     if (enumQueryInteger != null) {
-      queryParams.addAll(_queryParams('', 'enum_query_integer', enumQueryInteger));
+      __queryParams.addAll(_queryParams('', 'enum_query_integer', enumQueryInteger));
     }
     if (enumQueryDouble != null) {
-      queryParams.addAll(_queryParams('', 'enum_query_double', enumQueryDouble));
+      __queryParams.addAll(_queryParams('', 'enum_query_double', enumQueryDouble));
     }
     if (enumQueryModelArray != null) {
-      queryParams.addAll(_queryParams('multi', 'enum_query_model_array', enumQueryModelArray));
+      __queryParams.addAll(_queryParams('multi', 'enum_query_model_array', enumQueryModelArray));
     }
 
     if (enumHeaderStringArray != null) {
-      headerParams[r'enum_header_string_array'] = parameterToString(enumHeaderStringArray);
+      _headerParams[r'enum_header_string_array'] = parameterToString(enumHeaderStringArray);
     }
     if (enumHeaderString != null) {
-      headerParams[r'enum_header_string'] = parameterToString(enumHeaderString);
+      _headerParams[r'enum_header_string'] = parameterToString(enumHeaderString);
     }
 
-    const contentTypes = <String>['application/x-www-form-urlencoded'];
+    const _contentTypes = <String>['application/x-www-form-urlencoded'];
 
     if (enumFormStringArray != null) {
-      formParams[r'enum_form_string_array'] = parameterToString(enumFormStringArray);
+      _formParams[r'enum_form_string_array'] = parameterToString(enumFormStringArray);
     }
     if (enumFormString != null) {
-      formParams[r'enum_form_string'] = parameterToString(enumFormString);
+      _formParams[r'enum_form_string'] = parameterToString(enumFormString);
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -919,9 +919,9 @@ class FakeApi {
   /// * [String] enumFormString:
   ///   Form parameter enum test (string)
   Future<void> testEnumParameters({ List<String>? enumHeaderStringArray, String? enumHeaderString, List<String>? enumQueryStringArray, String? enumQueryString, int? enumQueryInteger, double? enumQueryDouble, List<EnumClass>? enumQueryModelArray, List<String>? enumFormStringArray, String? enumFormString, }) async {
-    final response = await testEnumParametersWithHttpInfo( enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumQueryModelArray: enumQueryModelArray, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testEnumParametersWithHttpInfo( enumHeaderStringArray: enumHeaderStringArray, enumHeaderString: enumHeaderString, enumQueryStringArray: enumQueryStringArray, enumQueryString: enumQueryString, enumQueryInteger: enumQueryInteger, enumQueryDouble: enumQueryDouble, enumQueryModelArray: enumQueryModelArray, enumFormStringArray: enumFormStringArray, enumFormString: enumFormString, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -952,40 +952,40 @@ class FakeApi {
   ///   Integer in group parameters
   Future<Response> testGroupParametersWithHttpInfo(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake';
+    final _path = r'/fake';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('', 'required_string_group', requiredStringGroup));
-      queryParams.addAll(_queryParams('', 'required_int64_group', requiredInt64Group));
+      __queryParams.addAll(_queryParams('', 'required_string_group', requiredStringGroup));
+      __queryParams.addAll(_queryParams('', 'required_int64_group', requiredInt64Group));
     if (stringGroup != null) {
-      queryParams.addAll(_queryParams('', 'string_group', stringGroup));
+      __queryParams.addAll(_queryParams('', 'string_group', stringGroup));
     }
     if (int64Group != null) {
-      queryParams.addAll(_queryParams('', 'int64_group', int64Group));
+      __queryParams.addAll(_queryParams('', 'int64_group', int64Group));
     }
 
-    headerParams[r'required_boolean_group'] = parameterToString(requiredBooleanGroup);
+    _headerParams[r'required_boolean_group'] = parameterToString(requiredBooleanGroup);
     if (booleanGroup != null) {
-      headerParams[r'boolean_group'] = parameterToString(booleanGroup);
+      _headerParams[r'boolean_group'] = parameterToString(booleanGroup);
     }
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1013,9 +1013,9 @@ class FakeApi {
   /// * [int] int64Group:
   ///   Integer in group parameters
   Future<void> testGroupParameters(int requiredStringGroup, bool requiredBooleanGroup, int requiredInt64Group, { int? stringGroup, bool? booleanGroup, int? int64Group, }) async {
-    final response = await testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group,  stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testGroupParametersWithHttpInfo(requiredStringGroup, requiredBooleanGroup, requiredInt64Group,  stringGroup: stringGroup, booleanGroup: booleanGroup, int64Group: int64Group, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -1031,26 +1031,26 @@ class FakeApi {
   ///   request body
   Future<Response> testInlineAdditionalPropertiesWithHttpInfo(Map<String, String> requestBody,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/inline-additionalProperties';
+    final _path = r'/fake/inline-additionalProperties';
 
     // ignore: prefer_final_locals
-    Object? postBody = requestBody;
+    Object? _postBody = requestBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1063,9 +1063,9 @@ class FakeApi {
   /// * [Map<String, String>] requestBody (required):
   ///   request body
   Future<void> testInlineAdditionalProperties(Map<String, String> requestBody,) async {
-    final response = await testInlineAdditionalPropertiesWithHttpInfo(requestBody,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testInlineAdditionalPropertiesWithHttpInfo(requestBody,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -1081,26 +1081,26 @@ class FakeApi {
   ///   request body
   Future<Response> testInlineFreeformAdditionalPropertiesWithHttpInfo(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/inline-freeform-additionalProperties';
+    final _path = r'/fake/inline-freeform-additionalProperties';
 
     // ignore: prefer_final_locals
-    Object? postBody = testInlineFreeformAdditionalPropertiesRequest;
+    Object? _postBody = testInlineFreeformAdditionalPropertiesRequest;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1113,9 +1113,9 @@ class FakeApi {
   /// * [TestInlineFreeformAdditionalPropertiesRequest] testInlineFreeformAdditionalPropertiesRequest (required):
   ///   request body
   Future<void> testInlineFreeformAdditionalProperties(TestInlineFreeformAdditionalPropertiesRequest testInlineFreeformAdditionalPropertiesRequest,) async {
-    final response = await testInlineFreeformAdditionalPropertiesWithHttpInfo(testInlineFreeformAdditionalPropertiesRequest,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testInlineFreeformAdditionalPropertiesWithHttpInfo(testInlineFreeformAdditionalPropertiesRequest,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -1134,32 +1134,32 @@ class FakeApi {
   ///   field2
   Future<Response> testJsonFormDataWithHttpInfo(String param, String param2,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/jsonFormData';
+    final _path = r'/fake/jsonFormData';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/x-www-form-urlencoded'];
+    const _contentTypes = <String>['application/x-www-form-urlencoded'];
 
     if (param != null) {
-      formParams[r'param'] = parameterToString(param);
+      _formParams[r'param'] = parameterToString(param);
     }
     if (param2 != null) {
-      formParams[r'param2'] = parameterToString(param2);
+      _formParams[r'param2'] = parameterToString(param2);
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1175,9 +1175,9 @@ class FakeApi {
   /// * [String] param2 (required):
   ///   field2
   Future<void> testJsonFormData(String param, String param2,) async {
-    final response = await testJsonFormDataWithHttpInfo(param, param2,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testJsonFormDataWithHttpInfo(param, param2,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -1193,26 +1193,26 @@ class FakeApi {
   ///   request body
   Future<Response> testNullableWithHttpInfo(ChildWithNullable childWithNullable,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/nullable';
+    final _path = r'/fake/nullable';
 
     // ignore: prefer_final_locals
-    Object? postBody = childWithNullable;
+    Object? _postBody = childWithNullable;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1225,9 +1225,9 @@ class FakeApi {
   /// * [ChildWithNullable] childWithNullable (required):
   ///   request body
   Future<void> testNullable(ChildWithNullable childWithNullable,) async {
-    final response = await testNullableWithHttpInfo(childWithNullable,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testNullableWithHttpInfo(childWithNullable,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -1252,36 +1252,36 @@ class FakeApi {
   /// * [Map<String, String>] language:
   Future<Response> testQueryParameterCollectionFormatWithHttpInfo(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/test-query-parameters';
+    final _path = r'/fake/test-query-parameters';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('pipes', 'pipe', pipe));
-      queryParams.addAll(_queryParams('csv', 'ioutil', ioutil));
-      queryParams.addAll(_queryParams('ssv', 'http', http));
-      queryParams.addAll(_queryParams('csv', 'url', url));
-      queryParams.addAll(_queryParams('multi', 'context', context));
+      __queryParams.addAll(_queryParams('pipes', 'pipe', pipe));
+      __queryParams.addAll(_queryParams('csv', 'ioutil', ioutil));
+      __queryParams.addAll(_queryParams('ssv', 'http', http));
+      __queryParams.addAll(_queryParams('csv', 'url', url));
+      __queryParams.addAll(_queryParams('multi', 'context', context));
     if (language != null) {
-      queryParams.addAll(_queryParams('', 'language', language));
+      __queryParams.addAll(_queryParams('', 'language', language));
     }
-      queryParams.addAll(_queryParams('', 'allowEmpty', allowEmpty));
+      __queryParams.addAll(_queryParams('', 'allowEmpty', allowEmpty));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -1303,9 +1303,9 @@ class FakeApi {
   ///
   /// * [Map<String, String>] language:
   Future<void> testQueryParameterCollectionFormat(List<String> pipe, List<String> ioutil, List<String> http, List<String> url, List<String> context, String allowEmpty, { Map<String, String>? language, }) async {
-    final response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty,  language: language, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testQueryParameterCollectionFormatWithHttpInfo(pipe, ioutil, http, url, context, allowEmpty,  language: language, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -28,26 +28,26 @@ class FakeClassnameTags123Api {
   ///   client model
   Future<Response> testClassnameWithHttpInfo(ModelClient modelClient,) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake_classname_test';
+    final _path = r'/fake_classname_test';
 
     // ignore: prefer_final_locals
-    Object? postBody = modelClient;
+    Object? _postBody = modelClient;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PATCH',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,15 +60,15 @@ class FakeClassnameTags123Api {
   /// * [ModelClient] modelClient (required):
   ///   client model
   Future<ModelClient?> testClassname(ModelClient modelClient,) async {
-    final response = await testClassnameWithHttpInfo(modelClient,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await testClassnameWithHttpInfo(modelClient,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ModelClient',) as ModelClient;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ModelClient',) as ModelClient;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -28,26 +28,26 @@ class PetApi {
   ///   Pet object that needs to be added to the store
   Future<Response> addPetWithHttpInfo(Pet pet,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet';
+    final _path = r'/pet';
 
     // ignore: prefer_final_locals
-    Object? postBody = pet;
+    Object? _postBody = pet;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json', 'application/xml'];
+    const _contentTypes = <String>['application/json', 'application/xml'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,9 +60,9 @@ class PetApi {
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
   Future<void> addPet(Pet pet,) async {
-    final response = await addPetWithHttpInfo(pet,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await addPetWithHttpInfo(pet,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -80,31 +80,31 @@ class PetApi {
   /// * [String] apiKey:
   Future<Response> deletePetWithHttpInfo(int petId, { String? apiKey, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
     if (apiKey != null) {
-      headerParams[r'api_key'] = parameterToString(apiKey);
+      _headerParams[r'api_key'] = parameterToString(apiKey);
     }
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -119,9 +119,9 @@ class PetApi {
   ///
   /// * [String] apiKey:
   Future<void> deletePet(int petId, { String? apiKey, }) async {
-    final response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deletePetWithHttpInfo(petId,  apiKey: apiKey, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -137,28 +137,28 @@ class PetApi {
   ///   Status values that need to be considered for filter
   Future<Response> findPetsByStatusWithHttpInfo(List<String> status,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/findByStatus';
+    final _path = r'/pet/findByStatus';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('csv', 'status', status));
+      __queryParams.addAll(_queryParams('csv', 'status', status));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -171,16 +171,16 @@ class PetApi {
   /// * [List<String>] status (required):
   ///   Status values that need to be considered for filter
   Future<List<Pet>?> findPetsByStatus(List<String> status,) async {
-    final response = await findPetsByStatusWithHttpInfo(status,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await findPetsByStatusWithHttpInfo(status,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'List<Pet>') as List)
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      final _responseBody = await _decodeBodyBytes(_response);
+      return (await apiClient.deserializeAsync(_responseBody, 'List<Pet>') as List)
         .cast<Pet>()
         .toList(growable: false);
 
@@ -200,28 +200,28 @@ class PetApi {
   ///   Tags to filter by
   Future<Response> findPetsByTagsWithHttpInfo(Set<String> tags,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/findByTags';
+    final _path = r'/pet/findByTags';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('csv', 'tags', tags));
+      __queryParams.addAll(_queryParams('csv', 'tags', tags));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -234,16 +234,16 @@ class PetApi {
   /// * [Set<String>] tags (required):
   ///   Tags to filter by
   Future<Set<Pet>?> findPetsByTags(Set<String> tags,) async {
-    final response = await findPetsByTagsWithHttpInfo(tags,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await findPetsByTagsWithHttpInfo(tags,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      final responseBody = await _decodeBodyBytes(response);
-      return (await apiClient.deserializeAsync(responseBody, 'Set<Pet>') as List)
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      final _responseBody = await _decodeBodyBytes(_response);
+      return (await apiClient.deserializeAsync(_responseBody, 'Set<Pet>') as List)
         .cast<Pet>()
         .toSet();
 
@@ -263,27 +263,27 @@ class PetApi {
   ///   ID of pet to return
   Future<Response> getPetByIdWithHttpInfo(int petId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -296,15 +296,15 @@ class PetApi {
   /// * [int] petId (required):
   ///   ID of pet to return
   Future<Pet?> getPetById(int petId,) async {
-    final response = await getPetByIdWithHttpInfo(petId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getPetByIdWithHttpInfo(petId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Pet',) as Pet;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Pet',) as Pet;
     
     }
     return null;
@@ -322,26 +322,26 @@ class PetApi {
   ///   Pet object that needs to be added to the store
   Future<Response> updatePetWithHttpInfo(Pet pet,) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet';
+    final _path = r'/pet';
 
     // ignore: prefer_final_locals
-    Object? postBody = pet;
+    Object? _postBody = pet;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json', 'application/xml'];
+    const _contentTypes = <String>['application/json', 'application/xml'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -354,9 +354,9 @@ class PetApi {
   /// * [Pet] pet (required):
   ///   Pet object that needs to be added to the store
   Future<void> updatePet(Pet pet,) async {
-    final response = await updatePetWithHttpInfo(pet,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updatePetWithHttpInfo(pet,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -378,33 +378,33 @@ class PetApi {
   ///   Updated status of the pet
   Future<Response> updatePetWithFormWithHttpInfo(int petId, { String? name, String? status, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}'
+    final _path = r'/pet/{petId}'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/x-www-form-urlencoded'];
+    const _contentTypes = <String>['application/x-www-form-urlencoded'];
 
     if (name != null) {
-      formParams[r'name'] = parameterToString(name);
+      _formParams[r'name'] = parameterToString(name);
     }
     if (status != null) {
-      formParams[r'status'] = parameterToString(status);
+      _formParams[r'status'] = parameterToString(status);
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -423,9 +423,9 @@ class PetApi {
   /// * [String] status:
   ///   Updated status of the pet
   Future<void> updatePetWithForm(int petId, { String? name, String? status, }) async {
-    final response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updatePetWithFormWithHttpInfo(petId,  name: name, status: status, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -447,41 +447,41 @@ class PetApi {
   ///   file to upload
   Future<Response> uploadFileWithHttpInfo(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/pet/{petId}/uploadImage'
+    final _path = r'/pet/{petId}/uploadImage'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['multipart/form-data'];
+    const _contentTypes = <String>['multipart/form-data'];
 
-    bool hasFields = false;
-    final mp = MultipartRequest('POST', Uri.parse(path));
+    bool _hasFields = false;
+    final _mp = MultipartRequest('POST', Uri.parse(_path));
     if (additionalMetadata != null) {
-      hasFields = true;
-      mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
+      _hasFields = true;
+      _mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
     }
     if (file != null) {
-      hasFields = true;
-      mp.fields[r'file'] = file.field;
-      mp.files.add(file);
+      _hasFields = true;
+      _mp.fields[r'file'] = file.field;
+      _mp.files.add(file);
     }
-    if (hasFields) {
-      postBody = mp;
+    if (_hasFields) {
+      _postBody = _mp;
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -500,15 +500,15 @@ class PetApi {
   /// * [MultipartFile] file:
   ///   file to upload
   Future<ApiResponse?> uploadFile(int petId, { String? additionalMetadata, MultipartFile? file, }) async {
-    final response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await uploadFileWithHttpInfo(petId,  additionalMetadata: additionalMetadata, file: file, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ApiResponse',) as ApiResponse;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ApiResponse',) as ApiResponse;
     
     }
     return null;
@@ -532,41 +532,41 @@ class PetApi {
   ///   Additional data to pass to server
   Future<Response> uploadFileWithRequiredFileWithHttpInfo(int petId, MultipartFile requiredFile, { String? additionalMetadata, }) async {
     // ignore: prefer_const_declarations
-    final path = r'/fake/{petId}/uploadImageWithRequiredFile'
+    final _path = r'/fake/{petId}/uploadImageWithRequiredFile'
       .replaceAll('{petId}', petId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['multipart/form-data'];
+    const _contentTypes = <String>['multipart/form-data'];
 
-    bool hasFields = false;
-    final mp = MultipartRequest('POST', Uri.parse(path));
+    bool _hasFields = false;
+    final _mp = MultipartRequest('POST', Uri.parse(_path));
     if (additionalMetadata != null) {
-      hasFields = true;
-      mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
+      _hasFields = true;
+      _mp.fields[r'additionalMetadata'] = parameterToString(additionalMetadata);
     }
     if (requiredFile != null) {
-      hasFields = true;
-      mp.fields[r'requiredFile'] = requiredFile.field;
-      mp.files.add(requiredFile);
+      _hasFields = true;
+      _mp.fields[r'requiredFile'] = requiredFile.field;
+      _mp.files.add(requiredFile);
     }
-    if (hasFields) {
-      postBody = mp;
+    if (_hasFields) {
+      _postBody = _mp;
     }
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -585,15 +585,15 @@ class PetApi {
   /// * [String] additionalMetadata:
   ///   Additional data to pass to server
   Future<ApiResponse?> uploadFileWithRequiredFile(int petId, MultipartFile requiredFile, { String? additionalMetadata, }) async {
-    final response = await uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile,  additionalMetadata: additionalMetadata, );
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await uploadFileWithRequiredFileWithHttpInfo(petId, requiredFile,  additionalMetadata: additionalMetadata, );
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'ApiResponse',) as ApiResponse;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'ApiResponse',) as ApiResponse;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
@@ -28,27 +28,27 @@ class StoreApi {
   ///   ID of the order that needs to be deleted
   Future<Response> deleteOrderWithHttpInfo(String orderId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order/{order_id}'
+    final _path = r'/store/order/{order_id}'
       .replaceAll('{order_id}', orderId);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -61,9 +61,9 @@ class StoreApi {
   /// * [String] orderId (required):
   ///   ID of the order that needs to be deleted
   Future<void> deleteOrder(String orderId,) async {
-    final response = await deleteOrderWithHttpInfo(orderId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deleteOrderWithHttpInfo(orderId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -74,26 +74,26 @@ class StoreApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> getInventoryWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/store/inventory';
+    final _path = r'/store/inventory';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -101,15 +101,15 @@ class StoreApi {
   ///
   /// Returns a map of status codes to quantities
   Future<Map<String, int>?> getInventory() async {
-    final response = await getInventoryWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getInventoryWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return Map<String, int>.from(await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Map<String, int>'),);
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return Map<String, int>.from(await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Map<String, int>'),);
 
     }
     return null;
@@ -127,27 +127,27 @@ class StoreApi {
   ///   ID of pet that needs to be fetched
   Future<Response> getOrderByIdWithHttpInfo(int orderId,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order/{order_id}'
+    final _path = r'/store/order/{order_id}'
       .replaceAll('{order_id}', orderId.toString());
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -160,15 +160,15 @@ class StoreApi {
   /// * [int] orderId (required):
   ///   ID of pet that needs to be fetched
   Future<Order?> getOrderById(int orderId,) async {
-    final response = await getOrderByIdWithHttpInfo(orderId,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getOrderByIdWithHttpInfo(orderId,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Order',) as Order;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Order',) as Order;
     
     }
     return null;
@@ -186,26 +186,26 @@ class StoreApi {
   ///   order placed for purchasing the pet
   Future<Response> placeOrderWithHttpInfo(Order order,) async {
     // ignore: prefer_const_declarations
-    final path = r'/store/order';
+    final _path = r'/store/order';
 
     // ignore: prefer_final_locals
-    Object? postBody = order;
+    Object? _postBody = order;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -218,15 +218,15 @@ class StoreApi {
   /// * [Order] order (required):
   ///   order placed for purchasing the pet
   Future<Order?> placeOrder(Order order,) async {
-    final response = await placeOrderWithHttpInfo(order,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await placeOrderWithHttpInfo(order,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'Order',) as Order;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'Order',) as Order;
     
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
@@ -28,26 +28,26 @@ class UserApi {
   ///   Created user object
   Future<Response> createUserWithHttpInfo(User user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user';
+    final _path = r'/user';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -60,9 +60,9 @@ class UserApi {
   /// * [User] user (required):
   ///   Created user object
   Future<void> createUser(User user,) async {
-    final response = await createUserWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUserWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -78,26 +78,26 @@ class UserApi {
   ///   List of user object
   Future<Response> createUsersWithArrayInputWithHttpInfo(List<User> user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/createWithArray';
+    final _path = r'/user/createWithArray';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -110,9 +110,9 @@ class UserApi {
   /// * [List<User>] user (required):
   ///   List of user object
   Future<void> createUsersWithArrayInput(List<User> user,) async {
-    final response = await createUsersWithArrayInputWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUsersWithArrayInputWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -128,26 +128,26 @@ class UserApi {
   ///   List of user object
   Future<Response> createUsersWithListInputWithHttpInfo(List<User> user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/createWithList';
+    final _path = r'/user/createWithList';
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'POST',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -160,9 +160,9 @@ class UserApi {
   /// * [List<User>] user (required):
   ///   List of user object
   Future<void> createUsersWithListInput(List<User> user,) async {
-    final response = await createUsersWithListInputWithHttpInfo(user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await createUsersWithListInputWithHttpInfo(user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -178,27 +178,27 @@ class UserApi {
   ///   The name that needs to be deleted
   Future<Response> deleteUserWithHttpInfo(String username,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'DELETE',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -211,9 +211,9 @@ class UserApi {
   /// * [String] username (required):
   ///   The name that needs to be deleted
   Future<void> deleteUser(String username,) async {
-    final response = await deleteUserWithHttpInfo(username,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await deleteUserWithHttpInfo(username,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -229,27 +229,27 @@ class UserApi {
   ///   The name that needs to be fetched. Use user1 for testing.
   Future<Response> getUserByNameWithHttpInfo(String username,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -262,15 +262,15 @@ class UserApi {
   /// * [String] username (required):
   ///   The name that needs to be fetched. Use user1 for testing.
   Future<User?> getUserByName(String username,) async {
-    final response = await getUserByNameWithHttpInfo(username,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await getUserByNameWithHttpInfo(username,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'User',) as User;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'User',) as User;
     
     }
     return null;
@@ -291,29 +291,29 @@ class UserApi {
   ///   The password for login in clear text
   Future<Response> loginUserWithHttpInfo(String username, String password,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/login';
+    final _path = r'/user/login';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-      queryParams.addAll(_queryParams('', 'username', username));
-      queryParams.addAll(_queryParams('', 'password', password));
+      __queryParams.addAll(_queryParams('', 'username', username));
+      __queryParams.addAll(_queryParams('', 'password', password));
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -329,15 +329,15 @@ class UserApi {
   /// * [String] password (required):
   ///   The password for login in clear text
   Future<String?> loginUser(String username, String password,) async {
-    final response = await loginUserWithHttpInfo(username, password,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await loginUserWithHttpInfo(username, password,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
     // When a remote server returns no body with a status of 204, we shall not decode it.
     // At the time of writing this, `dart:convert` will throw an "Unexpected end of input"
     // FormatException when trying to decode an empty string.
-    if (response.body.isNotEmpty && response.statusCode != HttpStatus.noContent) {
-      return await apiClient.deserializeAsync(await _decodeBodyBytes(response), 'String',) as String;
+    if (_response.bodyBytes.isNotEmpty && _response.statusCode != HttpStatus.noContent) {
+      return await apiClient.deserializeAsync(await _decodeBodyBytes(_response), 'String',) as String;
     
     }
     return null;
@@ -350,26 +350,26 @@ class UserApi {
   /// Note: This method returns the HTTP [Response].
   Future<Response> logoutUserWithHttpInfo() async {
     // ignore: prefer_const_declarations
-    final path = r'/user/logout';
+    final _path = r'/user/logout';
 
     // ignore: prefer_final_locals
-    Object? postBody;
+    Object? _postBody;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>[];
+    const _contentTypes = <String>[];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'GET',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -377,9 +377,9 @@ class UserApi {
   ///
   /// 
   Future<void> logoutUser() async {
-    final response = await logoutUserWithHttpInfo();
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await logoutUserWithHttpInfo();
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 
@@ -398,27 +398,27 @@ class UserApi {
   ///   Updated user object
   Future<Response> updateUserWithHttpInfo(String username, User user,) async {
     // ignore: prefer_const_declarations
-    final path = r'/user/{username}'
+    final _path = r'/user/{username}'
       .replaceAll('{username}', username);
 
     // ignore: prefer_final_locals
-    Object? postBody = user;
+    Object? _postBody = user;
 
-    final queryParams = <QueryParam>[];
-    final headerParams = <String, String>{};
-    final formParams = <String, String>{};
+    final __queryParams = <QueryParam>[];
+    final _headerParams = <String, String>{};
+    final _formParams = <String, String>{};
 
-    const contentTypes = <String>['application/json'];
+    const _contentTypes = <String>['application/json'];
 
 
     return apiClient.invokeAPI(
-      path,
+      _path,
       'PUT',
-      queryParams,
-      postBody,
-      headerParams,
-      formParams,
-      contentTypes.isEmpty ? null : contentTypes.first,
+      __queryParams,
+      _postBody,
+      _headerParams,
+      _formParams,
+      _contentTypes.isEmpty ? null : _contentTypes.first,
     );
   }
 
@@ -434,9 +434,9 @@ class UserApi {
   /// * [User] user (required):
   ///   Updated user object
   Future<void> updateUser(String username, User user,) async {
-    final response = await updateUserWithHttpInfo(username, user,);
-    if (response.statusCode >= HttpStatus.badRequest) {
-      throw ApiException(response.statusCode, await _decodeBodyBytes(response));
+    final _response = await updateUserWithHttpInfo(username, user,);
+    if (_response.statusCode >= HttpStatus.badRequest) {
+      throw ApiException(_response.statusCode, await _decodeBodyBytes(_response));
     }
   }
 }

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -143,19 +143,21 @@ class ApiClient {
     );
   }
 
-  Future<dynamic> deserializeAsync(String value, String targetType, {bool growable = false,}) async =>
+  Future<dynamic> deserializeAsync(dynamic value, String targetType, {bool growable = false,}) async =>
     // ignore: deprecated_member_use_from_same_package
     deserialize(value, targetType, growable: growable);
 
   @Deprecated('Scheduled for removal in OpenAPI Generator 6.x. Use deserializeAsync() instead.')
-  dynamic deserialize(String value, String targetType, {bool growable = false,}) {
+  dynamic deserialize(dynamic value, String targetType, {bool growable = false,}) {
     // Remove all spaces. Necessary for regular expressions as well.
     targetType = targetType.replaceAll(' ', ''); // ignore: parameter_assignments
 
-    // If the expected target type is String, nothing to do...
-    return targetType == 'String'
-      ? value
-      : fromJson(json.decode(value), targetType, growable: growable);
+    // If targetType is a known primitive, utilize it directly
+    if (targetType == 'String' || targetType == 'int' || targetType == 'double' || targetType == 'bool' || targetType == 'DateTime' || targetType == 'Uint8List') {
+      return fromJson(value, targetType, growable: growable);
+    } else {
+      return fromJson(json.decode(value), targetType, growable: growable);
+    }
   }
 
   // ignore: deprecated_member_use_from_same_package
@@ -182,6 +184,8 @@ class ApiClient {
           return valueString == 'true' || valueString == '1';
         case 'DateTime':
           return value is DateTime ? value : DateTime.tryParse(value);
+        case 'Uint8List':
+          return value as Uint8List;
         case 'AdditionalPropertiesClass':
           return AdditionalPropertiesClass.fromJson(value);
         case 'AllOfWithSingleRef':

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
@@ -76,18 +76,26 @@ String parameterToString(dynamic value) {
   return value.toString();
 }
 
-/// Returns the decoded body as UTF-8 if the given headers indicate an 'application/json'
-/// content type. Otherwise, returns the decoded body as decoded by dart:http package.
-Future<String> _decodeBodyBytes(Response response) async {
-  final contentType = response.headers['content-type'];
-  return contentType != null && contentType.toLowerCase().startsWith('application/json')
-    ? response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes)
-    : response.body;
+/// Decodes the body based on the content-type
+/// application/json and text/plain are decoded as utf-8
+/// all other types will be returned as Uint8List
+Future<dynamic> _decodeBodyBytes(Response response) async {
+  final contentType = response.headers['content-type']?.toLowerCase();
+  if (contentType != null) {
+    if (contentType.startsWith('application/json') || contentType.startsWith('text/plain')) {
+      return response.bodyBytes.isEmpty ? '' : utf8.decode(response.bodyBytes);
+    }
+  }
+  /* all other responses should be returned as a raw Uint8List */
+  return response.bodyBytes;
 }
 
 /// Returns a valid [T] value found at the specified Map [key], null otherwise.
 T? mapValueOfType<T>(dynamic map, String key) {
   final dynamic value = map is Map ? map[key] : null;
+  if (T == double && value is int) {
+    return value.toDouble() as T;
+  }
   return value is T ? value : null;
 }
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class AdditionalPropertiesClass {
   /// Returns a new [AdditionalPropertiesClass] instance.
   AdditionalPropertiesClass({
-    this.mapProperty = const {},
-    this.mapOfMapProperty = const {},
+     this.mapProperty = const {},
+     this.mapOfMapProperty = const {},
   });
 
   Map<String, String> mapProperty;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class AllOfWithSingleRef {
   /// Returns a new [AllOfWithSingleRef] instance.
   AllOfWithSingleRef({
-    this.username,
-    this.singleRefType,
+     this.username,
+     this.singleRefType,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Animal {
   /// Returns a new [Animal] instance.
   Animal({
-    required this.className,
-    this.color = 'red',
+     required this.className,
+     this.color = 'red',
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ApiResponse {
   /// Returns a new [ApiResponse] instance.
   ApiResponse({
-    this.code,
-    this.type,
-    this.message,
+     this.code,
+     this.type,
+     this.message,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ArrayOfArrayOfNumberOnly {
   /// Returns a new [ArrayOfArrayOfNumberOnly] instance.
   ArrayOfArrayOfNumberOnly({
-    this.arrayArrayNumber = const [],
+     this.arrayArrayNumber = const [],
   });
 
   List<List<num>> arrayArrayNumber;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ArrayOfNumberOnly {
   /// Returns a new [ArrayOfNumberOnly] instance.
   ArrayOfNumberOnly({
-    this.arrayNumber = const [],
+     this.arrayNumber = const [],
   });
 
   List<num> arrayNumber;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ArrayTest {
   /// Returns a new [ArrayTest] instance.
   ArrayTest({
-    this.arrayOfString = const [],
-    this.arrayArrayOfInteger = const [],
-    this.arrayArrayOfModel = const [],
+     this.arrayOfString = const [],
+     this.arrayArrayOfInteger = const [],
+     this.arrayArrayOfModel = const [],
   });
 
   List<String> arrayOfString;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Capitalization {
   /// Returns a new [Capitalization] instance.
   Capitalization({
-    this.smallCamel,
-    this.capitalCamel,
-    this.smallSnake,
-    this.capitalSnake,
-    this.sCAETHFlowPoints,
-    this.ATT_NAME,
+     this.smallCamel,
+     this.capitalCamel,
+     this.smallSnake,
+     this.capitalSnake,
+     this.sCAETHFlowPoints,
+     this.ATT_NAME,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class Cat {
   /// Returns a new [Cat] instance.
   Cat({
-    required this.className,
-    this.color = 'red',
-    this.declawed,
+     required this.className,
+     this.color = 'red',
+     this.declawed,
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Category {
   /// Returns a new [Category] instance.
   Category({
-    this.id,
-    this.name = 'default-name',
+     this.id,
+     this.name = 'default-name',
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ChildWithNullable {
   /// Returns a new [ChildWithNullable] instance.
   ChildWithNullable({
-    this.type,
-    this.nullableProperty,
-    this.otherProperty,
+     this.type,
+     this.nullableProperty,
+     this.otherProperty,
   });
 
   ChildWithNullableTypeEnum? type;
@@ -172,6 +172,12 @@ class ChildWithNullableTypeEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is ChildWithNullableTypeEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [ChildWithNullableTypeEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ClassModel {
   /// Returns a new [ClassModel] instance.
   ClassModel({
-    this.class_,
+     this.class_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class DeprecatedObject {
   /// Returns a new [DeprecatedObject] instance.
   DeprecatedObject({
-    this.name,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class Dog {
   /// Returns a new [Dog] instance.
   Dog({
-    required this.className,
-    this.color = 'red',
-    this.breed,
+     required this.className,
+     this.color = 'red',
+     this.breed,
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class EnumArrays {
   /// Returns a new [EnumArrays] instance.
   EnumArrays({
-    this.justSymbol,
-    this.arrayEnum = const [],
+     this.justSymbol,
+     this.arrayEnum = const [],
   });
 
   EnumArraysJustSymbolEnum? justSymbol;
@@ -153,6 +153,12 @@ class EnumArraysJustSymbolEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumArraysJustSymbolEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumArraysJustSymbolEnum] to String,
@@ -227,6 +233,12 @@ class EnumArraysArrayEnumEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumArraysArrayEnumEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumArraysArrayEnumEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
@@ -48,6 +48,13 @@ class EnumClass {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumClass && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumClass] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class EnumTest {
   /// Returns a new [EnumTest] instance.
   EnumTest({
-    this.enumString,
-    required this.enumStringRequired,
-    this.enumInteger,
-    this.enumNumber,
-    this.outerEnum,
-    this.outerEnumInteger,
-    this.outerEnumDefaultValue,
-    this.outerEnumIntegerDefaultValue,
+     this.enumString,
+     required this.enumStringRequired,
+     this.enumInteger,
+     this.enumNumber,
+     this.outerEnum,
+     this.outerEnumInteger,
+     this.outerEnumDefaultValue,
+     this.outerEnumIntegerDefaultValue,
   });
 
   EnumTestEnumStringEnum? enumString;
@@ -240,6 +240,12 @@ class EnumTestEnumStringEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumStringEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumStringEnum] to String,
@@ -317,6 +323,12 @@ class EnumTestEnumStringRequiredEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumStringRequiredEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumStringRequiredEnum] to String,
@@ -392,6 +404,12 @@ class EnumTestEnumIntegerEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumIntegerEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumIntegerEnum] to int,
@@ -466,6 +484,12 @@ class EnumTestEnumNumberEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumNumberEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumNumberEnum] to double,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class FakeBigDecimalMap200Response {
   /// Returns a new [FakeBigDecimalMap200Response] instance.
   FakeBigDecimalMap200Response({
-    this.someId,
-    this.someMap = const {},
+     this.someId,
+     this.someMap = const {},
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class FileSchemaTestClass {
   /// Returns a new [FileSchemaTestClass] instance.
   FileSchemaTestClass({
-    this.file,
-    this.files = const [],
+     this.file,
+     this.files = const [],
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class Foo {
   /// Returns a new [Foo] instance.
   Foo({
-    this.bar = 'bar',
+     this.bar = 'bar',
   });
 
   String bar;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class FooGetDefaultResponse {
   /// Returns a new [FooGetDefaultResponse] instance.
   FooGetDefaultResponse({
-    this.string,
+     this.string,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -13,22 +13,22 @@ part of openapi.api;
 class FormatTest {
   /// Returns a new [FormatTest] instance.
   FormatTest({
-    this.integer,
-    this.int32,
-    this.int64,
-    required this.number,
-    this.float,
-    this.double_,
-    this.decimal,
-    this.string,
-    required this.byte,
-    this.binary,
-    required this.date,
-    this.dateTime,
-    this.uuid,
-    required this.password,
-    this.patternWithDigits,
-    this.patternWithDigitsAndDelimiter,
+     this.integer,
+     this.int32,
+     this.int64,
+     required this.number,
+     this.float,
+     this.double_,
+     this.decimal,
+     this.string,
+     required this.byte,
+     this.binary,
+     required this.date,
+     this.dateTime,
+     this.uuid,
+     required this.password,
+     this.patternWithDigits,
+     this.patternWithDigitsAndDelimiter,
   });
 
   /// Minimum value: 10
@@ -107,7 +107,7 @@ class FormatTest {
   /// source code must fall back to having a nullable type.
   /// Consider adding a "default:" property in the specification file to hide this note.
   ///
-  MultipartFile? binary;
+  Uint8List? binary;
 
   DateTime date;
 

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class HasOnlyReadOnly {
   /// Returns a new [HasOnlyReadOnly] instance.
   HasOnlyReadOnly({
-    this.bar,
-    this.foo,
+     this.bar,
+     this.foo,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class HealthCheckResult {
   /// Returns a new [HealthCheckResult] instance.
   HealthCheckResult({
-    this.nullableMessage,
+     this.nullableMessage,
   });
 
   String? nullableMessage;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class MapTest {
   /// Returns a new [MapTest] instance.
   MapTest({
-    this.mapMapOfString = const {},
-    this.mapOfEnumString = const {},
-    this.directMap = const {},
-    this.indirectMap = const {},
+     this.mapMapOfString = const {},
+     this.mapOfEnumString = const {},
+     this.directMap = const {},
+     this.indirectMap = const {},
   });
 
   Map<String, Map<String, String>> mapMapOfString;
@@ -163,6 +163,12 @@ class MapTestMapOfEnumStringEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is MapTestMapOfEnumStringEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [MapTestMapOfEnumStringEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class MixedPropertiesAndAdditionalPropertiesClass {
   /// Returns a new [MixedPropertiesAndAdditionalPropertiesClass] instance.
   MixedPropertiesAndAdditionalPropertiesClass({
-    this.uuid,
-    this.dateTime,
-    this.map = const {},
+     this.uuid,
+     this.dateTime,
+     this.map = const {},
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Model200Response {
   /// Returns a new [Model200Response] instance.
   Model200Response({
-    this.name,
-    this.class_,
+     this.name,
+     this.class_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelClient {
   /// Returns a new [ModelClient] instance.
   ModelClient({
-    this.client,
+     this.client,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelFile {
   /// Returns a new [ModelFile] instance.
   ModelFile({
-    this.sourceURI,
+     this.sourceURI,
   });
 
   /// Test capitalization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelList {
   /// Returns a new [ModelList] instance.
   ModelList({
-    this.n123list,
+     this.n123list,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelReturn {
   /// Returns a new [ModelReturn] instance.
   ModelReturn({
-    this.return_,
+     this.return_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class Name {
   /// Returns a new [Name] instance.
   Name({
-    required this.name,
-    this.snakeCase,
-    this.property,
-    this.n123number,
+     required this.name,
+     this.snakeCase,
+     this.property,
+     this.n123number,
   });
 
   int name;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -13,18 +13,18 @@ part of openapi.api;
 class NullableClass {
   /// Returns a new [NullableClass] instance.
   NullableClass({
-    this.integerProp,
-    this.numberProp,
-    this.booleanProp,
-    this.stringProp,
-    this.dateProp,
-    this.datetimeProp,
-    this.arrayNullableProp = const [],
-    this.arrayAndItemsNullableProp = const [],
-    this.arrayItemsNullable = const [],
-    this.objectNullableProp = const {},
-    this.objectAndItemsNullableProp = const {},
-    this.objectItemsNullable = const {},
+     this.integerProp,
+     this.numberProp,
+     this.booleanProp,
+     this.stringProp,
+     this.dateProp,
+     this.datetimeProp,
+     this.arrayNullableProp = const [],
+     this.arrayAndItemsNullableProp = const [],
+     this.arrayItemsNullable = const [],
+     this.objectNullableProp = const {},
+     this.objectAndItemsNullableProp = const {},
+     this.objectItemsNullable = const {},
   });
 
   int? integerProp;
@@ -169,9 +169,15 @@ class NullableClass {
         stringProp: mapValueOfType<String>(json, r'string_prop'),
         dateProp: mapDateTime(json, r'date_prop', r''),
         datetimeProp: mapDateTime(json, r'datetime_prop', r''),
-        arrayNullableProp: Object.listFromJson(json[r'array_nullable_prop']),
-        arrayAndItemsNullableProp: Object.listFromJson(json[r'array_and_items_nullable_prop']),
-        arrayItemsNullable: Object.listFromJson(json[r'array_items_nullable']),
+        arrayNullableProp: json[r'array_nullable_prop'] is Iterable
+            ? (json[r'array_nullable_prop'] as Iterable).cast<Object>().toList(growable: false)
+            : const [],
+        arrayAndItemsNullableProp: json[r'array_and_items_nullable_prop'] is Iterable
+            ? (json[r'array_and_items_nullable_prop'] as Iterable).cast<Object>().toList(growable: false)
+            : const [],
+        arrayItemsNullable: json[r'array_items_nullable'] is Iterable
+            ? (json[r'array_items_nullable'] as Iterable).cast<Object>().toList(growable: false)
+            : const [],
         objectNullableProp: mapCastOfType<String, Object>(json, r'object_nullable_prop') ?? const {},
         objectAndItemsNullableProp: mapCastOfType<String, Object>(json, r'object_and_items_nullable_prop') ?? const {},
         objectItemsNullable: mapCastOfType<String, Object>(json, r'object_items_nullable') ?? const {},

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class NumberOnly {
   /// Returns a new [NumberOnly] instance.
   NumberOnly({
-    this.justNumber,
+     this.justNumber,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class ObjectWithDeprecatedFields {
   /// Returns a new [ObjectWithDeprecatedFields] instance.
   ObjectWithDeprecatedFields({
-    this.uuid,
-    this.id,
-    this.deprecatedRef,
-    this.bars = const [],
+     this.uuid,
+     this.id,
+     this.deprecatedRef,
+     this.bars = const [],
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Order {
   /// Returns a new [Order] instance.
   Order({
-    this.id,
-    this.petId,
-    this.quantity,
-    this.shipDate,
-    this.status,
-    this.complete = false,
+     this.id,
+     this.petId,
+     this.quantity,
+     this.shipDate,
+     this.status,
+     this.complete = false,
   });
 
   ///
@@ -224,6 +224,12 @@ class OrderStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OrderStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OrderStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class OuterComposite {
   /// Returns a new [OuterComposite] instance.
   OuterComposite({
-    this.myNumber,
-    this.myString,
-    this.myBoolean,
+     this.myNumber,
+     this.myString,
+     this.myBoolean,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
@@ -48,6 +48,13 @@ class OuterEnum {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
@@ -48,6 +48,13 @@ class OuterEnumDefaultValue {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumDefaultValue && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumDefaultValue] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
@@ -48,6 +48,13 @@ class OuterEnumInteger {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumInteger && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumInteger] to int,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
@@ -48,6 +48,13 @@ class OuterEnumIntegerDefaultValue {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumIntegerDefaultValue && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumIntegerDefaultValue] to int,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
@@ -13,26 +13,26 @@ part of openapi.api;
 class OuterObjectWithEnumProperty {
   /// Returns a new [OuterObjectWithEnumProperty] instance.
   OuterObjectWithEnumProperty({
-    required this.value,
+     required this.value_,
   });
 
-  OuterEnumInteger value;
+  OuterEnumInteger value_;
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is OuterObjectWithEnumProperty &&
-    other.value == value;
+    other.value_ == value_;
 
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
-    (value.hashCode);
+    (value_.hashCode);
 
   @override
-  String toString() => 'OuterObjectWithEnumProperty[value=$value]';
+  String toString() => 'OuterObjectWithEnumProperty[value_=$value_]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
-      json[r'value'] = this.value;
+      json[r'value'] = this.value_;
     return json;
   }
 
@@ -55,7 +55,7 @@ class OuterObjectWithEnumProperty {
       }());
 
       return OuterObjectWithEnumProperty(
-        value: OuterEnumInteger.fromJson(json[r'value'])!,
+        value_: OuterEnumInteger.fromJson(json[r'value'])!,
       );
     }
     return null;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class ParentWithNullable {
   /// Returns a new [ParentWithNullable] instance.
   ParentWithNullable({
-    this.type,
-    this.nullableProperty,
+     this.type,
+     this.nullableProperty,
   });
 
   ParentWithNullableTypeEnum? type;
@@ -155,6 +155,12 @@ class ParentWithNullableTypeEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is ParentWithNullableTypeEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [ParentWithNullableTypeEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Pet {
   /// Returns a new [Pet] instance.
   Pet({
-    this.id,
-    this.category,
-    required this.name,
-    this.photoUrls = const {},
-    this.tags = const [],
-    this.status,
+     this.id,
+     this.category,
+     required this.name,
+     this.photoUrls = const {},
+     this.tags = const [],
+     this.status,
   });
 
   ///
@@ -208,6 +208,12 @@ class PetStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PetStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [PetStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class ReadOnlyFirst {
   /// Returns a new [ReadOnlyFirst] instance.
   ReadOnlyFirst({
-    this.bar,
-    this.baz,
+     this.bar,
+     this.baz,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
@@ -46,6 +46,13 @@ class SingleRefType {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is SingleRefType && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [SingleRefType] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class SpecialModelName {
   /// Returns a new [SpecialModelName] instance.
   SpecialModelName({
-    this.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket,
+     this.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Tag {
   /// Returns a new [Tag] instance.
   Tag({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class TestInlineFreeformAdditionalPropertiesRequest {
   /// Returns a new [TestInlineFreeformAdditionalPropertiesRequest] instance.
   TestInlineFreeformAdditionalPropertiesRequest({
-    this.someProperty,
+     this.someProperty,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class User {
   /// Returns a new [User] instance.
   User({
-    this.id,
-    this.username,
-    this.firstName,
-    this.lastName,
-    this.email,
-    this.password,
-    this.phone,
-    this.userStatus,
+     this.id,
+     this.username,
+     this.firstName,
+     this.lastName,
+     this.email,
+     this.password,
+     this.phone,
+     this.userStatus,
   });
 
   ///


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This update addresses a number of pain points I've encountered while using the Dart2 generator. I understand that this generator is considered deprecated, but as there has been no serious movement on the dart-next generator for 6+ months, I thought that it may as well get some attention.

This PR contains fixes for the following: 
#15393	(f80b51c5c56055d9eba86d01d0b24cbcb6ba0eec)
#12456	(6e5368c58ecf504fde8ba8a67737d378b963d0b7 and 271bd9b1fafd59ee045c9ec17bede393d0e2306f)
#17546	(8ed191c104ec09b413ae3252cceff03a71020628)
#17547 and #13459	(83f5ecb2b44f0fd87acd44a6a483699c461e3e92)
#12161	(1a30296185ecd9bef2def1a37772467149ce713d)


In summary:

* File and Binary response return types are now marked as Uint8List instead of MultipartFile, which was never semantically correct

* _decodeBodyBytes has been reworked to return either 'String' or 'Uint8List' based on the ContentType.
* _deserialize now returns 'dynamic' to work with the new _decodeBodyBytes
* Generated Enums now have equality and hashcode methods checking against their in-memory id then against their underlying value
* Classes with a generated Numeric Enum in their constructor enums now instantiate sytactically correctly, without causing compile errors
* Classes with default-available generated Enum in their fromJson() method now use a syntactically correct default, without causing compile errors
* Added 'value' and 'apiClient' to reserved dart keywords, which is not strictly true, but allows for better generation of Enums that may use it
* Added better double handling to 'mapValueOfType<T>', which previously would fail when deserding doubles
* Moved from checking Response.body.isEmpty to Response.bodyBytes.isEmpty because .body implicitly converts to a utf-8 string which is will cause crashes when the data isnt utf-8
* All local variables in the 'Api' generations now begin with an underscore to avoid name conficts with user supplied parameters


You can use the following OpenAPI file to test the generation: https://gist.github.com/0xNF/f0119f6a6a49424570803d7d3ed450ff


<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` 
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.



@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)