### PR TITLE
[cpp-ue4] Fix generated code not compiling when using unique array items

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -206,7 +206,7 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 		return Output;
 	}
 	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
-	bool Index = 0;
+	int32 Index = 0;
 	while (Iter)
 	{
 		if (Index == 0)

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -197,6 +197,7 @@ inline FString CollectionToUrlString_multi(const TArray<T>& Collection, const TC
 	return Output;
 }
 
+
 template <typename T>
 inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHAR* BaseName)
 {
@@ -205,9 +206,9 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 	{
 		return Output;
 	}
-	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
+
 	int32 Index = 0;
-	while (Iter)
+	for (typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator(); Iter; ++Iter)
 	{
 		if (Index == 0)
 		{
@@ -219,6 +220,7 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 	}
 	return Output;
 }
+	
 //////////////////////////////////////////////////////////////////////////
 
 inline void WriteJsonValue(JsonWriter& Writer, const TSharedPtr<FJsonValue>& Value)

--- a/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-ue4/helpers-header.mustache
@@ -197,6 +197,28 @@ inline FString CollectionToUrlString_multi(const TArray<T>& Collection, const TC
 	return Output;
 }
 
+template <typename T>
+inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHAR* BaseName)
+{
+	FString Output;
+	if (Collection.Num() == 0)
+	{
+		return Output;
+	}
+	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
+	bool Index = 0;
+	while (Iter)
+	{
+		if (Index == 0)
+		{
+			Output += FString::Format(TEXT("{0}={1}"), { FStringFormatArg(BaseName), ToUrlString(*Iter) });
+			Index++;
+			continue;
+		}
+		Output += FString::Format(TEXT("&{0}={1}"), { FStringFormatArg(BaseName), ToUrlString(*Iter) });
+	}
+	return Output;
+}
 //////////////////////////////////////////////////////////////////////////
 
 inline void WriteJsonValue(JsonWriter& Writer, const TSharedPtr<FJsonValue>& Value)

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
@@ -206,6 +206,28 @@ inline FString CollectionToUrlString_multi(const TArray<T>& Collection, const TC
 	return Output;
 }
 
+template <typename T>
+inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHAR* BaseName)
+{
+	FString Output;
+	if (Collection.Num() == 0)
+	{
+		return Output;
+	}
+	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
+	bool Index = 0;
+	while (Iter)
+	{
+		if (Index == 0)
+		{
+			Output += FString::Format(TEXT("{0}={1}"), { FStringFormatArg(BaseName), ToUrlString(*Iter) });
+			Index++;
+			continue;
+		}
+		Output += FString::Format(TEXT("&{0}={1}"), { FStringFormatArg(BaseName), ToUrlString(*Iter) });
+	}
+	return Output;
+}
 //////////////////////////////////////////////////////////////////////////
 
 inline void WriteJsonValue(JsonWriter& Writer, const TSharedPtr<FJsonValue>& Value)

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
@@ -215,7 +215,7 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 		return Output;
 	}
 	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
-	bool Index = 0;
+	int32 Index = 0;
 	while (Iter)
 	{
 		if (Index == 0)

--- a/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
+++ b/samples/client/petstore/cpp-ue4/Public/OpenAPIHelpers.h
@@ -206,6 +206,7 @@ inline FString CollectionToUrlString_multi(const TArray<T>& Collection, const TC
 	return Output;
 }
 
+
 template <typename T>
 inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHAR* BaseName)
 {
@@ -214,9 +215,9 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 	{
 		return Output;
 	}
-	typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator();
+
 	int32 Index = 0;
-	while (Iter)
+	for (typename TSet<T>::TConstIterator Iter = Collection.CreateConstIterator(); Iter; ++Iter)
 	{
 		if (Index == 0)
 		{
@@ -228,6 +229,7 @@ inline FString CollectionToUrlString_multi(const TSet<T>& Collection, const TCHA
 	}
 	return Output;
 }
+	
 //////////////////////////////////////////////////////////////////////////
 
 inline void WriteJsonValue(JsonWriter& Writer, const TSharedPtr<FJsonValue>& Value)


### PR DESCRIPTION

Currently if the `"uniqueItems": true,` is present in the schema for array items, the generated code does not compile due to lack of support for TSet container

```cpp
0>GenericApiOperations.cpp(151): Error C2672 : 'CollectionToUrlString_multi': no matching overloaded function found
0>Helpers.h(203): Reference  : could be 'FString ::CollectionToUrlString_multi(const TArray<T,FDefaultAllocator> &,const TCHAR *)'
0>GenericApiOperations.cpp(151): Reference  : 'FString ::CollectionToUrlString_multi(const TArray<T,FDefaultAllocator> &,const TCHAR *)': could not deduce template argument for 'const TArray<T,FDefaultAllocator> &' from 'const TSet<FString,DefaultKeyFuncs<InElementType,false>,FDefaultSetAllocator>'
0>        with
0>        [
0>            InElementType=FString
0>        ]
```


This PR adds a template that correctly combines the URL parameters for associative container TSet and fixes the compilation issue.

Testing:

Based on the following schema:
```json
"schema": {
    "pattern": "^[^/\\\\]*$",
    "uniqueItems": true,
    "type": "array",
    "items": {
      "type": "string"
    }
  }
```
I verified in the debugger that the URL parameters were added 
