### PR TITLE
[java] fix Use jackson-jakarta-rs-json-provider when useJakartaEe is true

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -260,11 +260,20 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        {{^useJakartaEe}}
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        {{/useJakartaEe}}
+        {{#useJakartaEe}}
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+            <version>${jackson-version}</version>
+        </dependency>
+        {{/useJakartaEe}}
         {{#withXml}}
 
             <!-- XML processing: Jackson -->

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/pom.mustache
@@ -269,7 +269,7 @@
         {{/useJakartaEe}}
         {{#useJakartaEe}}
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -261,11 +261,20 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        {{^useJakartaEe}}
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        {{/useJakartaEe}}
+        {{#useJakartaEe}}
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+            <version>${jackson-version}</version>
+        </dependency>
+        {{/useJakartaEe}}
         {{#openApiNullable}}
         <dependency>
             <groupId>org.openapitools</groupId>

--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -270,7 +270,7 @@
         {{/useJakartaEe}}
         {{#useJakartaEe}}
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -274,7 +274,7 @@
         {{/useJakartaEe}}
         {{#useJakartaEe}}
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>

--- a/modules/openapi-generator/src/main/resources/Java/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/pom.mustache
@@ -265,11 +265,20 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind-version}</version>
         </dependency>
+        {{^useJakartaEe}}
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
+        {{/useJakartaEe}}
+        {{#useJakartaEe}}
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+            <version>${jackson-version}</version>
+        </dependency>
+        {{/useJakartaEe}}
         {{#withXml}}
 
             <!-- XML processing: Jackson -->

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -184,7 +184,7 @@ for this project used jakarta.validation-api -->
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/pom.mustache
@@ -174,12 +174,22 @@ for this project used jakarta.validation-api -->
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    {{^useJakartaEe}}
     <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>
     </dependency>
+    {{/useJakartaEe}}
+    {{#useJakartaEe}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    {{/useJakartaEe}}
     <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -189,12 +189,22 @@ for this project used jakarta.validation-api -->
         <version>${cxf-version}</version>
         <scope>compile</scope>
     </dependency>
+    {{^useJakartaEe}}
     <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>
     </dependency>
+    {{/useJakartaEe}}
+    {{#useJakartaEe}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+        <version>${jackson-jaxrs-version}</version>
+        <scope>compile</scope>
+    </dependency>
+    {{/useJakartaEe}}
     <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf/server/pom.mustache
@@ -199,7 +199,7 @@ for this project used jakarta.validation-api -->
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
         <artifactId>jackson-jakarta-rs-json-provider</artifactId>
         <version>${jackson-jaxrs-version}</version>
         <scope>compile</scope>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -88,7 +88,7 @@
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -81,16 +81,16 @@
     </dependency>
     {{^useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>${jackson-version}</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson-version}</version>
     </dependency>
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-        <version>${jackson-version}</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+      <version>${jackson-version}</version>
     </dependency>
     {{/useJakartaEe}}
     <dependency>

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pom.mustache
@@ -79,11 +79,20 @@
       <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+    {{^useJakartaEe}}
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
-      <version>${jackson-version}</version>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-version}</version>
     </dependency>
+    {{/useJakartaEe}}
+    {{#useJakartaEe}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+        <version>${jackson-version}</version>
+    </dependency>
+    {{/useJakartaEe}}
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
@@ -61,11 +61,20 @@
       <artifactId>jackson-datatype-joda</artifactId>
       <version>${jackson-version}</version>
     </dependency>
+    {{^useJakartaEe}}
     <dependency>
-       <groupId>com.fasterxml.jackson.jaxrs</groupId>
-       <artifactId>jackson-jaxrs-json-provider</artifactId>
-       <version>${jackson-version}</version>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>${jackson-version}</version>
     </dependency>
+    {{/useJakartaEe}}
+    {{#useJakartaEe}}
+    <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+        <version>${jackson-version}</version>
+    </dependency>
+    {{/useJakartaEe}}
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
@@ -70,7 +70,7 @@
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>

--- a/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/java-msf4j-server/pom.mustache
@@ -63,16 +63,16 @@
     </dependency>
     {{^useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>${jackson-version}</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson-version}</version>
     </dependency>
     {{/useJakartaEe}}
     {{#useJakartaEe}}
     <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-        <version>${jackson-version}</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+      <version>${jackson-version}</version>
     </dependency>
     {{/useJakartaEe}}
     <dependency>

--- a/samples/client/petstore/java/resttemplate-jakarta/pom.xml
+++ b/samples/client/petstore/java/resttemplate-jakarta/pom.xml
@@ -235,7 +235,7 @@
             <version>${jackson-databind-version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>

--- a/samples/client/petstore/java/resttemplate-jakarta/pom.xml
+++ b/samples/client/petstore/java/resttemplate-jakarta/pom.xml
@@ -236,7 +236,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <artifactId>jackson-jakarta-rs-json-provider</artifactId>
             <version>${jackson-version}</version>
         </dependency>
         <dependency>

--- a/samples/server/petstore/java-msf4j/pom.xml
+++ b/samples/server/petstore/java-msf4j/pom.xml
@@ -62,9 +62,9 @@
       <version>${jackson-version}</version>
     </dependency>
     <dependency>
-       <groupId>com.fasterxml.jackson.jaxrs</groupId>
-       <artifactId>jackson-jaxrs-json-provider</artifactId>
-       <version>${jackson-version}</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson-version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>
     <dependency>

--- a/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
+++ b/samples/server/petstore/jaxrs-spec-jakarta/pom.xml
@@ -64,7 +64,7 @@
       <version>${jackson-version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <version>${jackson-version}</version>
     </dependency>


### PR DESCRIPTION
Closes #17590 

Use dependency com.fasterxml.jackson.jaxrs:jackson-jakarta-rs-json-provider instead of com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider in pom when useJakartaEe is true for Java projects.

Tagging the Java technical committee: @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

### PR checklist
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
