### PR TITLE
fix typescript-nestjs services when using api_key authentication

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -121,7 +121,7 @@ export class {{classname}} {
         // authentication ({{name}}) required
 {{#isApiKey}}
 {{#isKeyInHeader}}
-        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+        if (this.configuration.apiKeys?.["{{keyParamName}}"]) {
             headers['{{keyParamName}}'] = this.configuration.apiKeys["{{keyParamName}}"];
         }
 
@@ -130,7 +130,7 @@ export class {{classname}} {
         {{^hasQueryParams}}
         let queryParameters = new URLSearchParams();
         {{/hasQueryParams}}
-        if (this.configuration.apiKeys["{{keyParamName}}"]) {
+        if (this.configuration.apiKeys?.["{{keyParamName}}"]) {
             queryParameters.append('{{keyParamName}}', this.configuration.apiKeys["{{keyParamName}}"]);
         }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -255,7 +255,7 @@ export class PetService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -85,7 +85,7 @@ export class StoreService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -56,7 +56,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -101,7 +101,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -146,7 +146,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -191,7 +191,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -311,7 +311,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -355,7 +355,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -256,7 +256,7 @@ export class PetService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
@@ -86,7 +86,7 @@ export class StoreService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -102,7 +102,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -147,7 +147,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -192,7 +192,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -312,7 +312,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 
@@ -356,7 +356,7 @@ export class UserService {
         let headers = {...this.defaultHeaders};
 
         // authentication (api_key) required
-        if (this.configuration.apiKeys["api_key"]) {
+        if (this.configuration.apiKeys?.["api_key"]) {
             headers['api_key'] = this.configuration.apiKeys["api_key"];
         }
 


### PR DESCRIPTION
Closes: #17706

Typesafe access to `Configuration.apiKeys`

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka 
