### PR TITLE
python: enable more mypy checks 1/n

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api.mustache
@@ -10,7 +10,7 @@ from typing_extensions import Annotated
 {{import}}
 {{/imports}}
 
-from {{packageName}}.api_client import ApiClient
+from {{packageName}}.api_client import ApiClient, RequestSerialized
 from {{packageName}}.api_response import ApiResponse
 from {{packageName}}.rest import RESTResponseType
 
@@ -77,7 +77,7 @@ class {{classname}}:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         {{#servers.0}}
         _hosts = [{{#servers}}

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -409,12 +409,16 @@ class ApiClient:
 
         if isinstance(klass, str):
             if klass.startswith('List['):
-                sub_kls = re.match(r'List\[(.*)]', klass).group(1)
+                m = re.match(r'List\[(.*)]', klass)
+                assert m is not None, "Malformed List type definition"
+                sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
-                sub_kls = re.match(r'Dict\[([^,]*), (.*)]', klass).group(2)
+                m = re.match(r'Dict\[([^,]*), (.*)]', klass)
+                assert m is not None, "Malformed Dict type definition"
+                sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}
 
@@ -442,7 +446,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: Parameters as list of tuples, collections formatted
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -472,7 +476,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: URL query string (e.g. a=Hello%20World&b=123)
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -666,10 +670,12 @@ class ApiClient:
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.search(
+            m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
-            ).group(1)
+            )
+            assert m is not None, "Unexpected 'content-disposition' header value"
+            filename = m.group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -11,13 +11,13 @@ import re
 import tempfile
 
 from urllib.parse import quote
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Dict
 {{#tornado}}
 import tornado.gen
 {{/tornado}}
 
 from {{packageName}}.configuration import Configuration
-from {{packageName}}.api_response import ApiResponse
+from {{packageName}}.api_response import ApiResponse, T as ApiResponseT
 import {{modelPackage}}
 from {{packageName}} import rest
 from {{packageName}}.exceptions import (
@@ -30,6 +30,7 @@ from {{packageName}}.exceptions import (
     ServiceException
 )
 
+RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -151,7 +152,7 @@ class ApiClient:
         collection_formats=None,
         _host=None,
         _request_auth=None
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         """Builds the HTTP request params needed by the request.
         :param method: Method to call.
@@ -287,8 +288,8 @@ class ApiClient:
     def response_deserialize(
         self,
         response_data: rest.RESTResponse,
-        response_types_map=None
-    ) -> ApiResponse:
+        response_types_map: Optional[Dict[str, ApiResponseT]]=None
+    ) -> ApiResponse[ApiResponseT]:
         """Deserializes response into an object.
         :param response_data: RESTResponse object to be deserialized.
         :param response_types_map: dict of response types.

--- a/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/asyncio/rest.mustache
@@ -6,7 +6,7 @@ import io
 import json
 import re
 import ssl
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 import aiohttp_retry
@@ -189,6 +189,7 @@ class RESTClientObject:
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
+        pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
         if self.retry_client is not None and method in ALLOW_RETRY_METHODS:
             pool_manager = self.retry_client
         else:

--- a/modules/openapi-generator/src/main/resources/python/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/python/configuration.mustache
@@ -4,10 +4,12 @@
 
 import copy
 import logging
+from logging import FileHandler
 {{^asyncio}}
 import multiprocessing
 {{/asyncio}}
 import sys
+from typing import Optional
 import urllib3
 
 import http.client as httplib
@@ -204,7 +206,7 @@ conf = {{{packageName}}}.Configuration(
         self.logger_stream_handler = None
         """Log stream handler
         """
-        self.logger_file_handler = None
+        self.logger_file_handler: Optional[FileHandler] = None
         """Log file handler
         """
         self.logger_file = None
@@ -252,7 +254,7 @@ conf = {{{packageName}}}.Configuration(
         """
         {{/asyncio}}
 
-        self.proxy = None
+        self.proxy: Optional[str] = None
         """Proxy URL
         """
         self.proxy_headers = None

--- a/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_anyof.mustache
@@ -95,7 +95,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Dict[str, Any]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -159,7 +159,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, {{#anyOf}}{{.}}{{^-last}}, {{/-last}}{{/anyOf}}]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], {{#anyOf}}{{.}}{{^-last}}, {{/-last}}{{/anyOf}}]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/modules/openapi-generator/src/main/resources/python/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_generic.mustache
@@ -93,7 +93,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     }
 
     @classmethod
-    def get_discriminator_value(cls, obj: Dict) -> Optional[str]:
+    def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
@@ -236,7 +236,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
     {{#hasChildren}}
     @classmethod
-    def from_dict(cls, obj: Dict) -> Optional[{{#discriminator}}Union[{{#children}}Self{{^-last}}, {{/-last}}{{/children}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}]:
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[{{#discriminator}}Union[{{#children}}Self{{^-last}}, {{/-last}}{{/children}}]{{/discriminator}}{{^discriminator}}Self{{/discriminator}}]:
         """Create an instance of {{{classname}}} from a dict"""
         {{#discriminator}}
         # look up the object type based on discriminator mapping
@@ -252,7 +252,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
     {{/hasChildren}}
     {{^hasChildren}}
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of {{{classname}}} from a dict"""
         if obj is None:
             return None

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -93,7 +93,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -185,7 +185,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], {{#oneOf}}{{{.}}}{{^-last}}, {{/-last}}{{/oneOf}}]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
+++ b/modules/openapi-generator/src/main/resources/python/model_oneof.mustache
@@ -93,11 +93,16 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
+    {{#isNullable}}
+    def from_json(cls, json_str: Optional[str]) -> Self:
+    {{/isNullable}}
+    {{^isNullable}}
     def from_json(cls, json_str: str) -> Self:
+    {{/isNullable}}
         """Returns the object represented by the json string"""
         instance = cls.model_construct()
         {{#isNullable}}

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -49,3 +49,34 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
+# TODO: enable "strict" once all these individual checks are passing
+# strict = true
+
+# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+## Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+### Strongly recommend enabling this one as soon as you can
+#check_untyped_defs = true
+
+### These shouldn't be too much additional work, but may be tricky to
+### get passing if you use a lot of untyped libraries
+#disallow_subclassing_any = true
+#disallow_untyped_decorators = true
+#disallow_any_generics = true
+#
+### These next few are various gradations of forcing use of type annotations
+#disallow_untyped_calls = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#
+### This one isn't too hard to get passing, but return on investment is lower
+#no_implicit_reexport = true
+#
+### This one can be tricky to get passing if you use a lot of untyped libraries
+#warn_return_any = true

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -64,9 +64,9 @@ strict_concatenate = true
 ## Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true
 
-### These shouldn't be too much additional work, but may be tricky to
-### get passing if you use a lot of untyped libraries
-#disallow_subclassing_any = true
+## These shouldn't be too much additional work, but may be tricky to
+## get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
 #disallow_untyped_decorators = true
 #disallow_any_generics = true
 #

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -68,8 +68,8 @@ check_untyped_defs = true
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-#disallow_any_generics = true
-#
+disallow_any_generics = true
+
 ### These next few are various gradations of forcing use of type annotations
 #disallow_untyped_calls = true
 #disallow_incomplete_defs = true

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -61,8 +61,8 @@ warn_unused_ignores = true
 strict_equality = true
 strict_concatenate = true
 
-### Strongly recommend enabling this one as soon as you can
-#check_untyped_defs = true
+## Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
 
 ### These shouldn't be too much additional work, but may be tricky to
 ### get passing if you use a lot of untyped libraries

--- a/modules/openapi-generator/src/main/resources/python/pyproject.mustache
+++ b/modules/openapi-generator/src/main/resources/python/pyproject.mustache
@@ -67,7 +67,7 @@ check_untyped_defs = true
 ## These shouldn't be too much additional work, but may be tricky to
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
-#disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 #disallow_any_generics = true
 #
 ### These next few are various gradations of forcing use of type annotations

--- a/modules/openapi-generator/src/main/resources/python/rest.mustache
+++ b/modules/openapi-generator/src/main/resources/python/rest.mustache
@@ -202,14 +202,13 @@ class RESTClientObject:
                         preload_content=False
                     )
                 # Pass a `string` parameter directly in the body to support
-                # other content types than Json when `body` argument is
-                # provided in serialized form
+                # other content types than JSON when `body` argument is
+                # provided in serialized form.
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
                     r = self.pool_manager.request(
                         method,
                         url,
-                        body=request_body,
+                        body=body,
                         timeout=timeout,
                         headers=headers,
                         preload_content=False

--- a/modules/openapi-generator/src/main/resources/python/signing.mustache
+++ b/modules/openapi-generator/src/main/resources/python/signing.mustache
@@ -3,12 +3,16 @@
 from base64 import b64encode
 from Crypto.IO import PEM, PKCS8
 from Crypto.Hash import SHA256, SHA512
+from Crypto.Hash.SHA512 import SHA512Hash
+from Crypto.Hash.SHA256 import SHA256Hash
 from Crypto.PublicKey import RSA, ECC
 from Crypto.Signature import PKCS1_v1_5, pss, DSS
+from datetime import timedelta
 from email.utils import formatdate
 import os
 import re
 from time import time
+from typing import List, Optional, Union
 from urllib.parse import urlencode, urlparse
 
 # The constants below define a subset of HTTP headers that can be included in the
@@ -57,18 +61,20 @@ HASH_SHA512 = 'sha512'
 
 class HttpSigningConfiguration:
     """The configuration parameters for the HTTP signature security scheme.
+
     The HTTP signature security scheme is used to sign HTTP requests with a private key
     which is in possession of the API client.
-    An 'Authorization' header is calculated by creating a hash of select headers,
+
+    An ``Authorization`` header is calculated by creating a hash of select headers,
     and optionally the body of the HTTP request, then signing the hash value using
-    a private key. The 'Authorization' header is added to outbound HTTP requests.
+    a private key. The ``Authorization`` header is added to outbound HTTP requests.
 
     :param key_id: A string value specifying the identifier of the cryptographic key,
         when signing HTTP requests.
     :param signing_scheme: A string value specifying the signature scheme, when
         signing HTTP requests.
-        Supported value are hs2019, rsa-sha256, rsa-sha512.
-        Avoid using rsa-sha256, rsa-sha512 as they are deprecated. These values are
+        Supported value are: ``hs2019``, ``rsa-sha256``, ``rsa-sha512``.
+        Avoid using ``rsa-sha256``, ``rsa-sha512`` as they are deprecated. These values are
         available for server-side applications that only support the older
         HTTP signature algorithms.
     :param private_key_path: A string value specifying the path of the file containing
@@ -77,18 +83,19 @@ class HttpSigningConfiguration:
         the private key.
     :param signed_headers: A list of strings. Each value is the name of a HTTP header
         that must be included in the HTTP signature calculation.
-        The two special signature headers '(request-target)' and '(created)' SHOULD be
+        The two special signature headers ``(request-target)`` and ``(created)`` SHOULD be
         included in SignedHeaders.
-        The '(created)' header expresses when the signature was created.
-        The '(request-target)' header is a concatenation of the lowercased :method, an
+        The ``(created)`` header expresses when the signature was created.
+        The ``(request-target)`` header is a concatenation of the lowercased :method, an
         ASCII space, and the :path pseudo-headers.
         When signed_headers is not specified, the client defaults to a single value,
-        '(created)', in the list of HTTP headers.
+        ``(created)``, in the list of HTTP headers.
         When SignedHeaders contains the 'Digest' value, the client performs the
         following operations:
-        1. Calculate a digest of request body, as specified in RFC3230, section 4.3.2.
-        2. Set the 'Digest' header in the request body.
-        3. Include the 'Digest' header and value in the HTTP signature.
+        1. Calculate a digest of request body, as specified in `RFC3230,
+          section 4.3.2<https://datatracker.ietf.org/doc/html/rfc3230#section-4.3.2>`_.
+        2. Set the ``Digest`` header in the request body.
+        3. Include the ``Digest`` header and value in the HTTP signature.
     :param signing_algorithm: A string value specifying the signature algorithm, when
         signing HTTP requests.
         Supported values are:
@@ -106,12 +113,16 @@ class HttpSigningConfiguration:
     :param signature_max_validity: The signature max validity, expressed as
         a datetime.timedelta value. It must be a positive value.
     """
-    def __init__(self, key_id, signing_scheme, private_key_path,
-                 private_key_passphrase=None,
-                 signed_headers=None,
-                 signing_algorithm=None,
-                 hash_algorithm=None,
-                 signature_max_validity=None) -> None:
+    def __init__(self,
+        key_id: str,
+        signing_scheme: str,
+        private_key_path: str,
+        private_key_passphrase: Union[None, str]=None,
+        signed_headers: Optional[List[str]]=None,
+        signing_algorithm: Optional[str]=None,
+        hash_algorithm: Optional[str]=None,
+        signature_max_validity: Optional[timedelta]=None,
+    ) -> None:
         self.key_id = key_id
         if signing_scheme not in {SCHEME_HS2019, SCHEME_RSA_SHA256, SCHEME_RSA_SHA512}:
             raise Exception("Unsupported security scheme: {0}".format(signing_scheme))
@@ -155,11 +166,11 @@ class HttpSigningConfiguration:
         if HEADER_AUTHORIZATION in signed_headers:
             raise Exception("'Authorization' header cannot be included in signed headers")
         self.signed_headers = signed_headers
-        self.private_key = None
+        self.private_key: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         """The private key used to sign HTTP requests.
            Initialized when the PEM-encoded private key is loaded from a file.
         """
-        self.host = None
+        self.host: Optional[str] = None
         """The host name, optionally followed by a colon and TCP port number.
         """
         self._load_private_key()
@@ -197,7 +208,7 @@ class HttpSigningConfiguration:
     def get_public_key(self):
         """Returns the public key object associated with the private key.
         """
-        pubkey = None
+        pubkey: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         if isinstance(self.private_key, RSA.RsaKey):
             pubkey = self.private_key.publickey()
         elif isinstance(self.private_key, ECC.EccKey):
@@ -226,8 +237,11 @@ class HttpSigningConfiguration:
             elif pem_header in {'PRIVATE KEY', 'ENCRYPTED PRIVATE KEY'}:
                 # Key is in PKCS8 format, which is capable of holding many different
                 # types of private keys, not just EC keys.
-                (key_binary, pem_header, is_encrypted) = \
-                    PEM.decode(pem_data, self.private_key_passphrase)
+                if self.private_key_passphrase is not None:
+                    passphrase = self.private_key_passphrase.encode("utf-8")
+                else:
+                    passphrase = None
+                (key_binary, pem_header, is_encrypted) = PEM.decode(pem_data, passphrase)
                 (oid, privkey, params) = \
                     PKCS8.unwrap(key_binary, passphrase=self.private_key_passphrase)
                 if oid == '1.2.840.10045.2.1':
@@ -308,8 +322,11 @@ class HttpSigningConfiguration:
                 request_headers_dict[HEADER_DIGEST] = '{0}{1}'.format(
                     digest_prefix, b64_body_digest.decode('ascii'))
             elif hdr_key == HEADER_HOST.lower():
-                value = target_host
-                request_headers_dict[HEADER_HOST] = '{0}'.format(target_host)
+                if isinstance(target_host, bytes):
+                    value = target_host.decode('ascii')
+                else:
+                    value = target_host
+                request_headers_dict[HEADER_HOST] = value
             else:
                 value = next((v for k, v in headers.items() if k.lower() == hdr_key), None)
                 if value is None:
@@ -330,6 +347,9 @@ class HttpSigningConfiguration:
             The prefix is a string that identifies the cryptographic hash. It is used
             to generate the 'Digest' header as specified in RFC 3230.
         """
+
+        digest: Union[SHA256Hash, SHA512Hash]
+
         if self.hash_algorithm == HASH_SHA512:
             digest = SHA512.new()
             prefix = 'SHA-512='

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/auth_api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -227,7 +227,7 @@ class AuthApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -470,7 +470,7 @@ class AuthApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/body_api.py
@@ -23,7 +23,7 @@ from typing_extensions import Annotated
 from openapi_client.models.pet import Pet
 from openapi_client.models.tag import Tag
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -232,7 +232,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -487,7 +487,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -762,7 +762,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1033,7 +1033,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1303,7 +1303,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1573,7 +1573,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1843,7 +1843,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2113,7 +2113,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2383,7 +2383,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/form_api.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated
 from pydantic import StrictBool, StrictInt, StrictStr
 from typing import Optional
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -268,7 +268,7 @@ class FormApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -607,7 +607,7 @@ class FormApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/header_api.py
@@ -21,7 +21,7 @@ from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 from typing import Optional
 from openapi_client.models.string_enum_ref import StringEnumRef
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -295,7 +295,7 @@ class HeaderApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/path_api.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated
 from pydantic import StrictInt, StrictStr, field_validator
 from openapi_client.models.string_enum_ref import StringEnumRef
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -281,7 +281,7 @@ class PathApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api/query_api.py
@@ -24,7 +24,7 @@ from openapi_client.models.pet import Pet
 from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.test_query_style_form_explode_true_array_string_query_object_parameter import TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -259,7 +259,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -548,7 +548,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -859,7 +859,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1126,7 +1126,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1385,7 +1385,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1644,7 +1644,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1903,7 +1903,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2162,7 +2162,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
@@ -402,12 +402,16 @@ class ApiClient:
 
         if isinstance(klass, str):
             if klass.startswith('List['):
-                sub_kls = re.match(r'List\[(.*)]', klass).group(1)
+                m = re.match(r'List\[(.*)]', klass)
+                assert m is not None, "Malformed List type definition"
+                sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
-                sub_kls = re.match(r'Dict\[([^,]*), (.*)]', klass).group(2)
+                m = re.match(r'Dict\[([^,]*), (.*)]', klass)
+                assert m is not None, "Malformed Dict type definition"
+                sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}
 
@@ -435,7 +439,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: Parameters as list of tuples, collections formatted
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -465,7 +469,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: URL query string (e.g. a=Hello%20World&b=123)
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -650,10 +654,12 @@ class ApiClient:
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.search(
+            m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
-            ).group(1)
+            )
+            assert m is not None, "Unexpected 'content-disposition' header value"
+            filename = m.group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/api_client.py
@@ -22,10 +22,10 @@ import re
 import tempfile
 
 from urllib.parse import quote
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Dict
 
 from openapi_client.configuration import Configuration
-from openapi_client.api_response import ApiResponse
+from openapi_client.api_response import ApiResponse, T as ApiResponseT
 import openapi_client.models
 from openapi_client import rest
 from openapi_client.exceptions import (
@@ -38,6 +38,7 @@ from openapi_client.exceptions import (
     ServiceException
 )
 
+RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -147,7 +148,7 @@ class ApiClient:
         collection_formats=None,
         _host=None,
         _request_auth=None
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         """Builds the HTTP request params needed by the request.
         :param method: Method to call.
@@ -280,8 +281,8 @@ class ApiClient:
     def response_deserialize(
         self,
         response_data: rest.RESTResponse,
-        response_types_map=None
-    ) -> ApiResponse:
+        response_types_map: Optional[Dict[str, ApiResponseT]]=None
+    ) -> ApiResponse[ApiResponseT]:
         """Deserializes response into an object.
         :param response_data: RESTResponse object to be deserialized.
         :param response_types_map: dict of response types.

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/configuration.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/configuration.py
@@ -15,8 +15,10 @@
 
 import copy
 import logging
+from logging import FileHandler
 import multiprocessing
 import sys
+from typing import Optional
 import urllib3
 
 import http.client as httplib
@@ -133,7 +135,7 @@ conf = openapi_client.Configuration(
         self.logger_stream_handler = None
         """Log stream handler
         """
-        self.logger_file_handler = None
+        self.logger_file_handler: Optional[FileHandler] = None
         """Log file handler
         """
         self.logger_file = None
@@ -173,7 +175,7 @@ conf = openapi_client.Configuration(
            cpu_count * 5 is used as default value to increase performance.
         """
 
-        self.proxy = None
+        self.proxy: Optional[str] = None
         """Proxy URL
         """
         self.proxy_headers = None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/bird.py
@@ -73,7 +73,7 @@ class Bird(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Bird from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/category.py
@@ -73,7 +73,7 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/data_query.py
@@ -76,7 +76,7 @@ class DataQuery(Query):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DataQuery from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/default_value.py
@@ -106,7 +106,7 @@ class DefaultValue(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DefaultValue from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/number_properties_only.py
@@ -75,7 +75,7 @@ class NumberPropertiesOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NumberPropertiesOnly from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/pet.py
@@ -99,7 +99,7 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/query.py
@@ -84,7 +84,7 @@ class Query(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Dict) -> Optional[Self]:
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[Self]:
         """Create an instance of Query from a dict"""
 
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/tag.py
@@ -73,7 +73,7 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -75,7 +75,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -72,7 +72,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/openapi_client/rest.py
@@ -213,14 +213,13 @@ class RESTClientObject:
                         preload_content=False
                     )
                 # Pass a `string` parameter directly in the body to support
-                # other content types than Json when `body` argument is
-                # provided in serialized form
+                # other content types than JSON when `body` argument is
+                # provided in serialized form.
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
                     r = self.pool_manager.request(
                         method,
                         url,
-                        body=request_body,
+                        body=body,
                         timeout=timeout,
                         headers=headers,
                         preload_content=False

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -38,3 +38,34 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
+# TODO: enable "strict" once all these individual checks are passing
+# strict = true
+
+# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+## Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+### Strongly recommend enabling this one as soon as you can
+#check_untyped_defs = true
+
+### These shouldn't be too much additional work, but may be tricky to
+### get passing if you use a lot of untyped libraries
+#disallow_subclassing_any = true
+#disallow_untyped_decorators = true
+#disallow_any_generics = true
+#
+### These next few are various gradations of forcing use of type annotations
+#disallow_untyped_calls = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#
+### This one isn't too hard to get passing, but return on investment is lower
+#no_implicit_reexport = true
+#
+### This one can be tricky to get passing if you use a lot of untyped libraries
+#warn_return_any = true

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -57,8 +57,8 @@ check_untyped_defs = true
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-#disallow_any_generics = true
-#
+disallow_any_generics = true
+
 ### These next few are various gradations of forcing use of type annotations
 #disallow_untyped_calls = true
 #disallow_incomplete_defs = true

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -50,8 +50,8 @@ warn_unused_ignores = true
 strict_equality = true
 strict_concatenate = true
 
-### Strongly recommend enabling this one as soon as you can
-#check_untyped_defs = true
+## Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
 
 ### These shouldn't be too much additional work, but may be tricky to
 ### get passing if you use a lot of untyped libraries

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -53,9 +53,9 @@ strict_concatenate = true
 ## Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true
 
-### These shouldn't be too much additional work, but may be tricky to
-### get passing if you use a lot of untyped libraries
-#disallow_subclassing_any = true
+## These shouldn't be too much additional work, but may be tricky to
+## get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
 #disallow_untyped_decorators = true
 #disallow_any_generics = true
 #

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/pyproject.toml
@@ -56,7 +56,7 @@ check_untyped_defs = true
 ## These shouldn't be too much additional work, but may be tricky to
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
-#disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 #disallow_any_generics = true
 #
 ### These next few are various gradations of forcing use of type annotations

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/tests/test_manual.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent-true/tests/test_manual.py
@@ -52,7 +52,7 @@ class TestManual(unittest.TestCase):
         datetime_format_backup = api_instance.api_client.configuration.datetime_format # backup dateime_format
         api_instance.api_client.configuration.datetime_format = "%Y-%m-%d %a %H:%M:%S%Z"
         datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
-        date_query = '2013-10-20' # date |  (optional)
+        date_query = datetime.date(2013, 10, 20) # date |  (optional)
         string_query = 'string_query_example' # str |  (optional)
 
         # Test query parameter(s)
@@ -66,7 +66,7 @@ class TestManual(unittest.TestCase):
     def testDateTimeQueryWithDateTime(self):
         api_instance = openapi_client.QueryApi()
         datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
-        date_query = '2013-10-20' # date |  (optional)
+        date_query = datetime.date(2013, 10, 20) # date |  (optional)
         string_query = 'string_query_example' # str |  (optional)
     
         # Test query parameter(s)
@@ -147,11 +147,14 @@ class TestManual(unittest.TestCase):
                     " \"status\": \"available\",\n"
                     " \"tags\": [{\"id\": 1, \"name\": \"None\"}]}")
         pet = openapi_client.Pet.from_json(json_str)
+        assert pet is not None
         self.assertEqual(pet.id, 1)
         self.assertEqual(pet.status, "available")
         self.assertEqual(pet.photo_urls, ["string"])
+        assert pet.tags is not None
         self.assertEqual(pet.tags[0].id, 1)
         self.assertEqual(pet.tags[0].name, "None")
+        assert pet.category is not None
         self.assertEqual(pet.category.id, 1)
         # test to_json
         self.assertEqual(pet.to_json(),
@@ -165,11 +168,14 @@ class TestManual(unittest.TestCase):
 
         # test from_dict
         pet2 = openapi_client.Pet.from_dict(pet.to_dict())
+        assert pet2 is not None
         self.assertEqual(pet2.id, 1)
         self.assertEqual(pet2.status, "available")
         self.assertEqual(pet2.photo_urls, ["string"])
+        assert pet2.tags is not None
         self.assertEqual(pet2.tags[0].id, 1)
         self.assertEqual(pet2.tags[0].name, "None")
+        assert pet2.category is not None
         self.assertEqual(pet2.category.id, 1)
 
     def echoServerResponseParaserTest(self):

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -227,7 +227,7 @@ class AuthApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -470,7 +470,7 @@ class AuthApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -23,7 +23,7 @@ from typing_extensions import Annotated
 from openapi_client.models.pet import Pet
 from openapi_client.models.tag import Tag
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -232,7 +232,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -487,7 +487,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -762,7 +762,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1033,7 +1033,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1303,7 +1303,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1573,7 +1573,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1843,7 +1843,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2113,7 +2113,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2383,7 +2383,7 @@ class BodyApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api/form_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/form_api.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated
 from pydantic import StrictBool, StrictInt, StrictStr
 from typing import Optional
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -268,7 +268,7 @@ class FormApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -607,7 +607,7 @@ class FormApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api/header_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/header_api.py
@@ -21,7 +21,7 @@ from pydantic import StrictBool, StrictInt, StrictStr, field_validator
 from typing import Optional
 from openapi_client.models.string_enum_ref import StringEnumRef
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -295,7 +295,7 @@ class HeaderApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api/path_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/path_api.py
@@ -20,7 +20,7 @@ from typing_extensions import Annotated
 from pydantic import StrictInt, StrictStr, field_validator
 from openapi_client.models.string_enum_ref import StringEnumRef
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -281,7 +281,7 @@ class PathApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api/query_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/query_api.py
@@ -24,7 +24,7 @@ from openapi_client.models.pet import Pet
 from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.test_query_style_form_explode_true_array_string_query_object_parameter import TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 
-from openapi_client.api_client import ApiClient
+from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse
 from openapi_client.rest import RESTResponseType
 
@@ -259,7 +259,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -548,7 +548,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -859,7 +859,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1126,7 +1126,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1385,7 +1385,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1644,7 +1644,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1903,7 +1903,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2162,7 +2162,7 @@ class QueryApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -402,12 +402,16 @@ class ApiClient:
 
         if isinstance(klass, str):
             if klass.startswith('List['):
-                sub_kls = re.match(r'List\[(.*)]', klass).group(1)
+                m = re.match(r'List\[(.*)]', klass)
+                assert m is not None, "Malformed List type definition"
+                sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
-                sub_kls = re.match(r'Dict\[([^,]*), (.*)]', klass).group(2)
+                m = re.match(r'Dict\[([^,]*), (.*)]', klass)
+                assert m is not None, "Malformed Dict type definition"
+                sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}
 
@@ -435,7 +439,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: Parameters as list of tuples, collections formatted
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -465,7 +469,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: URL query string (e.g. a=Hello%20World&b=123)
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -650,10 +654,12 @@ class ApiClient:
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.search(
+            m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
-            ).group(1)
+            )
+            assert m is not None, "Unexpected 'content-disposition' header value"
+            filename = m.group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -22,10 +22,10 @@ import re
 import tempfile
 
 from urllib.parse import quote
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Dict
 
 from openapi_client.configuration import Configuration
-from openapi_client.api_response import ApiResponse
+from openapi_client.api_response import ApiResponse, T as ApiResponseT
 import openapi_client.models
 from openapi_client import rest
 from openapi_client.exceptions import (
@@ -38,6 +38,7 @@ from openapi_client.exceptions import (
     ServiceException
 )
 
+RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -147,7 +148,7 @@ class ApiClient:
         collection_formats=None,
         _host=None,
         _request_auth=None
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         """Builds the HTTP request params needed by the request.
         :param method: Method to call.
@@ -280,8 +281,8 @@ class ApiClient:
     def response_deserialize(
         self,
         response_data: rest.RESTResponse,
-        response_types_map=None
-    ) -> ApiResponse:
+        response_types_map: Optional[Dict[str, ApiResponseT]]=None
+    ) -> ApiResponse[ApiResponseT]:
         """Deserializes response into an object.
         :param response_data: RESTResponse object to be deserialized.
         :param response_types_map: dict of response types.

--- a/samples/client/echo_api/python/openapi_client/configuration.py
+++ b/samples/client/echo_api/python/openapi_client/configuration.py
@@ -15,8 +15,10 @@
 
 import copy
 import logging
+from logging import FileHandler
 import multiprocessing
 import sys
+from typing import Optional
 import urllib3
 
 import http.client as httplib
@@ -133,7 +135,7 @@ conf = openapi_client.Configuration(
         self.logger_stream_handler = None
         """Log stream handler
         """
-        self.logger_file_handler = None
+        self.logger_file_handler: Optional[FileHandler] = None
         """Log file handler
         """
         self.logger_file = None
@@ -173,7 +175,7 @@ conf = openapi_client.Configuration(
            cpu_count * 5 is used as default value to increase performance.
         """
 
-        self.proxy = None
+        self.proxy: Optional[str] = None
         """Proxy URL
         """
         self.proxy_headers = None

--- a/samples/client/echo_api/python/openapi_client/models/bird.py
+++ b/samples/client/echo_api/python/openapi_client/models/bird.py
@@ -73,7 +73,7 @@ class Bird(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Bird from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/category.py
+++ b/samples/client/echo_api/python/openapi_client/models/category.py
@@ -73,7 +73,7 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python/openapi_client/models/data_query.py
@@ -76,7 +76,7 @@ class DataQuery(Query):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DataQuery from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/default_value.py
+++ b/samples/client/echo_api/python/openapi_client/models/default_value.py
@@ -106,7 +106,7 @@ class DefaultValue(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DefaultValue from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
+++ b/samples/client/echo_api/python/openapi_client/models/number_properties_only.py
@@ -75,7 +75,7 @@ class NumberPropertiesOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NumberPropertiesOnly from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python/openapi_client/models/pet.py
@@ -99,7 +99,7 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/query.py
+++ b/samples/client/echo_api/python/openapi_client/models/query.py
@@ -84,7 +84,7 @@ class Query(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Dict) -> Optional[Self]:
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[Self]:
         """Create an instance of Query from a dict"""
 
 

--- a/samples/client/echo_api/python/openapi_client/models/tag.py
+++ b/samples/client/echo_api/python/openapi_client/models/tag.py
@@ -73,7 +73,7 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_deep_object_explode_true_object_all_of_query_object_parameter.py
@@ -75,7 +75,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter(BaseMod
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
+++ b/samples/client/echo_api/python/openapi_client/models/test_query_style_form_explode_true_array_string_query_object_parameter.py
@@ -72,7 +72,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter from a dict"""
         if obj is None:
             return None

--- a/samples/client/echo_api/python/openapi_client/rest.py
+++ b/samples/client/echo_api/python/openapi_client/rest.py
@@ -213,14 +213,13 @@ class RESTClientObject:
                         preload_content=False
                     )
                 # Pass a `string` parameter directly in the body to support
-                # other content types than Json when `body` argument is
-                # provided in serialized form
+                # other content types than JSON when `body` argument is
+                # provided in serialized form.
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
                     r = self.pool_manager.request(
                         method,
                         url,
-                        body=request_body,
+                        body=body,
                         timeout=timeout,
                         headers=headers,
                         preload_content=False

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -38,3 +38,34 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
+# TODO: enable "strict" once all these individual checks are passing
+# strict = true
+
+# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+## Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+### Strongly recommend enabling this one as soon as you can
+#check_untyped_defs = true
+
+### These shouldn't be too much additional work, but may be tricky to
+### get passing if you use a lot of untyped libraries
+#disallow_subclassing_any = true
+#disallow_untyped_decorators = true
+#disallow_any_generics = true
+#
+### These next few are various gradations of forcing use of type annotations
+#disallow_untyped_calls = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#
+### This one isn't too hard to get passing, but return on investment is lower
+#no_implicit_reexport = true
+#
+### This one can be tricky to get passing if you use a lot of untyped libraries
+#warn_return_any = true

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -57,8 +57,8 @@ check_untyped_defs = true
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-#disallow_any_generics = true
-#
+disallow_any_generics = true
+
 ### These next few are various gradations of forcing use of type annotations
 #disallow_untyped_calls = true
 #disallow_incomplete_defs = true

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -50,8 +50,8 @@ warn_unused_ignores = true
 strict_equality = true
 strict_concatenate = true
 
-### Strongly recommend enabling this one as soon as you can
-#check_untyped_defs = true
+## Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
 
 ### These shouldn't be too much additional work, but may be tricky to
 ### get passing if you use a lot of untyped libraries

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -53,9 +53,9 @@ strict_concatenate = true
 ## Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true
 
-### These shouldn't be too much additional work, but may be tricky to
-### get passing if you use a lot of untyped libraries
-#disallow_subclassing_any = true
+## These shouldn't be too much additional work, but may be tricky to
+## get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
 #disallow_untyped_decorators = true
 #disallow_any_generics = true
 #

--- a/samples/client/echo_api/python/pyproject.toml
+++ b/samples/client/echo_api/python/pyproject.toml
@@ -56,7 +56,7 @@ check_untyped_defs = true
 ## These shouldn't be too much additional work, but may be tricky to
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
-#disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 #disallow_any_generics = true
 #
 ### These next few are various gradations of forcing use of type annotations

--- a/samples/client/echo_api/python/tests/test_manual.py
+++ b/samples/client/echo_api/python/tests/test_manual.py
@@ -85,7 +85,7 @@ class TestManual(unittest.TestCase):
         datetime_format_backup = api_instance.api_client.configuration.datetime_format # backup dateime_format
         api_instance.api_client.configuration.datetime_format = "%Y-%m-%d %a %H:%M:%S%Z"
         datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
-        date_query = '2013-10-20' # date |  (optional)
+        date_query = datetime.date(2013, 10, 20) # date |  (optional)
         string_query = 'string_query_example' # str |  (optional)
 
         # Test query parameter(s)
@@ -99,7 +99,7 @@ class TestManual(unittest.TestCase):
     def testDateTimeQueryWithDateTime(self):
         api_instance = openapi_client.QueryApi()
         datetime_query = datetime.datetime.fromisoformat('2013-10-20T19:20:30-05:00') # datetime |  (optional)
-        date_query = '2013-10-20' # date |  (optional)
+        date_query = datetime.date(2013, 10, 20) # date |  (optional)
         string_query = 'string_query_example' # str |  (optional)
     
         # Test query parameter(s)
@@ -116,12 +116,14 @@ class TestManual(unittest.TestCase):
 
     def testNumberPropertiesOnly(self):
         n = openapi_client.NumberPropertiesOnly.from_json('{"number": 123, "float": 456, "double": 34}')
+        assert n is not None
         self.assertEqual(n.number, 123)
         # TODO: pydantic v2: this field name override the default `float` type
         # self.assertEqual(n.float, 456)
         self.assertEqual(n.double, 34)
 
         n = openapi_client.NumberPropertiesOnly.from_json('{"number": 123.1, "float": 456.2, "double": 34.3}')
+        assert n is not None
         self.assertEqual(n.number, 123.1)
         # TODO: pydantic v2: this field name override the default `float` type
         # self.assertEqual(n.float, 456.2)
@@ -187,11 +189,14 @@ class TestManual(unittest.TestCase):
                     " \"status\": \"available\",\n"
                     " \"tags\": [{\"id\": 1, \"name\": \"None\"}]}")
         pet = openapi_client.Pet.from_json(json_str)
+        assert pet is not None
         self.assertEqual(pet.id, 1)
         self.assertEqual(pet.status, "available")
         self.assertEqual(pet.photo_urls, ["string"])
+        assert pet.tags is not None
         self.assertEqual(pet.tags[0].id, 1)
         self.assertEqual(pet.tags[0].name, "None")
+        assert pet.category is not None
         self.assertEqual(pet.category.id, 1)
         # test to_json
         self.assertEqual(pet.to_json(),
@@ -205,11 +210,14 @@ class TestManual(unittest.TestCase):
 
         # test from_dict
         pet2 = openapi_client.Pet.from_dict(pet.to_dict())
+        assert pet2 is not None
         self.assertEqual(pet2.id, 1)
         self.assertEqual(pet2.status, "available")
         self.assertEqual(pet2.photo_urls, ["string"])
+        assert pet2.tags is not None
         self.assertEqual(pet2.tags[0].id, 1)
         self.assertEqual(pet2.tags[0].name, "None")
+        assert pet2.category is not None
         self.assertEqual(pet2.category.id, 1)
 
     def test_parameters_to_url_query_boolean_value(self):

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/another_fake_api.py
@@ -20,7 +20,7 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -242,7 +242,7 @@ class AnotherFakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/default_api.py
@@ -18,7 +18,7 @@ from typing_extensions import Annotated
 
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -221,7 +221,7 @@ class DefaultApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_api.py
@@ -31,7 +31,7 @@ from petstore_api.models.tag import Tag
 from petstore_api.models.test_inline_freeform_additional_properties_request import TestInlineFreeformAdditionalPropertiesRequest
 from petstore_api.models.user import User
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -250,7 +250,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -511,7 +511,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -748,7 +748,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1026,7 +1026,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1298,7 +1298,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1568,7 +1568,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1838,7 +1838,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2108,7 +2108,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2378,7 +2378,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2632,7 +2632,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2871,7 +2871,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3123,7 +3123,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3376,7 +3376,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3640,7 +3640,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3909,7 +3909,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4183,7 +4183,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4451,7 +4451,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4731,7 +4731,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4987,7 +4987,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -5427,7 +5427,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -5710,7 +5710,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6030,7 +6030,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6300,7 +6300,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6564,7 +6564,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6841,7 +6841,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -7185,7 +7185,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/fake_classname_tags123_api.py
@@ -20,7 +20,7 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -242,7 +242,7 @@ class FakeClassnameTags123Api:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/pet_api.py
@@ -22,7 +22,7 @@ from typing_extensions import Annotated
 from petstore_api.models.model_api_response import ModelApiResponse
 from petstore_api.models.pet import Pet
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -247,7 +247,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -530,7 +530,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -787,7 +787,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1056,7 +1056,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1325,7 +1325,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1593,7 +1593,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1889,7 +1889,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2184,7 +2184,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2485,7 +2485,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -20,7 +20,7 @@ from pydantic import Field, StrictStr
 from typing_extensions import Annotated
 from petstore_api.models.order import Order
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -245,7 +245,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -483,7 +483,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -745,7 +745,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1006,7 +1006,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/user_api.py
@@ -21,7 +21,7 @@ from typing import List
 from typing_extensions import Annotated
 from petstore_api.models.user import User
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -240,7 +240,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _hosts = [
             'http://petstore.swagger.io/v2',
@@ -506,7 +506,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -768,7 +768,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1036,7 +1036,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1293,7 +1293,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1567,7 +1567,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1815,7 +1815,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2080,7 +2080,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -21,10 +21,10 @@ import re
 import tempfile
 
 from urllib.parse import quote
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Dict
 
 from petstore_api.configuration import Configuration
-from petstore_api.api_response import ApiResponse
+from petstore_api.api_response import ApiResponse, T as ApiResponseT
 import petstore_api.models
 from petstore_api import rest
 from petstore_api.exceptions import (
@@ -37,6 +37,7 @@ from petstore_api.exceptions import (
     ServiceException
 )
 
+RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -149,7 +150,7 @@ class ApiClient:
         collection_formats=None,
         _host=None,
         _request_auth=None
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         """Builds the HTTP request params needed by the request.
         :param method: Method to call.
@@ -282,8 +283,8 @@ class ApiClient:
     def response_deserialize(
         self,
         response_data: rest.RESTResponse,
-        response_types_map=None
-    ) -> ApiResponse:
+        response_types_map: Optional[Dict[str, ApiResponseT]]=None
+    ) -> ApiResponse[ApiResponseT]:
         """Deserializes response into an object.
         :param response_data: RESTResponse object to be deserialized.
         :param response_types_map: dict of response types.

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -404,12 +404,16 @@ class ApiClient:
 
         if isinstance(klass, str):
             if klass.startswith('List['):
-                sub_kls = re.match(r'List\[(.*)]', klass).group(1)
+                m = re.match(r'List\[(.*)]', klass)
+                assert m is not None, "Malformed List type definition"
+                sub_kls = m.group(1)
                 return [self.__deserialize(sub_data, sub_kls)
                         for sub_data in data]
 
             if klass.startswith('Dict['):
-                sub_kls = re.match(r'Dict\[([^,]*), (.*)]', klass).group(2)
+                m = re.match(r'Dict\[([^,]*), (.*)]', klass)
+                assert m is not None, "Malformed Dict type definition"
+                sub_kls = m.group(2)
                 return {k: self.__deserialize(v, sub_kls)
                         for k, v in data.items()}
 
@@ -437,7 +441,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: Parameters as list of tuples, collections formatted
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -467,7 +471,7 @@ class ApiClient:
         :param dict collection_formats: Parameter collection formats
         :return: URL query string (e.g. a=Hello%20World&b=123)
         """
-        new_params = []
+        new_params: List[Tuple[str, str]] = []
         if collection_formats is None:
             collection_formats = {}
         for k, v in params.items() if isinstance(params, dict) else params:
@@ -659,10 +663,12 @@ class ApiClient:
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.search(
+            m = re.search(
                 r'filename=[\'"]?([^\'"\s]+)[\'"]?',
                 content_disposition
-            ).group(1)
+            )
+            assert m is not None, "Unexpected 'content-disposition' header value"
+            filename = m.group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "wb") as f:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/configuration.py
@@ -14,7 +14,9 @@
 
 import copy
 import logging
+from logging import FileHandler
 import sys
+from typing import Optional
 import urllib3
 
 import http.client as httplib
@@ -197,7 +199,7 @@ conf = petstore_api.Configuration(
         self.logger_stream_handler = None
         """Log stream handler
         """
-        self.logger_file_handler = None
+        self.logger_file_handler: Optional[FileHandler] = None
         """Log file handler
         """
         self.logger_file = None
@@ -234,7 +236,7 @@ conf = petstore_api.Configuration(
            Default values is 100, None means no-limit.
         """
 
-        self.proxy = None
+        self.proxy: Optional[str] = None
         """Proxy URL
         """
         self.proxy_headers = None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_any_type.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesAnyType(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesAnyType from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_class.py
@@ -72,7 +72,7 @@ class AdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_object.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesObject from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/additional_properties_with_description_only.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -73,7 +73,7 @@ class AllOfWithSingleRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AllOfWithSingleRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/animal.py
@@ -46,7 +46,7 @@ class Animal(BaseModel):
     }
 
     @classmethod
-    def get_discriminator_value(cls, obj: Dict) -> Optional[str]:
+    def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
@@ -89,7 +89,7 @@ class Animal(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Dict) -> Optional[Union[Self, Self]]:
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[Union[Self, Self]]:
         """Create an instance of Animal from a dict"""
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_color.py
@@ -87,7 +87,7 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Dict[str, Any]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -139,7 +139,7 @@ class AnyOfColor(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, List[int], str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], List[int], str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/any_of_pig.py
@@ -80,7 +80,7 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Dict[str, Any]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -117,7 +117,7 @@ class AnyOfPig(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, BasquePig, DanishPig]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], BasquePig, DanishPig]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -81,7 +81,7 @@ class ArrayOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfArrayOfModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -71,7 +71,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfArrayOfNumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_of_number_only.py
@@ -71,7 +71,7 @@ class ArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfNumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -84,7 +84,7 @@ class ArrayTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/basque_pig.py
@@ -72,7 +72,7 @@ class BasquePig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of BasquePig from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/capitalization.py
@@ -76,7 +76,7 @@ class Capitalization(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Capitalization from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/cat.py
@@ -72,7 +72,7 @@ class Cat(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Cat from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/category.py
@@ -72,7 +72,7 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/circular_reference_model.py
@@ -75,7 +75,7 @@ class CircularReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of CircularReferenceModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/class_model.py
@@ -71,7 +71,7 @@ class ClassModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ClassModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/client.py
@@ -71,7 +71,7 @@ class Client(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Client from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
@@ -89,11 +89,11 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Self:
+    def from_json(cls, json_str: Optional[str]) -> Self:
         """Returns the object represented by the json string"""
         instance = cls.model_construct()
         if json_str is None:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/color.py
@@ -89,7 +89,7 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -149,7 +149,7 @@ class Color(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, List[int], str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], List[int], str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature.py
@@ -76,7 +76,7 @@ class Creature(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Creature from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/creature_info.py
@@ -71,7 +71,7 @@ class CreatureInfo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of CreatureInfo from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/danish_pig.py
@@ -72,7 +72,7 @@ class DanishPig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DanishPig from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/deprecated_object.py
@@ -71,7 +71,7 @@ class DeprecatedObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DeprecatedObject from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dog.py
@@ -72,7 +72,7 @@ class Dog(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Dog from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/dummy_model.py
@@ -75,7 +75,7 @@ class DummyModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DummyModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_arrays.py
@@ -93,7 +93,7 @@ class EnumArrays(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of EnumArrays from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -135,7 +135,7 @@ class EnumTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of EnumTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file.py
@@ -71,7 +71,7 @@ class File(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of File from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -83,7 +83,7 @@ class FileSchemaTestClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FileSchemaTestClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/first_ref.py
@@ -75,7 +75,7 @@ class FirstRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FirstRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo.py
@@ -71,7 +71,7 @@ class Foo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Foo from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/foo_get_default_response.py
@@ -75,7 +75,7 @@ class FooGetDefaultResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FooGetDefaultResponse from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/format_test.py
@@ -130,7 +130,7 @@ class FormatTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FormatTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/has_only_read_only.py
@@ -76,7 +76,7 @@ class HasOnlyReadOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of HasOnlyReadOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/health_check_result.py
@@ -76,7 +76,7 @@ class HealthCheckResult(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of HealthCheckResult from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -71,7 +71,7 @@ class InnerDictWithProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of InnerDictWithProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
@@ -78,7 +78,7 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -126,7 +126,7 @@ class IntOrString(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, int, str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], int, str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/int_or_string.py
@@ -78,7 +78,7 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/list_class.py
@@ -71,7 +71,7 @@ class ListClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ListClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -81,7 +81,7 @@ class MapOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MapOfArrayOfModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/map_test.py
@@ -84,7 +84,7 @@ class MapTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MapTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -82,7 +82,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model200_response.py
@@ -72,7 +72,7 @@ class Model200Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Model200Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_api_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_api_response.py
@@ -73,7 +73,7 @@ class ModelApiResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ModelApiResponse from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/model_return.py
@@ -71,7 +71,7 @@ class ModelReturn(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ModelReturn from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/name.py
@@ -78,7 +78,7 @@ class Name(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Name from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -147,7 +147,7 @@ class NullableClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NullableClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_property.py
@@ -88,7 +88,7 @@ class NullableProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NullableProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/number_only.py
@@ -71,7 +71,7 @@ class NumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -71,7 +71,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ObjectToTestAdditionalProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -78,7 +78,7 @@ class ObjectWithDeprecatedFields(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ObjectWithDeprecatedFields from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
@@ -77,7 +77,7 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/one_of_enum_string.py
@@ -77,7 +77,7 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -119,7 +119,7 @@ class OneOfEnumString(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, EnumString1, EnumString2]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], EnumString1, EnumString2]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/order.py
@@ -87,7 +87,7 @@ class Order(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Order from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_composite.py
@@ -73,7 +73,7 @@ class OuterComposite(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of OuterComposite from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/outer_object_with_enum_property.py
@@ -79,7 +79,7 @@ class OuterObjectWithEnumProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of OuterObjectWithEnumProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent.py
@@ -79,7 +79,7 @@ class Parent(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Parent from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -79,7 +79,7 @@ class ParentWithOptionalDict(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ParentWithOptionalDict from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pet.py
@@ -99,7 +99,7 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
@@ -80,7 +80,7 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -122,7 +122,7 @@ class Pig(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, BasquePig, DanishPig]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], BasquePig, DanishPig]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/pig.py
@@ -80,7 +80,7 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/property_name_collision.py
@@ -73,7 +73,7 @@ class PropertyNameCollision(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of PropertyNameCollision from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/read_only_first.py
@@ -74,7 +74,7 @@ class ReadOnlyFirst(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ReadOnlyFirst from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/second_ref.py
@@ -75,7 +75,7 @@ class SecondRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SecondRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/self_reference_model.py
@@ -75,7 +75,7 @@ class SelfReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SelfReferenceModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_model_name.py
@@ -71,7 +71,7 @@ class SpecialModelName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SpecialModelName from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/special_name.py
@@ -87,7 +87,7 @@ class SpecialName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SpecialName from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tag.py
@@ -72,7 +72,7 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model400_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model400_response.py
@@ -71,7 +71,7 @@ class TestErrorResponsesWithModel400Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestErrorResponsesWithModel400Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model404_response.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_error_responses_with_model404_response.py
@@ -71,7 +71,7 @@ class TestErrorResponsesWithModel404Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestErrorResponsesWithModel404Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -79,7 +79,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/tiger.py
@@ -71,7 +71,7 @@ class Tiger(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tiger from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -81,7 +81,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of UnnamedDictWithAdditionalModelListProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -71,7 +71,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of UnnamedDictWithAdditionalStringListProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/user.py
@@ -78,7 +78,7 @@ class User(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of User from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/with_nested_one_of.py
@@ -81,7 +81,7 @@ class WithNestedOneOf(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of WithNestedOneOf from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/rest.py
@@ -16,7 +16,7 @@ import io
 import json
 import re
 import ssl
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 import aiohttp_retry
@@ -199,6 +199,7 @@ class RESTClientObject:
                          declared content type."""
                 raise ApiException(status=0, reason=msg)
 
+        pool_manager: Union[aiohttp.ClientSession, aiohttp_retry.RetryClient]
         if self.retry_client is not None and method in ALLOW_RETRY_METHODS:
             pool_manager = self.retry_client
         else:

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/signing.py
@@ -13,12 +13,16 @@
 from base64 import b64encode
 from Crypto.IO import PEM, PKCS8
 from Crypto.Hash import SHA256, SHA512
+from Crypto.Hash.SHA512 import SHA512Hash
+from Crypto.Hash.SHA256 import SHA256Hash
 from Crypto.PublicKey import RSA, ECC
 from Crypto.Signature import PKCS1_v1_5, pss, DSS
+from datetime import timedelta
 from email.utils import formatdate
 import os
 import re
 from time import time
+from typing import List, Optional, Union
 from urllib.parse import urlencode, urlparse
 
 # The constants below define a subset of HTTP headers that can be included in the
@@ -67,18 +71,20 @@ HASH_SHA512 = 'sha512'
 
 class HttpSigningConfiguration:
     """The configuration parameters for the HTTP signature security scheme.
+
     The HTTP signature security scheme is used to sign HTTP requests with a private key
     which is in possession of the API client.
-    An 'Authorization' header is calculated by creating a hash of select headers,
+
+    An ``Authorization`` header is calculated by creating a hash of select headers,
     and optionally the body of the HTTP request, then signing the hash value using
-    a private key. The 'Authorization' header is added to outbound HTTP requests.
+    a private key. The ``Authorization`` header is added to outbound HTTP requests.
 
     :param key_id: A string value specifying the identifier of the cryptographic key,
         when signing HTTP requests.
     :param signing_scheme: A string value specifying the signature scheme, when
         signing HTTP requests.
-        Supported value are hs2019, rsa-sha256, rsa-sha512.
-        Avoid using rsa-sha256, rsa-sha512 as they are deprecated. These values are
+        Supported value are: ``hs2019``, ``rsa-sha256``, ``rsa-sha512``.
+        Avoid using ``rsa-sha256``, ``rsa-sha512`` as they are deprecated. These values are
         available for server-side applications that only support the older
         HTTP signature algorithms.
     :param private_key_path: A string value specifying the path of the file containing
@@ -87,18 +93,19 @@ class HttpSigningConfiguration:
         the private key.
     :param signed_headers: A list of strings. Each value is the name of a HTTP header
         that must be included in the HTTP signature calculation.
-        The two special signature headers '(request-target)' and '(created)' SHOULD be
+        The two special signature headers ``(request-target)`` and ``(created)`` SHOULD be
         included in SignedHeaders.
-        The '(created)' header expresses when the signature was created.
-        The '(request-target)' header is a concatenation of the lowercased :method, an
+        The ``(created)`` header expresses when the signature was created.
+        The ``(request-target)`` header is a concatenation of the lowercased :method, an
         ASCII space, and the :path pseudo-headers.
         When signed_headers is not specified, the client defaults to a single value,
-        '(created)', in the list of HTTP headers.
+        ``(created)``, in the list of HTTP headers.
         When SignedHeaders contains the 'Digest' value, the client performs the
         following operations:
-        1. Calculate a digest of request body, as specified in RFC3230, section 4.3.2.
-        2. Set the 'Digest' header in the request body.
-        3. Include the 'Digest' header and value in the HTTP signature.
+        1. Calculate a digest of request body, as specified in `RFC3230,
+          section 4.3.2<https://datatracker.ietf.org/doc/html/rfc3230#section-4.3.2>`_.
+        2. Set the ``Digest`` header in the request body.
+        3. Include the ``Digest`` header and value in the HTTP signature.
     :param signing_algorithm: A string value specifying the signature algorithm, when
         signing HTTP requests.
         Supported values are:
@@ -116,12 +123,16 @@ class HttpSigningConfiguration:
     :param signature_max_validity: The signature max validity, expressed as
         a datetime.timedelta value. It must be a positive value.
     """
-    def __init__(self, key_id, signing_scheme, private_key_path,
-                 private_key_passphrase=None,
-                 signed_headers=None,
-                 signing_algorithm=None,
-                 hash_algorithm=None,
-                 signature_max_validity=None) -> None:
+    def __init__(self,
+        key_id: str,
+        signing_scheme: str,
+        private_key_path: str,
+        private_key_passphrase: Union[None, str]=None,
+        signed_headers: Optional[List[str]]=None,
+        signing_algorithm: Optional[str]=None,
+        hash_algorithm: Optional[str]=None,
+        signature_max_validity: Optional[timedelta]=None,
+    ) -> None:
         self.key_id = key_id
         if signing_scheme not in {SCHEME_HS2019, SCHEME_RSA_SHA256, SCHEME_RSA_SHA512}:
             raise Exception("Unsupported security scheme: {0}".format(signing_scheme))
@@ -165,11 +176,11 @@ class HttpSigningConfiguration:
         if HEADER_AUTHORIZATION in signed_headers:
             raise Exception("'Authorization' header cannot be included in signed headers")
         self.signed_headers = signed_headers
-        self.private_key = None
+        self.private_key: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         """The private key used to sign HTTP requests.
            Initialized when the PEM-encoded private key is loaded from a file.
         """
-        self.host = None
+        self.host: Optional[str] = None
         """The host name, optionally followed by a colon and TCP port number.
         """
         self._load_private_key()
@@ -207,7 +218,7 @@ class HttpSigningConfiguration:
     def get_public_key(self):
         """Returns the public key object associated with the private key.
         """
-        pubkey = None
+        pubkey: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         if isinstance(self.private_key, RSA.RsaKey):
             pubkey = self.private_key.publickey()
         elif isinstance(self.private_key, ECC.EccKey):
@@ -236,8 +247,11 @@ class HttpSigningConfiguration:
             elif pem_header in {'PRIVATE KEY', 'ENCRYPTED PRIVATE KEY'}:
                 # Key is in PKCS8 format, which is capable of holding many different
                 # types of private keys, not just EC keys.
-                (key_binary, pem_header, is_encrypted) = \
-                    PEM.decode(pem_data, self.private_key_passphrase)
+                if self.private_key_passphrase is not None:
+                    passphrase = self.private_key_passphrase.encode("utf-8")
+                else:
+                    passphrase = None
+                (key_binary, pem_header, is_encrypted) = PEM.decode(pem_data, passphrase)
                 (oid, privkey, params) = \
                     PKCS8.unwrap(key_binary, passphrase=self.private_key_passphrase)
                 if oid == '1.2.840.10045.2.1':
@@ -318,8 +332,11 @@ class HttpSigningConfiguration:
                 request_headers_dict[HEADER_DIGEST] = '{0}{1}'.format(
                     digest_prefix, b64_body_digest.decode('ascii'))
             elif hdr_key == HEADER_HOST.lower():
-                value = target_host
-                request_headers_dict[HEADER_HOST] = '{0}'.format(target_host)
+                if isinstance(target_host, bytes):
+                    value = target_host.decode('ascii')
+                else:
+                    value = target_host
+                request_headers_dict[HEADER_HOST] = value
             else:
                 value = next((v for k, v in headers.items() if k.lower() == hdr_key), None)
                 if value is None:
@@ -340,6 +357,9 @@ class HttpSigningConfiguration:
             The prefix is a string that identifies the cryptographic hash. It is used
             to generate the 'Digest' header as specified in RFC 3230.
         """
+
+        digest: Union[SHA256Hash, SHA512Hash]
+
         if self.hash_algorithm == HASH_SHA512:
             digest = SHA512.new()
             prefix = 'SHA-512='

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -42,3 +42,34 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
+# TODO: enable "strict" once all these individual checks are passing
+# strict = true
+
+# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+## Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+### Strongly recommend enabling this one as soon as you can
+#check_untyped_defs = true
+
+### These shouldn't be too much additional work, but may be tricky to
+### get passing if you use a lot of untyped libraries
+#disallow_subclassing_any = true
+#disallow_untyped_decorators = true
+#disallow_any_generics = true
+#
+### These next few are various gradations of forcing use of type annotations
+#disallow_untyped_calls = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#
+### This one isn't too hard to get passing, but return on investment is lower
+#no_implicit_reexport = true
+#
+### This one can be tricky to get passing if you use a lot of untyped libraries
+#warn_return_any = true

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -57,9 +57,9 @@ strict_concatenate = true
 ## Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true
 
-### These shouldn't be too much additional work, but may be tricky to
-### get passing if you use a lot of untyped libraries
-#disallow_subclassing_any = true
+## These shouldn't be too much additional work, but may be tricky to
+## get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
 #disallow_untyped_decorators = true
 #disallow_any_generics = true
 #

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -54,8 +54,8 @@ warn_unused_ignores = true
 strict_equality = true
 strict_concatenate = true
 
-### Strongly recommend enabling this one as soon as you can
-#check_untyped_defs = true
+## Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
 
 ### These shouldn't be too much additional work, but may be tricky to
 ### get passing if you use a lot of untyped libraries

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -61,8 +61,8 @@ check_untyped_defs = true
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-#disallow_any_generics = true
-#
+disallow_any_generics = true
+
 ### These next few are various gradations of forcing use of type annotations
 #disallow_untyped_calls = true
 #disallow_incomplete_defs = true

--- a/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
+++ b/samples/openapi3/client/petstore/python-aiohttp/pyproject.toml
@@ -60,7 +60,7 @@ check_untyped_defs = true
 ## These shouldn't be too much additional work, but may be tricky to
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
-#disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 #disallow_any_generics = true
 #
 ### These next few are various gradations of forcing use of type annotations

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_api.py
@@ -71,6 +71,7 @@ class TestPetApiTests(unittest.TestCase):
     @async_test
     async def test_async_with_result(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         tasks = [
             asyncio.create_task(coro)
@@ -100,31 +101,32 @@ class TestPetApiTests(unittest.TestCase):
     @async_test
     async def test_add_pet_and_get_pet_by_id(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = await self.pet_api.get_pet_by_id(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched)
         self.assertEqual(self.pet.id, fetched.id)
-        self.assertIsNotNone(fetched.category)
+        assert self.pet.category is not None
+        assert fetched.category is not None
         self.assertEqual(self.pet.category.name, fetched.category.name)
 
     @async_test
     async def test_add_pet_and_get_pet_by_id_with_http_info(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = await self.pet_api.get_pet_by_id_with_http_info(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched)
         self.assertEqual(self.pet.id, fetched.data.id)
-        self.assertIsNotNone(fetched.data.category)
+        assert self.pet.category is not None
+        assert fetched.data.category is not None
         self.assertEqual(self.pet.category.name, fetched.data.category.name)
 
     @async_test
     async def test_add_pet_and_get_pet_by_id_without_preload_content(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = await self.pet_api.get_pet_by_id_without_preload_content(pet_id=self.pet.id)
         self.assertIsInstance(fetched, aiohttp.ClientResponse)
-        # self.assertFalse(fetched.closed)
-        # self.assertFalse(fetched.content._eof)
         read = await fetched.content.read()
         self.assertTrue(fetched.closed)
         self.assertTrue(fetched.content._eof)
@@ -136,17 +138,19 @@ class TestPetApiTests(unittest.TestCase):
     async def test_update_pet(self):
         self.pet.name = "hello kity with updated"
         await self.pet_api.update_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = await self.pet_api.get_pet_by_id(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched)
         self.assertEqual(self.pet.id, fetched.id)
         self.assertEqual(self.pet.name, fetched.name)
-        self.assertIsNotNone(fetched.category)
+        assert self.pet.category is not None
+        assert fetched.category is not None
         self.assertEqual(fetched.category.name, self.pet.category.name)
 
     @async_test
     async def test_find_pets_by_status(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.status is not None
         pets = await self.pet_api.find_pets_by_status(status=[self.pet.status])
         self.assertIn(
             self.pet.id,
@@ -156,6 +160,7 @@ class TestPetApiTests(unittest.TestCase):
     @async_test
     async def test_find_pets_by_tags(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.tag.name is not None
         pets = await self.pet_api.find_pets_by_tags(tags=[self.tag.name])
         self.assertIn(
             self.pet.id,
@@ -165,6 +170,7 @@ class TestPetApiTests(unittest.TestCase):
     @async_test
     async def test_update_pet_with_form(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         name = "hello kity with form updated"
         status = "pending"
@@ -180,6 +186,7 @@ class TestPetApiTests(unittest.TestCase):
         # upload file with form parameter
         try:
             additional_metadata = "special"
+            assert self.pet.id is not None
             await self.pet_api.upload_file(
                 pet_id=self.pet.id,
                 additional_metadata=additional_metadata,
@@ -197,6 +204,7 @@ class TestPetApiTests(unittest.TestCase):
     @async_test
     async def test_delete_pet(self):
         await self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
         await self.pet_api.delete_pet(pet_id=self.pet.id, api_key="special-key")
 
         try:
@@ -213,6 +221,7 @@ class TestPetApiTests(unittest.TestCase):
         config.proxy = 'http://localhost:8080/proxy'
         async with petstore_api.ApiClient(config) as client:
             pet_api = petstore_api.PetApi(client)
+            assert self.pet.id is not None
 
             with self.assertRaisesRegex(petstore_api.rest.aiohttp.client_exceptions.ClientProxyConnectionError,
                                         'Cannot connect to host localhost:8080'):

--- a/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_model.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/tests/test_pet_model.py
@@ -72,11 +72,14 @@ class PetModelTests(unittest.TestCase):
                     " \"status\": \"available\",\n"
                     " \"tags\": [{\"id\": 1, \"name\": \"None\"}]}")
         pet = petstore_api.Pet.from_json(json_str)
+        assert pet is not None
         self.assertEqual(pet.id, 1)
         self.assertEqual(pet.status, "available")
         self.assertEqual(pet.photo_urls, ["string"])
+        assert pet.tags is not None
         self.assertEqual(pet.tags[0].id, 1)
         self.assertEqual(pet.tags[0].name, "None")
+        assert pet.category is not None
         self.assertEqual(pet.category.id, 1)
         # test to_json
         self.assertEqual(pet.to_json(),
@@ -90,16 +93,22 @@ class PetModelTests(unittest.TestCase):
 
         # test from_dict
         pet2 = petstore_api.Pet.from_dict(pet.to_dict())
+        assert pet2 is not None
         self.assertEqual(pet2.id, 1)
         self.assertEqual(pet2.status, "available")
         self.assertEqual(pet2.photo_urls, ["string"])
+        assert pet2.tags is not None
         self.assertEqual(pet2.tags[0].id, 1)
         self.assertEqual(pet2.tags[0].name, "None")
+        assert pet2.category is not None
         self.assertEqual(pet2.category.id, 1)
 
     def test_unpack_operator(self):
-        d = {"name": "required name", "id": 123, "photoUrls": ["https://a.com", "https://b.com"]}
-        pet = petstore_api.Pet(**d)
+        pet = petstore_api.Pet(
+            name="required name",
+            id=123,
+            photoUrls=["https://a.com", "https://b.com"],
+        )
         self.assertEqual(pet.to_json(), '{"id": 123, "name": "required name", "photoUrls": ["https://a.com", "https://b.com"]}')
         self.assertEqual(pet.to_dict(), {"id": 123, "name": "required name", "photoUrls": ["https://a.com", "https://b.com"]})
     def test_optional_fields(self):

--- a/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/another_fake_api.py
@@ -20,7 +20,7 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -242,7 +242,7 @@ class AnotherFakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/default_api.py
@@ -18,7 +18,7 @@ from typing_extensions import Annotated
 
 from petstore_api.models.foo_get_default_response import FooGetDefaultResponse
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -221,7 +221,7 @@ class DefaultApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_api.py
@@ -31,7 +31,7 @@ from petstore_api.models.tag import Tag
 from petstore_api.models.test_inline_freeform_additional_properties_request import TestInlineFreeformAdditionalPropertiesRequest
 from petstore_api.models.user import User
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -250,7 +250,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -511,7 +511,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -748,7 +748,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1026,7 +1026,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1298,7 +1298,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1568,7 +1568,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1838,7 +1838,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2108,7 +2108,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2378,7 +2378,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2632,7 +2632,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2871,7 +2871,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3123,7 +3123,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3376,7 +3376,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3640,7 +3640,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -3909,7 +3909,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4183,7 +4183,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4451,7 +4451,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4731,7 +4731,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -4987,7 +4987,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -5427,7 +5427,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -5710,7 +5710,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6030,7 +6030,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6300,7 +6300,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6564,7 +6564,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -6841,7 +6841,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -7185,7 +7185,7 @@ class FakeApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/fake_classname_tags123_api.py
@@ -20,7 +20,7 @@ from pydantic import Field
 from typing_extensions import Annotated
 from petstore_api.models.client import Client
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -242,7 +242,7 @@ class FakeClassnameTags123Api:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/pet_api.py
@@ -22,7 +22,7 @@ from typing_extensions import Annotated
 from petstore_api.models.model_api_response import ModelApiResponse
 from petstore_api.models.pet import Pet
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -247,7 +247,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -530,7 +530,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -787,7 +787,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1056,7 +1056,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1325,7 +1325,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1593,7 +1593,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1889,7 +1889,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2184,7 +2184,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2485,7 +2485,7 @@ class PetApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -20,7 +20,7 @@ from pydantic import Field, StrictStr
 from typing_extensions import Annotated
 from petstore_api.models.order import Order
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -245,7 +245,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -483,7 +483,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -745,7 +745,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1006,7 +1006,7 @@ class StoreApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/user_api.py
@@ -21,7 +21,7 @@ from typing import List
 from typing_extensions import Annotated
 from petstore_api.models.user import User
 
-from petstore_api.api_client import ApiClient
+from petstore_api.api_client import ApiClient, RequestSerialized
 from petstore_api.api_response import ApiResponse
 from petstore_api.rest import RESTResponseType
 
@@ -240,7 +240,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _hosts = [
             'http://petstore.swagger.io/v2',
@@ -506,7 +506,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -768,7 +768,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1036,7 +1036,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1293,7 +1293,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1567,7 +1567,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -1815,7 +1815,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 
@@ -2080,7 +2080,7 @@ class UserApi:
         _content_type,
         _headers,
         _host_index,
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         _host = None
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -21,10 +21,10 @@ import re
 import tempfile
 
 from urllib.parse import quote
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Dict
 
 from petstore_api.configuration import Configuration
-from petstore_api.api_response import ApiResponse
+from petstore_api.api_response import ApiResponse, T as ApiResponseT
 import petstore_api.models
 from petstore_api import rest
 from petstore_api.exceptions import (
@@ -37,6 +37,7 @@ from petstore_api.exceptions import (
     ServiceException
 )
 
+RequestSerialized = Tuple[str, str, Dict[str, str], Optional[str], List[str]]
 
 class ApiClient:
     """Generic API client for OpenAPI client library builds.
@@ -146,7 +147,7 @@ class ApiClient:
         collection_formats=None,
         _host=None,
         _request_auth=None
-    ) -> Tuple:
+    ) -> RequestSerialized:
 
         """Builds the HTTP request params needed by the request.
         :param method: Method to call.
@@ -279,8 +280,8 @@ class ApiClient:
     def response_deserialize(
         self,
         response_data: rest.RESTResponse,
-        response_types_map=None
-    ) -> ApiResponse:
+        response_types_map: Optional[Dict[str, ApiResponseT]]=None
+    ) -> ApiResponse[ApiResponseT]:
         """Deserializes response into an object.
         :param response_data: RESTResponse object to be deserialized.
         :param response_types_map: dict of response types.

--- a/samples/openapi3/client/petstore/python/petstore_api/configuration.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/configuration.py
@@ -14,8 +14,10 @@
 
 import copy
 import logging
+from logging import FileHandler
 import multiprocessing
 import sys
+from typing import Optional
 import urllib3
 
 import http.client as httplib
@@ -198,7 +200,7 @@ conf = petstore_api.Configuration(
         self.logger_stream_handler = None
         """Log stream handler
         """
-        self.logger_file_handler = None
+        self.logger_file_handler: Optional[FileHandler] = None
         """Log file handler
         """
         self.logger_file = None
@@ -238,7 +240,7 @@ conf = petstore_api.Configuration(
            cpu_count * 5 is used as default value to increase performance.
         """
 
-        self.proxy = None
+        self.proxy: Optional[str] = None
         """Proxy URL
         """
         self.proxy_headers = None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_any_type.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesAnyType(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesAnyType from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_class.py
@@ -80,7 +80,7 @@ class AdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_object.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesObject from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/additional_properties_with_description_only.py
@@ -79,7 +79,7 @@ class AdditionalPropertiesWithDescriptionOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AdditionalPropertiesWithDescriptionOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/all_of_with_single_ref.py
@@ -81,7 +81,7 @@ class AllOfWithSingleRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of AllOfWithSingleRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/animal.py
@@ -47,7 +47,7 @@ class Animal(BaseModel):
     }
 
     @classmethod
-    def get_discriminator_value(cls, obj: Dict) -> Optional[str]:
+    def get_discriminator_value(cls, obj: Dict[str, Any]) -> Optional[str]:
         """Returns the discriminator value (object type) of the data"""
         discriminator_value = obj[cls.__discriminator_property_name]
         if discriminator_value:
@@ -97,7 +97,7 @@ class Animal(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Dict) -> Optional[Union[Self, Self]]:
+    def from_dict(cls, obj: Dict[str, Any]) -> Optional[Union[Self, Self]]:
         """Create an instance of Animal from a dict"""
         # look up the object type based on discriminator mapping
         object_type = cls.get_discriminator_value(obj)

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_color.py
@@ -87,7 +87,7 @@ class AnyOfColor(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Dict[str, Any]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -139,7 +139,7 @@ class AnyOfColor(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, List[int], str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], List[int], str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/any_of_pig.py
@@ -80,7 +80,7 @@ class AnyOfPig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Dict[str, Any]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -117,7 +117,7 @@ class AnyOfPig(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, BasquePig, DanishPig]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], BasquePig, DanishPig]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_model.py
@@ -89,7 +89,7 @@ class ArrayOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfArrayOfModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_array_of_number_only.py
@@ -79,7 +79,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfArrayOfNumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_of_number_only.py
@@ -79,7 +79,7 @@ class ArrayOfNumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayOfNumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -92,7 +92,7 @@ class ArrayTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ArrayTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/basque_pig.py
@@ -80,7 +80,7 @@ class BasquePig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of BasquePig from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/capitalization.py
@@ -84,7 +84,7 @@ class Capitalization(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Capitalization from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/cat.py
@@ -80,7 +80,7 @@ class Cat(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Cat from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/category.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/category.py
@@ -80,7 +80,7 @@ class Category(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Category from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/circular_reference_model.py
@@ -83,7 +83,7 @@ class CircularReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of CircularReferenceModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/class_model.py
@@ -79,7 +79,7 @@ class ClassModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ClassModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/client.py
@@ -79,7 +79,7 @@ class Client(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Client from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/color.py
@@ -89,11 +89,11 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
-    def from_json(cls, json_str: str) -> Self:
+    def from_json(cls, json_str: Optional[str]) -> Self:
         """Returns the object represented by the json string"""
         instance = cls.model_construct()
         if json_str is None:

--- a/samples/openapi3/client/petstore/python/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/color.py
@@ -89,7 +89,7 @@ class Color(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -149,7 +149,7 @@ class Color(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, List[int], str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], List[int], str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature.py
@@ -84,7 +84,7 @@ class Creature(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Creature from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/creature_info.py
@@ -79,7 +79,7 @@ class CreatureInfo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of CreatureInfo from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/danish_pig.py
@@ -80,7 +80,7 @@ class DanishPig(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DanishPig from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/deprecated_object.py
@@ -79,7 +79,7 @@ class DeprecatedObject(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DeprecatedObject from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dog.py
@@ -80,7 +80,7 @@ class Dog(Animal):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Dog from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/dummy_model.py
@@ -83,7 +83,7 @@ class DummyModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of DummyModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_arrays.py
@@ -101,7 +101,7 @@ class EnumArrays(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of EnumArrays from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -143,7 +143,7 @@ class EnumTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of EnumTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file.py
@@ -79,7 +79,7 @@ class File(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of File from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/file_schema_test_class.py
@@ -91,7 +91,7 @@ class FileSchemaTestClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FileSchemaTestClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/first_ref.py
@@ -83,7 +83,7 @@ class FirstRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FirstRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo.py
@@ -79,7 +79,7 @@ class Foo(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Foo from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/foo_get_default_response.py
@@ -83,7 +83,7 @@ class FooGetDefaultResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FooGetDefaultResponse from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/format_test.py
@@ -138,7 +138,7 @@ class FormatTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of FormatTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/has_only_read_only.py
@@ -84,7 +84,7 @@ class HasOnlyReadOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of HasOnlyReadOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/health_check_result.py
@@ -84,7 +84,7 @@ class HealthCheckResult(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of HealthCheckResult from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/inner_dict_with_property.py
@@ -79,7 +79,7 @@ class InnerDictWithProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of InnerDictWithProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
@@ -78,7 +78,7 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -126,7 +126,7 @@ class IntOrString(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, int, str]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], int, str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/int_or_string.py
@@ -78,7 +78,7 @@ class IntOrString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/list_class.py
@@ -79,7 +79,7 @@ class ListClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ListClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_of_array_of_model.py
@@ -89,7 +89,7 @@ class MapOfArrayOfModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MapOfArrayOfModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/map_test.py
@@ -92,7 +92,7 @@ class MapTest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MapTest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -90,7 +90,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of MixedPropertiesAndAdditionalPropertiesClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model200_response.py
@@ -80,7 +80,7 @@ class Model200Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Model200Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_api_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_api_response.py
@@ -81,7 +81,7 @@ class ModelApiResponse(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ModelApiResponse from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/model_return.py
@@ -79,7 +79,7 @@ class ModelReturn(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ModelReturn from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/name.py
@@ -86,7 +86,7 @@ class Name(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Name from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -147,7 +147,7 @@ class NullableClass(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NullableClass from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_property.py
@@ -96,7 +96,7 @@ class NullableProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NullableProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/number_only.py
@@ -79,7 +79,7 @@ class NumberOnly(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of NumberOnly from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_to_test_additional_properties.py
@@ -79,7 +79,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ObjectToTestAdditionalProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/object_with_deprecated_fields.py
@@ -86,7 +86,7 @@ class ObjectWithDeprecatedFields(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ObjectWithDeprecatedFields from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
@@ -77,7 +77,7 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/one_of_enum_string.py
@@ -77,7 +77,7 @@ class OneOfEnumString(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -119,7 +119,7 @@ class OneOfEnumString(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, EnumString1, EnumString2]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], EnumString1, EnumString2]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/order.py
@@ -95,7 +95,7 @@ class Order(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Order from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_composite.py
@@ -81,7 +81,7 @@ class OuterComposite(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of OuterComposite from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/outer_object_with_enum_property.py
@@ -87,7 +87,7 @@ class OuterObjectWithEnumProperty(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of OuterObjectWithEnumProperty from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent.py
@@ -87,7 +87,7 @@ class Parent(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Parent from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/parent_with_optional_dict.py
@@ -87,7 +87,7 @@ class ParentWithOptionalDict(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ParentWithOptionalDict from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pet.py
@@ -107,7 +107,7 @@ class Pet(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Pet from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
@@ -80,7 +80,7 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: Union[str, dict]) -> Self:
+    def from_dict(cls, obj: Union[str, Dict[str, Any]]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod
@@ -137,7 +137,7 @@ class Pig(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
-    def to_dict(self) -> Optional[Union[Dict, BasquePig, DanishPig]]:
+    def to_dict(self) -> Optional[Union[Dict[str, Any], BasquePig, DanishPig]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/pig.py
@@ -80,7 +80,7 @@ class Pig(BaseModel):
             return v
 
     @classmethod
-    def from_dict(cls, obj: dict) -> Self:
+    def from_dict(cls, obj: Union[str, dict]) -> Self:
         return cls.from_json(json.dumps(obj))
 
     @classmethod

--- a/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/property_name_collision.py
@@ -81,7 +81,7 @@ class PropertyNameCollision(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of PropertyNameCollision from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/read_only_first.py
@@ -82,7 +82,7 @@ class ReadOnlyFirst(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of ReadOnlyFirst from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/second_ref.py
@@ -83,7 +83,7 @@ class SecondRef(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SecondRef from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/self_reference_model.py
@@ -83,7 +83,7 @@ class SelfReferenceModel(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SelfReferenceModel from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_model_name.py
@@ -79,7 +79,7 @@ class SpecialModelName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SpecialModelName from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/special_name.py
@@ -95,7 +95,7 @@ class SpecialName(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of SpecialName from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tag.py
@@ -80,7 +80,7 @@ class Tag(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tag from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model400_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model400_response.py
@@ -79,7 +79,7 @@ class TestErrorResponsesWithModel400Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestErrorResponsesWithModel400Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model404_response.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_error_responses_with_model404_response.py
@@ -79,7 +79,7 @@ class TestErrorResponsesWithModel404Response(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestErrorResponsesWithModel404Response from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -79,7 +79,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of TestInlineFreeformAdditionalPropertiesRequest from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/tiger.py
@@ -79,7 +79,7 @@ class Tiger(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of Tiger from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -89,7 +89,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of UnnamedDictWithAdditionalModelListProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -79,7 +79,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of UnnamedDictWithAdditionalStringListProperties from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/user.py
@@ -86,7 +86,7 @@ class User(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of User from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/with_nested_one_of.py
@@ -89,7 +89,7 @@ class WithNestedOneOf(BaseModel):
         return _dict
 
     @classmethod
-    def from_dict(cls, obj: Optional[Dict]) -> Optional[Self]:
+    def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
         """Create an instance of WithNestedOneOf from a dict"""
         if obj is None:
             return None

--- a/samples/openapi3/client/petstore/python/petstore_api/rest.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/rest.py
@@ -212,14 +212,13 @@ class RESTClientObject:
                         preload_content=False
                     )
                 # Pass a `string` parameter directly in the body to support
-                # other content types than Json when `body` argument is
-                # provided in serialized form
+                # other content types than JSON when `body` argument is
+                # provided in serialized form.
                 elif isinstance(body, str) or isinstance(body, bytes):
-                    request_body = body
                     r = self.pool_manager.request(
                         method,
                         url,
-                        body=request_body,
+                        body=body,
                         timeout=timeout,
                         headers=headers,
                         preload_content=False

--- a/samples/openapi3/client/petstore/python/petstore_api/signing.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/signing.py
@@ -13,12 +13,16 @@
 from base64 import b64encode
 from Crypto.IO import PEM, PKCS8
 from Crypto.Hash import SHA256, SHA512
+from Crypto.Hash.SHA512 import SHA512Hash
+from Crypto.Hash.SHA256 import SHA256Hash
 from Crypto.PublicKey import RSA, ECC
 from Crypto.Signature import PKCS1_v1_5, pss, DSS
+from datetime import timedelta
 from email.utils import formatdate
 import os
 import re
 from time import time
+from typing import List, Optional, Union
 from urllib.parse import urlencode, urlparse
 
 # The constants below define a subset of HTTP headers that can be included in the
@@ -67,18 +71,20 @@ HASH_SHA512 = 'sha512'
 
 class HttpSigningConfiguration:
     """The configuration parameters for the HTTP signature security scheme.
+
     The HTTP signature security scheme is used to sign HTTP requests with a private key
     which is in possession of the API client.
-    An 'Authorization' header is calculated by creating a hash of select headers,
+
+    An ``Authorization`` header is calculated by creating a hash of select headers,
     and optionally the body of the HTTP request, then signing the hash value using
-    a private key. The 'Authorization' header is added to outbound HTTP requests.
+    a private key. The ``Authorization`` header is added to outbound HTTP requests.
 
     :param key_id: A string value specifying the identifier of the cryptographic key,
         when signing HTTP requests.
     :param signing_scheme: A string value specifying the signature scheme, when
         signing HTTP requests.
-        Supported value are hs2019, rsa-sha256, rsa-sha512.
-        Avoid using rsa-sha256, rsa-sha512 as they are deprecated. These values are
+        Supported value are: ``hs2019``, ``rsa-sha256``, ``rsa-sha512``.
+        Avoid using ``rsa-sha256``, ``rsa-sha512`` as they are deprecated. These values are
         available for server-side applications that only support the older
         HTTP signature algorithms.
     :param private_key_path: A string value specifying the path of the file containing
@@ -87,18 +93,19 @@ class HttpSigningConfiguration:
         the private key.
     :param signed_headers: A list of strings. Each value is the name of a HTTP header
         that must be included in the HTTP signature calculation.
-        The two special signature headers '(request-target)' and '(created)' SHOULD be
+        The two special signature headers ``(request-target)`` and ``(created)`` SHOULD be
         included in SignedHeaders.
-        The '(created)' header expresses when the signature was created.
-        The '(request-target)' header is a concatenation of the lowercased :method, an
+        The ``(created)`` header expresses when the signature was created.
+        The ``(request-target)`` header is a concatenation of the lowercased :method, an
         ASCII space, and the :path pseudo-headers.
         When signed_headers is not specified, the client defaults to a single value,
-        '(created)', in the list of HTTP headers.
+        ``(created)``, in the list of HTTP headers.
         When SignedHeaders contains the 'Digest' value, the client performs the
         following operations:
-        1. Calculate a digest of request body, as specified in RFC3230, section 4.3.2.
-        2. Set the 'Digest' header in the request body.
-        3. Include the 'Digest' header and value in the HTTP signature.
+        1. Calculate a digest of request body, as specified in `RFC3230,
+          section 4.3.2<https://datatracker.ietf.org/doc/html/rfc3230#section-4.3.2>`_.
+        2. Set the ``Digest`` header in the request body.
+        3. Include the ``Digest`` header and value in the HTTP signature.
     :param signing_algorithm: A string value specifying the signature algorithm, when
         signing HTTP requests.
         Supported values are:
@@ -116,12 +123,16 @@ class HttpSigningConfiguration:
     :param signature_max_validity: The signature max validity, expressed as
         a datetime.timedelta value. It must be a positive value.
     """
-    def __init__(self, key_id, signing_scheme, private_key_path,
-                 private_key_passphrase=None,
-                 signed_headers=None,
-                 signing_algorithm=None,
-                 hash_algorithm=None,
-                 signature_max_validity=None) -> None:
+    def __init__(self,
+        key_id: str,
+        signing_scheme: str,
+        private_key_path: str,
+        private_key_passphrase: Union[None, str]=None,
+        signed_headers: Optional[List[str]]=None,
+        signing_algorithm: Optional[str]=None,
+        hash_algorithm: Optional[str]=None,
+        signature_max_validity: Optional[timedelta]=None,
+    ) -> None:
         self.key_id = key_id
         if signing_scheme not in {SCHEME_HS2019, SCHEME_RSA_SHA256, SCHEME_RSA_SHA512}:
             raise Exception("Unsupported security scheme: {0}".format(signing_scheme))
@@ -165,11 +176,11 @@ class HttpSigningConfiguration:
         if HEADER_AUTHORIZATION in signed_headers:
             raise Exception("'Authorization' header cannot be included in signed headers")
         self.signed_headers = signed_headers
-        self.private_key = None
+        self.private_key: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         """The private key used to sign HTTP requests.
            Initialized when the PEM-encoded private key is loaded from a file.
         """
-        self.host = None
+        self.host: Optional[str] = None
         """The host name, optionally followed by a colon and TCP port number.
         """
         self._load_private_key()
@@ -207,7 +218,7 @@ class HttpSigningConfiguration:
     def get_public_key(self):
         """Returns the public key object associated with the private key.
         """
-        pubkey = None
+        pubkey: Optional[Union[ECC.EccKey, RSA.RsaKey]] = None
         if isinstance(self.private_key, RSA.RsaKey):
             pubkey = self.private_key.publickey()
         elif isinstance(self.private_key, ECC.EccKey):
@@ -236,8 +247,11 @@ class HttpSigningConfiguration:
             elif pem_header in {'PRIVATE KEY', 'ENCRYPTED PRIVATE KEY'}:
                 # Key is in PKCS8 format, which is capable of holding many different
                 # types of private keys, not just EC keys.
-                (key_binary, pem_header, is_encrypted) = \
-                    PEM.decode(pem_data, self.private_key_passphrase)
+                if self.private_key_passphrase is not None:
+                    passphrase = self.private_key_passphrase.encode("utf-8")
+                else:
+                    passphrase = None
+                (key_binary, pem_header, is_encrypted) = PEM.decode(pem_data, passphrase)
                 (oid, privkey, params) = \
                     PKCS8.unwrap(key_binary, passphrase=self.private_key_passphrase)
                 if oid == '1.2.840.10045.2.1':
@@ -318,8 +332,11 @@ class HttpSigningConfiguration:
                 request_headers_dict[HEADER_DIGEST] = '{0}{1}'.format(
                     digest_prefix, b64_body_digest.decode('ascii'))
             elif hdr_key == HEADER_HOST.lower():
-                value = target_host
-                request_headers_dict[HEADER_HOST] = '{0}'.format(target_host)
+                if isinstance(target_host, bytes):
+                    value = target_host.decode('ascii')
+                else:
+                    value = target_host
+                request_headers_dict[HEADER_HOST] = value
             else:
                 value = next((v for k, v in headers.items() if k.lower() == hdr_key), None)
                 if value is None:
@@ -340,6 +357,9 @@ class HttpSigningConfiguration:
             The prefix is a string that identifies the cryptographic hash. It is used
             to generate the 'Digest' header as specified in RFC 3230.
         """
+
+        digest: Union[SHA256Hash, SHA512Hash]
+
         if self.hash_algorithm == HASH_SHA512:
             digest = SHA512.new()
             prefix = 'SHA-512='

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -40,3 +40,34 @@ files = [
   #"test",  # auto-generated tests
   "tests", # hand-written tests
 ]
+# TODO: enable "strict" once all these individual checks are passing
+# strict = true
+
+# List from: https://mypy.readthedocs.io/en/stable/existing_code.html#introduce-stricter-options
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+## Getting these passing should be easy
+strict_equality = true
+strict_concatenate = true
+
+### Strongly recommend enabling this one as soon as you can
+#check_untyped_defs = true
+
+### These shouldn't be too much additional work, but may be tricky to
+### get passing if you use a lot of untyped libraries
+#disallow_subclassing_any = true
+#disallow_untyped_decorators = true
+#disallow_any_generics = true
+#
+### These next few are various gradations of forcing use of type annotations
+#disallow_untyped_calls = true
+#disallow_incomplete_defs = true
+#disallow_untyped_defs = true
+#
+### This one isn't too hard to get passing, but return on investment is lower
+#no_implicit_reexport = true
+#
+### This one can be tricky to get passing if you use a lot of untyped libraries
+#warn_return_any = true

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -52,8 +52,8 @@ warn_unused_ignores = true
 strict_equality = true
 strict_concatenate = true
 
-### Strongly recommend enabling this one as soon as you can
-#check_untyped_defs = true
+## Strongly recommend enabling this one as soon as you can
+check_untyped_defs = true
 
 ### These shouldn't be too much additional work, but may be tricky to
 ### get passing if you use a lot of untyped libraries

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -58,7 +58,7 @@ check_untyped_defs = true
 ## These shouldn't be too much additional work, but may be tricky to
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
-#disallow_untyped_decorators = true
+disallow_untyped_decorators = true
 #disallow_any_generics = true
 #
 ### These next few are various gradations of forcing use of type annotations

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -59,8 +59,8 @@ check_untyped_defs = true
 ## get passing if you use a lot of untyped libraries
 disallow_subclassing_any = true
 disallow_untyped_decorators = true
-#disallow_any_generics = true
-#
+disallow_any_generics = true
+
 ### These next few are various gradations of forcing use of type annotations
 #disallow_untyped_calls = true
 #disallow_incomplete_defs = true

--- a/samples/openapi3/client/petstore/python/pyproject.toml
+++ b/samples/openapi3/client/petstore/python/pyproject.toml
@@ -55,9 +55,9 @@ strict_concatenate = true
 ## Strongly recommend enabling this one as soon as you can
 check_untyped_defs = true
 
-### These shouldn't be too much additional work, but may be tricky to
-### get passing if you use a lot of untyped libraries
-#disallow_subclassing_any = true
+## These shouldn't be too much additional work, but may be tricky to
+## get passing if you use a lot of untyped libraries
+disallow_subclassing_any = true
 #disallow_untyped_decorators = true
 #disallow_any_generics = true
 #

--- a/samples/openapi3/client/petstore/python/tests/test_api_client.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_client.py
@@ -125,48 +125,47 @@ class ApiClientTests(unittest.TestCase):
         content_type = self.api_client.select_header_content_type(content_types)
         self.assertEqual(content_type, None)
 
-    def test_sanitize_for_serialization(self):
-        # None
+    def test_sanitize_for_serialization_none(self):
         data = None
         result = self.api_client.sanitize_for_serialization(None)
         self.assertEqual(result, data)
 
-        # str
+    def test_sanitize_for_serialization_str(self):
         data = "test string"
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, data)
 
-        # int
+    def test_sanitize_for_serialization_int(self):
         data = 1
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, data)
 
-        # bool
+    def test_sanitize_for_serialization_bool(self):
         data = True
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, data)
 
-        # date
+    def test_sanitize_for_serialization_date(self):
         data = parse("1997-07-16").date()  # date
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, "1997-07-16")
 
-        # datetime
+    def test_sanitize_for_serialization_datetime(self):
         data = parse("1997-07-16T19:20:30.45+01:00")  # datetime
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, "1997-07-16T19:20:30.450000+01:00")
 
-        # list
+    def test_sanitize_for_serialization_list(self):
         data = [1]
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, data)
 
-        # dict
+    def test_sanitize_for_serialization_dict(self):
         data = {"test key": "test value"}
         result = self.api_client.sanitize_for_serialization(data)
         self.assertEqual(result, data)
 
-        # model
+    def test_sanitize_for_serialization_model(self):
         pet_dict = {"id": 1, "name": "monkey",
                     "category": {"id": 1, "name": "test category"},
                     "tags": [{"id": 1, "name": "test tag1"},
@@ -174,20 +173,19 @@ class ApiClientTests(unittest.TestCase):
                     "status": "available",
                     "photoUrls": ["http://foo.bar.com/3",
                                   "http://foo.bar.com/4"]}
-        pet = petstore_api.Pet(name=pet_dict["name"], photoUrls=pet_dict["photoUrls"])
-        pet.id = pet_dict["id"]
-        cate = petstore_api.Category(name="something")
-        cate.id = pet_dict["category"]["id"]
-        cate.name = pet_dict["category"]["name"]
+        pet = petstore_api.Pet(name="monkey", photoUrls=["http://foo.bar.com/3", "http://foo.bar.com/4"])
+        pet.id = 1
+        cate = petstore_api.Category(name="test category")
+        cate.id = 1
         pet.category = cate
         tag1 = petstore_api.Tag()
-        tag1.id = pet_dict["tags"][0]["id"]
-        tag1.name = pet_dict["tags"][0]["name"]
+        tag1.id = 1
+        tag1.name = "test tag1"
         tag2 = petstore_api.Tag()
-        tag2.id = pet_dict["tags"][1]["id"]
-        tag2.name = pet_dict["tags"][1]["name"]
+        tag2.id = 2
+        tag2.name = "test tag2"
         pet.tags = [tag1, tag2]
-        pet.status = pet_dict["status"]
+        pet.status = "available"
 
         data = pet
         result = self.api_client.sanitize_for_serialization(data)
@@ -195,11 +193,10 @@ class ApiClientTests(unittest.TestCase):
 
         # list of models
         list_of_pet_dict = [pet_dict]
-        data = [pet]
-        result = self.api_client.sanitize_for_serialization(data)
+        result = self.api_client.sanitize_for_serialization([pet])
         self.assertEqual(result, list_of_pet_dict)
 
-    def test_parameters_to_url_query(self):
+    def test_parameters_to_url_query_simple_values(self):
         data = 'value={"category": "example", "category2": "example2"}'
         dictionary = {
             "category": "example",
@@ -208,6 +205,7 @@ class ApiClientTests(unittest.TestCase):
         result = self.api_client.parameters_to_url_query([('value', dictionary)], {})
         self.assertEqual(result, "value=%7B%22category%22%3A%20%22example%22%2C%20%22category2%22%3A%20%22example2%22%7D")
         
+    def test_parameters_to_url_query_complex_values(self):
         data='value={"number": 1, "string": "str", "bool": true, "dict": {"number": 1, "string": "str", "bool": true}}'
         dictionary = {
             "number": 1,
@@ -222,6 +220,7 @@ class ApiClientTests(unittest.TestCase):
         result = self.api_client.parameters_to_url_query([('value', dictionary)], {})
         self.assertEqual(result, 'value=%7B%22number%22%3A%201%2C%20%22string%22%3A%20%22str%22%2C%20%22bool%22%3A%20true%2C%20%22dict%22%3A%20%7B%22number%22%3A%201%2C%20%22string%22%3A%20%22str%22%2C%20%22bool%22%3A%20true%7D%7D')
 
+    def test_parameters_to_url_query_dict_values(self):
         data='value={"strValues": ["one", "two", "three"], "dictValues": [{"name": "value1", "age": 14}, {"name": "value2", "age": 12}]}'
         dictionary = {
             "strValues": [

--- a/samples/openapi3/client/petstore/python/tests/test_api_exception.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_exception.py
@@ -41,6 +41,7 @@ class ApiExceptionTests(unittest.TestCase):
 
     def test_404_error(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
         self.pet_api.delete_pet(pet_id=self.pet.id)
 
         with self.checkRaiseRegex(ApiException, "Pet not found"):
@@ -55,6 +56,7 @@ class ApiExceptionTests(unittest.TestCase):
 
     def test_500_error(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         with self.checkRaiseRegex(ApiException, "Internal Server Error"):
             self.pet_api.upload_file(

--- a/samples/openapi3/client/petstore/python/tests/test_api_validation.py
+++ b/samples/openapi3/client/petstore/python/tests/test_api_validation.py
@@ -48,14 +48,14 @@ class ApiExceptionTests(unittest.TestCase):
 
     def test_required_param_validation(self):
         try:
-            self.pet_api.get_pet_by_id()
+            self.pet_api.get_pet_by_id()  # type: ignore
         except ValidationError as e:
             self.assertIn("1 validation error for get_pet_by_id", str(e))
             self.assertIn("Missing required argument", str(e))
 
     def test_integer_validation(self):
         try:
-            self.pet_api.get_pet_by_id("123")
+            self.pet_api.get_pet_by_id("123")  # type: ignore
         except ValidationError as e:
             # 1 validation error for get_pet_by_id
             # pet_id
@@ -75,25 +75,32 @@ class ApiExceptionTests(unittest.TestCase):
             self.assertIn("unexpected value; permitted: 'available', 'pending', 'sold'", str(e))
 
     def test_request_timeout_validation(self):
+        assert self.pet.id is not None
         try:
-            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout="1.0")
+            # should be a number
+            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout="1.0")  # type: ignore
             self.assertTrue(False)
         except ValidationError as e:
             pass
         try:
-            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout=())
+            # should be a number or a pair
+            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout=())  # type: ignore
             self.assertTrue(False)
         except ValidationError as e:
             pass
         try:
-            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout=(1.0, 1.0, 1.0))
+            # should be a a pair
+            self.pet_api.get_pet_by_id(self.pet.id, _request_timeout=(1.0, 1.0, 1.0))  # type: ignore
             self.assertTrue(False)
         except ValidationError as e:
             pass
 
+
     def test_host_index_validation(self):
+        assert self.pet.id is not None
         try:
-            self.pet_api.get_pet_by_id(self.pet.id, _host_index="1")
+            # should be a number
+            self.pet_api.get_pet_by_id(self.pet.id, _host_index="1") # type: ignore
             self.assertTrue(False)
         except ValidationError as e:
             pass

--- a/samples/openapi3/client/petstore/python/tests/test_http_signature.py
+++ b/samples/openapi3/client/petstore/python/tests/test_http_signature.py
@@ -17,11 +17,14 @@ import json
 import os
 import re
 import shutil
+from typing import Union
 import unittest
 from urllib.parse import urlencode, urlparse
 
 from Crypto.Hash import SHA256, SHA512
 from Crypto.PublicKey import ECC, RSA
+from Crypto.Hash.SHA512 import SHA512Hash
+from Crypto.Hash.SHA256 import SHA256Hash
 from Crypto.Signature import pkcs1_15, pss, DSS
 
 import petstore_api
@@ -73,7 +76,7 @@ class TimeoutWithEqual(urllib3.Timeout):
     def __eq__(self, other):
         return self._read == other._read and self._connect == other._connect and self.total == other.total
 
-class MockPoolManager(object):
+class MockPoolManager(urllib3.PoolManager):
     def __init__(self, tc):
         self._tc = tc
         self._reqs = []
@@ -83,9 +86,9 @@ class MockPoolManager(object):
 
     def set_signing_config(self, signing_cfg):
         self.signing_cfg = signing_cfg
-        self._tc.assertIsNotNone(self.signing_cfg)
+        assert self.signing_cfg is not None
         self.pubkey = self.signing_cfg.get_public_key()
-        self._tc.assertIsNotNone(self.pubkey)
+        assert self.pubkey is not None
 
     def request(self, *actual_request_target, **actual_request_headers_and_body):
         self._tc.assertTrue(len(self._reqs) > 0)
@@ -124,13 +127,13 @@ class MockPoolManager(object):
         # Extract (created)
         r1 = re.compile(r'created=([0-9]+)')
         m1 = r1.search(authorization_header)
-        self._tc.assertIsNotNone(m1)
+        assert m1 is not None
         created = m1.group(1)
 
         # Extract list of signed headers
         r1 = re.compile(r'headers="([^"]+)"')
         m1 = r1.search(authorization_header)
-        self._tc.assertIsNotNone(m1)
+        assert m1 is not None
         headers = m1.group(1).split(' ')
         signed_headers_list = []
         for h in headers:
@@ -142,25 +145,26 @@ class MockPoolManager(object):
                 signed_headers_list.append((h, "{0} {1}".format(request_target[0].lower(), target_path)))
             else:
                 value = next((v for k, v in actual_headers.items() if k.lower() == h), None)
-                self._tc.assertIsNotNone(value)
+                assert value is not None
                 signed_headers_list.append((h, value))
         header_items = [
             "{0}: {1}".format(key.lower(), value) for key, value in signed_headers_list]
         string_to_sign = "\n".join(header_items)
-        digest = None
+        digest: Union[SHA512Hash, SHA256Hash]
         if self.signing_cfg.hash_algorithm == signing.HASH_SHA512:
             digest = SHA512.new()
         elif self.signing_cfg.hash_algorithm == signing.HASH_SHA256:
             digest = SHA256.new()
         else:
             self._tc.fail("Unsupported hash algorithm: {0}".format(self.signing_cfg.hash_algorithm))
+
         digest.update(string_to_sign.encode())
         b64_body_digest = base64.b64encode(digest.digest()).decode()
 
         # Extract the signature
         r2 = re.compile(r'signature="([^"]+)"')
         m2 = r2.search(authorization_header)
-        self._tc.assertIsNotNone(m2)
+        assert m2 is not None
         b64_signature = m2.group(1)
         signature = base64.b64decode(b64_signature)
         # Build the message
@@ -190,6 +194,12 @@ class MockPoolManager(object):
             self._tc.fail("Unsupported signing algorithm: {0}".format(signing_alg))
 
 class PetApiTests(unittest.TestCase):
+    rsa_key_path: str
+    rsa4096_key_path: str
+    ec_p521_key_path: str
+    pet: petstore_api.Pet
+    test_file_dir: str
+    private_key_passphrase: str
 
     @classmethod
     def setUpClass(cls):
@@ -208,19 +218,19 @@ class PetApiTests(unittest.TestCase):
 
     @classmethod
     def setUpModels(cls):
-        cls.category = petstore_api.Category(name="dog")
-        cls.category.id = id_gen()
-        cls.tag = petstore_api.Tag()
-        cls.tag.id = id_gen()
-        cls.tag.name = "python-pet-tag"
+        category = petstore_api.Category(name="dog")
+        category.id = id_gen()
+        tag = petstore_api.Tag()
+        tag.id = id_gen()
+        tag.name = "python-pet-tag"
         cls.pet = petstore_api.Pet(
             name="hello kity",
             photoUrls=["http://foo.bar.com/1", "http://foo.bar.com/2"]
         )
         cls.pet.id = id_gen()
         cls.pet.status = "sold"
-        cls.pet.category = cls.category
-        cls.pet.tags = [cls.tag]
+        cls.pet.category = category
+        cls.pet.tags = [tag]
 
     @classmethod
     def setUpFiles(cls):
@@ -239,6 +249,8 @@ class PetApiTests(unittest.TestCase):
             with open(cls.rsa_key_path, 'w') as f:
                 f.write(RSA_TEST_PRIVATE_KEY)
 
+        key: Union[RSA.RsaKey, ECC.EccKey]
+
         if not os.path.exists(cls.rsa4096_key_path):
             key = RSA.generate(4096)
             private_key = key.export_key(
@@ -250,13 +262,17 @@ class PetApiTests(unittest.TestCase):
 
         if not os.path.exists(cls.ec_p521_key_path):
             key = ECC.generate(curve='P-521')
-            private_key = key.export_key(
+            pkey = key.export_key(
                 format='PEM',
                 passphrase=cls.private_key_passphrase,
                 use_pkcs8=True,
                 protection='PBKDF2WithHMAC-SHA1AndAES128-CBC'
             )
-            with open(cls.ec_p521_key_path, "wt") as f:
+            if isinstance(pkey, str):
+                private_key = pkey.encode("ascii")
+            else:
+                private_key = pkey
+            with open(cls.ec_p521_key_path, "wb") as f:
                 f.write(private_key)
 
     def test_valid_http_signature(self):
@@ -459,7 +475,7 @@ class PetApiTests(unittest.TestCase):
             signing_cfg = signing.HttpSigningConfiguration(
                 key_id="my-key-id",
                 private_key_path=self.ec_p521_key_path,
-                signing_scheme=None
+                signing_scheme=None  # type: ignore
             )
         self.assertTrue(re.match('Unsupported security scheme', str(cm.exception)),
             'Exception message: {0}'.format(str(cm.exception)))

--- a/samples/openapi3/client/petstore/python/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python/tests/test_model.py
@@ -2,6 +2,7 @@
 
 # flake8: noqa
 
+from datetime import date
 import json
 import os
 import time
@@ -134,28 +135,36 @@ class ModelTests(unittest.TestCase):
         p = petstore_api.Color.from_json(None)
         self.assertEqual(p.actual_instance, None)
 
-    def test_oneof_enum_string(self):
-        enum_string1 = petstore_api.EnumString1('a')
+    def test_oneof_enum_string_from_json(self):
         # test from_json
         oneof_enum = petstore_api.OneOfEnumString.from_json('"a"')
+
+    def test_oneof_nested_from_enum_string(self):
         # test from_dict
         oneof_enum = petstore_api.OneOfEnumString.from_dict("a")
+        assert oneof_enum is not None
         nested = petstore_api.WithNestedOneOf(size = 1, nested_oneof_enum_string = oneof_enum)
         # test to_json
         self.assertEqual(nested.to_json(), '{"size": 1, "nested_oneof_enum_string": "a"}')
-        # test from_json
+
+    def test_oneof_nested_from_json(self):
         nested = petstore_api.WithNestedOneOf.from_json('{"size": 1, "nested_oneof_enum_string": "c"}')
+        assert nested is not None
         self.assertEqual(nested.to_json(), '{"size": 1, "nested_oneof_enum_string": "c"}')
-        # test from_dict
+
+    def test_oneof_nested_from_dict(self):
         nested = petstore_api.WithNestedOneOf.from_dict({"size": 1, "nested_oneof_enum_string": "c"})
+        assert nested is not None
         # test to_dict
         self.assertEqual(nested.to_dict(), {"size": 1, "nested_oneof_enum_string": "c"})
-        # invalid enum value
+
+    def test_oneof_nested_from_json_invalid(self):
         try:
             nested2 = petstore_api.WithNestedOneOf.from_json('{"size": 1, "nested_oneof_enum_string": "e"}')
         except ValueError as e:
             self.assertTrue("'e' is not a valid EnumString1, 'e' is not a valid EnumString" in str(e))
 
+    def test_oneof_enum_string(self):
         # test the constructor
         enum_string1 = petstore_api.EnumString1('a')
         constructor1 = petstore_api.OneOfEnumString(actual_instance=enum_string1)
@@ -276,6 +285,7 @@ class ModelTests(unittest.TestCase):
 
         nested_json = nested.to_json()
         nested2 = petstore_api.WithNestedOneOf.from_json(nested_json)
+        assert nested2 is not None
         self.assertEqual(nested2.to_json(), nested_json)
 
     def test_anyOf(self):
@@ -328,30 +338,30 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(dog.to_dict(), {'breed': 'bulldog', 'className':
             'dog', 'color': 'white'})
         dog2 = petstore_api.Dog.from_json(dog.to_json())
+        assert dog2 is not None
         self.assertEqual(dog2.breed, 'bulldog')
         self.assertEqual(dog2.class_name, "dog")
         self.assertEqual(dog2.color, 'white')
 
     def test_list(self):
         # should throw exception as var_123_list should be string
-        kw = {"123-list": 123}
         try:
-            l3 = petstore_api.ListClass(**kw)
+            # Don't check the typing, because we are actually testing a typing error.
+            l3 = petstore_api.ListClass(**{"123-list": 123})  # type: ignore
             self.assertTrue(False)  # this line shouldn't execute
-            breakpoint()
         except ValueError as e:
             #   var_123_list
             #     Input should be a valid string [type=string_type, input_value=123, input_type=int]
             #       For further information visit https://errors.pydantic.dev/2.3/v/string_type
             self.assertTrue("Input should be a valid string" in str(e))
 
-        kw = {"123-list": "bulldog"}
-        l = petstore_api.ListClass(**kw)
+        l = petstore_api.ListClass(**{"123-list": "bulldog"})  # type: ignore
         self.assertEqual(l.to_json(), '{"123-list": "bulldog"}')
         self.assertEqual(l.to_dict(), {'123-list': 'bulldog'})
-        l2 = petstore_api.ListClass.from_json(l.to_json())
-        self.assertEqual(l2.var_123_list, 'bulldog')
 
+        l2 = petstore_api.ListClass.from_json(l.to_json())
+        assert l2 is not None
+        self.assertEqual(l2.var_123_list, 'bulldog')
         self.assertTrue(isinstance(l2, petstore_api.ListClass))
 
     def test_enum_ref_property(self):
@@ -363,6 +373,7 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(d2.to_json(), '{"str_value": "delivered", "value": 1}')
         # test from_json (round trip)
         d3 = petstore_api.OuterObjectWithEnumProperty.from_json(d2.to_json())
+        assert d3 is not None
         self.assertEqual(d3.str_value, petstore_api.OuterEnum.DELIVERED)
         self.assertEqual(d3.value, petstore_api.OuterEnumInteger.NUMBER_1)
         self.assertEqual(d3.to_json(), '{"str_value": "delivered", "value": 1}')
@@ -376,7 +387,7 @@ class ModelTests(unittest.TestCase):
 
     def test_valdiator(self):
         # test regular expression
-        a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date="2013-09-17", password="testing09876")
+        a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date=date(2013, 9, 17), password="testing09876")
         try:
             a.pattern_with_digits_and_delimiter = "123"
             self.assertTrue(False) # this line shouldn't execute
@@ -384,7 +395,7 @@ class ModelTests(unittest.TestCase):
             self.assertTrue(r"must validate the regular expression /^image_\d{1,3}$/i" in str(e))
 
         # test None with optional string (with regualr expression)
-        a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date="2013-09-17", password="testing09876")
+        a = petstore_api.FormatTest(number=123.45, byte=bytes("string", 'utf-8'), date=date(2013, 9, 17), password="testing09876")
         a.string = None # shouldn't throw an exception
 
         a.pattern_with_digits_and_delimiter = "IMAGE_123"
@@ -475,11 +486,12 @@ class ModelTests(unittest.TestCase):
         pet_ap_dict["array"] = ["a", "b"]
         pet_ap_dict["dict"] = {"key999": "value999"}
 
-        pet_ap2 = petstore_api.Pet.from_dict(pet_ap_dict)
+        pet_ap3 = petstore_api.Pet.from_dict(pet_ap_dict)
+        assert pet_ap3 is not None
 
-        self.assertEqual(pet_ap2.additional_properties["array"], ["a", "b"])
-        self.assertEqual(pet_ap2.additional_properties["something-new"], 123)
-        self.assertEqual(pet_ap2.additional_properties["dict"], {"key999": "value999"})
+        self.assertEqual(pet_ap3.additional_properties["array"], ["a", "b"])
+        self.assertEqual(pet_ap3.additional_properties["something-new"], 123)
+        self.assertEqual(pet_ap3.additional_properties["dict"], {"key999": "value999"})
 
     def test_nullable(self):
         h = petstore_api.HealthCheckResult(NullableMessage="Not none")
@@ -507,10 +519,11 @@ class ModelTests(unittest.TestCase):
         # for https://github.com/OpenAPITools/openapi-generator/issues/14913
         # shouldn't throw exception by the optional dict property
         a = petstore_api.ParentWithOptionalDict.from_dict({})
-        self.assertFalse(a is None)
 
         b = petstore_api.ParentWithOptionalDict.from_dict({"optionalDict": {"key": {"aProperty": {"a": "b"}}}})
-        self.assertFalse(b is None)
+        assert b is not None
+        assert b.optional_dict is not None
+        assert b.optional_dict["key"].a_property is not None
         self.assertEqual(b.optional_dict["key"].a_property["a"], "b")
 
     def test_freeform_object(self):
@@ -530,6 +543,7 @@ class ModelTests(unittest.TestCase):
         # for https://github.com/OpenAPITools/openapi-generator/issues/15135
         d = {"optionalDict": {"a": {"b": {"aProperty": "value"}}}}
         a = petstore_api.Parent.from_dict(d)
+        assert a is not None
         self.assertEqual(a.to_dict(), d)
 
     def test_eum_class(self):
@@ -561,6 +575,7 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(a.to_dict(), {'shopIdToOrgOnlineLipMap': {'somekey': [{'id': 123, 'name': 'tag name'}]}})
         self.assertEqual(a.to_json(), '{"shopIdToOrgOnlineLipMap": {"somekey": [{"id": 123, "name": "tag name"}]}}')
         a2 = petstore_api.MapOfArrayOfModel.from_dict(a.to_dict())
+        assert a2 is not None
         self.assertEqual(a.to_dict(), a2.to_dict())
 
     def test_array_of_array_of_model(self):
@@ -570,6 +585,7 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(a.to_dict(), {'another_property': [[ {'id': 123, 'name': 'tag name'} ]]})
         self.assertEqual(a.to_json(), '{"another_property": [[{"id": 123, "name": "tag name"}]]}')
         a2 = petstore_api.ArrayOfArrayOfModel.from_dict(a.to_dict())
+        assert a2 is not None
         self.assertEqual(a.to_dict(), a2.to_dict())
 
     def test_object_with_additional_properties(self):
@@ -581,12 +597,14 @@ class ModelTests(unittest.TestCase):
     def test_first_ref(self):
         # shouldn't throw "still a ForwardRef" error
         a = petstore_api.FirstRef.from_dict({})
+        assert a is not None
         self.assertEqual(a.to_json(), "{}")
 
     def test_allof(self):
         # for issue 16104
         model = petstore_api.Tiger.from_json('{"skill": "none", "type": "tiger", "info": {"name": "creature info"}}')
         # shouldn't throw NameError
+        assert model is not None
         self.assertEqual(model.to_json(), '{"skill": "none", "type": "tiger", "info": {"name": "creature info"}}')
 
 
@@ -609,27 +627,29 @@ class TestdditionalPropertiesAnyType(unittest.TestCase):
 
 class TestUnnamedDictWithAdditionalStringListProperties:
     def test_empty_dict(self):
-        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={})
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dictProperty={})
+        assert a is not None
         assert a.to_dict() == {"dictProperty": {}}
 
     def test_empty_list(self):
-        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={"b": []})
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dictProperty={"b": []})
+        assert a is not None
         assert a.to_dict() == {"dictProperty": {"b": []}}
 
     def test_single_string_item(self):
-        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={"b": ["c"]})
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dictProperty={"b": ["c"]})
         assert a.to_dict() == {"dictProperty": {"b": ["c"]}}
 
 class TestUnnamedDictWithAdditionalModelListProperties:
     def test_empty_dict(self):
-        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property={})
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dictProperty={})
         assert a.to_dict() == {"dictProperty": {}}
 
     def test_empty_list(self):
-        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property={"b": []})
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dictProperty={"b": []})
         assert a.to_dict() == {"dictProperty": {"b": []}}
 
     def test_single_string_item(self):
         value = {"b": [petstore_api.CreatureInfo(name="creature_name")]}
-        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property=value)
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dictProperty=value)
         assert a.to_dict() == {"dictProperty": {"b": [{"name": "creature_name"}]}}

--- a/samples/openapi3/client/petstore/python/tests/test_pet_api.py
+++ b/samples/openapi3/client/petstore/python/tests/test_pet_api.py
@@ -35,7 +35,7 @@ class TimeoutWithEqual(urllib3.Timeout):
         return self._read == other._read and self._connect == other._connect and self.total == other.total
 
 
-class MockPoolManager(object):
+class MockPoolManager(urllib3.PoolManager):
     def __init__(self, tc):
         self._tc = tc
         self._reqs = []
@@ -117,16 +117,19 @@ class PetApiTests(unittest.TestCase):
 
     def test_add_pet_and_get_pet_by_id(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = self.pet_api.get_pet_by_id(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched)
+        assert fetched is not None
         self.assertEqual(self.pet.id, fetched.id)
-        self.assertIsNotNone(fetched.category)
+        assert fetched.category is not None
+        assert self.pet.category is not None
         self.assertEqual(self.pet.category.name, fetched.category.name)
 
     def test_add_pet_and_get_pet_by_id_without_preload_content_flag(self):
-
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
+
         fetched = self.pet_api.get_pet_by_id_without_preload_content(pet_id=self.pet.id)
 
         self.assertIsInstance(fetched, urllib3.HTTPResponse)
@@ -141,30 +144,35 @@ class PetApiTests(unittest.TestCase):
 
     def test_add_pet_and_get_pet_by_id_with_http_info(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         # fetched is an ApiResponse object
         fetched = self.pet_api.get_pet_by_id_with_http_info(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched.data)
+        assert fetched.data is not None
         self.assertEqual(self.pet.id, fetched.data.id)
-        self.assertIsNotNone(fetched.data.category)
+        assert fetched.data.category is not None
+        assert self.pet.category is not None
         self.assertEqual(self.pet.category.name, fetched.data.category.name)
 
     def test_get_pet_by_id_serialize(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = self.pet_api._get_pet_by_id_serialize(self.pet.id, None, None, None, None)
-        self.assertIsNotNone(fetched)
+        assert fetched is not None
         self.assertIsInstance(fetched, tuple)
 
     def test_update_pet(self):
         self.pet.name = "hello kity with updated"
         self.pet_api.update_pet(self.pet)
+        assert self.pet.id is not None
 
         fetched = self.pet_api.get_pet_by_id(pet_id=self.pet.id)
-        self.assertIsNotNone(fetched)
+        assert fetched is not None
         self.assertEqual(self.pet.id, fetched.id)
         self.assertEqual(self.pet.name, fetched.name)
-        self.assertIsNotNone(fetched.category)
+        assert fetched.category is not None
+        assert self.pet.category is not None
         self.assertEqual(fetched.category.name, self.pet.category.name)
 
     def test_find_pets_by_status(self):
@@ -180,6 +188,8 @@ class PetApiTests(unittest.TestCase):
 
     def test_find_pets_by_tags(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
+        assert self.tag.name is not None
 
         self.assertIn(
             self.pet.id,
@@ -188,6 +198,7 @@ class PetApiTests(unittest.TestCase):
 
     def test_update_pet_with_form(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
 
         name = "hello kity with form updated abc"
         status = "pending"
@@ -199,6 +210,7 @@ class PetApiTests(unittest.TestCase):
         self.assertEqual(status, fetched.status)
 
     def test_upload_file(self):
+        assert self.pet.id is not None
         # upload file with form parameter
         try:
             additional_metadata = "special data 123"
@@ -218,6 +230,7 @@ class PetApiTests(unittest.TestCase):
 
     def test_delete_pet(self):
         self.pet_api.add_pet(self.pet)
+        assert self.pet.id is not None
         self.pet_api.delete_pet(pet_id=self.pet.id, api_key="special-key")
 
         try:

--- a/samples/openapi3/client/petstore/python/tests/test_pet_model.py
+++ b/samples/openapi3/client/petstore/python/tests/test_pet_model.py
@@ -73,11 +73,14 @@ class PetModelTests(unittest.TestCase):
                     " \"status\": \"available\",\n"
                     " \"tags\": [{\"id\": 1, \"name\": \"None\"}]}")
         pet = petstore_api.Pet.from_json(json_str)
+        assert pet is not None
         self.assertEqual(pet.id, 1)
         self.assertEqual(pet.status, "available")
         self.assertEqual(pet.photo_urls, ["string"])
+        assert pet.tags is not None
         self.assertEqual(pet.tags[0].id, 1)
         self.assertEqual(pet.tags[0].name, "None")
+        assert pet.category is not None
         self.assertEqual(pet.category.id, 1)
         # test to_json
         self.assertEqual(pet.to_json(),
@@ -91,16 +94,18 @@ class PetModelTests(unittest.TestCase):
 
         # test from_dict
         pet2 = petstore_api.Pet.from_dict(pet.to_dict())
+        assert pet2 is not None
         self.assertEqual(pet2.id, 1)
         self.assertEqual(pet2.status, "available")
         self.assertEqual(pet2.photo_urls, ["string"])
+        assert pet2.tags is not None
         self.assertEqual(pet2.tags[0].id, 1)
         self.assertEqual(pet2.tags[0].name, "None")
+        assert pet2.category is not None
         self.assertEqual(pet2.category.id, 1)
 
     def test_unpack_operator(self):
-        d = {"name": "required name", "id": 123, "photoUrls": ["https://a.com", "https://b.com"]}
-        pet = petstore_api.Pet(**d)
+        pet = petstore_api.Pet(name="required name", id=123, photoUrls=["https://a.com", "https://b.com"])
         self.assertEqual(pet.to_json(), '{"id": 123, "name": "required name", "photoUrls": ["https://a.com", "https://b.com"]}')
         self.assertEqual(pet.to_dict(), {"id": 123, "name": "required name", "photoUrls": ["https://a.com", "https://b.com"]})
 


### PR DESCRIPTION
This is a follow-up to #17511.

In #17511, I configured basic typing information to have `mypy` running successfully with the default options.

This new PR enables more checks towards running mypy using the `strict` set of options, which enabled more typing checks:

* mypy is configured with more options, with the unimplemented target list of options (towards `strict` mode) commented out
* Most the changes are for:
  *  Checking for `None` for `Optional` values, before trying to check the actual content of the values
  * Typing the generic types Dict, Tuple, List, etc.

I think this highlights a few places that could be improved, although I didn't do these improvements here:

* Some functions return complex tuples, that could be wrapped into object to make the intent clearer
* Tests could be simplified by using less unittest and more pytest-style assertions.

I hope to enable more checks after this one, but it may take bit longer and this is already a good second improvement after #17511.

See the individual commits for details on which mypy check required which changes.

cc @cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10) + @robertschweizer (who expressed interest around more typing)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
