### PR TITLE
fix: update dead link to TypeScript docs

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-aurelia/README.md
+++ b/modules/openapi-generator/src/main/resources/typescript-aurelia/README.md
@@ -1,57 +1,69 @@
 # TypeScript-Aurelia
 
 This generator creates TypeScript/JavaScript client that is injectable by [Aurelia](http://aurelia.io/).
-The generated Node module can be used in the following environments: 
+The generated Node module can be used in the following environments:
 
 Environment
-* Node.js
-* Webpack
-* Browserify
+
+- Node.js
+- Webpack
+- Browserify
 
 Language level
-* ES5 - you must have a Promises/A+ library installed
-* ES6
+
+- ES5 - you must have a Promises/A+ library installed
+- ES6
 
 Module system
-* CommonJS
-* ES6 module system
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+- CommonJS
+- ES6 module system
 
-### Building ####
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
+
+### Building
 
 To build and compile the typescript sources to javascript use:
+
 ```
 npm install
 npm run build
 ```
 
-#### NPM ####
+#### NPM
+
 You may publish the module to NPM. In this case, you would be able to install the module as any other NPM module. It may be useful to use [scoped packages](https://docs.npmjs.com/misc/scope).
 
-You can also use `npm link` to link the module. However, this would not modify `package.json` of the installing project, as such you would need to relink every time you deploy that project. 
+You can also use `npm link` to link the module. However, this would not modify `package.json` of the installing project, as such you would need to relink every time you deploy that project.
 
-You can also directly install the module using `npm install file_path`. If you do `npm install file_path --save`, NPM will save relative path to `package.json`. In this case, `npm install` and `npm shrinkwrap` may misbehave. You would need to manually edit `package.json` and replace it with absolute path. 
+You can also directly install the module using `npm install file_path`. If you do `npm install file_path --save`, NPM will save relative path to `package.json`. In this case, `npm install` and `npm shrinkwrap` may misbehave. You would need to manually edit `package.json` and replace it with absolute path.
 
-Regardless of which method you deployed your NPM module, the ES6 module syntaxes are as follows: 
+Regardless of which method you deployed your NPM module, the ES6 module syntaxes are as follows:
+
 ```
 import * as localName from 'npmName';
 import {operationId} from 'npmName';
 ```
+
 The CommonJS syntax is as follows:
+
 ```
 import localName = require('npmName');
 ```
 
-#### Direct copy/symlink ####
+#### Direct copy/symlink
+
 You may also simply copy or symlink the generated module into a directory under your project. The syntax of this is as follows:
 
-With ES6 module syntax, the following syntaxes are supported: 
+With ES6 module syntax, the following syntaxes are supported:
+
 ```
 import * as localName from './symlinkDir';
 import {operationId} from './symlinkDir';
 ```
+
 The CommonJS syntax is as follows:
+
 ```
 import localName = require('./symlinkDir')';
 ```

--- a/modules/openapi-generator/src/main/resources/typescript-axios/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/README.mustache
@@ -15,7 +15,7 @@ Module system
 * CommonJS
 * ES6 module system
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
@@ -27,7 +27,7 @@ npm run build
 
 ### Publishing
 
-First build the package then run ```npm publish```
+First build the package then run `npm publish`
 
 ### Consuming
 
@@ -43,3 +43,4 @@ _unPublished (not recommended):_
 
 ```
 npm install PATH_TO_GENERATED_PACKAGE --save
+```

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/README.mustache
@@ -15,7 +15,7 @@ Module system
 * CommonJS
 * ES6 module system
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
@@ -27,7 +27,7 @@ npm run build
 
 ### Publishing
 
-First build the package then run ```npm publish```
+First build the package then run `npm publish`
 
 ### Consuming
 
@@ -43,3 +43,4 @@ _unPublished (not recommended):_
 
 ```
 npm install PATH_TO_GENERATED_PACKAGE --save
+```

--- a/modules/openapi-generator/src/main/resources/typescript-jquery/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-jquery/README.mustache
@@ -15,7 +15,7 @@ Module system
 * CommonJS
 * ES6 module system
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html))
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
@@ -27,7 +27,7 @@ npm run build
 
 ### Publishing
 
-First build the package then run ```npm publish```
+First build the package then run `npm publish`
 
 ### Consuming
 
@@ -43,3 +43,4 @@ _unPublished (not recommended):_
 
 ```
 npm install PATH_TO_GENERATED_PACKAGE --save
+```

--- a/modules/openapi-generator/src/main/resources/typescript-redux-query/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-redux-query/README.mustache
@@ -3,7 +3,7 @@
 This generator creates TypeScript/JavaScript client that utilizes [redux-query](https://amplitude.github.io/redux-query/).
 The generated Node module does not depend on ReactJS specifically.
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 
@@ -15,7 +15,7 @@ npm run build
 
 ### Publishing
 
-First build the package then run ```npm publish```
+First build the package then run `npm publish`
 
 ### Consuming
 
@@ -31,3 +31,4 @@ _unPublished (not recommended):_
 
 ```
 npm install PATH_TO_GENERATED_PACKAGE --save
+```

--- a/modules/openapi-generator/src/main/resources/typescript-rxjs/README.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-rxjs/README.mustache
@@ -15,7 +15,7 @@ Module system
 * CommonJS
 * ES6 module system
 
-It can be used in both TypeScript and JavaScript. In TypeScript, the definition should be automatically resolved via `package.json`. ([Reference](http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html))
+It can be used in both TypeScript and JavaScript. In TypeScript, the definition will be automatically resolved via `package.json`. ([Reference](https://www.typescriptlang.org/docs/handbook/declaration-files/consumption.html))
 
 ### Building
 


### PR DESCRIPTION
The previous link no longer worked, so I've updated it to the latest version of the TypeScript handbook.

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
