### PR TITLE
[BUG] [Java] Remove deprecation and serial warnings in ApiException.java and JSON.java

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/apiException.mustache
@@ -7,6 +7,8 @@ import java.util.List;
 
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey2/apiException.mustache
@@ -14,6 +14,8 @@ import java.util.TreeMap;
  */
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/apiException.mustache
@@ -14,6 +14,8 @@ import java.util.TreeMap;
  */
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/JSON.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/JSON.mustache
@@ -27,9 +27,9 @@ public class JSON {
   public JSON() {
     mapper = JsonMapper.builder()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true)
+        .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
         .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)

--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/apiException.mustache
@@ -6,6 +6,8 @@ import java.net.http.HttpHeaders;
 
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private HttpHeaders responseHeaders = null;
     private String responseBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/apiException.mustache
@@ -16,6 +16,8 @@ import java.util.TreeMap;
 @SuppressWarnings("serial")
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/apiException.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/apiException.mustache
@@ -8,6 +8,8 @@ import io.vertx.core.MultiMap;
 
 {{>generatedAnnotation}}
 public class ApiException extends{{#useRuntimeException}} RuntimeException {{/useRuntimeException}}{{^useRuntimeException}} Exception {{/useRuntimeException}}{
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private MultiMap responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
@@ -18,6 +18,8 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/ApiException.java
@@ -17,6 +17,8 @@ import java.net.http.HttpHeaders;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private HttpHeaders responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/JSON.java
@@ -20,9 +20,9 @@ public class JSON {
   public JSON() {
     mapper = JsonMapper.builder()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true)
+        .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
         .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
@@ -18,6 +18,8 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiException.java
@@ -18,6 +18,8 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2-java8-localdatetime/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/jersey3/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/ApiException.java
@@ -17,6 +17,8 @@ import java.net.http.HttpHeaders;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private HttpHeaders responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/native-async/src/main/java/org/openapitools/client/JSON.java
@@ -20,9 +20,9 @@ public class JSON {
   public JSON() {
     mapper = JsonMapper.builder()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true)
+        .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
         .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/ApiException.java
@@ -17,6 +17,8 @@ import java.net.http.HttpHeaders;
 
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private HttpHeaders responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/native-jakarta/src/main/java/org/openapitools/client/JSON.java
@@ -20,9 +20,9 @@ public class JSON {
   public JSON() {
     mapper = JsonMapper.builder()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true)
+        .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
         .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/ApiException.java
@@ -17,6 +17,8 @@ import java.net.http.HttpHeaders;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private HttpHeaders responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/native/src/main/java/org/openapitools/client/JSON.java
@@ -20,9 +20,9 @@ public class JSON {
   public JSON() {
     mapper = JsonMapper.builder()
         .serializationInclusion(JsonInclude.Include.NON_NULL)
-        .configure(MapperFeature.ALLOW_COERCION_OF_SCALARS, false)
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .configure(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE, true)
+        .disable(MapperFeature.ALLOW_COERCION_OF_SCALARS)
+        .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING)
         .enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING)

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiException.java
@@ -23,6 +23,8 @@ import java.util.List;
 @SuppressWarnings("serial")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/ApiException.java
@@ -18,6 +18,8 @@ import java.util.List;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiException.java
@@ -19,6 +19,8 @@ import io.vertx.core.MultiMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private MultiMap responseHeaders = null;
     private String responseBody = null;

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiException.java
@@ -19,6 +19,8 @@ import io.vertx.core.MultiMap;
 
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private MultiMap responseHeaders = null;
     private String responseBody = null;

--- a/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/openapi3/client/extensions/x-auth-id-alias/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-special-characters/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger1/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8-swagger2/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;

--- a/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/src/main/java/org/openapitools/client/ApiException.java
@@ -21,6 +21,8 @@ import java.util.List;
  */
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiException extends Exception {
+    private static final long serialVersionUID = 1L;
+
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;
     private String responseBody = null;


### PR DESCRIPTION
Fixes  #17715 

This PR adds `serialVersionUID` to all java `apiException.mustache` and removes deprecated usage of `ObjectMapper#configure()` in `JSON.mustache` for the `native` Java generator.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Mentions: @bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg
