### PR TITLE
feat(perl): Update agent to use version constant

### DIFF
--- a/modules/openapi-generator/src/main/resources/perl/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/perl/Configuration.mustache
@@ -82,7 +82,7 @@ sub new {
 
     # class/static variables
     $p{http_timeout} //= 180;
-    $p{http_user_agent} //= '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/{{{moduleVersion}}}/perl{{/httpUserAgent}}';
+    $p{http_user_agent} //= '{{{httpUserAgent}}}{{^httpUserAgent}}OpenAPI-Generator/' . VERSION . '/perl{{/httpUserAgent}}';
 
     # authentication setting
     $p{api_key} //= {};

--- a/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Configuration.pm
+++ b/samples/client/petstore/perl/lib/WWW/OpenAPIClient/Configuration.pm
@@ -95,7 +95,7 @@ sub new {
 
     # class/static variables
     $p{http_timeout} //= 180;
-    $p{http_user_agent} //= 'OpenAPI-Generator/1.0.0/perl';
+    $p{http_user_agent} //= 'OpenAPI-Generator/' . VERSION . '/perl';
 
     # authentication setting
     $p{api_key} //= {};


### PR DESCRIPTION
This is to address feature/issue #14297

IMHO, this is a somewhat trivial issue/PR. Yes, the version string is [hard-coded](https://github.com/OpenAPITools/openapi-generator/blob/3dcef8249b09f92fceba57e34b9c0cdaf7e7a758/modules/openapi-generator/src/main/resources/perl/Configuration.mustache#L85) into the http_user_agent default, but that hard-coded string is dynamically generated. Anyway, since the issue was accepted, here is a PR to resolve it.

Testing steps:
```
$ sudo apt install default-jdk maven
$ perlbrew use perl-5.36.0
$ perlbrew clean
$ perlbrew upgrade-perl
$ perl -E'say $]'
5.036003

$ ./mvnw clean package
$ ./bin/generate-samples.sh ./bin/configs/perl.yaml
$   ./bin/utils/export_docs_generators.sh

$ cd samples/client/petstore/perl
$ cpanm --installdeps .
$ prove -l
[... etc ...]
All tests successful.
Files=57, Tests=64,  7 wallclock secs ( 0.10 usr  0.02 sys +  6.01 cusr  0.76 csys =  6.89 CPU)
Result: PASS

$ perl -Ilib/ -MWWW::OpenAPIClient::ApiClient -wE 'say WWW::OpenAPIClient::ApiClient->new->{config}{http_user_agent}'
OpenAPI-Generator/1.0.0/perl
$ sed -i '/VERSION =>/{s/1.0.0/2.0.0/}' lib/WWW/OpenAPIClient/Configuration.pm
$ perl -Ilib/ -MWWW::OpenAPIClient::ApiClient -wE 'say WWW::OpenAPIClient::ApiClient->new->{config}{http_user_agent}'
OpenAPI-Generator/2.0.0/perl
```

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. [perl] @wing328 @yue9944882
