### PR TITLE
[typescript-nestjs] Compatability with tsc 'strict' flag

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.module.mustache
@@ -47,16 +47,16 @@ export class ApiModule {
     }
 
     private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
-        if (options.useExisting || options.useFactory) {
-            return [this.createAsyncConfigurationProvider(options)];
+        if (options.useClass) {
+            return [
+                this.createAsyncConfigurationProvider(options),
+                {
+                    provide: options.useClass,
+                    useClass: options.useClass,
+                },
+            ];
         }
-        return [
-            this.createAsyncConfigurationProvider(options),
-            {
-                provide: options.useClass,
-                useClass: options.useClass,
-            },
-        ];
+        return [this.createAsyncConfigurationProvider(options)];
     }
 
     private static createAsyncConfigurationProvider(
@@ -73,7 +73,7 @@ export class ApiModule {
             provide: Configuration,
             useFactory: async (optionsFactory: ConfigurationFactory) =>
                 await optionsFactory.createConfiguration(),
-            inject: [options.useExisting || options.useClass],
+            inject: (options.useExisting && [options.useExisting]) || (options.useClass && [options.useClass]) || [],
         };
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -121,7 +121,7 @@ export class {{classname}} {
         // authentication ({{name}}) required
 {{#isApiKey}}
 {{#isKeyInHeader}}
-        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+        if (this.configuration.apiKeys?.["{{keyParamName}}"]) {
             headers['{{keyParamName}}'] = this.configuration.apiKeys["{{keyParamName}}"];
         }
 
@@ -130,7 +130,7 @@ export class {{classname}} {
         {{^hasQueryParams}}
         let queryParameters = new URLSearchParams();
         {{/hasQueryParams}}
-        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+        if (this.configuration.apiKeys?.["{{keyParamName}}"]) {
             queryParameters.append('{{keyParamName}}', this.configuration.apiKeys["{{keyParamName}}"]);
         }
 
@@ -201,24 +201,24 @@ export class {{classname}} {
         if ({{paramName}}) {
         {{#isCollectionFormatMulti}}
             {{paramName}}.forEach((element) => {
-                formParams.append('{{baseName}}', <any>element);
+                formParams!.append('{{baseName}}', <any>element);
             })
         {{/isCollectionFormatMulti}}
         {{^isCollectionFormatMulti}}
-            formParams.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
+            formParams!.append('{{baseName}}', {{paramName}}.join(COLLECTION_FORMATS['{{collectionFormat}}']));
         {{/isCollectionFormatMulti}}
         }
         {{/isArray}}
         {{^isArray}}
         if ({{paramName}} !== undefined) {
-            formParams.append('{{baseName}}', <any>{{paramName}});
+            formParams!.append('{{baseName}}', <any>{{paramName}});
         }
         {{/isArray}}
 {{/formParams}}
 
 {{/hasFormParams}}
         return this.httpClient.{{httpMethod}}{{^isResponseFile}}<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>{{/isResponseFile}}(`${this.basePath}{{{path}}}`,{{#isBodyAllowed}}
-            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams.toString() : formParams{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
+            {{#bodyParam}}{{paramName}}{{/bodyParam}}{{^bodyParam}}{{#hasFormParams}}convertFormParamsToString ? formParams!.toString() : formParams!{{/hasFormParams}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}},{{/isBodyAllowed}}
             {
 {{#hasQueryParams}}
                 params: queryParameters,

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api.module.ts
@@ -41,16 +41,16 @@ export class ApiModule {
     }
 
     private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
-        if (options.useExisting || options.useFactory) {
-            return [this.createAsyncConfigurationProvider(options)];
+        if (options.useClass) {
+            return [
+                this.createAsyncConfigurationProvider(options),
+                {
+                    provide: options.useClass,
+                    useClass: options.useClass,
+                },
+            ];
         }
-        return [
-            this.createAsyncConfigurationProvider(options),
-            {
-                provide: options.useClass,
-                useClass: options.useClass,
-            },
-        ];
+        return [this.createAsyncConfigurationProvider(options)];
     }
 
     private static createAsyncConfigurationProvider(
@@ -67,7 +67,7 @@ export class ApiModule {
             provide: Configuration,
             useFactory: async (optionsFactory: ConfigurationFactory) =>
                 await optionsFactory.createConfiguration(),
-            inject: [options.useExisting || options.useClass],
+            inject: (options.useExisting && [options.useExisting]) || (options.useClass && [options.useClass]) || [],
         };
     }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -255,7 +255,7 @@ export class PetService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -383,15 +383,15 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams.append('name', <any>name);
+            formParams!.append('name', <any>name);
         }
 
         if (status !== undefined) {
-            formParams.append('status', <any>status);
+            formParams!.append('status', <any>status);
         }
 
         return this.httpClient.post<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+            convertFormParamsToString ? formParams!.toString() : formParams!,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers
@@ -456,15 +456,15 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams.append('additionalMetadata', <any>additionalMetadata);
+            formParams!.append('additionalMetadata', <any>additionalMetadata);
         }
 
         if (file !== undefined) {
-            formParams.append('file', <any>file);
+            formParams!.append('file', <any>file);
         }
 
         return this.httpClient.post<ApiResponse>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+            convertFormParamsToString ? formParams!.toString() : formParams!,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -85,7 +85,7 @@ export class StoreService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -56,7 +56,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -101,7 +101,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -146,7 +146,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -191,7 +191,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -311,7 +311,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -355,7 +355,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api.module.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api.module.ts
@@ -42,16 +42,16 @@ export class ApiModule {
     }
 
     private static createAsyncProviders(options: AsyncConfiguration): Provider[] {
-        if (options.useExisting || options.useFactory) {
-            return [this.createAsyncConfigurationProvider(options)];
+        if (options.useClass) {
+            return [
+                this.createAsyncConfigurationProvider(options),
+                {
+                    provide: options.useClass,
+                    useClass: options.useClass,
+                },
+            ];
         }
-        return [
-            this.createAsyncConfigurationProvider(options),
-            {
-                provide: options.useClass,
-                useClass: options.useClass,
-            },
-        ];
+        return [this.createAsyncConfigurationProvider(options)];
     }
 
     private static createAsyncConfigurationProvider(
@@ -68,7 +68,7 @@ export class ApiModule {
             provide: Configuration,
             useFactory: async (optionsFactory: ConfigurationFactory) =>
                 await optionsFactory.createConfiguration(),
-            inject: [options.useExisting || options.useClass],
+            inject: (options.useExisting && [options.useExisting]) || (options.useClass && [options.useClass]) || [],
         };
     }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -256,7 +256,7 @@ export class PetService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -384,15 +384,15 @@ export class PetService {
         }
 
         if (name !== undefined) {
-            formParams.append('name', <any>name);
+            formParams!.append('name', <any>name);
         }
 
         if (status !== undefined) {
-            formParams.append('status', <any>status);
+            formParams!.append('status', <any>status);
         }
 
         return this.httpClient.post<any>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+            convertFormParamsToString ? formParams!.toString() : formParams!,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers
@@ -457,15 +457,15 @@ export class PetService {
         }
 
         if (additionalMetadata !== undefined) {
-            formParams.append('additionalMetadata', <any>additionalMetadata);
+            formParams!.append('additionalMetadata', <any>additionalMetadata);
         }
 
         if (file !== undefined) {
-            formParams.append('file', <any>file);
+            formParams!.append('file', <any>file);
         }
 
         return this.httpClient.post<ApiResponse>(`${this.basePath}/pet/${encodeURIComponent(String(petId))}/uploadImage`,
-            convertFormParamsToString ? formParams.toString() : formParams,
+            convertFormParamsToString ? formParams!.toString() : formParams!,
             {
                 withCredentials: this.configuration.withCredentials,
                 headers: headers

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
@@ -86,7 +86,7 @@ export class StoreService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -102,7 +102,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -147,7 +147,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -192,7 +192,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -312,7 +312,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -356,7 +356,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 


### PR DESCRIPTION
Addresses fix #17671 
A quick pass over the nullability issues reported by the tsc `strict` flag. Does not solve all issues - for example, the `queryParameters` still have one branch where they are accessed by index rather than with `.append`

@macjohnny hope you don't mind being pinged here