### PR TITLE
Add JavaDoc to api and apiInterface templates for the JavaJaxRS spec generator

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/api.mustache
@@ -20,6 +20,9 @@ import java.util.List;
 {{#useBeanValidation}}import {{javaxPackage}}.validation.constraints.*;
 import {{javaxPackage}}.validation.Valid;{{/useBeanValidation}}
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("{{commonPath}}"){{#useSwaggerAnnotations}}
 @Api(description = "the {{{baseName}}} API"){{/useSwaggerAnnotations}}{{#hasConsumes}}
 @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiInterface.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/apiInterface.mustache
@@ -1,3 +1,13 @@
+    /**
+     * {{{notes}}}
+     *
+     {{#allParams}}
+     * @param {{paramName}} {{description}}
+     {{/allParams}}
+     {{#responses}}
+     * @return {{{message}}}
+     {{/responses}}
+     */
     @{{httpMethod}}{{#subresourceOperation}}
     @Path("{{{path}}}"){{/subresourceOperation}}{{#hasConsumes}}
     @Consumes({ {{#consumes}}"{{{mediaType}}}"{{^-last}}, {{/-last}}{{/consumes}} }){{/hasConsumes}}{{#hasProduces}}

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -14,11 +14,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/another-fake/dummy")
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface AnotherFakeApi {
 
+    /**
+     * To test special tags and operation ID starting with number
+     *
+     * @param uuidTest to test uuid example value
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeApi.java
@@ -23,11 +23,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake")
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeApi {
 
+    /**
+     * this route creates an XmlItem
+     *
+     * @param xmlItem XmlItem Body
+     * @return successful operation
+     */
     @POST
     @Path("/create_xml_item")
     @Consumes({ "application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16" })
@@ -37,6 +46,12 @@ public interface FakeApi {
     Response createXmlItem(@Valid @NotNull XmlItem xmlItem);
 
 
+    /**
+     * Test serialization of outer boolean types
+     *
+     * @param body Input boolean as post body
+     * @return Output boolean
+     */
     @POST
     @Path("/outer/boolean")
     @Produces({ "*/*" })
@@ -46,6 +61,12 @@ public interface FakeApi {
     Response fakeOuterBooleanSerialize(@Valid Boolean body);
 
 
+    /**
+     * Test serialization of object with outer number type
+     *
+     * @param body Input composite as post body
+     * @return Output composite
+     */
     @POST
     @Path("/outer/composite")
     @Produces({ "*/*" })
@@ -55,6 +76,12 @@ public interface FakeApi {
     Response fakeOuterCompositeSerialize(@Valid OuterComposite body);
 
 
+    /**
+     * Test serialization of outer number types
+     *
+     * @param body Input number as post body
+     * @return Output number
+     */
     @POST
     @Path("/outer/number")
     @Produces({ "*/*" })
@@ -64,6 +91,12 @@ public interface FakeApi {
     Response fakeOuterNumberSerialize(@Valid BigDecimal body);
 
 
+    /**
+     * Test serialization of outer string types
+     *
+     * @param body Input string as post body
+     * @return Output string
+     */
     @POST
     @Path("/outer/string")
     @Produces({ "*/*" })
@@ -73,6 +106,12 @@ public interface FakeApi {
     Response fakeOuterStringSerialize(@Valid String body);
 
 
+    /**
+     * For this test, the body for this request much reference a schema named `File`.
+     *
+     * @param body 
+     * @return Success
+     */
     @PUT
     @Path("/body-with-file-schema")
     @Consumes({ "application/json" })
@@ -82,6 +121,13 @@ public interface FakeApi {
     Response testBodyWithFileSchema(@Valid @NotNull FileSchemaTestClass body);
 
 
+    /**
+     * 
+     *
+     * @param query 
+     * @param body 
+     * @return Success
+     */
     @PUT
     @Path("/body-with-query-params")
     @Consumes({ "application/json" })
@@ -91,6 +137,12 @@ public interface FakeApi {
     Response testBodyWithQueryParams(@QueryParam("query") @NotNull   String query,@Valid @NotNull User body);
 
 
+    /**
+     * To test \"client\" model
+     *
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
@@ -100,6 +152,26 @@ public interface FakeApi {
     Response testClientModel(@Valid @NotNull Client body);
 
 
+    /**
+     * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+     *
+     * @param number None
+     * @param _double None
+     * @param patternWithoutDelimiter None
+     * @param _byte None
+     * @param integer None
+     * @param int32 None
+     * @param int64 None
+     * @param _float None
+     * @param string None
+     * @param binary None
+     * @param date None
+     * @param dateTime None
+     * @param password None
+     * @param paramCallback None
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @POST
     @Consumes({ "application/x-www-form-urlencoded" })
     @ApiOperation(value = "Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트", notes = "Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트", authorizations = {
@@ -112,6 +184,20 @@ public interface FakeApi {
     Response testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "double")  Double _double,@FormParam(value = "pattern_without_delimiter")  String patternWithoutDelimiter,@FormParam(value = "byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "float")  Float _float,@FormParam(value = "string")  String string, @FormParam(value = "binary") InputStream binaryInputStream,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  Date dateTime,@FormParam(value = "password")  String password,@FormParam(value = "callback")  String paramCallback);
 
 
+    /**
+     * To test enum parameters
+     *
+     * @param enumHeaderStringArray Header parameter enum test (string array)
+     * @param enumHeaderString Header parameter enum test (string)
+     * @param enumQueryStringArray Query parameter enum test (string array)
+     * @param enumQueryString Query parameter enum test (string)
+     * @param enumQueryInteger Query parameter enum test (double)
+     * @param enumQueryDouble Query parameter enum test (double)
+     * @param enumFormStringArray Form parameter enum test (string array)
+     * @param enumFormString Form parameter enum test (string)
+     * @return Invalid request
+     * @return Not found
+     */
     @GET
     @Consumes({ "application/x-www-form-urlencoded" })
     @ApiOperation(value = "To test enum parameters", notes = "To test enum parameters", tags={ "fake" })
@@ -121,6 +207,17 @@ public interface FakeApi {
     Response testEnumParameters(@HeaderParam("enum_header_string_array")   @ApiParam("Header parameter enum test (string array)") List<String> enumHeaderStringArray,@HeaderParam("enum_header_string")  @DefaultValue("-efg")  @ApiParam("Header parameter enum test (string)") String enumHeaderString,@QueryParam("enum_query_string_array")  @ApiParam("Query parameter enum test (string array)")  List<String> enumQueryStringArray,@QueryParam("enum_query_string") @DefaultValue("-efg")  @ApiParam("Query parameter enum test (string)")  String enumQueryString,@QueryParam("enum_query_integer")  @ApiParam("Query parameter enum test (double)")  Integer enumQueryInteger,@QueryParam("enum_query_double")  @ApiParam("Query parameter enum test (double)")  Double enumQueryDouble,@FormParam(value = "enum_form_string_array")  List<String> enumFormStringArray,@FormParam(value = "enum_form_string")  String enumFormString);
 
 
+    /**
+     * Fake endpoint to test group parameters (optional)
+     *
+     * @param requiredStringGroup Required String in group parameters
+     * @param requiredBooleanGroup Required Boolean in group parameters
+     * @param requiredInt64Group Required Integer in group parameters
+     * @param stringGroup String in group parameters
+     * @param booleanGroup Boolean in group parameters
+     * @param int64Group Integer in group parameters
+     * @return Something wrong
+     */
     @DELETE
     @ApiOperation(value = "Fake endpoint to test group parameters (optional)", notes = "Fake endpoint to test group parameters (optional)", tags={ "fake" })
     @ApiResponses(value = { 
@@ -128,6 +225,12 @@ public interface FakeApi {
     Response testGroupParameters(@QueryParam("required_string_group") @NotNull  @ApiParam("Required String in group parameters")  Integer requiredStringGroup,@HeaderParam("required_boolean_group") @NotNull   @ApiParam("Required Boolean in group parameters") Boolean requiredBooleanGroup,@QueryParam("required_int64_group") @NotNull  @ApiParam("Required Integer in group parameters")  Long requiredInt64Group,@QueryParam("string_group")  @ApiParam("String in group parameters")  Integer stringGroup,@HeaderParam("boolean_group")   @ApiParam("Boolean in group parameters") Boolean booleanGroup,@QueryParam("int64_group")  @ApiParam("Integer in group parameters")  Long int64Group);
 
 
+    /**
+     * 
+     *
+     * @param param request body
+     * @return successful operation
+     */
     @POST
     @Path("/inline-additionalProperties")
     @Consumes({ "application/json" })
@@ -137,6 +240,13 @@ public interface FakeApi {
     Response testInlineAdditionalProperties(@Valid @NotNull Map<String, String> param);
 
 
+    /**
+     * 
+     *
+     * @param param field1
+     * @param param2 field2
+     * @return successful operation
+     */
     @GET
     @Path("/jsonFormData")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -146,6 +256,16 @@ public interface FakeApi {
     Response testJsonFormData(@FormParam(value = "param")  String param,@FormParam(value = "param2")  String param2);
 
 
+    /**
+     * To test the collection format in query parameters
+     *
+     * @param pipe 
+     * @param ioutil 
+     * @param http 
+     * @param url 
+     * @param context 
+     * @return Success
+     */
     @PUT
     @Path("/test-query-parameters")
     @ApiOperation(value = "", notes = "To test the collection format in query parameters", tags={ "fake" })
@@ -154,6 +274,14 @@ public interface FakeApi {
     Response testQueryParameterCollectionFormat(@QueryParam("pipe") @NotNull   List<String> pipe,@QueryParam("ioutil") @NotNull   List<String> ioutil,@QueryParam("http") @NotNull   List<String> http,@QueryParam("url") @NotNull   List<String> url,@QueryParam("context") @NotNull   List<String> context);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet to update
+     * @param requiredFile file to upload
+     * @param additionalMetadata Additional data to pass to server
+     * @return successful operation
+     */
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -13,11 +13,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake_classname_test")
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeClassnameTestApi {
 
+    /**
+     * To test class name in snake case
+     *
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/PetApi.java
@@ -16,11 +16,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/pet")
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface PetApi {
 
+    /**
+     * 
+     *
+     * @param body Pet object that needs to be added to the store
+     * @return successful operation
+     * @return Invalid input
+     */
     @POST
     @Consumes({ "application/json", "application/xml" })
     @ApiOperation(value = "Add a new pet to the store", notes = "", authorizations = {
@@ -34,6 +44,14 @@ public interface PetApi {
     Response addPet(@Valid @NotNull Pet body);
 
 
+    /**
+     * 
+     *
+     * @param petId Pet id to delete
+     * @param apiKey 
+     * @return successful operation
+     * @return Invalid pet value
+     */
     @DELETE
     @Path("/{petId}")
     @ApiOperation(value = "Deletes a pet", notes = "", authorizations = {
@@ -47,6 +65,13 @@ public interface PetApi {
     Response deletePet(@PathParam("petId") @ApiParam("Pet id to delete") Long petId,@HeaderParam("api_key")   String apiKey);
 
 
+    /**
+     * Multiple status values can be provided with comma separated strings
+     *
+     * @param status Status values that need to be considered for filter
+     * @return successful operation
+     * @return Invalid status value
+     */
     @GET
     @Path("/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -61,6 +86,13 @@ public interface PetApi {
     Response findPetsByStatus(@QueryParam("status") @NotNull  @ApiParam("Status values that need to be considered for filter")  List<String> status);
 
 
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     * @param tags Tags to filter by
+     * @return successful operation
+     * @return Invalid tag value
+     */
     @GET
     @Path("/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -75,6 +107,14 @@ public interface PetApi {
     Response findPetsByTags(@QueryParam("tags") @NotNull  @ApiParam("Tags to filter by")  Set<String> tags);
 
 
+    /**
+     * Returns a single pet
+     *
+     * @param petId ID of pet to return
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     */
     @GET
     @Path("/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -89,6 +129,15 @@ public interface PetApi {
     Response getPetById(@PathParam("petId") @ApiParam("ID of pet to return") Long petId);
 
 
+    /**
+     * 
+     *
+     * @param body Pet object that needs to be added to the store
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     * @return Validation exception
+     */
     @PUT
     @Consumes({ "application/json", "application/xml" })
     @ApiOperation(value = "Update an existing pet", notes = "", authorizations = {
@@ -104,6 +153,14 @@ public interface PetApi {
     Response updatePet(@Valid @NotNull Pet body);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     * @return Invalid input
+     */
     @POST
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -117,6 +174,14 @@ public interface PetApi {
     Response updatePetWithForm(@PathParam("petId") @ApiParam("ID of pet that needs to be updated") Long petId,@FormParam(value = "name")  String name,@FormParam(value = "status")  String status);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param _file file to upload
+     * @return successful operation
+     */
     @POST
     @Path("/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/StoreApi.java
@@ -14,11 +14,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/store")
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface StoreApi {
 
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     * @param orderId ID of the order that needs to be deleted
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
     @DELETE
     @Path("/order/{order_id}")
     @ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store" })
@@ -28,6 +38,11 @@ public interface StoreApi {
     Response deleteOrder(@PathParam("order_id") @ApiParam("ID of the order that needs to be deleted") String orderId);
 
 
+    /**
+     * Returns a map of status codes to quantities
+     *
+     * @return successful operation
+     */
     @GET
     @Path("/inventory")
     @Produces({ "application/json" })
@@ -40,6 +55,14 @@ public interface StoreApi {
     Response getInventory();
 
 
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     *
+     * @param orderId ID of pet that needs to be fetched
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
     @GET
     @Path("/order/{order_id}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +74,13 @@ public interface StoreApi {
     Response getOrderById(@PathParam("order_id") @Min(1L) @Max(5L) @ApiParam("ID of pet that needs to be fetched") Long orderId);
 
 
+    /**
+     * 
+     *
+     * @param body order placed for purchasing the pet
+     * @return successful operation
+     * @return Invalid Order
+     */
     @POST
     @Path("/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/api/UserApi.java
@@ -14,11 +14,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/user")
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface UserApi {
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param body Created user object
+     * @return successful operation
+     */
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", tags={ "user" })
     @ApiResponses(value = { 
@@ -26,6 +35,12 @@ public interface UserApi {
     Response createUser(@Valid @NotNull User body);
 
 
+    /**
+     * 
+     *
+     * @param body List of user object
+     * @return successful operation
+     */
     @POST
     @Path("/createWithArray")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
@@ -34,6 +49,12 @@ public interface UserApi {
     Response createUsersWithArrayInput(@Valid @NotNull List<@Valid User> body);
 
 
+    /**
+     * 
+     *
+     * @param body List of user object
+     * @return successful operation
+     */
     @POST
     @Path("/createWithList")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
@@ -42,6 +63,13 @@ public interface UserApi {
     Response createUsersWithListInput(@Valid @NotNull List<@Valid User> body);
 
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param username The name that needs to be deleted
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @DELETE
     @Path("/{username}")
     @ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", tags={ "user" })
@@ -51,6 +79,14 @@ public interface UserApi {
     Response deleteUser(@PathParam("username") @ApiParam("The name that needs to be deleted") String username);
 
 
+    /**
+     * 
+     *
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @return successful operation
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @GET
     @Path("/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -62,6 +98,14 @@ public interface UserApi {
     Response getUserByName(@PathParam("username") @ApiParam("The name that needs to be fetched. Use user1 for testing.") String username);
 
 
+    /**
+     * 
+     *
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     * @return successful operation
+     * @return Invalid username/password supplied
+     */
     @GET
     @Path("/login")
     @Produces({ "application/xml", "application/json" })
@@ -72,6 +116,11 @@ public interface UserApi {
     Response loginUser(@QueryParam("username") @NotNull  @ApiParam("The user name for login")  String username,@QueryParam("password") @NotNull  @ApiParam("The password for login in clear text")  String password);
 
 
+    /**
+     * 
+     *
+     * @return successful operation
+     */
     @GET
     @Path("/logout")
     @ApiOperation(value = "Logs out current logged in user session", notes = "", tags={ "user" })
@@ -80,6 +129,14 @@ public interface UserApi {
     Response logoutUser();
 
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param username name that need to be deleted
+     * @param body Updated user object
+     * @return Invalid user supplied
+     * @return User not found
+     */
     @PUT
     @Path("/{username}")
     @ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", tags={ "user" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -14,11 +14,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/another-fake/dummy")
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface AnotherFakeApi {
 
+    /**
+     * To test special tags and operation ID starting with number
+     *
+     * @param uuidTest to test uuid example value
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeApi.java
@@ -23,11 +23,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake")
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeApi {
 
+    /**
+     * this route creates an XmlItem
+     *
+     * @param xmlItem XmlItem Body
+     * @return successful operation
+     */
     @POST
     @Path("/create_xml_item")
     @Consumes({ "application/xml", "application/xml; charset=utf-8", "application/xml; charset=utf-16", "text/xml", "text/xml; charset=utf-8", "text/xml; charset=utf-16" })
@@ -37,6 +46,12 @@ public interface FakeApi {
     void createXmlItem(@Valid @NotNull XmlItem xmlItem);
 
 
+    /**
+     * Test serialization of outer boolean types
+     *
+     * @param body Input boolean as post body
+     * @return Output boolean
+     */
     @POST
     @Path("/outer/boolean")
     @Produces({ "*/*" })
@@ -46,6 +61,12 @@ public interface FakeApi {
     Boolean fakeOuterBooleanSerialize(@Valid Boolean body);
 
 
+    /**
+     * Test serialization of object with outer number type
+     *
+     * @param body Input composite as post body
+     * @return Output composite
+     */
     @POST
     @Path("/outer/composite")
     @Produces({ "*/*" })
@@ -55,6 +76,12 @@ public interface FakeApi {
     OuterComposite fakeOuterCompositeSerialize(@Valid OuterComposite body);
 
 
+    /**
+     * Test serialization of outer number types
+     *
+     * @param body Input number as post body
+     * @return Output number
+     */
     @POST
     @Path("/outer/number")
     @Produces({ "*/*" })
@@ -64,6 +91,12 @@ public interface FakeApi {
     BigDecimal fakeOuterNumberSerialize(@Valid BigDecimal body);
 
 
+    /**
+     * Test serialization of outer string types
+     *
+     * @param body Input string as post body
+     * @return Output string
+     */
     @POST
     @Path("/outer/string")
     @Produces({ "*/*" })
@@ -73,6 +106,12 @@ public interface FakeApi {
     String fakeOuterStringSerialize(@Valid String body);
 
 
+    /**
+     * For this test, the body for this request much reference a schema named `File`.
+     *
+     * @param body 
+     * @return Success
+     */
     @PUT
     @Path("/body-with-file-schema")
     @Consumes({ "application/json" })
@@ -82,6 +121,13 @@ public interface FakeApi {
     void testBodyWithFileSchema(@Valid @NotNull FileSchemaTestClass body);
 
 
+    /**
+     * 
+     *
+     * @param query 
+     * @param body 
+     * @return Success
+     */
     @PUT
     @Path("/body-with-query-params")
     @Consumes({ "application/json" })
@@ -91,6 +137,12 @@ public interface FakeApi {
     void testBodyWithQueryParams(@QueryParam("query") @NotNull   String query,@Valid @NotNull User body);
 
 
+    /**
+     * To test \"client\" model
+     *
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
@@ -100,6 +152,26 @@ public interface FakeApi {
     Client testClientModel(@Valid @NotNull Client body);
 
 
+    /**
+     * Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트
+     *
+     * @param number None
+     * @param _double None
+     * @param patternWithoutDelimiter None
+     * @param _byte None
+     * @param integer None
+     * @param int32 None
+     * @param int64 None
+     * @param _float None
+     * @param string None
+     * @param binary None
+     * @param date None
+     * @param dateTime None
+     * @param password None
+     * @param paramCallback None
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @POST
     @Consumes({ "application/x-www-form-urlencoded" })
     @ApiOperation(value = "Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트", notes = "Fake endpoint for testing various parameters  假端點  偽のエンドポイント  가짜 엔드 포인트", authorizations = {
@@ -112,6 +184,19 @@ public interface FakeApi {
     void testEndpointParameters(@FormParam(value = "number")  BigDecimal number,@FormParam(value = "double")  Double _double,@FormParam(value = "pattern_without_delimiter")  String patternWithoutDelimiter,@FormParam(value = "byte")  byte[] _byte,@FormParam(value = "integer")  Integer integer,@FormParam(value = "int32")  Integer int32,@FormParam(value = "int64")  Long int64,@FormParam(value = "float")  Float _float,@FormParam(value = "string")  String string, @FormParam(value = "binary") InputStream binaryInputStream,@FormParam(value = "date")  LocalDate date,@FormParam(value = "dateTime")  Date dateTime,@FormParam(value = "password")  String password,@FormParam(value = "callback")  String paramCallback);
 
 
+    /**
+     * To test enum parameters
+     *
+     * @param enumHeaderStringArray Header parameter enum test (string array)
+     * @param enumQueryStringArray Query parameter enum test (string array)
+     * @param enumQueryString Query parameter enum test (string)
+     * @param enumQueryInteger Query parameter enum test (double)
+     * @param enumQueryDouble Query parameter enum test (double)
+     * @param enumFormStringArray Form parameter enum test (string array)
+     * @param enumFormString Form parameter enum test (string)
+     * @return Invalid request
+     * @return Not found
+     */
     @GET
     @Consumes({ "application/x-www-form-urlencoded" })
     @ApiOperation(value = "To test enum parameters", notes = "To test enum parameters", tags={ "fake" })
@@ -124,6 +209,17 @@ public interface FakeApi {
     void testEnumParameters(@HeaderParam("enum_header_string_array")   @ApiParam("Header parameter enum test (string array)") List<String> enumHeaderStringArray,@QueryParam("enum_query_string_array")  @ApiParam("Query parameter enum test (string array)")  List<String> enumQueryStringArray,@QueryParam("enum_query_string") @DefaultValue("-efg")  @ApiParam("Query parameter enum test (string)")  String enumQueryString,@QueryParam("enum_query_integer")  @ApiParam("Query parameter enum test (double)")  Integer enumQueryInteger,@QueryParam("enum_query_double")  @ApiParam("Query parameter enum test (double)")  Double enumQueryDouble,@FormParam(value = "enum_form_string_array")  List<String> enumFormStringArray,@FormParam(value = "enum_form_string")  String enumFormString);
 
 
+    /**
+     * Fake endpoint to test group parameters (optional)
+     *
+     * @param requiredStringGroup Required String in group parameters
+     * @param requiredBooleanGroup Required Boolean in group parameters
+     * @param requiredInt64Group Required Integer in group parameters
+     * @param stringGroup String in group parameters
+     * @param booleanGroup Boolean in group parameters
+     * @param int64Group Integer in group parameters
+     * @return Something wrong
+     */
     @DELETE
     @ApiOperation(value = "Fake endpoint to test group parameters (optional)", notes = "Fake endpoint to test group parameters (optional)", tags={ "fake" })
     @ApiResponses(value = { 
@@ -131,6 +227,12 @@ public interface FakeApi {
     void testGroupParameters(@QueryParam("required_string_group") @NotNull  @ApiParam("Required String in group parameters")  Integer requiredStringGroup,@HeaderParam("required_boolean_group") @NotNull   @ApiParam("Required Boolean in group parameters") Boolean requiredBooleanGroup,@QueryParam("required_int64_group") @NotNull  @ApiParam("Required Integer in group parameters")  Long requiredInt64Group,@QueryParam("string_group")  @ApiParam("String in group parameters")  Integer stringGroup,@HeaderParam("boolean_group")   @ApiParam("Boolean in group parameters") Boolean booleanGroup,@QueryParam("int64_group")  @ApiParam("Integer in group parameters")  Long int64Group);
 
 
+    /**
+     * 
+     *
+     * @param param request body
+     * @return successful operation
+     */
     @POST
     @Path("/inline-additionalProperties")
     @Consumes({ "application/json" })
@@ -140,6 +242,13 @@ public interface FakeApi {
     void testInlineAdditionalProperties(@Valid @NotNull Map<String, String> param);
 
 
+    /**
+     * 
+     *
+     * @param param field1
+     * @param param2 field2
+     * @return successful operation
+     */
     @GET
     @Path("/jsonFormData")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -149,6 +258,16 @@ public interface FakeApi {
     void testJsonFormData(@FormParam(value = "param")  String param,@FormParam(value = "param2")  String param2);
 
 
+    /**
+     * To test the collection format in query parameters
+     *
+     * @param pipe 
+     * @param ioutil 
+     * @param http 
+     * @param url 
+     * @param context 
+     * @return Success
+     */
     @PUT
     @Path("/test-query-parameters")
     @ApiOperation(value = "", notes = "To test the collection format in query parameters", tags={ "fake" })
@@ -157,6 +276,14 @@ public interface FakeApi {
     void testQueryParameterCollectionFormat(@QueryParam("pipe") @NotNull   List<String> pipe,@QueryParam("ioutil") @NotNull   List<String> ioutil,@QueryParam("http") @NotNull   List<String> http,@QueryParam("url") @NotNull   List<String> url,@QueryParam("context") @NotNull   List<String> context);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet to update
+     * @param requiredFile file to upload
+     * @param additionalMetadata Additional data to pass to server
+     * @return successful operation
+     */
     @POST
     @Path("/{petId}/uploadImageWithRequiredFile")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -13,11 +13,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake_classname_test")
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface FakeClassnameTestApi {
 
+    /**
+     * To test class name in snake case
+     *
+     * @param body client model
+     * @return successful operation
+     */
     @PATCH
     @Consumes({ "application/json" })
     @Produces({ "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/PetApi.java
@@ -16,11 +16,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/pet")
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface PetApi {
 
+    /**
+     * 
+     *
+     * @param body Pet object that needs to be added to the store
+     * @return successful operation
+     * @return Invalid input
+     */
     @POST
     @Consumes({ "application/json", "application/xml" })
     @ApiOperation(value = "Add a new pet to the store", notes = "", authorizations = {
@@ -34,6 +44,13 @@ public interface PetApi {
     void addPet(@Valid @NotNull Pet body);
 
 
+    /**
+     * 
+     *
+     * @param petId Pet id to delete
+     * @return successful operation
+     * @return Invalid pet value
+     */
     @DELETE
     @Path("/{petId}")
     @ApiOperation(value = "Deletes a pet", notes = "", authorizations = {
@@ -50,6 +67,13 @@ public interface PetApi {
     void deletePet(@PathParam("petId") @ApiParam("Pet id to delete") Long petId);
 
 
+    /**
+     * Multiple status values can be provided with comma separated strings
+     *
+     * @param status Status values that need to be considered for filter
+     * @return successful operation
+     * @return Invalid status value
+     */
     @GET
     @Path("/findByStatus")
     @Produces({ "application/xml", "application/json" })
@@ -64,6 +88,13 @@ public interface PetApi {
     List<Pet> findPetsByStatus(@QueryParam("status") @NotNull  @ApiParam("Status values that need to be considered for filter")  List<String> status);
 
 
+    /**
+     * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+     *
+     * @param tags Tags to filter by
+     * @return successful operation
+     * @return Invalid tag value
+     */
     @GET
     @Path("/findByTags")
     @Produces({ "application/xml", "application/json" })
@@ -78,6 +109,14 @@ public interface PetApi {
     Set<Pet> findPetsByTags(@QueryParam("tags") @NotNull  @ApiParam("Tags to filter by")  Set<String> tags);
 
 
+    /**
+     * Returns a single pet
+     *
+     * @param petId ID of pet to return
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     */
     @GET
     @Path("/{petId}")
     @Produces({ "application/xml", "application/json" })
@@ -92,6 +131,15 @@ public interface PetApi {
     Pet getPetById(@PathParam("petId") @ApiParam("ID of pet to return") Long petId);
 
 
+    /**
+     * 
+     *
+     * @param body Pet object that needs to be added to the store
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Pet not found
+     * @return Validation exception
+     */
     @PUT
     @Consumes({ "application/json", "application/xml" })
     @ApiOperation(value = "Update an existing pet", notes = "", authorizations = {
@@ -107,6 +155,14 @@ public interface PetApi {
     void updatePet(@Valid @NotNull Pet body);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet that needs to be updated
+     * @param name Updated name of the pet
+     * @param status Updated status of the pet
+     * @return Invalid input
+     */
     @POST
     @Path("/{petId}")
     @Consumes({ "application/x-www-form-urlencoded" })
@@ -120,6 +176,14 @@ public interface PetApi {
     void updatePetWithForm(@PathParam("petId") @ApiParam("ID of pet that needs to be updated") Long petId,@FormParam(value = "name")  String name,@FormParam(value = "status")  String status);
 
 
+    /**
+     * 
+     *
+     * @param petId ID of pet to update
+     * @param additionalMetadata Additional data to pass to server
+     * @param _file file to upload
+     * @return successful operation
+     */
     @POST
     @Path("/{petId}/uploadImage")
     @Consumes({ "multipart/form-data" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/StoreApi.java
@@ -14,11 +14,21 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/store")
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface StoreApi {
 
+    /**
+     * For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+     *
+     * @param orderId ID of the order that needs to be deleted
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
     @DELETE
     @Path("/order/{order_id}")
     @ApiOperation(value = "Delete purchase order by ID", notes = "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors", tags={ "store" })
@@ -28,6 +38,11 @@ public interface StoreApi {
     void deleteOrder(@PathParam("order_id") @ApiParam("ID of the order that needs to be deleted") String orderId);
 
 
+    /**
+     * Returns a map of status codes to quantities
+     *
+     * @return successful operation
+     */
     @GET
     @Path("/inventory")
     @Produces({ "application/json" })
@@ -40,6 +55,14 @@ public interface StoreApi {
     Map<String, Integer> getInventory();
 
 
+    /**
+     * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions
+     *
+     * @param orderId ID of pet that needs to be fetched
+     * @return successful operation
+     * @return Invalid ID supplied
+     * @return Order not found
+     */
     @GET
     @Path("/order/{order_id}")
     @Produces({ "application/xml", "application/json" })
@@ -51,6 +74,13 @@ public interface StoreApi {
     Order getOrderById(@PathParam("order_id") @Min(1L) @Max(5L) @ApiParam("ID of pet that needs to be fetched") Long orderId);
 
 
+    /**
+     * 
+     *
+     * @param body order placed for purchasing the pet
+     * @return successful operation
+     * @return Invalid Order
+     */
     @POST
     @Path("/order")
     @Produces({ "application/xml", "application/json" })

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/api/UserApi.java
@@ -14,11 +14,20 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/user")
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")
 public interface UserApi {
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param body Created user object
+     * @return successful operation
+     */
     @POST
     @ApiOperation(value = "Create user", notes = "This can only be done by the logged in user.", tags={ "user" })
     @ApiResponses(value = { 
@@ -26,6 +35,12 @@ public interface UserApi {
     void createUser(@Valid @NotNull User body);
 
 
+    /**
+     * 
+     *
+     * @param body List of user object
+     * @return successful operation
+     */
     @POST
     @Path("/createWithArray")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
@@ -34,6 +49,12 @@ public interface UserApi {
     void createUsersWithArrayInput(@Valid @NotNull List<@Valid User> body);
 
 
+    /**
+     * 
+     *
+     * @param body List of user object
+     * @return successful operation
+     */
     @POST
     @Path("/createWithList")
     @ApiOperation(value = "Creates list of users with given input array", notes = "", tags={ "user" })
@@ -42,6 +63,13 @@ public interface UserApi {
     void createUsersWithListInput(@Valid @NotNull List<@Valid User> body);
 
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param username The name that needs to be deleted
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @DELETE
     @Path("/{username}")
     @ApiOperation(value = "Delete user", notes = "This can only be done by the logged in user.", tags={ "user" })
@@ -51,6 +79,14 @@ public interface UserApi {
     void deleteUser(@PathParam("username") @ApiParam("The name that needs to be deleted") String username);
 
 
+    /**
+     * 
+     *
+     * @param username The name that needs to be fetched. Use user1 for testing.
+     * @return successful operation
+     * @return Invalid username supplied
+     * @return User not found
+     */
     @GET
     @Path("/{username}")
     @Produces({ "application/xml", "application/json" })
@@ -62,6 +98,14 @@ public interface UserApi {
     User getUserByName(@PathParam("username") @ApiParam("The name that needs to be fetched. Use user1 for testing.") String username);
 
 
+    /**
+     * 
+     *
+     * @param username The user name for login
+     * @param password The password for login in clear text
+     * @return successful operation
+     * @return Invalid username/password supplied
+     */
     @GET
     @Path("/login")
     @Produces({ "application/xml", "application/json" })
@@ -72,6 +116,11 @@ public interface UserApi {
     String loginUser(@QueryParam("username") @NotNull  @ApiParam("The user name for login")  String username,@QueryParam("password") @NotNull  @ApiParam("The password for login in clear text")  String password);
 
 
+    /**
+     * 
+     *
+     * @return successful operation
+     */
     @GET
     @Path("/logout")
     @ApiOperation(value = "Logs out current logged in user session", notes = "", tags={ "user" })
@@ -80,6 +129,14 @@ public interface UserApi {
     void logoutUser();
 
 
+    /**
+     * This can only be done by the logged in user.
+     *
+     * @param username name that need to be deleted
+     * @param body Updated user object
+     * @return Invalid user supplied
+     * @return User not found
+     */
     @PUT
     @Path("/{username}")
     @ApiOperation(value = "Updated user", notes = "This can only be done by the logged in user.", tags={ "user" })

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/another-fake/dummy")
 @Api(description = "the another-fake API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeApi.java
@@ -23,6 +23,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake")
 @Api(description = "the fake API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -13,6 +13,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake_classname_test")
 @Api(description = "the fake_classname_test API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/PetApi.java
@@ -16,6 +16,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/pet")
 @Api(description = "the pet API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/StoreApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/store")
 @Api(description = "the store API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/api/UserApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/user")
 @Api(description = "the user API")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/api/UserApi.java
@@ -13,6 +13,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/user")
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/another-fake/dummy")
 @Api(description = "the another-fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeApi.java
@@ -23,6 +23,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake")
 @Api(description = "the fake API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -13,6 +13,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/fake_classname_test")
 @Api(description = "the fake_classname_test API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/PetApi.java
@@ -16,6 +16,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/pet")
 @Api(description = "the pet API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/StoreApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/store")
 @Api(description = "the store API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/api/UserApi.java
@@ -14,6 +14,9 @@ import java.util.List;
 import javax.validation.constraints.*;
 import javax.validation.Valid;
 
+/**
+* Represents a collection of functions to interact with the API endpoints.
+*/
 @Path("/user")
 @Api(description = "the user API")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR adds some fairly informative JavaDoc to the api methods for the jaxrs spec  generator.
The class level doc comment is copied from the `charp` equivalent.

Fixes issue ##17704

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Mentions: @bbdouglas @sreeshas  @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608  @martin-mfg

