### PR TITLE
include API information in RestConfiguration Template

### DIFF
--- a/modules/openapi-generator/src/main/resources/java-camel-server/restConfiguration.mustache
+++ b/modules/openapi-generator/src/main/resources/java-camel-server/restConfiguration.mustache
@@ -19,6 +19,8 @@ public class RestConfiguration extends RouteBuilder {
             .component("{{camelRestComponent}}")
             .bindingMode(RestBindingMode.{{camelRestBindingMode}}){{#camelDataformatProperties}}
                 .dataFormatProperty("{{key}}", "{{value}}"){{/camelDataformatProperties}}
-            .clientRequestValidation({{camelRestClientRequestValidation}});
+            .clientRequestValidation({{camelRestClientRequestValidation}})
+            .apiProperty("api.title", "{{appName}}")
+            .apiProperty("api.version", "{{appVersion}}");
     }
 }


### PR DESCRIPTION
Include API info in RestConfiguration for java-camel-server mustache template to prevent warning on startup as OpenAPI information can't be created otherwise.

Use java-camel-server generator to build the server and run it using the spring-boot-starter as described here: https://camel.apache.org/components/4.0.x/rest-component.html#_spring_boot_auto_configuration

@carnevalegiacomo
@martin-mfg
@lwlee2608

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
