### PR TITLE
Adds Merged File Publish Options

### DIFF
--- a/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
+++ b/modules/openapi-generator-cli/src/main/java/org/openapitools/codegen/cmd/Generate.java
@@ -327,7 +327,7 @@ public class Generate extends OpenApiGeneratorCommand {
     @Override
     public void execute() {
         if (StringUtils.isNotBlank(inputSpecRootDirectory)) {
-            spec = new MergedSpecBuilder(inputSpecRootDirectory, StringUtils.isBlank(mergedFileName) ? "_merged_spec" : mergedFileName)
+            spec = new MergedSpecBuilder(inputSpecRootDirectory, inputSpecRootDirectory, StringUtils.isBlank(mergedFileName) ? "_merged_spec" : mergedFileName)
                 .buildMergedSpec();
             System.out.println("Merge input spec would be used - " + spec);
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/config/MergedSpecBuilder.java
@@ -32,10 +32,12 @@ public class MergedSpecBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(MergedSpecBuilder.class);
 
     private final String inputSpecRootDirectory;
+    private final String outputDirectory;
     private final String mergeFileName;
 
-    public MergedSpecBuilder(final String rootDirectory, final String mergeFileName) {
+    public MergedSpecBuilder(final String rootDirectory, final String outputDirectory, final String mergeFileName) {
         this.inputSpecRootDirectory = rootDirectory;
+        this.outputDirectory = outputDirectory;
         this.mergeFileName = mergeFileName;
     }
 
@@ -76,7 +78,7 @@ public class MergedSpecBuilder {
 
         Map<String, Object> mergedSpec = generatedMergedSpec(openapiVersion, allPaths);
         String mergedFilename = this.mergeFileName + (isJson ? ".json" : ".yaml");
-        Path mergedFilePath = Paths.get(inputSpecRootDirectory, mergedFilename);
+        Path mergedFilePath = Paths.get(outputDirectory, mergedFilename);
 
         try {
             ObjectMapper objectMapper = isJson ? new ObjectMapper() : new ObjectMapper(new YAMLFactory());

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/MergedSpecBuilderTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/config/MergedSpecBuilderTest.java
@@ -41,7 +41,7 @@ public class MergedSpecBuilderTest {
 
         String outputPath = output.getAbsolutePath().replace('\\', '/');
 
-        String mergedSpec = new MergedSpecBuilder(outputPath, "_merged_file")
+        String mergedSpec = new MergedSpecBuilder(outputPath, outputPath, "_merged_file")
             .buildMergedSpec();
 
         assertFilesFromMergedSpec(mergedSpec);


### PR DESCRIPTION
:warning: **PR is still a WIP** :warning:

* Adds an option to the maven plugin to publish the merged file to the maven build output directory.
* Adds an option to the maven plugin to include the merged file in the maven artifacts list.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
