### PR TITLE
addition: api response examples + spring generator can generate response examples (#17610, #16051)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ExamplesUtils.java
@@ -1,0 +1,94 @@
+package org.openapitools.codegen.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+import static org.openapitools.codegen.utils.OnceLogger.once;
+
+public class ExamplesUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExamplesUtils.class);
+
+    /**
+     * Return examples of API response.
+     *
+     * @param openAPI OpenAPI spec.
+     * @param response ApiResponse of the operation
+     * @return examples of API response
+     */
+    public static Map<String, Example> getExamplesFromResponse(OpenAPI openAPI, ApiResponse response) {
+        ApiResponse result = ModelUtils.getReferencedApiResponse(openAPI, response);
+        if (result == null) {
+            return Collections.emptyMap();
+        } else {
+            return getExamplesFromContent(result.getContent());
+        }
+    }
+
+    private static Map<String, Example> getExamplesFromContent(Content content) {
+        if (content == null || content.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map.Entry<String, MediaType> entry = content.entrySet().iterator().next();
+        if (content.size() > 1) {
+            once(LOGGER).debug("Multiple API response examples found in the OAS 'content' section, returning only the first one ({})",
+                    entry.getKey());
+        }
+        return entry.getValue().getExamples();
+    }
+
+
+    /**
+     * Return actual examples objects of API response with values and processed from references (unaliased)
+     *
+     * @param openapi OpenAPI spec.
+     * @param apiRespExamples examples of API response
+     * @return unaliased examples of API response
+     */
+    public static List<Map<String, Object>> unaliasExamples(OpenAPI openapi, Map<String, Example> apiRespExamples) {
+        Map<String, Example> actualComponentsExamples = getAllExamples(openapi);
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map.Entry<String, Example> example : apiRespExamples.entrySet()) {
+            try {
+                Map<String, Object> exampleRepr = new LinkedHashMap<>();
+                String exampleName = ModelUtils.getSimpleRef(example.getValue().get$ref());
+
+                // api response example can both be a reference and specified directly in the code
+                // if the reference is null, we get the value directly from the example -- no unaliasing is needed
+                // if it isn't, we get the value from the components examples
+                Object exampleValue;
+                if(example.getValue().get$ref() != null){
+                    exampleValue = actualComponentsExamples.get(exampleName).getValue();
+                    LOGGER.trace("Unaliased example value from components examples: {}", exampleValue);
+                } else {
+                    exampleValue = example.getValue().getValue();
+                    LOGGER.trace("Retrieved example value directly from the api response example definition: {}", exampleValue);
+                }
+
+                exampleRepr.put("exampleName", exampleName);
+                exampleRepr.put("exampleValue", new ObjectMapper().writeValueAsString(exampleValue)
+                        .replace("\"", "\\\""));
+
+                result.add(exampleRepr);
+            } catch (JsonProcessingException e) {
+                LOGGER.error("Failed to serialize example value", e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        return result;
+    }
+
+    private static Map<String, Example> getAllExamples(OpenAPI openapi) {
+        return openapi.getComponents().getExamples();
+    }
+}

--- a/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 {{/swagger2AnnotationLibrary}}
 {{#swagger1AnnotationLibrary}}
 import io.swagger.annotations.*;
@@ -171,7 +172,19 @@ public interface {{classname}} {
             {{#responses}}
             @ApiResponse(responseCode = {{#isDefault}}"default"{{/isDefault}}{{^isDefault}}"{{{code}}}"{{/isDefault}}, description = "{{{message}}}"{{#baseType}}, content = {
                 {{#produces}}
-                @Content(mediaType = "{{{mediaType}}}", {{#isArray}}array = @ArraySchema({{/isArray}}schema = @Schema(implementation = {{{baseType}}}.class){{#isArray}}){{/isArray}}){{^-last}},{{/-last}}
+                @Content(mediaType = "{{{mediaType}}}", {{#isArray}}array = @ArraySchema({{/isArray}}schema = @Schema(implementation = {{{baseType}}}.class){{#isArray}}){{/isArray}}{{^examples.0}}{{#-last}}){{/-last}}{{^-last}}),{{/-last}}{{/examples.0}}{{#examples.0}}, examples = {
+                {{#examples}}
+                    @ExampleObject(
+                        name = "{{{exampleName}}}",
+                        value = "{{{exampleValue}}}"
+                    ){{^-last}},{{/-last}}
+                {{/examples}}
+                {{#-last}}
+                })
+                {{/-last}}
+                {{^-last}}
+                }),
+                {{/-last}}{{/examples.0}}
                 {{/produces}}
             }{{/baseType}}){{^-last}},{{/-last}}
             {{/responses}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/assertions/AbstractAnnotationAssert.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.Node;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.util.CanIgnoreReturnValue;
 
@@ -71,5 +72,33 @@ public abstract class AbstractAnnotationAssert<ACTUAL extends AbstractAnnotation
     @SuppressWarnings("unchecked")
     private ACTUAL myself() {
         return (ACTUAL) this;
+    }
+
+    public ACTUAL recursivelyContainsWithName(String name) {
+        super
+            .withFailMessage("Should have annotation with name: " + name)
+            .anyMatch(annotation -> containsSpecificAnnotationName(annotation, name));
+
+        return myself();
+    }
+
+    private boolean containsSpecificAnnotationName(Node node, String name) {
+        if (node == null || name == null)
+            return false;
+
+        if (node instanceof AnnotationExpr) {
+            AnnotationExpr annotation = (AnnotationExpr) node;
+
+            if(annotation.getNameAsString().equals(name))
+                return true;
+
+        }
+
+        for(Node child: node.getChildNodes()){
+            if(containsSpecificAnnotationName(child, name))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/spring/SpringCodegenTest.java
@@ -4427,4 +4427,14 @@ public class SpringCodegenTest {
                 .hasParameter("race").toConstructor()
         ;
     }
+
+    @Test
+    public void testExampleAnnotationGeneration_issue17610() throws IOException {
+        final Map<String, File> generatedCodeFiles = generateFromContract("src/test/resources/3_0/spring/api-response-examples_issue17610.yaml", SPRING_BOOT);
+
+        JavaFileAssert.assertThat(generatedCodeFiles.get("DogsApi.java"))
+                .assertMethod("createDog")
+                .assertMethodAnnotations()
+                .recursivelyContainsWithName("ExampleObject");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_0/spring/api-response-examples_issue17610.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/spring/api-response-examples_issue17610.yaml
@@ -1,0 +1,80 @@
+openapi: 3.0.3
+info:
+  title: No examples in annotation example API
+  description: No examples in annotation example API
+  version: 1.0.0
+servers:
+  - url: 'https://localhost:8080'
+paths:
+  /dogs:
+    post:
+      summary: Create a dog
+      operationId: createDog
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dog'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Dog'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                dog name length:
+                  $ref: '#/components/examples/DogNameBiggerThan50Error'
+                dog name contains numbers:
+                  $ref: '#/components/examples/DogNameContainsNumbersError'
+                dog age negative:
+                  $ref: '#/components/examples/DogAgeNegativeError'
+
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 50
+          pattern: '^[a-zA-Z]+$'
+          x-pattern-message: Name must contain only letters
+          example: 'Rex'
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          example: 5
+    # NOTE: not picked up by the generator
+    # TODO: consider adding support for this
+    #      example:
+    #        name: 'Rex'
+    #        age: 5
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+  examples:
+    DogNameBiggerThan50Error:
+      value:
+        code: 400
+        message: name size must be between 0 and 50
+    DogNameContainsNumbersError:
+      value:
+        code: 400
+        message: Name must contain only letters
+    DogAgeNegativeError:
+      value:
+        code: 400
+        message: age must be greater than or equal to 0

--- a/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/petstore/java/apache-httpclient/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/feign-no-nullable/api/openapi.yaml
+++ b/samples/client/petstore/java/feign-no-nullable/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/PetApi.java
@@ -83,7 +83,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   List<Pet> findPetsByStatus(@Param("status") List<String> status);
 
@@ -96,7 +96,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@Param("status") List<String> status);
 
@@ -118,7 +118,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   List<Pet> findPetsByStatus(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
@@ -136,7 +136,7 @@ public interface PetApi extends ApiClient.Api {
       */
       @RequestLine("GET /pet/findByStatus?status={status}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
@@ -162,7 +162,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Set<Pet> findPetsByTags(@Param("tags") Set<String> tags);
 
@@ -177,7 +177,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@Param("tags") Set<String> tags);
 
@@ -201,7 +201,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   Set<Pet> findPetsByTags(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
@@ -221,7 +221,7 @@ public interface PetApi extends ApiClient.Api {
           @Deprecated
       @RequestLine("GET /pet/findByTags?tags={tags}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
@@ -245,7 +245,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/{petId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Pet getPetById(@Param("petId") Long petId);
 
@@ -258,7 +258,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/{petId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Pet> getPetByIdWithHttpInfo(@Param("petId") Long petId);
 

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -74,7 +74,7 @@ public interface StoreApi extends ApiClient.Api {
    */
   @RequestLine("GET /store/order/{orderId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Order getOrderById(@Param("orderId") Long orderId);
 
@@ -87,7 +87,7 @@ public interface StoreApi extends ApiClient.Api {
    */
   @RequestLine("GET /store/order/{orderId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Order> getOrderByIdWithHttpInfo(@Param("orderId") Long orderId);
 
@@ -102,7 +102,7 @@ public interface StoreApi extends ApiClient.Api {
   @RequestLine("POST /store/order")
   @Headers({
     "Content-Type: */*",
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Order placeOrder(Order body);
 
@@ -116,7 +116,7 @@ public interface StoreApi extends ApiClient.Api {
   @RequestLine("POST /store/order")
   @Headers({
     "Content-Type: */*",
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Order> placeOrderWithHttpInfo(Order body);
 

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/api/UserApi.java
@@ -131,7 +131,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/{username}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   User getUserByName(@Param("username") String username);
 
@@ -144,7 +144,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/{username}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<User> getUserByNameWithHttpInfo(@Param("username") String username);
 
@@ -159,7 +159,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   String loginUser(@Param("username") String username, @Param("password") String password);
 
@@ -173,7 +173,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<String> loginUserWithHttpInfo(@Param("username") String username, @Param("password") String password);
 
@@ -196,7 +196,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   String loginUser(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
@@ -215,7 +215,7 @@ public interface UserApi extends ApiClient.Api {
       */
       @RequestLine("GET /user/login?username={username}&password={password}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 

--- a/samples/client/petstore/java/feign/api/openapi.yaml
+++ b/samples/client/petstore/java/feign/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/PetApi.java
@@ -83,7 +83,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   List<Pet> findPetsByStatus(@Param("status") List<String> status);
 
@@ -96,7 +96,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@Param("status") List<String> status);
 
@@ -118,7 +118,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/findByStatus?status={status}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   List<Pet> findPetsByStatus(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
@@ -136,7 +136,7 @@ public interface PetApi extends ApiClient.Api {
       */
       @RequestLine("GET /pet/findByStatus?status={status}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<List<Pet>> findPetsByStatusWithHttpInfo(@QueryMap(encoded=true) FindPetsByStatusQueryParams queryParams);
 
@@ -162,7 +162,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Set<Pet> findPetsByTags(@Param("tags") Set<String> tags);
 
@@ -177,7 +177,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@Param("tags") Set<String> tags);
 
@@ -201,7 +201,7 @@ public interface PetApi extends ApiClient.Api {
   @Deprecated
   @RequestLine("GET /pet/findByTags?tags={tags}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   Set<Pet> findPetsByTags(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
@@ -221,7 +221,7 @@ public interface PetApi extends ApiClient.Api {
           @Deprecated
       @RequestLine("GET /pet/findByTags?tags={tags}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<Set<Pet>> findPetsByTagsWithHttpInfo(@QueryMap(encoded=true) FindPetsByTagsQueryParams queryParams);
 
@@ -245,7 +245,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/{petId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Pet getPetById(@Param("petId") Long petId);
 
@@ -258,7 +258,7 @@ public interface PetApi extends ApiClient.Api {
    */
   @RequestLine("GET /pet/{petId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Pet> getPetByIdWithHttpInfo(@Param("petId") Long petId);
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -74,7 +74,7 @@ public interface StoreApi extends ApiClient.Api {
    */
   @RequestLine("GET /store/order/{orderId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Order getOrderById(@Param("orderId") Long orderId);
 
@@ -87,7 +87,7 @@ public interface StoreApi extends ApiClient.Api {
    */
   @RequestLine("GET /store/order/{orderId}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Order> getOrderByIdWithHttpInfo(@Param("orderId") Long orderId);
 
@@ -102,7 +102,7 @@ public interface StoreApi extends ApiClient.Api {
   @RequestLine("POST /store/order")
   @Headers({
     "Content-Type: application/json",
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   Order placeOrder(Order order);
 
@@ -116,7 +116,7 @@ public interface StoreApi extends ApiClient.Api {
   @RequestLine("POST /store/order")
   @Headers({
     "Content-Type: application/json",
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<Order> placeOrderWithHttpInfo(Order order);
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/api/UserApi.java
@@ -131,7 +131,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/{username}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   User getUserByName(@Param("username") String username);
 
@@ -144,7 +144,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/{username}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<User> getUserByNameWithHttpInfo(@Param("username") String username);
 
@@ -159,7 +159,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   String loginUser(@Param("username") String username, @Param("password") String password);
 
@@ -173,7 +173,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
   })
   ApiResponse<String> loginUserWithHttpInfo(@Param("username") String username, @Param("password") String password);
 
@@ -196,7 +196,7 @@ public interface UserApi extends ApiClient.Api {
    */
   @RequestLine("GET /user/login?username={username}&password={password}")
   @Headers({
-  "Accept: application/json,application/xml",
+  "Accept: application/json",
   })
   String loginUser(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 
@@ -215,7 +215,7 @@ public interface UserApi extends ApiClient.Api {
       */
       @RequestLine("GET /user/login?username={username}&password={password}")
       @Headers({
-    "Accept: application/json,application/xml",
+    "Accept: application/json",
       })
    ApiResponse<String> loginUserWithHttpInfo(@QueryMap(encoded=true) LoginUserQueryParams queryParams);
 

--- a/samples/client/petstore/java/google-api-client/api/openapi.yaml
+++ b/samples/client/petstore/java/google-api-client/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/jersey3/api/openapi.yaml
+++ b/samples/client/petstore/java/jersey3/api/openapi.yaml
@@ -140,7 +140,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -182,7 +182,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -247,7 +247,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -360,7 +360,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -417,7 +417,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -516,7 +516,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/native-async/api/openapi.yaml
+++ b/samples/client/petstore/java/native-async/api/openapi.yaml
@@ -140,7 +140,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -182,7 +182,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -247,7 +247,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -360,7 +360,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -417,7 +417,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -516,7 +516,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/native-jakarta/api/openapi.yaml
+++ b/samples/client/petstore/java/native-jakarta/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/native/api/openapi.yaml
+++ b/samples/client/petstore/java/native/api/openapi.yaml
@@ -140,7 +140,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -182,7 +182,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -247,7 +247,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -360,7 +360,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -417,7 +417,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -516,7 +516,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-3.1/.openapi-generator/FILES
+++ b/samples/client/petstore/java/okhttp-gson-3.1/.openapi-generator/FILES
@@ -18,7 +18,6 @@ docs/Order.md
 docs/Pet.md
 docs/PetApi.md
 docs/StoreApi.md
-docs/StringOrInt.md
 docs/Tag.md
 docs/User.md
 docs/UserApi.md
@@ -67,6 +66,5 @@ src/main/java/org/openapitools/client/model/ModelApiResponse.java
 src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
 src/main/java/org/openapitools/client/model/Order.java
 src/main/java/org/openapitools/client/model/Pet.java
-src/main/java/org/openapitools/client/model/StringOrInt.java
 src/main/java/org/openapitools/client/model/Tag.java
 src/main/java/org/openapitools/client/model/User.java

--- a/samples/client/petstore/java/okhttp-gson-3.1/README.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/README.md
@@ -152,7 +152,6 @@ Class | Method | HTTP request | Description
  - [OneOfStringOrInt](docs/OneOfStringOrInt.md)
  - [Order](docs/Order.md)
  - [Pet](docs/Pet.md)
- - [StringOrInt](docs/StringOrInt.md)
  - [Tag](docs/Tag.md)
  - [User](docs/User.md)
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -340,7 +340,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -397,7 +397,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -511,7 +511,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -578,7 +578,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser
@@ -744,138 +744,106 @@ components:
     Order:
       description: An order for a pets from the pet store
       example:
-        petId: 6
-        quantity: 1
-        id: 0
-        shipDate: 2000-01-23T04:56:07.000+00:00
-        complete: false
-        status: placed
+        petId: ""
+        quantity: ""
+        id: ""
+        shipDate: ""
+        complete: ""
+        status: ""
       properties:
         id:
           format: int64
-          type: integer
         petId:
           format: int64
-          type: integer
         quantity:
           format: int32
-          type: integer
         shipDate:
           format: date-time
-          type: string
         status:
           description: Order Status
           enum:
           - placed
           - approved
           - delivered
-          type: string
         complete:
           default: false
-          type: boolean
       title: Pet Order
       xml:
         name: Order
     Category:
       description: A category for a pet
       example:
-        name: name
-        id: 6
+        name: ""
+        id: ""
       properties:
         id:
           format: int64
-          type: integer
         name:
           pattern: "^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$"
-          type: string
       title: Pet category
       xml:
         name: Category
     User:
       description: A User who is purchasing from the pet store
       example:
-        firstName: firstName
-        lastName: lastName
-        password: password
-        userStatus: 6
-        phone: phone
-        id: 0
-        email: email
-        username: username
+        firstName: ""
+        lastName: ""
+        password: ""
+        userStatus: ""
+        phone: ""
+        id: ""
+        email: ""
+        username: ""
       properties:
         id:
           format: int64
-          type: integer
-        username:
-          type: string
-        firstName:
-          type: string
-        lastName:
-          type: string
-        email:
-          type: string
-        password:
-          type: string
-        phone:
-          type: string
+        username: {}
+        firstName: {}
+        lastName: {}
+        email: {}
+        password: {}
+        phone: {}
         userStatus:
           description: User Status
           format: int32
-          type: integer
       title: a User
       xml:
         name: User
     Tag:
       description: A tag for a pet
-      example:
-        name: name
-        id: 1
       properties:
         id:
           format: int64
-          type: integer
-        name:
-          type: string
+        name: {}
       title: Pet Tag
       xml:
         name: Tag
     Pet:
       description: A pet for sale in the pet store
       example:
-        photoUrls:
-        - photoUrls
-        - photoUrls
+        photoUrls: ""
         name: doggie
-        id: 0
+        id: ""
         category:
-          name: name
-          id: 6
-        tags:
-        - name: name
-          id: 1
-        - name: name
-          id: 1
-        status: available
+          name: ""
+          id: ""
+        tags: ""
+        status: ""
       properties:
         id:
           format: int64
-          type: integer
         category:
           $ref: '#/components/schemas/Category'
         name:
           example: doggie
-          type: string
         photoUrls:
-          items:
-            type: string
-          type: array
+          items: {}
           xml:
             name: photoUrl
             wrapped: true
         tags:
           items:
             $ref: '#/components/schemas/Tag'
-          type: array
           xml:
             name: tag
             wrapped: true
@@ -886,7 +854,6 @@ components:
           - available
           - pending
           - sold
-          type: string
       required:
       - name
       - photoUrls
@@ -896,29 +863,22 @@ components:
     ApiResponse:
       description: Describes the result of uploading an image resource
       example:
-        code: 0
-        type: type
-        message: message
+        code: ""
+        type: ""
+        message: ""
       properties:
         code:
           format: int32
-          type: integer
-        type:
-          type: string
-        message:
-          type: string
+        type: {}
+        message: {}
       title: An uploaded response
     StringOrInt:
-      anyOf:
-      - type: string
-      - format: int32
-        type: integer
       description: string or int
     OneOfStringOrInt:
       description: string or int (onefOf)
       oneOf:
       - type: string
-      - type: integer
+      - {}
     Dog:
       allOf:
       - $ref: '#/components/schemas/Animal'
@@ -929,17 +889,14 @@ components:
       allOf:
       - $ref: '#/components/schemas/Animal'
       - properties:
-          declawed:
-            type: boolean
+          declawed: {}
     Animal:
       discriminator:
         propertyName: className
       properties:
-        className:
-          type: string
+        className: {}
         color:
           default: red
-          type: string
       required:
       - className
     simple_text:
@@ -951,17 +908,13 @@ components:
           description: test array in 3.1 spec
           items:
             type: string
-          type: array
     HTTPValidationError:
       properties: {}
       title: HTTPValidationError
-      type: object
     AnyOfArray:
       anyOf:
-      - items:
-          type: string
-      - items:
-          type: integer
+      - items: {}
+      - items: {}
     updatePetWithForm_request:
       properties:
         name:

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Animal.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Animal.md
@@ -7,8 +7,8 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**className** | **String** |  |  |
-|**color** | **String** |  |  [optional] |
+|**className** | **Object** |  |  |
+|**color** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/AnyTypeTest.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/AnyTypeTest.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**anyTypeProperty** | **Object** |  |  [optional] |
-|**arrayProp** | **List&lt;String&gt;** | test array in 3.1 spec |  [optional] |
+|**arrayProp** | **Object** | test array in 3.1 spec |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Cat.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Cat.md
@@ -7,7 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**declawed** | **Boolean** |  |  [optional] |
+|**declawed** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Category.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Category.md
@@ -8,8 +8,8 @@ A category for a pet
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **Long** |  |  [optional] |
-|**name** | **String** |  |  [optional] |
+|**id** | **Object** |  |  [optional] |
+|**name** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/ModelApiResponse.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/ModelApiResponse.md
@@ -8,9 +8,9 @@ Describes the result of uploading an image resource
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**code** | **Integer** |  |  [optional] |
-|**type** | **String** |  |  [optional] |
-|**message** | **String** |  |  [optional] |
+|**code** | **Object** |  |  [optional] |
+|**type** | **Object** |  |  [optional] |
+|**message** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Order.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Order.md
@@ -8,12 +8,12 @@ An order for a pets from the pet store
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **Long** |  |  [optional] |
-|**petId** | **Long** |  |  [optional] |
-|**quantity** | **Integer** |  |  [optional] |
-|**shipDate** | **OffsetDateTime** |  |  [optional] |
+|**id** | **Object** |  |  [optional] |
+|**petId** | **Object** |  |  [optional] |
+|**quantity** | **Object** |  |  [optional] |
+|**shipDate** | **Object** |  |  [optional] |
 |**status** | [**StatusEnum**](#StatusEnum) | Order Status |  [optional] |
-|**complete** | **Boolean** |  |  [optional] |
+|**complete** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Pet.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Pet.md
@@ -8,11 +8,11 @@ A pet for sale in the pet store
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **Long** |  |  [optional] |
+|**id** | **Object** |  |  [optional] |
 |**category** | [**Category**](Category.md) |  |  [optional] |
-|**name** | **String** |  |  |
-|**photoUrls** | **List&lt;String&gt;** |  |  |
-|**tags** | [**List&lt;Tag&gt;**](Tag.md) |  |  [optional] |
+|**name** | **Object** |  |  |
+|**photoUrls** | **Object** |  |  |
+|**tags** | **Object** |  |  [optional] |
 |**status** | [**StatusEnum**](#StatusEnum) | pet status in the store |  [optional] |
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/Tag.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/Tag.md
@@ -8,8 +8,8 @@ A tag for a pet
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **Long** |  |  [optional] |
-|**name** | **String** |  |  [optional] |
+|**id** | **Object** |  |  [optional] |
+|**name** | **Object** |  |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/docs/User.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/docs/User.md
@@ -8,14 +8,14 @@ A User who is purchasing from the pet store
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**id** | **Long** |  |  [optional] |
-|**username** | **String** |  |  [optional] |
-|**firstName** | **String** |  |  [optional] |
-|**lastName** | **String** |  |  [optional] |
-|**email** | **String** |  |  [optional] |
-|**password** | **String** |  |  [optional] |
-|**phone** | **String** |  |  [optional] |
-|**userStatus** | **Integer** | User Status |  [optional] |
+|**id** | **Object** |  |  [optional] |
+|**username** | **Object** |  |  [optional] |
+|**firstName** | **Object** |  |  [optional] |
+|**lastName** | **Object** |  |  [optional] |
+|**email** | **Object** |  |  [optional] |
+|**password** | **Object** |  |  [optional] |
+|**phone** | **Object** |  |  [optional] |
+|**userStatus** | **Object** | User Status |  [optional] |
 
 
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/JSON.java
@@ -138,7 +138,6 @@ public class JSON {
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.OneOfStringOrInt.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Order.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Pet.CustomTypeAdapterFactory());
-        gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.StringOrInt.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Tag.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.User.CustomTypeAdapterFactory());
         gson = gsonBuilder.create();

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Animal.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,17 +54,17 @@ import org.openapitools.client.JSON;
 public class Animal {
   public static final String SERIALIZED_NAME_CLASS_NAME = "className";
   @SerializedName(SERIALIZED_NAME_CLASS_NAME)
-  protected String className;
+  protected Object className = null;
 
   public static final String SERIALIZED_NAME_COLOR = "color";
   @SerializedName(SERIALIZED_NAME_COLOR)
-  private String color = "red";
+  private Object color = red;
 
   public Animal() {
     this.className = this.getClass().getSimpleName();
   }
 
-  public Animal className(String className) {
+  public Animal className(Object className) {
     this.className = className;
     return this;
   }
@@ -72,17 +73,17 @@ public class Animal {
    * Get className
    * @return className
   **/
-  @javax.annotation.Nonnull
-  public String getClassName() {
+  @javax.annotation.Nullable
+  public Object getClassName() {
     return className;
   }
 
-  public void setClassName(String className) {
+  public void setClassName(Object className) {
     this.className = className;
   }
 
 
-  public Animal color(String color) {
+  public Animal color(Object color) {
     this.color = color;
     return this;
   }
@@ -92,11 +93,11 @@ public class Animal {
    * @return color
   **/
   @javax.annotation.Nullable
-  public String getColor() {
+  public Object getColor() {
     return color;
   }
 
-  public void setColor(String color) {
+  public void setColor(Object color) {
     this.color = color;
   }
 
@@ -160,9 +161,20 @@ public class Animal {
         Objects.equals(this.additionalProperties, animal.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(className, color, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyTypeTest.java
@@ -20,9 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
@@ -60,7 +58,7 @@ public class AnyTypeTest {
 
   public static final String SERIALIZED_NAME_ARRAY_PROP = "array_prop";
   @SerializedName(SERIALIZED_NAME_ARRAY_PROP)
-  private List<String> arrayProp;
+  private Object arrayProp = null;
 
   public AnyTypeTest() {
   }
@@ -84,16 +82,8 @@ public class AnyTypeTest {
   }
 
 
-  public AnyTypeTest arrayProp(List<String> arrayProp) {
+  public AnyTypeTest arrayProp(Object arrayProp) {
     this.arrayProp = arrayProp;
-    return this;
-  }
-
-  public AnyTypeTest addArrayPropItem(String arrayPropItem) {
-    if (this.arrayProp == null) {
-      this.arrayProp = new ArrayList<>();
-    }
-    this.arrayProp.add(arrayPropItem);
     return this;
   }
 
@@ -102,11 +92,11 @@ public class AnyTypeTest {
    * @return arrayProp
   **/
   @javax.annotation.Nullable
-  public List<String> getArrayProp() {
+  public Object getArrayProp() {
     return arrayProp;
   }
 
-  public void setArrayProp(List<String> arrayProp) {
+  public void setArrayProp(Object arrayProp) {
     this.arrayProp = arrayProp;
   }
 
@@ -235,10 +225,6 @@ public class AnyTypeTest {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      // ensure the optional json data is an array if present
-      if (jsonObj.get("array_prop") != null && !jsonObj.get("array_prop").isJsonNull() && !jsonObj.get("array_prop").isJsonArray()) {
-        throw new IllegalArgumentException(String.format("Expected the field `array_prop` to be an array in the JSON string but got `%s`", jsonObj.get("array_prop").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Cat.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import org.openapitools.client.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -54,13 +55,13 @@ import org.openapitools.client.JSON;
 public class Cat extends Animal {
   public static final String SERIALIZED_NAME_DECLAWED = "declawed";
   @SerializedName(SERIALIZED_NAME_DECLAWED)
-  private Boolean declawed;
+  private Object declawed = null;
 
   public Cat() {
     this.className = this.getClass().getSimpleName();
   }
 
-  public Cat declawed(Boolean declawed) {
+  public Cat declawed(Object declawed) {
     this.declawed = declawed;
     return this;
   }
@@ -70,11 +71,11 @@ public class Cat extends Animal {
    * @return declawed
   **/
   @javax.annotation.Nullable
-  public Boolean getDeclawed() {
+  public Object getDeclawed() {
     return declawed;
   }
 
-  public void setDeclawed(Boolean declawed) {
+  public void setDeclawed(Object declawed) {
     this.declawed = declawed;
   }
 
@@ -138,9 +139,20 @@ public class Cat extends Animal {
         super.equals(o);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(declawed, super.hashCode(), additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Category.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,16 +54,16 @@ import org.openapitools.client.JSON;
 public class Category {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
-  private Long id;
+  private Object id = null;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
-  private String name;
+  private Object name = null;
 
   public Category() {
   }
 
-  public Category id(Long id) {
+  public Category id(Object id) {
     this.id = id;
     return this;
   }
@@ -72,16 +73,16 @@ public class Category {
    * @return id
   **/
   @javax.annotation.Nullable
-  public Long getId() {
+  public Object getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Object id) {
     this.id = id;
   }
 
 
-  public Category name(String name) {
+  public Category name(Object name) {
     this.name = name;
     return this;
   }
@@ -91,11 +92,11 @@ public class Category {
    * @return name
   **/
   @javax.annotation.Nullable
-  public String getName() {
+  public Object getName() {
     return name;
   }
 
-  public void setName(String name) {
+  public void setName(Object name) {
     this.name = name;
   }
 
@@ -159,9 +160,20 @@ public class Category {
         Objects.equals(this.additionalProperties, category.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, name, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -213,9 +225,6 @@ public class Category {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Dog.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import org.openapitools.client.model.Animal;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -138,9 +139,20 @@ public class Dog extends Animal {
         super.equals(o);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(breed, super.hashCode(), additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/ModelApiResponse.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,20 +54,20 @@ import org.openapitools.client.JSON;
 public class ModelApiResponse {
   public static final String SERIALIZED_NAME_CODE = "code";
   @SerializedName(SERIALIZED_NAME_CODE)
-  private Integer code;
+  private Object code = null;
 
   public static final String SERIALIZED_NAME_TYPE = "type";
   @SerializedName(SERIALIZED_NAME_TYPE)
-  private String type;
+  private Object type = null;
 
   public static final String SERIALIZED_NAME_MESSAGE = "message";
   @SerializedName(SERIALIZED_NAME_MESSAGE)
-  private String message;
+  private Object message = null;
 
   public ModelApiResponse() {
   }
 
-  public ModelApiResponse code(Integer code) {
+  public ModelApiResponse code(Object code) {
     this.code = code;
     return this;
   }
@@ -76,16 +77,16 @@ public class ModelApiResponse {
    * @return code
   **/
   @javax.annotation.Nullable
-  public Integer getCode() {
+  public Object getCode() {
     return code;
   }
 
-  public void setCode(Integer code) {
+  public void setCode(Object code) {
     this.code = code;
   }
 
 
-  public ModelApiResponse type(String type) {
+  public ModelApiResponse type(Object type) {
     this.type = type;
     return this;
   }
@@ -95,16 +96,16 @@ public class ModelApiResponse {
    * @return type
   **/
   @javax.annotation.Nullable
-  public String getType() {
+  public Object getType() {
     return type;
   }
 
-  public void setType(String type) {
+  public void setType(Object type) {
     this.type = type;
   }
 
 
-  public ModelApiResponse message(String message) {
+  public ModelApiResponse message(Object message) {
     this.message = message;
     return this;
   }
@@ -114,11 +115,11 @@ public class ModelApiResponse {
    * @return message
   **/
   @javax.annotation.Nullable
-  public String getMessage() {
+  public Object getMessage() {
     return message;
   }
 
-  public void setMessage(String message) {
+  public void setMessage(Object message) {
     this.message = message;
   }
 
@@ -183,9 +184,20 @@ public class ModelApiResponse {
         Objects.equals(this.additionalProperties, _apiResponse.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(code, type, message, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -239,12 +251,6 @@ public class ModelApiResponse {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      if ((jsonObj.get("type") != null && !jsonObj.get("type").isJsonNull()) && !jsonObj.get("type").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `type` to be a primitive type in the JSON string but got `%s`", jsonObj.get("type").toString()));
-      }
-      if ((jsonObj.get("message") != null && !jsonObj.get("message").isJsonNull()) && !jsonObj.get("message").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `message` to be a primitive type in the JSON string but got `%s`", jsonObj.get("message").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
@@ -63,7 +63,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
             }
             final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
             final TypeAdapter<String> adapterString = gson.getDelegateAdapter(this, TypeToken.get(String.class));
-            final TypeAdapter<Integer> adapterInteger = gson.getDelegateAdapter(this, TypeToken.get(Integer.class));
+            final TypeAdapter<Object> adapterObject = gson.getDelegateAdapter(this, TypeToken.get(Object.class));
 
             return (TypeAdapter<T>) new TypeAdapter<OneOfStringOrInt>() {
                 @Override
@@ -79,13 +79,13 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
                       elementAdapter.write(out, primitive);
                       return;
                     }
-                    // check if the actual instance is of the type `Integer`
-                    if (value.getActualInstance() instanceof Integer) {
-                      JsonPrimitive primitive = adapterInteger.toJsonTree((Integer)value.getActualInstance()).getAsJsonPrimitive();
+                    // check if the actual instance is of the type `Object`
+                    if (value.getActualInstance() instanceof Object) {
+                      JsonPrimitive primitive = adapterObject.toJsonTree((Object)value.getActualInstance()).getAsJsonPrimitive();
                       elementAdapter.write(out, primitive);
                       return;
                     }
-                    throw new IOException("Failed to serialize as the type doesn't match oneOf schemas: Integer, String");
+                    throw new IOException("Failed to serialize as the type doesn't match oneOf schemas: Object, String");
                 }
 
                 @Override
@@ -111,19 +111,19 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
                       errorMessages.add(String.format("Deserialization for String failed with `%s`.", e.getMessage()));
                       log.log(Level.FINER, "Input data does not match schema 'String'", e);
                     }
-                    // deserialize Integer
+                    // deserialize Object
                     try {
                       // validate the JSON object to see if any exception is thrown
                       if(!jsonElement.getAsJsonPrimitive().isNumber()) {
                         throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
                       }
-                      actualAdapter = adapterInteger;
+                      actualAdapter = adapterObject;
                       match++;
-                      log.log(Level.FINER, "Input data matches schema 'Integer'");
+                      log.log(Level.FINER, "Input data matches schema 'Object'");
                     } catch (Exception e) {
                       // deserialization failed, continue
-                      errorMessages.add(String.format("Deserialization for Integer failed with `%s`.", e.getMessage()));
-                      log.log(Level.FINER, "Input data does not match schema 'Integer'", e);
+                      errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
+                      log.log(Level.FINER, "Input data does not match schema 'Object'", e);
                     }
 
                     if (match == 1) {
@@ -145,7 +145,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
         super("oneOf", Boolean.FALSE);
     }
 
-    public OneOfStringOrInt(Integer o) {
+    public OneOfStringOrInt(Object o) {
         super("oneOf", Boolean.FALSE);
         setActualInstance(o);
     }
@@ -157,7 +157,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
 
     static {
         schemas.put("String", String.class);
-        schemas.put("Integer", Integer.class);
+        schemas.put("Object", Object.class);
     }
 
     @Override
@@ -168,7 +168,7 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the oneOf child schema, check
      * the instance parameter is valid against the oneOf child schemas:
-     * Integer, String
+     * Object, String
      *
      * It could be an instance of the 'oneOf' schemas.
      */
@@ -179,19 +179,19 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
             return;
         }
 
-        if (instance instanceof Integer) {
+        if (instance instanceof Object) {
             super.setActualInstance(instance);
             return;
         }
 
-        throw new RuntimeException("Invalid instance type. Must be Integer, String");
+        throw new RuntimeException("Invalid instance type. Must be Object, String");
     }
 
     /**
      * Get the actual instance, which can be the following:
-     * Integer, String
+     * Object, String
      *
-     * @return The actual instance (Integer, String)
+     * @return The actual instance (Object, String)
      */
     @Override
     public Object getActualInstance() {
@@ -209,14 +209,14 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
         return (String)super.getActualInstance();
     }
     /**
-     * Get the actual instance of `Integer`. If the actual instance is not `Integer`,
+     * Get the actual instance of `Object`. If the actual instance is not `Object`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `Integer`
-     * @throws ClassCastException if the instance is not `Integer`
+     * @return The actual instance of `Object`
+     * @throws ClassCastException if the instance is not `Object`
      */
-    public Integer getInteger() throws ClassCastException {
-        return (Integer)super.getActualInstance();
+    public Object getObject() throws ClassCastException {
+        return (Object)super.getActualInstance();
     }
 
  /**
@@ -239,18 +239,18 @@ public class OneOfStringOrInt extends AbstractOpenApiSchema {
       errorMessages.add(String.format("Deserialization for String failed with `%s`.", e.getMessage()));
       // continue to the next one
     }
-    // validate the json string with Integer
+    // validate the json string with Object
     try {
       if(!jsonElement.getAsJsonPrimitive().isNumber()) {
         throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
       }
       validCount++;
     } catch (Exception e) {
-      errorMessages.add(String.format("Deserialization for Integer failed with `%s`.", e.getMessage()));
+      errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
       // continue to the next one
     }
     if (validCount != 1) {
-      throw new IOException(String.format("The JSON string is invalid for OneOfStringOrInt with oneOf schemas: Integer, String. %d class(es) match the result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", validCount, errorMessages, jsonElement.toString()));
+      throw new IOException(String.format("The JSON string is invalid for OneOfStringOrInt with oneOf schemas: Object, String. %d class(es) match the result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", validCount, errorMessages, jsonElement.toString()));
     }
   }
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Order.java
@@ -20,8 +20,8 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -54,19 +54,19 @@ import org.openapitools.client.JSON;
 public class Order {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
-  private Long id;
+  private Object id = null;
 
   public static final String SERIALIZED_NAME_PET_ID = "petId";
   @SerializedName(SERIALIZED_NAME_PET_ID)
-  private Long petId;
+  private Object petId = null;
 
   public static final String SERIALIZED_NAME_QUANTITY = "quantity";
   @SerializedName(SERIALIZED_NAME_QUANTITY)
-  private Integer quantity;
+  private Object quantity = null;
 
   public static final String SERIALIZED_NAME_SHIP_DATE = "shipDate";
   @SerializedName(SERIALIZED_NAME_SHIP_DATE)
-  private OffsetDateTime shipDate;
+  private Object shipDate = null;
 
   /**
    * Order Status
@@ -79,13 +79,13 @@ public class Order {
     
     DELIVERED("delivered");
 
-    private String value;
+    private Object value;
 
-    StatusEnum(String value) {
+    StatusEnum(Object value) {
       this.value = value;
     }
 
-    public String getValue() {
+    public Object getValue() {
       return value;
     }
 
@@ -94,13 +94,13 @@ public class Order {
       return String.valueOf(value);
     }
 
-    public static StatusEnum fromValue(String value) {
+    public static StatusEnum fromValue(Object value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {
@@ -111,29 +111,29 @@ public class Order {
 
       @Override
       public StatusEnum read(final JsonReader jsonReader) throws IOException {
-        String value =  jsonReader.nextString();
+        Object value =  jsonReader.nextObject();
         return StatusEnum.fromValue(value);
       }
     }
 
     public static void validateJsonElement(JsonElement jsonElement) throws IOException {
-      String value = jsonElement.getAsString();
+      Object value = jsonElement.getAsObject();
       StatusEnum.fromValue(value);
     }
   }
 
   public static final String SERIALIZED_NAME_STATUS = "status";
   @SerializedName(SERIALIZED_NAME_STATUS)
-  private StatusEnum status;
+  private StatusEnum status = null;
 
   public static final String SERIALIZED_NAME_COMPLETE = "complete";
   @SerializedName(SERIALIZED_NAME_COMPLETE)
-  private Boolean complete = false;
+  private Object complete = false;
 
   public Order() {
   }
 
-  public Order id(Long id) {
+  public Order id(Object id) {
     this.id = id;
     return this;
   }
@@ -143,16 +143,16 @@ public class Order {
    * @return id
   **/
   @javax.annotation.Nullable
-  public Long getId() {
+  public Object getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Object id) {
     this.id = id;
   }
 
 
-  public Order petId(Long petId) {
+  public Order petId(Object petId) {
     this.petId = petId;
     return this;
   }
@@ -162,16 +162,16 @@ public class Order {
    * @return petId
   **/
   @javax.annotation.Nullable
-  public Long getPetId() {
+  public Object getPetId() {
     return petId;
   }
 
-  public void setPetId(Long petId) {
+  public void setPetId(Object petId) {
     this.petId = petId;
   }
 
 
-  public Order quantity(Integer quantity) {
+  public Order quantity(Object quantity) {
     this.quantity = quantity;
     return this;
   }
@@ -181,16 +181,16 @@ public class Order {
    * @return quantity
   **/
   @javax.annotation.Nullable
-  public Integer getQuantity() {
+  public Object getQuantity() {
     return quantity;
   }
 
-  public void setQuantity(Integer quantity) {
+  public void setQuantity(Object quantity) {
     this.quantity = quantity;
   }
 
 
-  public Order shipDate(OffsetDateTime shipDate) {
+  public Order shipDate(Object shipDate) {
     this.shipDate = shipDate;
     return this;
   }
@@ -200,11 +200,11 @@ public class Order {
    * @return shipDate
   **/
   @javax.annotation.Nullable
-  public OffsetDateTime getShipDate() {
+  public Object getShipDate() {
     return shipDate;
   }
 
-  public void setShipDate(OffsetDateTime shipDate) {
+  public void setShipDate(Object shipDate) {
     this.shipDate = shipDate;
   }
 
@@ -228,7 +228,7 @@ public class Order {
   }
 
 
-  public Order complete(Boolean complete) {
+  public Order complete(Object complete) {
     this.complete = complete;
     return this;
   }
@@ -238,11 +238,11 @@ public class Order {
    * @return complete
   **/
   @javax.annotation.Nullable
-  public Boolean getComplete() {
+  public Object getComplete() {
     return complete;
   }
 
-  public void setComplete(Boolean complete) {
+  public void setComplete(Object complete) {
     this.complete = complete;
   }
 
@@ -310,9 +310,20 @@ public class Order {
         Objects.equals(this.additionalProperties, order.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, petId, quantity, shipDate, status, complete, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -372,9 +383,6 @@ public class Order {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
-      }
       // validate the optional field `status`
       if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {
         StatusEnum.validateJsonElement(jsonObj.get("status"));

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Pet.java
@@ -20,11 +20,9 @@ import com.google.gson.annotations.SerializedName;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import org.openapitools.client.model.Category;
-import org.openapitools.client.model.Tag;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -57,7 +55,7 @@ import org.openapitools.client.JSON;
 public class Pet {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
-  private Long id;
+  private Object id = null;
 
   public static final String SERIALIZED_NAME_CATEGORY = "category";
   @SerializedName(SERIALIZED_NAME_CATEGORY)
@@ -65,15 +63,15 @@ public class Pet {
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
-  private String name;
+  private Object name = null;
 
   public static final String SERIALIZED_NAME_PHOTO_URLS = "photoUrls";
   @SerializedName(SERIALIZED_NAME_PHOTO_URLS)
-  private List<String> photoUrls = new ArrayList<>();
+  private Object photoUrls = null;
 
   public static final String SERIALIZED_NAME_TAGS = "tags";
   @SerializedName(SERIALIZED_NAME_TAGS)
-  private List<Tag> tags;
+  private Object tags = null;
 
   /**
    * pet status in the store
@@ -86,13 +84,13 @@ public class Pet {
     
     SOLD("sold");
 
-    private String value;
+    private Object value;
 
-    StatusEnum(String value) {
+    StatusEnum(Object value) {
       this.value = value;
     }
 
-    public String getValue() {
+    public Object getValue() {
       return value;
     }
 
@@ -101,13 +99,13 @@ public class Pet {
       return String.valueOf(value);
     }
 
-    public static StatusEnum fromValue(String value) {
+    public static StatusEnum fromValue(Object value) {
       for (StatusEnum b : StatusEnum.values()) {
         if (b.value.equals(value)) {
           return b;
         }
       }
-      throw new IllegalArgumentException("Unexpected value '" + value + "'");
+      return null;
     }
 
     public static class Adapter extends TypeAdapter<StatusEnum> {
@@ -118,13 +116,13 @@ public class Pet {
 
       @Override
       public StatusEnum read(final JsonReader jsonReader) throws IOException {
-        String value =  jsonReader.nextString();
+        Object value =  jsonReader.nextObject();
         return StatusEnum.fromValue(value);
       }
     }
 
     public static void validateJsonElement(JsonElement jsonElement) throws IOException {
-      String value = jsonElement.getAsString();
+      Object value = jsonElement.getAsObject();
       StatusEnum.fromValue(value);
     }
   }
@@ -132,12 +130,12 @@ public class Pet {
   public static final String SERIALIZED_NAME_STATUS = "status";
   @Deprecated
   @SerializedName(SERIALIZED_NAME_STATUS)
-  private StatusEnum status;
+  private StatusEnum status = null;
 
   public Pet() {
   }
 
-  public Pet id(Long id) {
+  public Pet id(Object id) {
     this.id = id;
     return this;
   }
@@ -147,11 +145,11 @@ public class Pet {
    * @return id
   **/
   @javax.annotation.Nullable
-  public Long getId() {
+  public Object getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Object id) {
     this.id = id;
   }
 
@@ -175,7 +173,7 @@ public class Pet {
   }
 
 
-  public Pet name(String name) {
+  public Pet name(Object name) {
     this.name = name;
     return this;
   }
@@ -184,26 +182,18 @@ public class Pet {
    * Get name
    * @return name
   **/
-  @javax.annotation.Nonnull
-  public String getName() {
+  @javax.annotation.Nullable
+  public Object getName() {
     return name;
   }
 
-  public void setName(String name) {
+  public void setName(Object name) {
     this.name = name;
   }
 
 
-  public Pet photoUrls(List<String> photoUrls) {
+  public Pet photoUrls(Object photoUrls) {
     this.photoUrls = photoUrls;
-    return this;
-  }
-
-  public Pet addPhotoUrlsItem(String photoUrlsItem) {
-    if (this.photoUrls == null) {
-      this.photoUrls = new ArrayList<>();
-    }
-    this.photoUrls.add(photoUrlsItem);
     return this;
   }
 
@@ -211,26 +201,18 @@ public class Pet {
    * Get photoUrls
    * @return photoUrls
   **/
-  @javax.annotation.Nonnull
-  public List<String> getPhotoUrls() {
+  @javax.annotation.Nullable
+  public Object getPhotoUrls() {
     return photoUrls;
   }
 
-  public void setPhotoUrls(List<String> photoUrls) {
+  public void setPhotoUrls(Object photoUrls) {
     this.photoUrls = photoUrls;
   }
 
 
-  public Pet tags(List<Tag> tags) {
+  public Pet tags(Object tags) {
     this.tags = tags;
-    return this;
-  }
-
-  public Pet addTagsItem(Tag tagsItem) {
-    if (this.tags == null) {
-      this.tags = new ArrayList<>();
-    }
-    this.tags.add(tagsItem);
     return this;
   }
 
@@ -239,11 +221,11 @@ public class Pet {
    * @return tags
   **/
   @javax.annotation.Nullable
-  public List<Tag> getTags() {
+  public Object getTags() {
     return tags;
   }
 
-  public void setTags(List<Tag> tags) {
+  public void setTags(Object tags) {
     this.tags = tags;
   }
 
@@ -334,9 +316,20 @@ public class Pet {
         Objects.equals(this.additionalProperties, pet.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, category, name, photoUrls, tags, status, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -408,32 +401,6 @@ public class Pet {
       // validate the optional field `category`
       if (jsonObj.get("category") != null && !jsonObj.get("category").isJsonNull()) {
         Category.validateJsonElement(jsonObj.get("category"));
-      }
-      if (!jsonObj.get("name").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
-      }
-      // ensure the required json array is present
-      if (jsonObj.get("photoUrls") == null) {
-        throw new IllegalArgumentException("Expected the field `linkedContent` to be an array in the JSON string but got `null`");
-      } else if (!jsonObj.get("photoUrls").isJsonArray()) {
-        throw new IllegalArgumentException(String.format("Expected the field `photoUrls` to be an array in the JSON string but got `%s`", jsonObj.get("photoUrls").toString()));
-      }
-      if (jsonObj.get("tags") != null && !jsonObj.get("tags").isJsonNull()) {
-        JsonArray jsonArraytags = jsonObj.getAsJsonArray("tags");
-        if (jsonArraytags != null) {
-          // ensure the json data is an array
-          if (!jsonObj.get("tags").isJsonArray()) {
-            throw new IllegalArgumentException(String.format("Expected the field `tags` to be an array in the JSON string but got `%s`", jsonObj.get("tags").toString()));
-          }
-
-          // validate the optional field `tags` (array)
-          for (int i = 0; i < jsonArraytags.size(); i++) {
-            Tag.validateJsonElement(jsonArraytags.get(i));
-          };
-        }
-      }
-      if ((jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) && !jsonObj.get("status").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `status` to be a primitive type in the JSON string but got `%s`", jsonObj.get("status").toString()));
       }
       // validate the optional field `status`
       if (jsonObj.get("status") != null && !jsonObj.get("status").isJsonNull()) {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/Tag.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,16 +54,16 @@ import org.openapitools.client.JSON;
 public class Tag {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
-  private Long id;
+  private Object id = null;
 
   public static final String SERIALIZED_NAME_NAME = "name";
   @SerializedName(SERIALIZED_NAME_NAME)
-  private String name;
+  private Object name = null;
 
   public Tag() {
   }
 
-  public Tag id(Long id) {
+  public Tag id(Object id) {
     this.id = id;
     return this;
   }
@@ -72,16 +73,16 @@ public class Tag {
    * @return id
   **/
   @javax.annotation.Nullable
-  public Long getId() {
+  public Object getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Object id) {
     this.id = id;
   }
 
 
-  public Tag name(String name) {
+  public Tag name(Object name) {
     this.name = name;
     return this;
   }
@@ -91,11 +92,11 @@ public class Tag {
    * @return name
   **/
   @javax.annotation.Nullable
-  public String getName() {
+  public Object getName() {
     return name;
   }
 
-  public void setName(String name) {
+  public void setName(Object name) {
     this.name = name;
   }
 
@@ -159,9 +160,20 @@ public class Tag {
         Objects.equals(this.additionalProperties, tag.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, name, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -213,9 +225,6 @@ public class Tag {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      if ((jsonObj.get("name") != null && !jsonObj.get("name").isJsonNull()) && !jsonObj.get("name").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `name` to be a primitive type in the JSON string but got `%s`", jsonObj.get("name").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/User.java
@@ -21,6 +21,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -53,40 +54,40 @@ import org.openapitools.client.JSON;
 public class User {
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)
-  private Long id;
+  private Object id = null;
 
   public static final String SERIALIZED_NAME_USERNAME = "username";
   @SerializedName(SERIALIZED_NAME_USERNAME)
-  private String username;
+  private Object username = null;
 
   public static final String SERIALIZED_NAME_FIRST_NAME = "firstName";
   @SerializedName(SERIALIZED_NAME_FIRST_NAME)
-  private String firstName;
+  private Object firstName = null;
 
   public static final String SERIALIZED_NAME_LAST_NAME = "lastName";
   @SerializedName(SERIALIZED_NAME_LAST_NAME)
-  private String lastName;
+  private Object lastName = null;
 
   public static final String SERIALIZED_NAME_EMAIL = "email";
   @SerializedName(SERIALIZED_NAME_EMAIL)
-  private String email;
+  private Object email = null;
 
   public static final String SERIALIZED_NAME_PASSWORD = "password";
   @SerializedName(SERIALIZED_NAME_PASSWORD)
-  private String password;
+  private Object password = null;
 
   public static final String SERIALIZED_NAME_PHONE = "phone";
   @SerializedName(SERIALIZED_NAME_PHONE)
-  private String phone;
+  private Object phone = null;
 
   public static final String SERIALIZED_NAME_USER_STATUS = "userStatus";
   @SerializedName(SERIALIZED_NAME_USER_STATUS)
-  private Integer userStatus;
+  private Object userStatus = null;
 
   public User() {
   }
 
-  public User id(Long id) {
+  public User id(Object id) {
     this.id = id;
     return this;
   }
@@ -96,16 +97,16 @@ public class User {
    * @return id
   **/
   @javax.annotation.Nullable
-  public Long getId() {
+  public Object getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(Object id) {
     this.id = id;
   }
 
 
-  public User username(String username) {
+  public User username(Object username) {
     this.username = username;
     return this;
   }
@@ -115,16 +116,16 @@ public class User {
    * @return username
   **/
   @javax.annotation.Nullable
-  public String getUsername() {
+  public Object getUsername() {
     return username;
   }
 
-  public void setUsername(String username) {
+  public void setUsername(Object username) {
     this.username = username;
   }
 
 
-  public User firstName(String firstName) {
+  public User firstName(Object firstName) {
     this.firstName = firstName;
     return this;
   }
@@ -134,16 +135,16 @@ public class User {
    * @return firstName
   **/
   @javax.annotation.Nullable
-  public String getFirstName() {
+  public Object getFirstName() {
     return firstName;
   }
 
-  public void setFirstName(String firstName) {
+  public void setFirstName(Object firstName) {
     this.firstName = firstName;
   }
 
 
-  public User lastName(String lastName) {
+  public User lastName(Object lastName) {
     this.lastName = lastName;
     return this;
   }
@@ -153,16 +154,16 @@ public class User {
    * @return lastName
   **/
   @javax.annotation.Nullable
-  public String getLastName() {
+  public Object getLastName() {
     return lastName;
   }
 
-  public void setLastName(String lastName) {
+  public void setLastName(Object lastName) {
     this.lastName = lastName;
   }
 
 
-  public User email(String email) {
+  public User email(Object email) {
     this.email = email;
     return this;
   }
@@ -172,16 +173,16 @@ public class User {
    * @return email
   **/
   @javax.annotation.Nullable
-  public String getEmail() {
+  public Object getEmail() {
     return email;
   }
 
-  public void setEmail(String email) {
+  public void setEmail(Object email) {
     this.email = email;
   }
 
 
-  public User password(String password) {
+  public User password(Object password) {
     this.password = password;
     return this;
   }
@@ -191,16 +192,16 @@ public class User {
    * @return password
   **/
   @javax.annotation.Nullable
-  public String getPassword() {
+  public Object getPassword() {
     return password;
   }
 
-  public void setPassword(String password) {
+  public void setPassword(Object password) {
     this.password = password;
   }
 
 
-  public User phone(String phone) {
+  public User phone(Object phone) {
     this.phone = phone;
     return this;
   }
@@ -210,16 +211,16 @@ public class User {
    * @return phone
   **/
   @javax.annotation.Nullable
-  public String getPhone() {
+  public Object getPhone() {
     return phone;
   }
 
-  public void setPhone(String phone) {
+  public void setPhone(Object phone) {
     this.phone = phone;
   }
 
 
-  public User userStatus(Integer userStatus) {
+  public User userStatus(Object userStatus) {
     this.userStatus = userStatus;
     return this;
   }
@@ -229,11 +230,11 @@ public class User {
    * @return userStatus
   **/
   @javax.annotation.Nullable
-  public Integer getUserStatus() {
+  public Object getUserStatus() {
     return userStatus;
   }
 
-  public void setUserStatus(Integer userStatus) {
+  public void setUserStatus(Object userStatus) {
     this.userStatus = userStatus;
   }
 
@@ -303,9 +304,20 @@ public class User {
         Objects.equals(this.additionalProperties, user.additionalProperties);
   }
 
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b || (a != null && b != null && a.isPresent() && b.isPresent() && Objects.deepEquals(a.get(), b.get()));
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(id, username, firstName, lastName, email, password, phone, userStatus, additionalProperties);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[]{a.get()}) : 31;
   }
 
   @Override
@@ -369,24 +381,6 @@ public class User {
         }
       }
         JsonObject jsonObj = jsonElement.getAsJsonObject();
-      if ((jsonObj.get("username") != null && !jsonObj.get("username").isJsonNull()) && !jsonObj.get("username").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `username` to be a primitive type in the JSON string but got `%s`", jsonObj.get("username").toString()));
-      }
-      if ((jsonObj.get("firstName") != null && !jsonObj.get("firstName").isJsonNull()) && !jsonObj.get("firstName").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `firstName` to be a primitive type in the JSON string but got `%s`", jsonObj.get("firstName").toString()));
-      }
-      if ((jsonObj.get("lastName") != null && !jsonObj.get("lastName").isJsonNull()) && !jsonObj.get("lastName").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `lastName` to be a primitive type in the JSON string but got `%s`", jsonObj.get("lastName").toString()));
-      }
-      if ((jsonObj.get("email") != null && !jsonObj.get("email").isJsonNull()) && !jsonObj.get("email").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `email` to be a primitive type in the JSON string but got `%s`", jsonObj.get("email").toString()));
-      }
-      if ((jsonObj.get("password") != null && !jsonObj.get("password").isJsonNull()) && !jsonObj.get("password").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `password` to be a primitive type in the JSON string but got `%s`", jsonObj.get("password").toString()));
-      }
-      if ((jsonObj.get("phone") != null && !jsonObj.get("phone").isJsonNull()) && !jsonObj.get("phone").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field `phone` to be a primitive type in the JSON string but got `%s`", jsonObj.get("phone").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/resources/openapi/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/resources/openapi/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       operationId: updatePet
@@ -76,7 +76,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -120,7 +120,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -160,7 +160,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/api/openapi.yaml
@@ -101,7 +101,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -141,7 +141,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -206,7 +206,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -319,7 +319,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -376,7 +376,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -490,7 +490,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -557,7 +557,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-swagger1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson-swagger2/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson/api/openapi.yaml
@@ -137,7 +137,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -243,7 +243,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -356,7 +356,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -413,7 +413,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -575,7 +575,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured-jackson/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/PetApi.java
@@ -273,7 +273,7 @@ public class PetApi {
 
         public FindPetsByStatusOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -348,7 +348,7 @@ public class PetApi {
 
         public FindPetsByTagsOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -421,7 +421,7 @@ public class PetApi {
 
         public GetPetByIdOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -232,7 +232,7 @@ public class StoreApi {
 
         public GetOrderByIdOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -306,7 +306,7 @@ public class StoreApi {
         public PlaceOrderOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
             reqSpec.setContentType("*/*");
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured-jackson/src/main/java/org/openapitools/client/api/UserApi.java
@@ -375,7 +375,7 @@ public class UserApi {
 
         public GetUserByNameOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -449,7 +449,7 @@ public class UserApi {
 
         public LoginUserOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/rest-assured/api/openapi.yaml
+++ b/samples/client/petstore/java/rest-assured/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/PetApi.java
@@ -274,7 +274,7 @@ public class PetApi {
 
         public FindPetsByStatusOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -349,7 +349,7 @@ public class PetApi {
 
         public FindPetsByTagsOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -422,7 +422,7 @@ public class PetApi {
 
         public GetPetByIdOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/StoreApi.java
@@ -233,7 +233,7 @@ public class StoreApi {
 
         public GetOrderByIdOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -307,7 +307,7 @@ public class StoreApi {
         public PlaceOrderOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
             reqSpec.setContentType("*/*");
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
+++ b/samples/client/petstore/java/rest-assured/src/main/java/org/openapitools/client/api/UserApi.java
@@ -376,7 +376,7 @@ public class UserApi {
 
         public GetUserByNameOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 
@@ -450,7 +450,7 @@ public class UserApi {
 
         public LoginUserOper(RequestSpecBuilder reqSpec) {
             this.reqSpec = reqSpec;
-            reqSpec.setAccept("application/json,application/xml");
+            reqSpec.setAccept("application/json");
             this.respSpec = new ResponseSpecBuilder();
         }
 

--- a/samples/client/petstore/java/resteasy/api/openapi.yaml
+++ b/samples/client/petstore/java/resteasy/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/resttemplate-jakarta/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-jakarta/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/resttemplate-swagger1/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-swagger1/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/resttemplate-swagger2/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-swagger2/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate-withXml/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/resttemplate/api/openapi.yaml
+++ b/samples/client/petstore/java/resttemplate/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2-play26/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/retrofit2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx2/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
+++ b/samples/client/petstore/java/retrofit2rx3/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/vertx-no-nullable/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx-no-nullable/api/openapi.yaml
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -172,7 +172,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       operationId: deletePet
@@ -235,7 +235,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       operationId: updatePetWithForm
       parameters:
@@ -344,7 +344,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -401,7 +401,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -510,7 +510,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       operationId: logoutUser
@@ -572,7 +572,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/vertx/api/openapi.yaml
+++ b/samples/client/petstore/java/vertx/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/webclient-jakarta/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient-jakarta/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/webclient-swagger2/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient-swagger2/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/java/webclient/api/openapi.yaml
+++ b/samples/client/petstore/java/webclient/api/openapi.yaml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -126,7 +127,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -164,7 +165,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -201,7 +202,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -155,7 +156,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-deprecated/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -185,7 +186,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -218,7 +219,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/PetApi.java
@@ -56,7 +56,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -127,7 +127,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -165,7 +165,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -200,7 +200,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -242,7 +242,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/StoreApi.java
@@ -111,7 +111,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -141,7 +141,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud-feign-without-url/src/main/java/org/openapitools/api/UserApi.java
@@ -173,7 +173,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -204,7 +204,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/PetController.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/PetController.java
@@ -124,7 +124,7 @@ public interface PetController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -164,7 +164,7 @@ public interface PetController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -200,7 +200,7 @@ public interface PetController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/StoreController.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/StoreController.java
@@ -111,7 +111,7 @@ public interface StoreController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -140,7 +140,7 @@ public interface StoreController {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> placeOrder(

--- a/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/UserController.java
+++ b/samples/client/petstore/spring-cloud-tags/src/main/java/org/openapitools/api/UserController.java
@@ -155,7 +155,7 @@ public interface UserController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -185,7 +185,7 @@ public interface UserController {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -56,7 +56,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -127,7 +127,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -165,7 +165,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -200,7 +200,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -242,7 +242,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -111,7 +111,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -141,7 +141,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -173,7 +173,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -204,7 +204,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/PetApi.java
@@ -77,7 +77,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/findByStatus",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<Flux<Pet>>> findPetsByStatus(
          @RequestParam(value = "status", required = true) List<String> status
@@ -97,7 +97,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/findByTags",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<Flux<Pet>>> findPetsByTags(
          @RequestParam(value = "tags", required = true) Set<String> tags
@@ -116,7 +116,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/{petId}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<Pet>> getPetById(
          @PathVariable("petId") Long petId

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/StoreApi.java
@@ -71,7 +71,7 @@ public interface StoreApi {
     @HttpExchange(
         method = "GET",
         value = "/store/order/{order_id}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<Order>> getOrderById(
          @PathVariable("order_id") Long orderId
@@ -89,7 +89,7 @@ public interface StoreApi {
     @HttpExchange(
         method = "POST",
         value = "/store/order",
-        accept = "application/json,application/xml",
+        accept = "application/json",
         contentType = "application/json"
     )
     Mono<ResponseEntity<Order>> placeOrder(

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/api/UserApi.java
@@ -109,7 +109,7 @@ public interface UserApi {
     @HttpExchange(
         method = "GET",
         value = "/user/{username}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<User>> getUserByName(
          @PathVariable("username") String username
@@ -128,7 +128,7 @@ public interface UserApi {
     @HttpExchange(
         method = "GET",
         value = "/user/login",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     Mono<ResponseEntity<String>> loginUser(
          @RequestParam(value = "username", required = true) String username,

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/PetApi.java
@@ -73,7 +73,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/findByStatus",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<List<PetDto>> findPetsByStatus(
          @RequestParam(value = "status", required = true) List<String> status
@@ -93,7 +93,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/findByTags",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<Set<PetDto>> findPetsByTags(
          @RequestParam(value = "tags", required = true) Set<String> tags
@@ -112,7 +112,7 @@ public interface PetApi {
     @HttpExchange(
         method = "GET",
         value = "/pet/{petId}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<PetDto> getPetById(
          @PathVariable("petId") Long petId

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/StoreApi.java
@@ -67,7 +67,7 @@ public interface StoreApi {
     @HttpExchange(
         method = "GET",
         value = "/store/order/{order_id}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<OrderDto> getOrderById(
          @PathVariable("order_id") Long orderId
@@ -85,7 +85,7 @@ public interface StoreApi {
     @HttpExchange(
         method = "POST",
         value = "/store/order",
-        accept = "application/json,application/xml",
+        accept = "application/json",
         contentType = "application/json"
     )
     ResponseEntity<OrderDto> placeOrder(

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/api/UserApi.java
@@ -105,7 +105,7 @@ public interface UserApi {
     @HttpExchange(
         method = "GET",
         value = "/user/{username}",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<UserDto> getUserByName(
          @PathVariable("username") String username
@@ -124,7 +124,7 @@ public interface UserApi {
     @HttpExchange(
         method = "GET",
         value = "/user/login",
-        accept = "application/json,application/xml"
+        accept = "application/json"
     )
     ResponseEntity<String> loginUser(
          @RequestParam(value = "username", required = true) String username,

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/api/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/api/openapi.yaml
@@ -140,7 +140,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -182,7 +182,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -247,7 +247,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -360,7 +360,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -417,7 +417,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -516,7 +516,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/ArrayTest.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/ArrayTest.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **array_of_string** | **List[str]** |  | [optional] 
-**array_of_nullable_float** | **List[Optional[float]]** |  | [optional] 
+**array_of_nullable_float** | **List[float]** |  | [optional] 
 **array_array_of_integer** | **List[List[int]]** |  | [optional] 
 **array_array_of_model** | **List[List[ReadOnlyFirst]]** |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/NullableClass.md
@@ -13,11 +13,11 @@ Name | Type | Description | Notes
 **date_prop** | **date** |  | [optional] 
 **datetime_prop** | **datetime** |  | [optional] 
 **array_nullable_prop** | **List[object]** |  | [optional] 
-**array_and_items_nullable_prop** | **List[Optional[object]]** |  | [optional] 
-**array_items_nullable** | **List[Optional[object]]** |  | [optional] 
+**array_and_items_nullable_prop** | **List[object]** |  | [optional] 
+**array_items_nullable** | **List[object]** |  | [optional] 
 **object_nullable_prop** | **Dict[str, object]** |  | [optional] 
-**object_and_items_nullable_prop** | **Dict[str, Optional[object]]** |  | [optional] 
-**object_items_nullable** | **Dict[str, Optional[object]]** |  | [optional] 
+**object_and_items_nullable_prop** | **Dict[str, object]** |  | [optional] 
+**object_items_nullable** | **Dict[str, object]** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/array_test.py
@@ -29,7 +29,7 @@ class ArrayTest(BaseModel):
     ArrayTest
     """ # noqa: E501
     array_of_string: Optional[Annotated[List[StrictStr], Field(min_length=0, max_length=3)]] = None
-    array_of_nullable_float: Optional[List[Optional[float]]] = None
+    array_of_nullable_float: Optional[List[float]] = None
     array_array_of_integer: Optional[List[List[StrictInt]]] = None
     array_array_of_model: Optional[List[List[ReadOnlyFirst]]] = None
     __properties: ClassVar[List[str]] = ["array_of_string", "array_of_nullable_float", "array_array_of_integer", "array_array_of_model"]

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/nullable_class.py
@@ -35,11 +35,11 @@ class NullableClass(BaseModel):
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
     array_nullable_prop: Optional[List[Dict[str, Any]]] = None
-    array_and_items_nullable_prop: Optional[List[Optional[Dict[str, Any]]]] = None
-    array_items_nullable: Optional[List[Optional[Dict[str, Any]]]] = None
+    array_and_items_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_items_nullable: Optional[List[Dict[str, Any]]] = None
     object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Optional[Dict[str, Any]]]] = None
-    object_items_nullable: Optional[Dict[str, Optional[Dict[str, Any]]]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 

--- a/samples/openapi3/client/petstore/python/docs/ArrayTest.md
+++ b/samples/openapi3/client/petstore/python/docs/ArrayTest.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **array_of_string** | **List[str]** |  | [optional] 
-**array_of_nullable_float** | **List[Optional[float]]** |  | [optional] 
+**array_of_nullable_float** | **List[float]** |  | [optional] 
 **array_array_of_integer** | **List[List[int]]** |  | [optional] 
 **array_array_of_model** | **List[List[ReadOnlyFirst]]** |  | [optional] 
 

--- a/samples/openapi3/client/petstore/python/docs/NullableClass.md
+++ b/samples/openapi3/client/petstore/python/docs/NullableClass.md
@@ -13,11 +13,11 @@ Name | Type | Description | Notes
 **date_prop** | **date** |  | [optional] 
 **datetime_prop** | **datetime** |  | [optional] 
 **array_nullable_prop** | **List[object]** |  | [optional] 
-**array_and_items_nullable_prop** | **List[Optional[object]]** |  | [optional] 
-**array_items_nullable** | **List[Optional[object]]** |  | [optional] 
+**array_and_items_nullable_prop** | **List[object]** |  | [optional] 
+**array_items_nullable** | **List[object]** |  | [optional] 
 **object_nullable_prop** | **Dict[str, object]** |  | [optional] 
-**object_and_items_nullable_prop** | **Dict[str, Optional[object]]** |  | [optional] 
-**object_items_nullable** | **Dict[str, Optional[object]]** |  | [optional] 
+**object_and_items_nullable_prop** | **Dict[str, object]** |  | [optional] 
+**object_items_nullable** | **Dict[str, object]** |  | [optional] 
 
 ## Example
 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/array_test.py
@@ -29,7 +29,7 @@ class ArrayTest(BaseModel):
     ArrayTest
     """ # noqa: E501
     array_of_string: Optional[Annotated[List[StrictStr], Field(min_length=0, max_length=3)]] = None
-    array_of_nullable_float: Optional[List[Optional[StrictFloat]]] = None
+    array_of_nullable_float: Optional[List[StrictFloat]] = None
     array_array_of_integer: Optional[List[List[StrictInt]]] = None
     array_array_of_model: Optional[List[List[ReadOnlyFirst]]] = None
     additional_properties: Dict[str, Any] = {}

--- a/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/nullable_class.py
@@ -35,11 +35,11 @@ class NullableClass(BaseModel):
     date_prop: Optional[date] = None
     datetime_prop: Optional[datetime] = None
     array_nullable_prop: Optional[List[Dict[str, Any]]] = None
-    array_and_items_nullable_prop: Optional[List[Optional[Dict[str, Any]]]] = None
-    array_items_nullable: Optional[List[Optional[Dict[str, Any]]]] = None
+    array_and_items_nullable_prop: Optional[List[Dict[str, Any]]] = None
+    array_items_nullable: Optional[List[Dict[str, Any]]] = None
     object_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
-    object_and_items_nullable_prop: Optional[Dict[str, Optional[Dict[str, Any]]]] = None
-    object_items_nullable: Optional[Dict[str, Optional[Dict[str, Any]]]] = None
+    object_and_items_nullable_prop: Optional[Dict[str, Dict[str, Any]]] = None
+    object_items_nullable: Optional[Dict[str, Dict[str, Any]]] = None
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["required_integer_prop", "integer_prop", "number_prop", "boolean_prop", "string_prop", "date_prop", "datetime_prop", "array_nullable_prop", "array_and_items_nullable_prop", "array_items_nullable", "object_nullable_prop", "object_and_items_nullable_prop", "object_items_nullable"]
 

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/PetApi.java
@@ -37,7 +37,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -76,7 +76,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -97,7 +97,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -117,7 +117,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -140,7 +140,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/StoreApi.java
@@ -73,7 +73,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -92,7 +92,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3-with-optional/src/main/java/org/openapitools/api/UserApi.java
@@ -110,7 +110,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -130,7 +130,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -65,7 +66,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -132,7 +133,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -170,7 +171,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -207,7 +208,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -249,7 +250,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -155,7 +156,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-3/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -185,7 +186,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -218,7 +219,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -66,7 +67,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -133,7 +134,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<List<Pet>>> findPetsByStatus(
@@ -171,7 +172,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<List<Pet>>> findPetsByTags(
@@ -208,7 +209,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<Pet>> getPetById(
@@ -250,7 +251,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -124,7 +125,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<Order>> getOrderById(
@@ -156,7 +157,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-async/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -186,7 +187,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<User>> getUserByName(
@@ -219,7 +220,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     CompletableFuture<ResponseEntity<String>> loginUser(

--- a/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/api/DefaultApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-date-time/src/main/java/org/openapitools/api/DefaultApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-http-basic/src/main/java/org/openapitools/api/PetApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -64,7 +65,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeApi.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -132,7 +133,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -170,7 +171,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Set<Pet>> findPetsByTags(
@@ -207,7 +208,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{order_id}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -155,7 +156,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -173,7 +174,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -206,7 +207,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/PetApi.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -124,7 +125,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -163,7 +164,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -201,7 +202,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -153,7 +154,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> placeOrder(

--- a/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud-spring-pageable/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -164,7 +165,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -195,7 +196,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -65,7 +66,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -132,7 +133,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -170,7 +171,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -207,7 +208,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -249,7 +250,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -155,7 +156,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-cloud/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -185,7 +186,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -218,7 +219,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -65,7 +66,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -132,7 +133,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByStatus(
@@ -170,7 +171,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<List<Pet>> findPetsByTags(
@@ -207,7 +208,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Pet> getPetById(
@@ -249,7 +250,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -123,7 +124,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<Order> getOrderById(
@@ -155,7 +156,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs-skip-default-interface/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -185,7 +186,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<User> getUserByName(
@@ -218,7 +219,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     ResponseEntity<String> loginUser(

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -69,7 +70,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     
@@ -156,7 +157,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByStatus",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<List<Pet>> findPetsByStatus(
@@ -211,7 +212,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/findByTags",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<List<Pet>> findPetsByTags(
@@ -265,7 +266,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/pet/{petId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<Pet> getPetById(
@@ -324,7 +325,7 @@ public interface PetApi {
     @RequestMapping(
         method = RequestMethod.PUT,
         value = "/pet",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -133,7 +134,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/store/order/{orderId}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<Order> getOrderById(
@@ -182,7 +183,7 @@ public interface StoreApi {
     @RequestMapping(
         method = RequestMethod.POST,
         value = "/store/order",
-        produces = "application/json,application/xml",
+        produces = "application/json",
         consumes = "application/json"
     )
     

--- a/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/client/petstore/spring-stubs/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -201,7 +202,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/{username}",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<User> getUserByName(
@@ -251,7 +252,7 @@ public interface UserApi {
     @RequestMapping(
         method = RequestMethod.GET,
         value = "/user/login",
-        produces = "application/json,application/xml"
+        produces = "application/json"
     )
     
     default ResponseEntity<String> loginUser(

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/BarApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/api/FooApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/spring-boot-springdoc/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-3/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-3/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeApi.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/PetApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeApi.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/PetApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot-source/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/PetApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/openapi3/server/petstore/springboot/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/openapi3/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/java-helidon-server/mp/src/main/resources/META-INF/openapi.yml
+++ b/samples/server/petstore/java-helidon-server/mp/src/main/resources/META-INF/openapi.yml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/server/petstore/java-helidon-server/se/src/main/resources/META-INF/openapi.yml
+++ b/samples/server/petstore/java-helidon-server/se/src/main/resources/META-INF/openapi.yml
@@ -158,7 +158,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -203,7 +203,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -271,7 +271,7 @@ paths:
       tags:
       - pet
       x-webclient-blocking: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -387,7 +387,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{order_id}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -444,7 +444,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -543,7 +543,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -606,7 +606,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/server/petstore/java-play-framework-api-package-override/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-api-package-override/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-async/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-async/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-controller-only/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-controller-only/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-fake-endpoints-with-security/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints-with-security/public/openapi.json
@@ -148,7 +148,7 @@
         },
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     }
   },

--- a/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-fake-endpoints/public/openapi.json
@@ -159,7 +159,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -216,7 +216,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -298,7 +298,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -446,7 +446,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{order_id}" : {
@@ -518,7 +518,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -668,7 +668,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -750,7 +750,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-no-bean-validation/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-no-bean-validation/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-no-exception-handling/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-no-exception-handling/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-no-interface/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-no-interface/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-no-nullable/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-no-nullable/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework-no-wrap-calls/public/openapi.json
+++ b/samples/server/petstore/java-play-framework-no-wrap-calls/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-play-framework/public/openapi.json
+++ b/samples/server/petstore/java-play-framework/public/openapi.json
@@ -151,7 +151,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -205,7 +205,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -283,7 +283,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "operationId" : "updatePetWithForm",
@@ -431,7 +431,7 @@
         "tags" : [ "store" ],
         "x-codegen-request-body-name" : "body",
         "x-content-type" : "*/*",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -503,7 +503,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -653,7 +653,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -735,7 +735,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-undertow/src/main/resources/config/openapi.json
+++ b/samples/server/petstore/java-undertow/src/main/resources/config/openapi.json
@@ -60,7 +60,7 @@
         "summary" : "Add a new pet to the store",
         "tags" : [ "pet" ],
         "x-content-type" : "application/json",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "",
@@ -104,7 +104,7 @@
         "summary" : "Update an existing pet",
         "tags" : [ "pet" ],
         "x-content-type" : "application/json",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByStatus" : {
@@ -159,7 +159,7 @@
         } ],
         "summary" : "Finds Pets by status",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/findByTags" : {
@@ -212,7 +212,7 @@
         } ],
         "summary" : "Finds Pets by tags",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/pet/{petId}" : {
@@ -295,7 +295,7 @@
         } ],
         "summary" : "Find pet by ID",
         "tags" : [ "pet" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "post" : {
         "description" : "",
@@ -447,7 +447,7 @@
         "summary" : "Place an order for a pet",
         "tags" : [ "store" ],
         "x-content-type" : "application/json",
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/store/order/{orderId}" : {
@@ -519,7 +519,7 @@
         },
         "summary" : "Find purchase order by ID",
         "tags" : [ "store" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user" : {
@@ -670,7 +670,7 @@
         },
         "summary" : "Logs user into the system",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       }
     },
     "/user/logout" : {
@@ -759,7 +759,7 @@
         },
         "summary" : "Get user by user name",
         "tags" : [ "user" ],
-        "x-accepts" : "application/json,application/xml"
+        "x-accepts" : "application/json"
       },
       "put" : {
         "description" : "This can only be done by the logged in user.",

--- a/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/java-vertx-web/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: ""
       externalDocs:
@@ -79,7 +79,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByStatus:
     get:
       description: Multiple status values can be provided with comma separated strings
@@ -123,7 +123,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/findByTags:
     get:
       deprecated: true
@@ -163,7 +163,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /pet/{petId}:
     delete:
       description: ""
@@ -228,7 +228,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     post:
       description: ""
       operationId: updatePetWithForm
@@ -341,7 +341,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /store/order/{orderId}:
     delete:
       description: For valid response try integer IDs with value < 1000. Anything
@@ -398,7 +398,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user:
     post:
       description: This can only be done by the logged in user.
@@ -512,7 +512,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
   /user/logout:
     get:
       description: ""
@@ -579,7 +579,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
     put:
       description: This can only be done by the logged in user.
       operationId: updateUser

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/main/openapi/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -245,7 +245,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -362,7 +362,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -423,7 +423,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -540,7 +540,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -608,7 +608,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-interface/src/main/openapi/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -245,7 +245,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -362,7 +362,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -423,7 +423,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -540,7 +540,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -608,7 +608,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/main/openapi/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -245,7 +245,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -362,7 +362,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -423,7 +423,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -540,7 +540,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -608,7 +608,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/main/resources/META-INF/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/main/resources/META-INF/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -245,7 +245,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -362,7 +362,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -423,7 +423,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -540,7 +540,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -608,7 +608,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
+++ b/samples/server/petstore/jaxrs-spec/src/main/openapi/openapi.yaml
@@ -131,7 +131,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -178,7 +178,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -245,7 +245,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -362,7 +362,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -423,7 +423,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -540,7 +540,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -608,7 +608,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/AnotherFakeApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeApi.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/PetApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/NullableApi.java
+++ b/samples/server/petstore/spring-boot-nullable-set/src/main/java/org/openapitools/api/NullableApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-delegate-no-response-entity/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate-no-response-entity/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-delegate/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders-annotationLibrary/src/main/resources/openapi.yaml
@@ -46,7 +46,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     put:
@@ -81,7 +81,7 @@ paths:
       tags:
       - pet
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByStatus:
@@ -127,7 +127,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -169,7 +169,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -238,7 +238,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -359,7 +359,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{orderId}:
@@ -420,7 +420,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -542,7 +542,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -615,7 +615,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-reactive/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/resources/openapi.yaml
@@ -132,7 +132,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/all:
@@ -163,7 +163,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -208,7 +208,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -282,7 +282,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -403,7 +403,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -468,7 +468,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -593,7 +593,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -665,7 +665,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/resources/openapi.yaml
@@ -132,7 +132,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/all:
@@ -163,7 +163,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -208,7 +208,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -282,7 +282,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -403,7 +403,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -468,7 +468,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -593,7 +593,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -665,7 +665,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/resources/openapi.yaml
@@ -132,7 +132,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/all:
@@ -163,7 +163,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -208,7 +208,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -282,7 +282,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -403,7 +403,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -468,7 +468,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -593,7 +593,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -665,7 +665,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-spring-pageable/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/resources/openapi.yaml
@@ -132,7 +132,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/all:
@@ -163,7 +163,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -208,7 +208,7 @@ paths:
       tags:
       - pet
       x-spring-paginated: true
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -282,7 +282,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -403,7 +403,7 @@ paths:
       - store
       x-codegen-request-body-name: body
       x-content-type: '*/*'
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -468,7 +468,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -593,7 +593,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -665,7 +665,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/springboot-spring-provide-args/src/main/java/org/openapitools/api/UserApi.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-useoptional/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/AnotherFakeApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeApi.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/FakeClassnameTestApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/PetApi.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/StoreApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/api/UserApi.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.virtualan.annotation.ApiVirtual;
 import io.virtualan.annotation.VirtualService;
 import org.springframework.http.HttpStatus;

--- a/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot-virtualan/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:

--- a/samples/server/petstore/springboot/src/main/resources/openapi.yaml
+++ b/samples/server/petstore/springboot/src/main/resources/openapi.yaml
@@ -108,7 +108,7 @@ paths:
       summary: Finds Pets by status
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/findByTags:
@@ -154,7 +154,7 @@ paths:
       summary: Finds Pets by tags
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
   /pet/{petId}:
@@ -225,7 +225,7 @@ paths:
       summary: Find pet by ID
       tags:
       - pet
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: pet
     post:
@@ -346,7 +346,7 @@ paths:
       tags:
       - store
       x-content-type: application/json
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /store/order/{order_id}:
@@ -407,7 +407,7 @@ paths:
       summary: Find purchase order by ID
       tags:
       - store
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: store
   /user:
@@ -514,7 +514,7 @@ paths:
       summary: Logs user into the system
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
   /user/logout:
@@ -583,7 +583,7 @@ paths:
       summary: Get user by user name
       tags:
       - user
-      x-accepts: "application/json,application/xml"
+      x-accepts: application/json
       x-tags:
       - tag: user
     put:


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

# Addition of API response examples to the core generator + Spring's `api.mustache` generates response examples  

This PR closes issues #17610 and #16051

## Reasons for creating this PR

Having response examples results in a more detailed and understandable API documentation, which covers all possible variations of the same response codes. For more details refer to the [issue](https://github.com/OpenAPITools/openapi-generator/issues/17610). This is particularly useful for integrating the front-end with the back-end. Having those corner cases and exact response examples covered in the documentation allows for a clear way of handling things on the front-end side.

## What was done

NOTE: There are 2 commits in this PR: the feature changes in the code itself and the sample updates. Due to the fact that updating samples introduced 208 file changes _(I suppose some PRs merged before opening this one did not run the update samples script_), please refer to the [feature commit](https://github.com/OpenAPITools/openapi-generator/commit/cb514a9c0e811a4b2a79590dd7b56eebb75ade33) to view only the code changes made to the generator, since viewing the whole diff of this PR just introduces too many changes because of sample updates.

### Changes introduced with the feature request:

#### 1. [Changes to the `DefaultCodegen` class.](https://github.com/OpenAPITools/openapi-generator/commit/cb514a9c0e811a4b2a79590dd7b56eebb75ade33#diff-3a138675e8cb40943bcb00feb46edd6f6ee5c5306c29cc19f02c845a299c8658R4920-R4926)

Response examples are retrieved from the [`ApiResponse`](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java) object and put into [`CodegenResponseObject`](https://github.com/OpenAPITools/openapi-generator/blob/64c763b87ac839e3bd6a4017a743197e2e6ab701/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenResponse.java#L32) if they are present. If examples are also links ($ref) they are dereferenced/unaliased. This is done with an [`ExampleUtils`](https://github.com/OpenAPITools/openapi-generator/commit/cb514a9c0e811a4b2a79590dd7b56eebb75ade33#diff-fafd68e157413c6679d4e7deb7bc8582f4e176b64ecd4c73ae4e10f457601e3f) file i have created. 

#### 2. Creation of [`ExampleUtils`](https://github.com/OpenAPITools/openapi-generator/commit/cb514a9c0e811a4b2a79590dd7b56eebb75ade33#diff-fafd68e157413c6679d4e7deb7bc8582f4e176b64ecd4c73ae4e10f457601e3f) class 

This class has been heavily inspired by an already existing [`ModelUtils`](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java)

The main purpose of this class is:
- retrieve [`Example`](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java) objects from the `ApiReponse` class
- unalias examples (resolve references to actual objects if they are present) 

#### 3. [Adjust Spring's `api.mutache`](https://github.com/OpenAPITools/openapi-generator/commit/cb514a9c0e811a4b2a79590dd7b56eebb75ade33#diff-5cdb43ab5b2469625bc1f47813b6d826768bd48576091fd0ffb7f85c1080c254) file to generate `@ExampleObject` swagger annotations with example content

After adding response examples in the DefaultCodegen, we can utilize that in templates. I primarily use spring generator so added to the template file to be able to generate examples if they are present.

As a result, `@ExamplesObject` swagger annotations will be generated:

![image](https://github.com/OpenAPITools/openapi-generator/assets/74022878/1cd448a3-e0c4-41ee-bfe3-a0a89bd10742)

#### 4. Test case to cover annotation generation 

Also made a little test that recursively checks to see if the `@ExampleObject` annotation is present in the generated Api class. 
The openapi spec resource for the test is this. 


## Result

![image](https://github.com/OpenAPITools/openapi-generator/assets/74022878/f8bfdec3-b112-4c42-a14c-fbfd8edbe737)

## Referencing technical committee

Since this PR includes both a core generator aspect as well as a spring aspect, I hope it is appropriate to mention the spring committee team here:

@cachescrubber, @welshm, @MelleD,  @atextor, @manedev79, @javisst, @borsch, @banlevente, @Zomzog, @martin-mfg 


## Final notes

Please feel free to leave your feedback about the changes and correct me on some things if I am wrong. If this PR ends up getting merged, would also love to see other generators take advantage of response examples : ) 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ```
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files.
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master.
  These must match the expectations made by your contribution.
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`.
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.