### PR TITLE
Modified to set to any type when additionalProperties is an Free-Form Object

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/modelGeneric.mustache
@@ -5,7 +5,7 @@
  */
 export interface {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{
 {{#additionalPropertiesType}}
-    [key: string]: {{{additionalPropertiesType}}}{{^additionalPropertiesIsAnyType}}{{#hasVars}} | any{{/hasVars}}{{/additionalPropertiesIsAnyType}};
+    [key: string]: {{#additionalProperties.isFreeFormObject}}any{{/additionalProperties.isFreeFormObject}}{{^additionalProperties.isFreeFormObject}}{{additionalPropertiesType}}{{^additionalPropertiesIsAnyType}}{{#hasVars}} | any{{/hasVars}}{{/additionalPropertiesIsAnyType}}{{/additionalProperties.isFreeFormObject}};
 
 {{/additionalPropertiesType}}
 {{#vars}}

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/api.ts
@@ -1043,7 +1043,7 @@ export interface Name {
  * @interface NullableClass
  */
 export interface NullableClass {
-    [key: string]: object;
+    [key: string]: any;
 
     /**
      * 

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/api.ts
@@ -811,7 +811,7 @@ export interface Name {
  * @interface NullableClass
  */
 export interface NullableClass {
-    [key: string]: object;
+    [key: string]: any;
 
     /**
      * 


### PR DESCRIPTION
Fixes: https://github.com/OpenAPITools/openapi-generator/issues/16494

Similar to the case when 'additionalProperties' is set to true(```additionalProperties: true```)), I think that when 'additionalProperties' is a Free-Form Object (```'additionalProperties: {}```), it would be better to set it to 'any' type."

This file too (samples/client/petstore/typescript-axios/builds/test-petstore/api.ts) has ```[key: string]: object;``` in it, which is causing a type error, but this issue will be resolved with the modifications in this PR.

I'm sorry, but when I was preparing to create a PR, I realized that there is already [an existing PR](https://github.com/OpenAPITools/openapi-generator/pull/17625) with a proposed fix. It seems our approaches to the solution differ, so if it turns out that my modifications are not needed, I will close my PR.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
