### PR TITLE
[scala-sttp]: fix for missing EnumNameSerializer for inner enum definitions

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp/jsonSupport.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp/jsonSupport.mustache
@@ -11,7 +11,8 @@ import scala.reflect.ClassTag
 
 object JsonSupport extends SttpJson4sApi {
   def enumSerializers: Seq[Serializer[_]] = Seq[Serializer[_]](){{#models}}{{#model}}{{#isEnum}} :+
-    new EnumNameSerializer({{classname}}){{/isEnum}}{{/model}}{{/models}}
+    new EnumNameSerializer({{classname}}){{/isEnum}}{{#hasEnums}}{{#vars}}{{#isEnum}} :+
+    new EnumNameSerializer({{classname}}Enums.{{datatypeWithEnum}}){{/isEnum}}{{/vars}}{{/hasEnums}}{{/model}}{{/models}}
 
   private class EnumNameSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Serializer[E#Value] {
     import JsonDSL._

--- a/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/core/JsonSupport.scala
+++ b/samples/client/petstore/scala-sttp/src/main/scala/org/openapitools/client/core/JsonSupport.scala
@@ -17,7 +17,11 @@ import sttp.client3.json4s.SttpJson4sApi
 import scala.reflect.ClassTag
 
 object JsonSupport extends SttpJson4sApi {
-  def enumSerializers: Seq[Serializer[_]] = Seq[Serializer[_]]()
+  def enumSerializers: Seq[Serializer[_]] = Seq[Serializer[_]]() :+
+    new EnumNameSerializer(EnumTestEnums.Search) :+
+    new EnumNameSerializer(EnumTestEnums.SortBy) :+
+    new EnumNameSerializer(OrderEnums.Status) :+
+    new EnumNameSerializer(PetEnums.Status)
 
   private class EnumNameSerializer[E <: Enumeration: ClassTag](enumeration: E) extends Serializer[E#Value] {
     import JsonDSL._


### PR DESCRIPTION
If an enum is specified directly in a field of another object, then the `EnumNameSerializer` is not created as part of `def enumSerializers` in `JsonSupport`

As a result these enumerations are not parsed correctly in the generated client.
