### PR TITLE
fix an issue the parameters_to_url_query method would throw an error if the input was of type List[int] BUG#15788

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/api_client.mustache
@@ -592,7 +592,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -507,7 +507,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -500,7 +500,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api_client.py
@@ -554,7 +554,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -500,7 +500,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -502,7 +502,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/api_client.py
@@ -524,7 +524,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/api_client.py
@@ -553,7 +553,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -499,7 +499,7 @@ class ApiClient:
             else:
                 new_params.append((k, quote(str(v))))
 
-        return "&".join(["=".join(item) for item in new_params])
+        return "&".join(["=".join(map(str, item)) for item in new_params])
 
     def files_parameters(self, files=None):
         """Builds form parameters.


### PR DESCRIPTION
Fixed an issue the parameters_to_url_query method would throw an error if the input was of type List[int] #15788(https://github.com/OpenAPITools/openapi-generator/issues/15788)
because the join operation expects string types, but it is being applied to integers.

### PR checklist
 
- [〇] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [〇] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [〇] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
