### PR TITLE
Add lamdas for docs

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -469,7 +469,9 @@ public class DefaultCodegen implements CodegenConfig {
                 .put("indented", new IndentedLambda())
                 .put("indented_8", new IndentedLambda(8, " ", false, false))
                 .put("indented_12", new IndentedLambda(12, " ", false, false))
-                .put("indented_16", new IndentedLambda(16, " ", false, false));
+                .put("indented_16", new IndentedLambda(16, " ", false, false))
+                .put("tidy", new TidyLambda())
+                .put("make-single-line", new MakeSingleLineLambda());
 
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/MakeSingleLineLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/MakeSingleLineLambda.java
@@ -1,0 +1,39 @@
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Converts any text into a single line, i.e. removes any line-breaks into a space.
+ * <p>
+ * Register:
+ * <pre>
+ * additionalProperties.put("make-single-line", new MakeSingleLineLambda());
+ * </pre>
+ * <p>
+ * Use:
+ * <pre>{@code
+ *     {{#make-single-line}}{{{text}}}{{/make-single-line}}
+ * }</pre>
+ */
+public class MakeSingleLineLambda implements Mustache.Lambda 
+{
+    private static final String MULTIPLE_NEWLINE_REGEX = "[\\r?\\n]+";
+
+    public MakeSingleLineLambda() 
+    {
+    }
+
+    @Override
+    public void execute(Template.Fragment i_fragment, Writer i_writer) throws IOException 
+    {
+        String text = 
+            i_fragment.execute()
+                .replaceAll(MULTIPLE_NEWLINE_REGEX, " ");
+        i_writer.write(text);
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/TidyLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/TidyLambda.java
@@ -1,0 +1,53 @@
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Creates a (multi/single-)line text into a tidy comment converting special tags
+ * <p>
+ * Register:
+ * <pre>
+ * additionalProperties.put("tidy", new TidyLambda());
+ * </pre>
+ * <p>
+ * Use:
+ * <pre>{@code
+ *     {{#tidy}}{{{text}}}{{/tidy}}
+ * }</pre>
+ */
+public class TidyLambda implements Mustache.Lambda 
+{
+    private static final String SINGLE_SPACE = " ";
+    private static final String MULTIPLE_SPACE_REGEX = "[ ]+";
+    private static final String HTML_BREAK_TAG = "<br>";
+    private static final String HTML_TAG_REGEX = "<[^>]*>";
+    private static final String MULTIPLE_NEWLINE_REGEX = "[\\r?\\n]{2,}";
+
+    @Override
+    public void execute(Template.Fragment i_fragment, Writer i_writer) throws IOException 
+    {
+        String text = 
+            i_fragment.execute()
+                // Replace and normalize all non-standard apostrophes
+                .replaceAll("`+", "'")
+                // Replace and normalize all non-standard quotes
+                .replaceAll("[“”]+", "\"")
+                // Replace all HTML break tags by new lines
+                .replaceAll(HTML_BREAK_TAG, "\r\n")
+                // Escape all opening/closing brackets
+                .replaceAll("<", "\\<")
+                .replaceAll(">", "\\>")
+                // Normalize spaces
+                .replaceAll(MULTIPLE_SPACE_REGEX, SINGLE_SPACE)
+                // Normalize new-lines (maximum 2 consecutive line-breaks)
+                .replaceAll(MULTIPLE_NEWLINE_REGEX, "\r\n\r\n")
+                // Remove new-lines at the end
+                .replaceAll("[\\r?\\n]$", "");
+        i_writer.write(text);
+    }
+}


### PR DESCRIPTION
When I am generating doc files using OpenAPI, sometimes tags like summaries or descriptions contain text that won't look so pretty in md files (e.g. generates common Markdown mistakes like the ones explained here: https://gist.github.com/DavidAnson/006a6c2a2d9d7b21b025)

The best way to see the difference is by trying a specification file that will have tags like this:
```yml
...
   description: >
        This is an example with a long description
        on multiple lines. It might not look good if the mustache
        templates will get this content as it is.
        <br>This tag won't be recognized as a standard for Markdown, so in a md file 
         this tag won't be changed into a new line.
         #Markdown rules say that you should have one blank line before and after this title




        Too many blank lines will look bad in the documentation.
   summary: A description that is written on
        multiple lines won't look so good in case we put it into a table.
...
```

In the mustache templates these contents won't look so good if we use simply {{description}} and {{summary}}.

Any generation that enables docs:
				--global-property apiDocs=true
				--global-property modelDocs=true

My suggestion is to use new lambda mustache templates:

1. TidyLambda for the following changes :
- Replace and normalize all non-standard apostrophes
- Replace and normalize all non-standard quotes
- Replace all HTML break tags with new lines
- Escape all opening/closing brackets
- Normalize spaces
- Normalize new lines (maximum 2 consecutive line breaks)
- Remove new lines at the end
2. MakeSingleLineLambda for the following changes:
- Convert any line breaks into a space

For these, I have a solution here: 
And in mustache templates, you can use them as follows:
```mustache
...
Here is a better version of our description example: 

{{#lambda.tidy}}{{description}}{{/lambda.tidy}}

Here is a way to show our summary example in one line:

{{#lambda.make-single-line}}{{summary}}{{/lambda.make-single-line}}
...
```

It's important to note that these lambdas are optional. This means that the suggested change won't cause any issues.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
