### PR TITLE
fix: DefaultCodegen now generates an exemple for each status codes

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -989,6 +989,36 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testExample5MultipleResponses() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/examples.yaml");
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+        String path = "/example5/multiple_responses";
+
+        Operation operation = openAPI.getPaths().get(path).getGet();
+        CodegenOperation codegenOperation = codegen.fromOperation(path, "GET", operation, null);
+        List<Map<String, String>> examples = codegenOperation.examples;
+
+        Assert.assertEquals(examples.size(), 4);
+        // 200 response example
+        Assert.assertEquals(examples.get(0).get("contentType"), "application/json");
+        Assert.assertEquals(examples.get(0).get("example"), "\"a successful response example\"");
+        Assert.assertEquals(examples.get(0).get("statusCode"), "200");
+        // 301 response example
+        Assert.assertEquals(examples.get(1).get("contentType"), "application/json");
+        Assert.assertEquals(examples.get(1).get("example"), "\"a redirect response example\"");
+        Assert.assertEquals(examples.get(1).get("statusCode"), "301");
+        // 404 response example
+        Assert.assertEquals(examples.get(2).get("contentType"), "application/json");
+        Assert.assertEquals(examples.get(2).get("example"), "\"a not found response example\"");
+        Assert.assertEquals(examples.get(2).get("statusCode"), "404");
+        // 500 response example
+        Assert.assertEquals(examples.get(3).get("contentType"), "application/json");
+        Assert.assertEquals(examples.get(3).get("example"), "\"an internal server error response example\"");
+        Assert.assertEquals(examples.get(3).get("statusCode"), "500");
+    }
+
+    @Test
     public void testDiscriminator() {
         final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/2_0/petstore-with-fake-endpoints-models-for-testing.yaml");
         DefaultCodegen codegen = new DefaultCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/examples.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/examples.yaml
@@ -107,6 +107,38 @@ paths:
       responses:
         '200':
           description: successful operation
+  /example5/multiple_responses:
+    get:
+      operationId: generateFromResponseSchemaWithOneOfModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+                example: a successful response example
+        '301':
+          description: permanent redirect
+          content:
+            application/json:
+              schema:
+                type: string
+                example: a redirect response example
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: string
+                example: a not found response example
+        '500':
+          description: internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                example: an internal server error response example
 components:
   schemas:
     User:


### PR DESCRIPTION
The DefaultCodegen now iterates through all api operations.

This allows to access different examples based on the response per status code and content type.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
