### PR TITLE
[C] Optimize memory usage when printing JSON

### DIFF
--- a/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api-body.mustache
@@ -320,7 +320,7 @@ end:
             goto end;
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_{{paramName}}, localVar_{{paramName}});
-        localVarBodyParameters = cJSON_Print(localVarItemJSON_{{paramName}});
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarItemJSON_{{paramName}});
     }
     {{/isArray}}
     {{^isArray}}
@@ -329,7 +329,7 @@ end:
     {
         //string
         localVarSingleItemJSON_{{paramName}} = {{dataType}}_convertToJSON({{paramName}});
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_{{paramName}});
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_{{paramName}});
     }
     {{/isArray}}
     {{/bodyParam}}
@@ -368,7 +368,7 @@ end:
     cJSON *{{{paramName}}}VarJSON;
     list_t *elementToReturn = list_createList();
     cJSON_ArrayForEach({{{paramName}}}VarJSON, {{paramName}}localVarJSON){
-        keyValuePair_t *keyPair = keyValuePair_create(strdup({{{paramName}}}VarJSON->string), cJSON_Print({{{paramName}}}VarJSON));
+        keyValuePair_t *keyPair = keyValuePair_create(strdup({{{paramName}}}VarJSON->string), cJSON_PrintUnformatted({{{paramName}}}VarJSON));
         list_addElement(elementToReturn, keyPair);
     }
     cJSON_Delete({{paramName}}localVarJSON);
@@ -389,7 +389,7 @@ end:
         {
            // return 0;
         }
-        char *localVarJSONToChar = cJSON_Print({{{paramName}}}VarJSON);
+        char *localVarJSONToChar = cJSON_PrintUnformatted({{{paramName}}}VarJSON);
         list_addElement(elementToReturn , localVarJSONToChar);
     }
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api_pet_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api_pet_test.mustache
@@ -88,7 +88,7 @@ int main() {
     pet_t *mypet = PetAPI_getPetById(apiClient2, EXAMPLE_PET_ID);
 
     cJSON *JSONR = pet_convertToJSON(mypet);
-    char *petJson = cJSON_Print(JSONR);
+    char *petJson = cJSON_PrintUnformatted(JSONR);
     printf("Data is:%s\n", petJson);
 
     assert(strcmp(mypet->name, "Rocky Handsome") == 0);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api_store_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api_store_test.mustache
@@ -37,7 +37,7 @@ int main() {
 
 	cJSON *JSONNODE = order_convertToJSON(returnorder);
 
-	char *dataToPrint = cJSON_Print(JSONNODE);
+	char *dataToPrint = cJSON_PrintUnformatted(JSONNODE);
 
 	printf("Placed order: \n%s\n", dataToPrint);
 	order_free(neworder);
@@ -52,7 +52,7 @@ int main() {
 
 	JSONNODE = order_convertToJSON(neworder);
 
-	char *dataToPrint1 = cJSON_Print(JSONNODE);
+	char *dataToPrint1 = cJSON_PrintUnformatted(JSONNODE);
 
 	printf("Order received: \n%s\n", dataToPrint1);
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/api_user_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/api_user_test.mustache
@@ -54,7 +54,7 @@ int main() {
 
 	cJSON *JSONNODE = user_convertToJSON(returnUser);
 
-	char *dataToPrint = cJSON_Print(JSONNODE);
+	char *dataToPrint = cJSON_PrintUnformatted(JSONNODE);
 
 	printf("User is: \n%s\n", dataToPrint);
 	user_free(returnUser);

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model_order_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model_order_test.mustache
@@ -21,7 +21,7 @@ COMPLETE);
 
 cJSON *JSONNODE = order_convertToJSON(neworder);
 
-char *dataToPrint = cJSON_Print(JSONNODE);
+char *dataToPrint = cJSON_PrintUnformatted(JSONNODE);
 
 printf("Created Order is: \n%s\n",dataToPrint);
 
@@ -29,7 +29,7 @@ order_t *parsedOrder = order_parseFromJSON( dataToPrint);
 
 cJSON *fromJSON = order_convertToJSON(parsedOrder);
 
-char *dataToPrintFromJSON = cJSON_Print(fromJSON);
+char *dataToPrintFromJSON = cJSON_PrintUnformatted(fromJSON);
 
 printf("Parsed Order From JSON is: \n%s\n",dataToPrintFromJSON);
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model_test.mustache
@@ -50,10 +50,10 @@ void test_{{classname}}(int include_optional) {
     {{classname}}_t* {{classname}}_1 = instantiate_{{classname}}(include_optional);
 
 	cJSON* json{{classname}}_1 = {{classname}}_convertToJSON({{classname}}_1);
-	printf("{{classname}} :\n%s\n", cJSON_Print(json{{classname}}_1));
+	printf("{{classname}} :\n%s\n", cJSON_PrintUnformatted(json{{classname}}_1));
 	{{classname}}_t* {{classname}}_2 = {{classname}}_parseFromJSON(json{{classname}}_1);
 	cJSON* json{{classname}}_2 = {{classname}}_convertToJSON({{classname}}_2);
-	printf("repeating {{classname}}:\n%s\n", cJSON_Print(json{{classname}}_2));
+	printf("repeating {{classname}}:\n%s\n", cJSON_PrintUnformatted(json{{classname}}_2));
 }
 
 int main() {

--- a/modules/openapi-generator/src/main/resources/C-libcurl/model_user_test.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/model_user_test.mustache
@@ -22,7 +22,7 @@ PASSWORD, PHONE, USER_STATUS );
 
 cJSON *JSONNODE = user_convertToJSON(newuser);
 
-char *dataToPrint = cJSON_Print(JSONNODE);
+char *dataToPrint = cJSON_PrintUnformatted(JSONNODE);
 
 printf("Created User is: \n%s\n",dataToPrint);
 
@@ -30,7 +30,7 @@ user_t *parsedUser = user_parseFromJSON( dataToPrint);
 
 cJSON *fromJSON = user_convertToJSON(parsedUser);
 
-char *dataToPrintFromJSON = cJSON_Print(fromJSON);
+char *dataToPrintFromJSON = cJSON_PrintUnformatted(fromJSON);
 
 printf("Parsed User From JSON is: \n%s\n",dataToPrintFromJSON);
 

--- a/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
+++ b/modules/openapi-generator/src/main/resources/C-libcurl/object-body.mustache
@@ -43,7 +43,7 @@ object_t *object_parseFromJSON(cJSON *json){
     if (!object) {
         goto end;
     }
-    object->temporary = cJSON_Print(json);
+    object->temporary = cJSON_PrintUnformatted(json);
     return object;
 
 end:

--- a/samples/client/petstore/c/api/PetAPI.c
+++ b/samples/client/petstore/c/api/PetAPI.c
@@ -81,7 +81,7 @@ PetAPI_addPet(apiClient_t *apiClient, pet_t *body)
     {
         //string
         localVarSingleItemJSON_body = pet_convertToJSON(body);
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes
@@ -264,7 +264,7 @@ PetAPI_findPetsByStatus(apiClient_t *apiClient, list_t *status)
         {
            // return 0;
         }
-        char *localVarJSONToChar = cJSON_Print(VarJSON);
+        char *localVarJSONToChar = cJSON_PrintUnformatted(VarJSON);
         list_addElement(elementToReturn , localVarJSONToChar);
     }
 
@@ -348,7 +348,7 @@ PetAPI_findPetsByTags(apiClient_t *apiClient, list_t *tags)
         {
            // return 0;
         }
-        char *localVarJSONToChar = cJSON_Print(VarJSON);
+        char *localVarJSONToChar = cJSON_PrintUnformatted(VarJSON);
         list_addElement(elementToReturn , localVarJSONToChar);
     }
 
@@ -486,7 +486,7 @@ PetAPI_updatePet(apiClient_t *apiClient, pet_t *body)
     {
         //string
         localVarSingleItemJSON_body = pet_convertToJSON(body);
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
     }
     list_addElement(localVarContentType,"application/json"); //consumes
     list_addElement(localVarContentType,"application/xml"); //consumes

--- a/samples/client/petstore/c/api/StoreAPI.c
+++ b/samples/client/petstore/c/api/StoreAPI.c
@@ -119,7 +119,7 @@ StoreAPI_getInventory(apiClient_t *apiClient)
     cJSON *VarJSON;
     list_t *elementToReturn = list_createList();
     cJSON_ArrayForEach(VarJSON, localVarJSON){
-        keyValuePair_t *keyPair = keyValuePair_create(strdup(VarJSON->string), cJSON_Print(VarJSON));
+        keyValuePair_t *keyPair = keyValuePair_create(strdup(VarJSON->string), cJSON_PrintUnformatted(VarJSON));
         list_addElement(elementToReturn, keyPair);
     }
     cJSON_Delete(localVarJSON);
@@ -255,7 +255,7 @@ StoreAPI_placeOrder(apiClient_t *apiClient, order_t *body)
     {
         //string
         localVarSingleItemJSON_body = order_convertToJSON(body);
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
     }
     list_addElement(localVarHeaderType,"application/xml"); //produces
     list_addElement(localVarHeaderType,"application/json"); //produces

--- a/samples/client/petstore/c/api/UserAPI.c
+++ b/samples/client/petstore/c/api/UserAPI.c
@@ -40,7 +40,7 @@ UserAPI_createUser(apiClient_t *apiClient, user_t *body)
     {
         //string
         localVarSingleItemJSON_body = user_convertToJSON(body);
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -123,7 +123,7 @@ UserAPI_createUsersWithArrayInput(apiClient_t *apiClient, list_t *body)
             goto end;
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
-        localVarBodyParameters = cJSON_Print(localVarItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarItemJSON_body);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -214,7 +214,7 @@ UserAPI_createUsersWithListInput(apiClient_t *apiClient, list_t *body)
             goto end;
         }
         cJSON_AddItemToArray(localVarSingleItemJSON_body, localVar_body);
-        localVarBodyParameters = cJSON_Print(localVarItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarItemJSON_body);
     }
     apiClient_invoke(apiClient,
                     localVarPath,
@@ -678,7 +678,7 @@ UserAPI_updateUser(apiClient_t *apiClient, char *username, user_t *body)
     {
         //string
         localVarSingleItemJSON_body = user_convertToJSON(body);
-        localVarBodyParameters = cJSON_Print(localVarSingleItemJSON_body);
+        localVarBodyParameters = cJSON_PrintUnformatted(localVarSingleItemJSON_body);
     }
     apiClient_invoke(apiClient,
                     localVarPath,

--- a/samples/client/petstore/c/model/object.c
+++ b/samples/client/petstore/c/model/object.c
@@ -43,7 +43,7 @@ object_t *object_parseFromJSON(cJSON *json){
     if (!object) {
         goto end;
     }
-    object->temporary = cJSON_Print(json);
+    object->temporary = cJSON_PrintUnformatted(json);
     return object;
 
 end:


### PR DESCRIPTION
This PR change `cJSON_Print` function with `cJSON_PrintUnformatted` allowing to create unindented json. This reduces the over number of characters required to create a json payload and by that memory allocated.

Also updated the samples.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
