### PR TITLE
support binary response for R api client

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -38,6 +38,23 @@ ApiResponse <- R6::R6Class(
       self$status_code <- status_code
       self$status_code_desc <- status_code_desc
       self$headers <- headers
+    },
+
+    #' Return the response as text
+    #'
+    #' @description
+    #' The response is stored as a raw vector. Use this to access the response after
+    #' converting it to text. If the response is not coercible to text NA is returned.
+    #'
+    #' @param from_encoding The encoding of the raw response.
+    #' @param to_encoding The target encoding of the return value.
+    #' @export
+    response_as_text = function(from_encoding = NULL, to_encoding = "UTF-8") {
+      text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
+      if (is.na(text_response)) {
+        warning("The response is binary and will not be converted to text.")
+      }
+      return(text_response)
     }
   )
 )

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -637,7 +637,7 @@
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "{{returnType}}", loadNamespace("{{packageName}}")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "{{returnType}}", loadNamespace("{{packageName}}")),
           error = function(e) {
             {{#useDefaultExceptionHandling}}
             stop("Failed to deserialize response")

--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -335,11 +335,7 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
-      if (is.na(text_response)) {
-        message("The response is binary and will not be converted to text.")
-      }
-      resp_obj <- jsonlite::fromJSON(text_response)
+      resp_obj <- jsonlite::fromJSON(raw_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -318,7 +318,7 @@ ApiClient <- R6::R6Class(
         api_response <- ApiResponse$new()
         api_response$status_code <- httr::status_code(httr_response) 
         api_response$status_code_desc <- httr::http_status(httr_response)$reason
-        api_response$response <- httr::content(httr_response, "text", encoding = "UTF-8")
+        api_response$response <- httr::content(httr_response, "raw")
         api_response$headers <- httr::headers(httr_response)
 
         api_response
@@ -335,7 +335,11 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
+      if (is.na(text_response)) {
+        message("The response is binary and will not be converted to text.")
+      }
+      resp_obj <- jsonlite::fromJSON(text_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -340,11 +340,7 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
-      if (is.na(text_response)) {
-        message("The response is binary and will not be converted to text.")
-      }
-      resp_obj <- jsonlite::fromJSON(text_response)
+      resp_obj <- jsonlite::fromJSON(raw_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -323,7 +323,7 @@ ApiClient  <- R6::R6Class(
         api_response <- ApiResponse$new()
         api_response$status_code <- resp %>% resp_status()
         api_response$status_code_desc <- resp %>% resp_status_desc()
-        api_response$response <- resp %>% resp_body_string()
+        api_response$response <- resp %>% resp_body_raw()
         api_response$headers <- resp %>% resp_headers()
 
         api_response
@@ -340,7 +340,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
+      if (is.na(text_response)) {
+        message("The response is binary and will not be converted to text.")
+      }
+      resp_obj <- jsonlite::fromJSON(text_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -329,11 +329,7 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
-      if (is.na(text_response)) {
-        message("The response is binary and will not be converted to text.")
-      }
-      resp_obj <- jsonlite::fromJSON(text_response)
+      resp_obj <- jsonlite::fromJSON(raw_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -312,7 +312,7 @@ ApiClient  <- R6::R6Class(
         api_response <- ApiResponse$new()
         api_response$status_code <- resp %>% resp_status()
         api_response$status_code_desc <- resp %>% resp_status_desc()
-        api_response$response <- resp %>% resp_body_string()
+        api_response$response <- resp %>% resp_body_raw()
         api_response$headers <- resp %>% resp_headers()
 
         api_response
@@ -329,7 +329,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
+      if (is.na(text_response)) {
+        message("The response is binary and will not be converted to text.")
+      }
+      resp_obj <- jsonlite::fromJSON(text_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -44,6 +44,23 @@ ApiResponse <- R6::R6Class(
       self$status_code <- status_code
       self$status_code_desc <- status_code_desc
       self$headers <- headers
+    },
+
+    #' Return the response as text
+    #'
+    #' @description
+    #' The response is stored as a raw vector. Use this to access the response after
+    #' converting it to text. If the response is not coercible to text NA is returned.
+    #'
+    #' @param from_encoding The encoding of the raw response.
+    #' @param to_encoding The target encoding of the return value.
+    #' @export
+    response_as_text = function(from_encoding = NULL, to_encoding = "UTF-8") {
+      text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
+      if (is.na(text_response)) {
+        warning("The response is binary and will not be converted to text.")
+      }
+      return(text_response)
     }
   )
 )

--- a/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/fake_api.R
@@ -365,7 +365,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -485,7 +485,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -746,7 +746,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -984,7 +984,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1100,7 +1100,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1221,7 +1221,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1353,7 +1353,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1483,7 +1483,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1605,7 +1605,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1843,7 +1843,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "ModelApiResponse", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2-wrapper/R/store_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/store_api.R
@@ -438,7 +438,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "map(integer)", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -567,7 +567,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -686,7 +686,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2-wrapper/R/user_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/user_api.R
@@ -970,7 +970,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1103,7 +1103,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "character", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -329,11 +329,7 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
-      if (is.na(text_response)) {
-        message("The response is binary and will not be converted to text.")
-      }
-      resp_obj <- jsonlite::fromJSON(text_response)
+      resp_obj <- jsonlite::fromJSON(raw_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -312,7 +312,7 @@ ApiClient  <- R6::R6Class(
         api_response <- ApiResponse$new()
         api_response$status_code <- resp %>% resp_status()
         api_response$status_code_desc <- resp %>% resp_status_desc()
-        api_response$response <- resp %>% resp_body_string()
+        api_response$response <- resp %>% resp_body_raw()
         api_response$headers <- resp %>% resp_headers()
 
         api_response
@@ -329,7 +329,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
+      if (is.na(text_response)) {
+        message("The response is binary and will not be converted to text.")
+      }
+      resp_obj <- jsonlite::fromJSON(text_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -44,6 +44,23 @@ ApiResponse <- R6::R6Class(
       self$status_code <- status_code
       self$status_code_desc <- status_code_desc
       self$headers <- headers
+    },
+
+    #' Return the response as text
+    #'
+    #' @description
+    #' The response is stored as a raw vector. Use this to access the response after
+    #' converting it to text. If the response is not coercible to text NA is returned.
+    #'
+    #' @param from_encoding The encoding of the raw response.
+    #' @param to_encoding The target encoding of the return value.
+    #' @export
+    response_as_text = function(from_encoding = NULL, to_encoding = "UTF-8") {
+      text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
+      if (is.na(text_response)) {
+        warning("The response is binary and will not be converted to text.")
+      }
+      return(text_response)
     }
   )
 )

--- a/samples/client/petstore/R-httr2/R/fake_api.R
+++ b/samples/client/petstore/R-httr2/R/fake_api.R
@@ -365,7 +365,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -485,7 +485,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -746,7 +746,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -984,7 +984,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1100,7 +1100,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1221,7 +1221,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1353,7 +1353,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1483,7 +1483,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1605,7 +1605,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1843,7 +1843,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "ModelApiResponse", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2/R/store_api.R
+++ b/samples/client/petstore/R-httr2/R/store_api.R
@@ -438,7 +438,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "map(integer)", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -567,7 +567,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -686,7 +686,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R-httr2/R/user_api.R
+++ b/samples/client/petstore/R-httr2/R/user_api.R
@@ -970,7 +970,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1103,7 +1103,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "character", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -299,7 +299,7 @@ ApiClient <- R6::R6Class(
         api_response <- ApiResponse$new()
         api_response$status_code <- httr::status_code(httr_response) 
         api_response$status_code_desc <- httr::http_status(httr_response)$reason
-        api_response$response <- httr::content(httr_response, "text", encoding = "UTF-8")
+        api_response$response <- httr::content(httr_response, "raw")
         api_response$headers <- httr::headers(httr_response)
 
         api_response
@@ -316,7 +316,11 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
+      if (is.na(text_response)) {
+        message("The response is binary and will not be converted to text.")
+      }
+      resp_obj <- jsonlite::fromJSON(text_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -316,11 +316,7 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      text_response <- iconv(readBin(raw_response, character()), from = NULL, to = "UTF-8")
-      if (is.na(text_response)) {
-        message("The response is binary and will not be converted to text.")
-      }
-      resp_obj <- jsonlite::fromJSON(text_response)
+      resp_obj <- jsonlite::fromJSON(raw_response)
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -44,6 +44,23 @@ ApiResponse <- R6::R6Class(
       self$status_code <- status_code
       self$status_code_desc <- status_code_desc
       self$headers <- headers
+    },
+
+    #' Return the response as text
+    #'
+    #' @description
+    #' The response is stored as a raw vector. Use this to access the response after
+    #' converting it to text. If the response is not coercible to text NA is returned.
+    #'
+    #' @param from_encoding The encoding of the raw response.
+    #' @param to_encoding The target encoding of the return value.
+    #' @export
+    response_as_text = function(from_encoding = NULL, to_encoding = "UTF-8") {
+      text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
+      if (is.na(text_response)) {
+        warning("The response is binary and will not be converted to text.")
+      }
+      return(text_response)
     }
   )
 )

--- a/samples/client/petstore/R/R/fake_api.R
+++ b/samples/client/petstore/R/R/fake_api.R
@@ -365,7 +365,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -485,7 +485,7 @@ FakeApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R/R/pet_api.R
+++ b/samples/client/petstore/R/R/pet_api.R
@@ -746,7 +746,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -984,7 +984,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1100,7 +1100,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "array[Pet]", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "array[Pet]", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1221,7 +1221,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1353,7 +1353,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1483,7 +1483,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1605,7 +1605,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Pet", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Pet", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1843,7 +1843,7 @@ PetApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "ModelApiResponse", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "ModelApiResponse", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R/R/store_api.R
+++ b/samples/client/petstore/R/R/store_api.R
@@ -438,7 +438,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "map(integer)", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "map(integer)", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -567,7 +567,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -686,7 +686,7 @@ StoreApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "Order", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "Order", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",

--- a/samples/client/petstore/R/R/user_api.R
+++ b/samples/client/petstore/R/R/user_api.R
@@ -970,7 +970,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "User", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "User", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",
@@ -1103,7 +1103,7 @@ UserApi <- R6::R6Class(
         }
 
         deserialized_resp_obj <- tryCatch(
-          self$api_client$deserialize(local_var_resp$response, "character", loadNamespace("petstore")),
+          self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("petstore")),
           error = function(e) {
             rlang::abort(message = "Failed to deserialize response",
                          .subclass = "ApiException",


### PR DESCRIPTION
@Ramanth  & @saigiridhar21 

There is currently no support in the generated R client for endpoints that return binary data which cannot be coerced to text. In the `self$Execute` method we have:

```r
    resp <- req %>% req_error(is_error = function(resp) FALSE) %>% 
      req_perform()
    api_response <- ApiResponse$new()
    api_response$status_code <- resp %>% resp_status()
    api_response$status_code_desc <- resp %>% resp_status_desc()
    api_response$response <- resp %>% resp_body_string()         ##### here
    api_response$headers <- resp %>% resp_headers()
    api_response
```

The `httr` implementation is similar. Both assume that the response content can be converted to a string. There are cases where the response is, for example, accepting `application/gzip` and returns a byte stream with content for a `tar.gz` file. This is not easily converted to text and both `httr` and `httr2` will return `NA` (correctly) when such a conversion is attempted.

This PR maintains existing behavior, while retaining the raw response so that non-text-returning endpoints can be used.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
