### PR TITLE
Include support to Mojolicious relaxed placeholders parsing path parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Javascript/libraries/javascript/ApiClient.mustache
@@ -160,7 +160,7 @@ class ApiClient {
             url = apiBasePath + path;
         }
 
-        url = url.replace(/\{([\w-\.]+)\}/g, (fullMatch, key) => {
+        url = url.replace(/\{([\w-\.#]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
                 value = this.paramToString(pathParams[key]);

--- a/samples/client/petstore/javascript-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-es6/src/ApiClient.js
@@ -159,7 +159,7 @@ class ApiClient {
             url = apiBasePath + path;
         }
 
-        url = url.replace(/\{([\w-\.]+)\}/g, (fullMatch, key) => {
+        url = url.replace(/\{([\w-\.#]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
                 value = this.paramToString(pathParams[key]);

--- a/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
+++ b/samples/client/petstore/javascript-promise-es6/src/ApiClient.js
@@ -159,7 +159,7 @@ class ApiClient {
             url = apiBasePath + path;
         }
 
-        url = url.replace(/\{([\w-\.]+)\}/g, (fullMatch, key) => {
+        url = url.replace(/\{([\w-\.#]+)\}/g, (fullMatch, key) => {
             var value;
             if (pathParams.hasOwnProperty(key)) {
                 value = this.paramToString(pathParams[key]);


### PR DESCRIPTION
This pull request introduces a crucial enhancement to the regex used for parsing path parameters. Specifically, a hashtag (#) has been included in the regex to support Mojolicious Relaxed placeholders. These placeholders utilize a hash prefix and match all characters except '/', akin to the regular expression ([^/]+).

https://docs.mojolicious.org/Mojolicious/Guides/Routing#Relaxed-placeholders
