### PR TITLE
Fixes #17645 When config option interfaceOnly is true, the class RestApplication will be generated as well

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/JavaJAXRSSpecServerCodegen.java
@@ -203,11 +203,10 @@ public class JavaJAXRSSpecServerCodegen extends AbstractJavaJAXRSServerCodegen {
             supportingFiles.add(new SupportingFile("pom.mustache", "", "pom.xml")
                 .doNotOverwrite());
         }
-        if (!interfaceOnly) {
-            supportingFiles.add(new SupportingFile("RestApplication.mustache",
-                    (sourceFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java")
+
+        supportingFiles.add(new SupportingFile("RestApplication.mustache",
+                (sourceFolder + '/' + invokerPackage).replace(".", "/"), "RestApplication.java")
                 .doNotOverwrite());
-        }
 
         if(StringUtils.isNotEmpty(openApiSpecFileLocation)) {
             int index = openApiSpecFileLocation.lastIndexOf('/');

--- a/samples/server/petstore/jaxrs-spec-interface-response/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec-interface-response/.openapi-generator/FILES
@@ -4,6 +4,7 @@ src/gen/java/org/openapitools/api/AnotherFakeApi.java
 src/gen/java/org/openapitools/api/FakeApi.java
 src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
 src/gen/java/org/openapitools/api/PetApi.java
+src/gen/java/org/openapitools/api/RestApplication.java
 src/gen/java/org/openapitools/api/RestResourceRoot.java
 src/gen/java/org/openapitools/api/StoreApi.java
 src/gen/java/org/openapitools/api/UserApi.java

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/RestApplication.java
@@ -1,0 +1,9 @@
+package org.openapitools.api;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath(RestResourceRoot.APPLICATION_PATH)
+public class RestApplication extends Application {
+
+}

--- a/samples/server/petstore/jaxrs-spec-interface/.openapi-generator/FILES
+++ b/samples/server/petstore/jaxrs-spec-interface/.openapi-generator/FILES
@@ -4,6 +4,7 @@ src/gen/java/org/openapitools/api/AnotherFakeApi.java
 src/gen/java/org/openapitools/api/FakeApi.java
 src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
 src/gen/java/org/openapitools/api/PetApi.java
+src/gen/java/org/openapitools/api/RestApplication.java
 src/gen/java/org/openapitools/api/RestResourceRoot.java
 src/gen/java/org/openapitools/api/StoreApi.java
 src/gen/java/org/openapitools/api/UserApi.java

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestApplication.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/RestApplication.java
@@ -1,0 +1,9 @@
+package org.openapitools.api;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath(RestResourceRoot.APPLICATION_PATH)
+public class RestApplication extends Application {
+
+}


### PR DESCRIPTION
Fixes #17645 

The class `RestApplication` with the optional OpenAPIDefinition annotations is now generated _always_. And not only when the interfaceOnly is set to false (default).

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@chameleon82 @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg