### PR TITLE
Bugfix/7720 typescript fetch support is response optional

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -351,10 +351,24 @@ export class {{classname}} extends runtime.BaseAPI {
      {{/isDeprecated}}
      */
     {{^useSingleRequestParameter}}
-    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams}}{{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, {{/allParams}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }, {{/allParams.0}}initOverrides);
+        {{#isResponseOptional}}
+        switch (response.raw.status) {
+            {{#responses}}
+            {{#is2xx}}
+            case {{code}}:
+                return {{#dataType}}await response.value(){{/dataType}}{{^dataType}}null{{/dataType}};
+            {{/is2xx}}
+            {{/responses}}
+            default:
+                return await response.value();
+        }
+        {{/isResponseOptional}}
+        {{^isResponseOptional}}
         return await response.value();
+        {{/isResponseOptional}}
         {{/returnType}}
         {{^returnType}}
         await this.{{nickname}}Raw({{#allParams.0}}{ {{#allParams}}{{paramName}}: {{paramName}}{{^-last}}, {{/-last}}{{/allParams}} }, {{/allParams.0}}initOverrides);
@@ -362,10 +376,24 @@ export class {{classname}} extends runtime.BaseAPI {
     }
     {{/useSingleRequestParameter}}
     {{#useSingleRequestParameter}}
-    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{^returnType}}void{{/returnType}}> {
+    async {{nickname}}({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{^hasRequiredParams}} = {}{{/hasRequiredParams}}, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}> {
         {{#returnType}}
         const response = await this.{{nickname}}Raw({{#allParams.0}}requestParameters, {{/allParams.0}}initOverrides);
+        {{#isResponseOptional}}
+        switch (response.raw.status) {
+            {{#responses}}
+            {{#is2xx}}
+            case {{code}}:
+                return {{#dataType}}await response.value(){{/dataType}}{{^dataType}}null{{/dataType}};
+            {{/is2xx}}
+            {{/responses}}
+            default:
+                return await response.value();
+        }
+        {{/isResponseOptional}}
+        {{^isResponseOptional}}
         return await response.value();
+        {{/isResponseOptional}}
         {{/returnType}}
         {{^returnType}}
         await this.{{nickname}}Raw({{#allParams.0}}requestParameters, {{/allParams.0}}initOverrides);


### PR DESCRIPTION
This PR implements a couple of minor changes to the `apis.mustache` template used by the `typescript-fetch` generator to resolve issue #7720 by utilizing the `isResponseOptional` value.

First, I extend the response types for each non-raw method in the generated APIs to potentially be nullable / undefined when `isResponseOptional=true` by adding the following to each.

```
{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}
```

This results in 2 parts of the template with the following response definition template (useSingleRequestParameter true vs false)
```
: Promise<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}>
```

I've kept the Raw method as is, as the current implementation of the `runtime.ApiResponse<T>`'s `value(): Promise<T>` will throw an exception if called when response body is empty (at `await this.raw.json()` inside `runtime.mustache`). If this should be changed to handle this case more gracefully, this raw method could also be changed to have the following response type:
```
: Promise<runtime.ApiResponse<{{{returnType}}}{{#returnType}}{{#isResponseOptional}} | null | undefined {{/isResponseOptional}}{{/returnType}}{{^returnType}}void{{/returnType}}>>
```
But this is _not_ included in this PR, so consumers of the API's Raw method where `isResponseOptional=true` will have the responsibility to only call value() when the status code indicates that one should expect a non-empty response. Which I think is acceptable.

In addition, I replace the current `return await response.value();` parts (2 locations) with the following:

```
{{#isResponseOptional}}
switch (response.raw.status) {
    {{#responses}}
    {{#is2xx}}
    case {{code}}:
        return {{#dataType}}await response.value(){{/dataType}}{{^dataType}}null{{/dataType}};
    {{/is2xx}}
    {{/responses}}
    default:
        return await response.value();
}
{{/isResponseOptional}}
{{^isResponseOptional}}
return await response.value();
{{/isResponseOptional}}
```

This is done to avoid calling `await response.value()` when a response with no data is received due to the exception that will then be thrown, as mentioned above.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
