### PR TITLE
#11737 Add package to bean name in converter.mustache for EnumConverterConfiguration.java

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaSpring/converter.mustache
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "{{configPackage}}.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
 {{#models}}

--- a/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/spring-boot-oneof/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.fruitTypeConverter")

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-delegatePattern/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable-without-j8/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-spring-pageable/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/configuration/EnumConverterConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 
-@Configuration
+@Configuration(value = "org.openapitools.configuration.enumConverterConfiguration")
 public class EnumConverterConfiguration {
 
     @Bean(name = "org.openapitools.configuration.EnumConverterConfiguration.enumClassConverter")


### PR DESCRIPTION
Add package to bean name in converter.mustache for EnumConverterConfiguration.java to resolve issue #17737 

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
