### PR TITLE
[JAVA][bugfix] Add dependency for jakarta-validation-api and hibernate-validator to pom.xml for Java Resttemplate client

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/pom.mustache
@@ -313,6 +313,23 @@
             <version>${jodatime-version}</version>
         </dependency>
         {{/joda}}
+      {{#useBeanValidation}}
+        <!-- Bean Validation API support -->
+        <dependency>
+          <groupId>jakarta.validation</groupId>
+          <artifactId>jakarta.validation-api</artifactId>
+          <version>${beanvalidation-version}</version>
+          <scope>provided</scope>
+        </dependency>
+      {{/useBeanValidation}}
+      {{#performBeanValidation}}
+        <!-- Bean Validation Impl. used to perform BeanValidation -->
+        <dependency>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-validator</artifactId>
+          <version>${hibernate-validator-version}</version>
+        </dependency>
+      {{/performBeanValidation}}
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
@@ -356,6 +373,12 @@
         {{#joda}}
         <jodatime-version>2.9.9</jodatime-version>
         {{/joda}}
+        {{#useBeanValidation}}
+        <beanvalidation-version>2.0.2</beanvalidation-version>
+        {{/useBeanValidation}}
+        {{#performBeanValidation}}
+        <hibernate-validator-version>5.4.3.Final</hibernate-validator-version>
+        {{/performBeanValidation}}
         <junit-version>4.13.2</junit-version>
     </properties>
 </project>

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -2644,6 +2644,129 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testRestTemplateWithUseBeanValidationEnabled() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.USE_BEANVALIDATION, true);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/petstore.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
+
+        Path pomFile = Paths.get(output + "/pom.xml");
+        TestUtils.assertFileContains(pomFile, "<artifactId>jakarta.validation-api</artifactId>");
+
+        Path petModel = Paths.get(output + "/src/main/java/org/openapitools/client/model/Pet.java");
+        TestUtils.assertFileContains(petModel, "@Valid");
+    }
+
+    @Test
+    public void testRestTemplateWithUseBeanValidationDisabled() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.USE_BEANVALIDATION, false);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/petstore.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
+
+        Path pomFile = Paths.get(output + "/pom.xml");
+        TestUtils.assertFileNotContains(pomFile, "<artifactId>jakarta.validation-api</artifactId>");
+
+        Path petModel = Paths.get(output + "/src/main/java/org/openapitools/client/model/Pet.java");
+        TestUtils.assertFileNotContains(petModel, "@Valid");
+    }
+
+    @Test
+    public void testRestTemplateWithPerformBeanValidationEnabled() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.PERFORM_BEANVALIDATION, true);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/petstore.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
+
+        Path pomFile = Paths.get(output + "/pom.xml");
+        TestUtils.assertFileContains(pomFile, "<artifactId>hibernate-validator</artifactId>");
+
+        Path petApi = Paths.get(output + "/src/main/java/xyz/abcdef/BeanValidationException.java");
+        TestUtils.assertFileExists(petApi);
+    }
+
+    @Test
+    public void testRestTemplateWithPerformBeanValidationDisabled() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.PERFORM_BEANVALIDATION, false);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.RESTTEMPLATE)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/petstore.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
+
+        Path pomFile = Paths.get(output + "/pom.xml");
+        TestUtils.assertFileNotContains(pomFile, "<artifactId>hibernate-validator</artifactId>");
+
+        Path petApi = Paths.get(output + "/src/main/java/org/openapitools/client/invoker/BeanValidationException.java");
+        TestUtils.assertFileNotExists(petApi);
+    }
+
+
+    @Test
     public void testLogicToAvoidStackOverflow() throws IOException {
         Map<String, Object> properties = new HashMap<>();
         properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");


### PR DESCRIPTION
Fixes #17752 

I've added in the pom.xml file for Java client with Resttemplate library the jakarta-validation-api dependency when setting the property userBeanValidation to true and the hibernate-validator dependecy when setting the property performBeanValidation to true. 

Versions are identical to other pom.xml files with the same dependencies. 

### Technical Committee Java

@cachescrubber @welshm @MelleD @atextor @manedev79 @javisst @borsch @banlevente @Zomzog @martin-mfg

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
