### PR TITLE
REQ-14868 - Support for custom template engine helpers

### DIFF
--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
@@ -118,5 +118,5 @@ public interface TemplatingEngineAdapter {
      * @param helpersJar The JAR to load helpers from
      * @throws IOException Helpers could not be loaded from the given JAR
      */
-	void useCustomHelpersFile(File helpersJar) throws IOException;
+    void useCustomHelpersFile(File helpersJar) throws IOException;
 }

--- a/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
+++ b/modules/openapi-generator-core/src/main/java/org/openapitools/codegen/api/TemplatingEngineAdapter.java
@@ -16,6 +16,7 @@
 
 package org.openapitools.codegen.api;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -111,4 +112,11 @@ public interface TemplatingEngineAdapter {
             return false;
         });
     }
+
+    /**
+     * Loads helpers provided via an external JAR for use in the templating engine
+     * @param helpersJar The JAR to load helpers from
+     * @throws IOException Helpers could not be loaded from the given JAR
+     */
+	void useCustomHelpersFile(File helpersJar) throws IOException;
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenConstants.java
@@ -232,6 +232,9 @@ public class CodegenConstants {
     public static final String TEMPLATING_ENGINE = "templatingEngine";
     public static final String TEMPLATING_ENGINE_DESC = "The templating engine plugin to use: \"mustache\" (default) or \"handlebars\" (beta)";
 
+    public static final String TEMPLATE_ENGINE_HELPERS = "templatingEngineHelpers";
+    public static final String TEMPLATE_ENGINE_HELPERS_DESC = "A JAR containing helper methods for the template engine. Currently only the \"mustache\" engine supports this feature";
+
     public static enum PARAM_NAMING_TYPE {camelCase, PascalCase, snake_case, original}
 
     public static enum MODEL_PROPERTY_NAMING_TYPE {camelCase, PascalCase, snake_case, original}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -126,6 +126,8 @@ public class DefaultGenerator implements Generator {
         } else {
             TemplatingEngineAdapter templatingEngine = this.config.getTemplatingEngine();
 
+			this.loadCustomHelpers(templatingEngine);
+
             if (templatingEngine instanceof MustacheEngineAdapter) {
                 MustacheEngineAdapter mustacheEngineAdapter = (MustacheEngineAdapter) templatingEngine;
                 mustacheEngineAdapter.setCompiler(this.config.processCompiler(mustacheEngineAdapter.getCompiler()));
@@ -1944,4 +1946,20 @@ public class DefaultGenerator implements Generator {
         return StringUtils.removeEnd(value, "/");
     }
 
+    /**
+     * Loads custom template helpers from a file, if one was provided via the TEMPLATE_ENGINE_HELPERS property
+     * @param templatingEngine The template engine adapter to load the custom helpers to
+     */
+    private void loadCustomHelpers(TemplatingEngineAdapter templatingEngine) {
+        try {
+            String customHelpersFilePath = (String) this.config.additionalProperties().get(CodegenConstants.TEMPLATE_ENGINE_HELPERS);
+            if (customHelpersFilePath != null && !customHelpersFilePath.isEmpty()) {
+                LOGGER.info("Loading custom helpers from {}", customHelpersFilePath);
+                templatingEngine.useCustomHelpersFile(new File(customHelpersFilePath));
+            }
+        } catch (IOException e) {
+            LOGGER.error("Encountered an IO exception during loading of custom helpers", e);
+            throw new RuntimeException("Encountered an IO exception during loading of custom helpers", e);
+        }
+    }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java
@@ -126,7 +126,8 @@ public class DefaultGenerator implements Generator {
         } else {
             TemplatingEngineAdapter templatingEngine = this.config.getTemplatingEngine();
 
-			this.loadCustomHelpers(templatingEngine);
+            // Load custom helpers if an external JAR was given via props
+            this.loadCustomHelpers(templatingEngine);
 
             if (templatingEngine instanceof MustacheEngineAdapter) {
                 MustacheEngineAdapter mustacheEngineAdapter = (MustacheEngineAdapter) templatingEngine;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
@@ -36,7 +36,7 @@ public class MustacheEngineAdapter implements TemplatingEngineAdapter {
 
     private final Logger LOGGER = LoggerFactory.getLogger(TemplatingEngineAdapter.class);
 
-	private Map<String, Mustache.Lambda> _helpers = new HashMap<>();
+    private Map<String, Mustache.Lambda> _helpers = new HashMap<>();
 
     /**
      * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/MustacheEngineAdapter.java
@@ -20,18 +20,23 @@ import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import org.openapitools.codegen.api.TemplatingEngineAdapter;
 import org.openapitools.codegen.api.TemplatingExecutor;
+import org.openapitools.codegen.utils.loaders.MustacheHelperLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.HashMap;
 import java.util.Map;
 
 
 public class MustacheEngineAdapter implements TemplatingEngineAdapter {
 
     private final Logger LOGGER = LoggerFactory.getLogger(TemplatingEngineAdapter.class);
+
+	private Map<String, Mustache.Lambda> _helpers = new HashMap<>();
 
     /**
      * Provides an identifier used to load the adapter. This could be a name, uuid, or any other string.
@@ -62,6 +67,9 @@ public class MustacheEngineAdapter implements TemplatingEngineAdapter {
                 .defaultValue("")
                 .compile(executor.getFullTemplateContents(templateFile));
 
+        this.insertCustomHelpersToContext(bundle);
+
+        LOGGER.debug("Registered {} custom Mustache helpers", this._helpers.size());
         return tmpl.execute(bundle);
     }
 
@@ -90,5 +98,41 @@ public class MustacheEngineAdapter implements TemplatingEngineAdapter {
     @Override
     public String[] getFileExtensions() {
         return extensions;
+    }
+
+    @Override
+    public void useCustomHelpersFile(File helpersJar) throws IOException, FileNotFoundException {
+        if (helpersJar == null) {
+            LOGGER.warn("Helpers file is null. Ignoring");
+            return;
+        }
+
+        if (!helpersJar.exists()) {
+            LOGGER.warn("Helpers file at {} does not exist. Ignoring", helpersJar.getPath());
+            return;
+        }
+
+        try {
+            MustacheHelperLoader loader = new MustacheHelperLoader(helpersJar);
+            loader.load();
+            this._helpers = loader.getHelpers();
+        } catch (Exception e) {
+            LOGGER.error("Could not load customer template helpers from {} - {}", helpersJar.getPath(), e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Inserts all available helpers into the given context
+     * @param context The Mustache engine context to insert helper Mustache.Lambdas to
+     * @throws IllegalStateException Some helper methods have keys that conflict with ones on the current context
+     */
+    private void insertCustomHelpersToContext(Map<String, Object> context) {
+        for (var entry : this._helpers.entrySet()) {
+            if (context.putIfAbsent(entry.getKey(), entry.getValue()) != null) {
+                throw new IllegalStateException("The Mustache context already has a definition for '" + entry.getKey() + "'");
+            }
+            LOGGER.debug("Registered helper '{}' ({})", entry.getKey(), entry.getValue().getClass().getCanonicalName());
+        }
     }
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/AbstractHelperLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/AbstractHelperLoader.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * An abstract class used to load helpers included in JARs into the template engine
+ *
  * @param <THelperType> The type of helper class this loader should output
  */
 public abstract class AbstractHelperLoader<THelperType> {
@@ -34,9 +35,9 @@ public abstract class AbstractHelperLoader<THelperType> {
      * An abstract class used to load helpers included in JARs into the template engine
      *
      * @param helperTypeClass The type of helper class to look for in the JAR. This could be Mustache.Lambda for example
-     * @param jar The JAR to look for helpers in
+     * @param jar             The JAR to look for helpers in
      * @throws IllegalArgumentException A helper class type or JAR path were not specified
-     * @throws FileNotFoundException The given JAR does not exist
+     * @throws FileNotFoundException    The given JAR does not exist
      */
     protected AbstractHelperLoader(Class<THelperType> helperTypeClass, File jar) throws IllegalArgumentException, FileNotFoundException {
         if (helperTypeClass == null) {
@@ -111,8 +112,9 @@ public abstract class AbstractHelperLoader<THelperType> {
 
     /**
      * Tests whether the given class JarEntry is a helper and returns an instance of it if it is
+     *
      * @param loader The class loader to use for instantiating the helper
-     * @param entry The class entry to test and construct
+     * @param entry  The class entry to test and construct
      * @return A new instance of THelperType if the entry is suitable, null otherwise
      */
     @SuppressWarnings("unchecked")

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/AbstractHelperLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/AbstractHelperLoader.java
@@ -1,0 +1,147 @@
+package org.openapitools.codegen.utils.loaders;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An abstract class used to load helpers included in JARs into the template engine
+ * @param <THelperType> The type of helper class this loader should output
+ */
+public abstract class AbstractHelperLoader<THelperType> {
+    protected final Logger LOGGER = LoggerFactory.getLogger(AbstractHelperLoader.class);
+
+    private final File _jar;
+
+    private final Map<String, THelperType> _helpers = new HashMap<>();
+
+    private final Class<THelperType> _helperClass;
+
+    public Map<String, THelperType> getHelpers() {
+        return this._helpers;
+    }
+
+    /**
+     * An abstract class used to load helpers included in JARs into the template engine
+     *
+     * @param helperTypeClass The type of helper class to look for in the JAR. This could be Mustache.Lambda for example
+     * @param jar The JAR to look for helpers in
+     * @throws IllegalArgumentException A helper class type or JAR path were not specified
+     * @throws FileNotFoundException The given JAR does not exist
+     */
+    protected AbstractHelperLoader(Class<THelperType> helperTypeClass, File jar) throws IllegalArgumentException, FileNotFoundException {
+        if (helperTypeClass == null) {
+            throw new IllegalArgumentException("helperTypeClass must be provided");
+        }
+        this._helperClass = helperTypeClass;
+
+        if (jar == null) {
+            throw new IllegalArgumentException("Given JAR cannot be null");
+        }
+
+        if (!jar.exists()) {
+            throw new FileNotFoundException("Given JAR ('" + jar.getPath() + "') does not exist");
+        }
+
+        this._jar = jar;
+    }
+
+    /**
+     * Loads the helpers defined in the JAR linked to this instance into the template engine
+     *
+     * @throws IOException Could not initialize an instance of URLClassLoader for the given JAR
+     */
+    public void load() throws IOException {
+        List<JarEntry> classEntries = this.getClassJarEntries(this._jar);
+
+        URL[] jarUrl = new URL[]{new URL("jar:file:" + this._jar.getAbsolutePath() + "!/")};
+        try (URLClassLoader loader = URLClassLoader.newInstance(jarUrl)) {
+
+            for (JarEntry classEntry : classEntries) {
+                THelperType lambda = this.filterEntry(loader, classEntry);
+                if (lambda != null) {
+                    String className = lambda.getClass().getSimpleName();
+                    LOGGER.debug("Storing helper {}", className);
+                    this._helpers.put(className, lambda);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get all classes from the given JAR
+     *
+     * @param jarPath The JAR to search for classes in
+     * @return A list of JarEntry where each entry is a class
+     * @throws IOException Could not read the given JAR
+     */
+    private List<JarEntry> getClassJarEntries(File jarPath) throws IOException {
+        ArrayList<JarEntry> classes = new ArrayList<>();
+
+        try (JarFile jarFile = new JarFile(jarPath)) {
+            Enumeration<JarEntry> e = jarFile.entries();
+            int entryCount = 0;
+            while (e.hasMoreElements()) {
+                JarEntry jarEntry = e.nextElement();
+                entryCount++;
+                if (jarEntry.getName().endsWith(".class")) {
+                    LOGGER.debug("Entry {} is a class and will be tested", jarEntry.getName());
+                    classes.add(jarEntry);
+                }
+            }
+            LOGGER.debug("JAR {} contains {} entries, of which {} are classes", jarPath, entryCount, classes.size());
+            return classes;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    protected boolean isClassRelevant(Class<THelperType> classToTest) {
+        // Parameter classToTest is for implementors to use if necessary
+        return true;
+    }
+
+    /**
+     * Tests whether the given class JarEntry is a helper and returns an instance of it if it is
+     * @param loader The class loader to use for instantiating the helper
+     * @param entry The class entry to test and construct
+     * @return A new instance of THelperType if the entry is suitable, null otherwise
+     */
+    @SuppressWarnings("unchecked")
+    protected THelperType filterEntry(URLClassLoader loader, JarEntry entry) {
+        LOGGER.debug("Processing entry {}", entry.getName());
+
+        if (!entry.getName().endsWith(".class")) {
+            return null;
+        }
+
+        String fullClassName = entry.getName()
+                .replace("/", ".")
+                .replace(".class", "");
+        try {
+            Class<?> loadedClass = loader.loadClass(fullClassName);
+            if (this._helperClass.isAssignableFrom(loadedClass)) {
+                Class<THelperType> helper = (Class<THelperType>) loadedClass;
+                if (this.isClassRelevant(helper)) {
+                    LOGGER.debug("Entry {} is a helper class and will be returned", fullClassName);
+                    return helper.getConstructor().newInstance();
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            LOGGER.warn("Could not load class {} from JAR", fullClassName);
+        } catch (NoSuchMethodException e) {
+            LOGGER.warn("Could not load class {} - no default constructor was found", fullClassName);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            LOGGER.warn("Could not instantiate class " + fullClassName, e);
+        }
+        return null;
+    }
+}

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/HandlebarsHelperLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/HandlebarsHelperLoader.java
@@ -1,0 +1,16 @@
+package org.openapitools.codegen.utils.loaders;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import com.github.jknack.handlebars.Helper;
+
+/**
+ * A class used to load helpers from an external JAR into the Handlebars engine
+ */
+public class HandlebarsHelperLoader extends AbstractHelperLoader<Helper> {
+    public HandlebarsHelperLoader(File jar) throws IllegalAccessError, FileNotFoundException {
+        super(Helper.class, jar);
+    }
+}
+

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/MustacheHelperLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/MustacheHelperLoader.java
@@ -2,6 +2,7 @@ package org.openapitools.codegen.utils.loaders;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+
 import com.samskivert.mustache.Mustache;
 
 /**

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/MustacheHelperLoader.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/loaders/MustacheHelperLoader.java
@@ -1,0 +1,15 @@
+package org.openapitools.codegen.utils.loaders;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import com.samskivert.mustache.Mustache;
+
+/**
+ * A class used to load helpers from an external JAR into the Mustache engine
+ */
+public class MustacheHelperLoader extends AbstractHelperLoader<Mustache.Lambda> {
+    public MustacheHelperLoader(File jar) throws IllegalAccessError, FileNotFoundException {
+        super(Mustache.Lambda.class, jar);
+    }
+}
+

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/CustomTemplateHelpersTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/CustomTemplateHelpersTest.java
@@ -1,0 +1,156 @@
+package org.openapitools.codegen;
+
+import io.vavr.collection.Array;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Tests for the Customer Template Helpers feature
+ */
+public class CustomTemplateHelpersTest {
+
+    @Test
+    public void testMustacheSingleCustomHelper() throws IOException {
+        final Path baseTestDir = Files.createTempDirectory("test");
+
+        String jarPath = assertCompileFileToJar(
+                baseTestDir,
+                Array.of(new File("src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintSuccessHelper.java"))
+        );
+
+        final CodegenConfigurator configurator = getConfigurator(
+                baseTestDir,
+                jarPath,
+                "mustache",
+                "src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/singlehelper"
+        );
+
+        assertCompilePetApiAndTestContent(baseTestDir, configurator, "SUCCESS");
+    }
+
+    @Test
+    public void testMustacheMultiCustomHelpers() throws IOException {
+        final Path baseTestDir = Files.createTempDirectory("test");
+
+        String jarPath = assertCompileFileToJar(
+                baseTestDir,
+                Array.of(
+                        new File("src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintSuccessHelper.java"),
+                        new File("src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintOkHelper.java")
+                )
+        );
+
+        final CodegenConfigurator configurator = getConfigurator(
+                baseTestDir,
+                jarPath,
+                "mustache",
+                "src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/multihelpers"
+        );
+
+        assertCompilePetApiAndTestContent(baseTestDir, configurator, "SUCCESS-OK");
+    }
+
+    @Test
+    public void testHandlebarsSingleCustomHelper() throws IOException {
+        final Path baseTestDir = Files.createTempDirectory("test");
+
+        String jarPath = assertCompileFileToJar(
+                baseTestDir,
+                Array.of(new File("src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintSuccessHelper.java"))
+        );
+
+        final CodegenConfigurator configurator = getConfigurator(
+                baseTestDir,
+                jarPath,
+                "handlebars",
+                "src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/singlehelper"
+        );
+
+        assertCompilePetApiAndTestContent(baseTestDir, configurator, "SUCCESS");
+    }
+
+    @Test
+    public void testHandlebarsMultiCustomHelpers() throws IOException {
+        final Path baseTestDir = Files.createTempDirectory("test");
+
+        String jarPath = assertCompileFileToJar(
+                baseTestDir,
+                Array.of(
+                        new File("src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintSuccessHelper.java"),
+                        new File("src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintOkHelper.java")
+                )
+        );
+
+        final CodegenConfigurator configurator = getConfigurator(
+                baseTestDir,
+                jarPath,
+                "handlebars",
+                "src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/multihelpers"
+        );
+
+        assertCompilePetApiAndTestContent(baseTestDir, configurator, "SUCCESS-OK");
+    }
+
+    private static String assertCompileFileToJar(Path baseTestDir, Iterable<File> inputJavaFiles) {
+        String jarPath = Path.of(baseTestDir.toAbsolutePath().toString(), "TemplateHelpers.jar").toAbsolutePath().toString();
+
+        try {
+            Assert.assertTrue(TestUtils.compileFilesToJar(
+                    inputJavaFiles,
+                    baseTestDir.toFile(),
+                    jarPath
+            ));
+        } catch (Exception e) {
+            Assert.fail("Custom helper compilation failed, cannot test feature", e);
+        }
+
+        return jarPath;
+    }
+
+    private static void assertCompilePetApiAndTestContent(Path baseTestDir, CodegenConfigurator configurator, String expectedContent) throws IOException {
+        final String outputDir = Path.of(baseTestDir.toAbsolutePath().toString(), "generated").toAbsolutePath().toString();
+
+        final DefaultGenerator generator = getDefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+
+        TestUtils.ensureContainsFile(files, new File(outputDir), "src/main/java/org/openapitools/client/api/PetApi.java");
+        File actualApiFile = new File(outputDir, "src/main/java/org/openapitools/client/api/PetApi.java");
+        Assert.assertTrue(actualApiFile.exists());
+
+        Assert.assertEquals(Files.readString(actualApiFile.toPath()), expectedContent);
+    }
+
+    private static CodegenConfigurator getConfigurator(Path baseTestDir, String jarPath, String templateEngineName, String templateDir) {
+        final String outputDir = Path.of(baseTestDir.toAbsolutePath().toString(), "generated").toAbsolutePath().toString();
+        return new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setTemplatingEngineName(templateEngineName)
+                .addAdditionalProperty(CodegenConstants.TEMPLATE_ENGINE_HELPERS, jarPath)
+                .addGlobalProperty(CodegenConstants.APIS, "Pet")
+                .setTemplateDir(templateDir)
+                .setInputSpec("src/test/resources/3_0/petstore.yaml")
+                .setOutputDir(outputDir);
+    }
+
+    private static DefaultGenerator getDefaultGenerator() {
+        final DefaultGenerator generator = new DefaultGenerator();
+
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODELS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.APIS, "true");
+        generator.setGeneratorPropertyDefault(CodegenConstants.SUPPORTING_FILES, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.API_DOCS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.MODEL_TESTS, "false");
+        generator.setGeneratorPropertyDefault(CodegenConstants.API_TESTS, "false");
+
+        return generator;
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintOkHelper.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintOkHelper.java
@@ -1,0 +1,14 @@
+package org.openapitools.codegen.customhelpers.handlebars;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.io.IOException;
+
+public class PrintOkHelper implements Helper<Object> {
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+        return "OK";
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintSuccessHelper.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/handlebars/PrintSuccessHelper.java
@@ -1,0 +1,14 @@
+package org.openapitools.codegen.customhelpers.handlebars;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.io.IOException;
+
+public class PrintSuccessHelper implements Helper<Object> {
+
+    @Override
+    public Object apply(Object context, Options options) throws IOException {
+        return "SUCCESS";
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintOkHelper.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintOkHelper.java
@@ -1,0 +1,15 @@
+package org.openapitools.codegen.customhelpers.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class PrintOkHelper implements Mustache.Lambda {
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        writer.write("OK");
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintSuccessHelper.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/customhelpers/mustache/PrintSuccessHelper.java
@@ -1,0 +1,15 @@
+package org.openapitools.codegen.customhelpers.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class PrintSuccessHelper implements Mustache.Lambda {
+
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        writer.write("SUCCESS");
+    }
+}

--- a/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/multihelpers/api.hbs
+++ b/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/multihelpers/api.hbs
@@ -1,0 +1,1 @@
+{{#PrintSuccessHelper}}{{/PrintSuccessHelper}}-{{#PrintOkHelper}}{{/PrintOkHelper}}

--- a/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/singlehelper/api.hbs
+++ b/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/handlebars/singlehelper/api.hbs
@@ -1,0 +1,1 @@
+{{#PrintSuccessHelper}}{{/PrintSuccessHelper}}

--- a/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/multihelpers/api.mustache
+++ b/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/multihelpers/api.mustache
@@ -1,0 +1,1 @@
+{{#PrintSuccessHelper}}{{/PrintSuccessHelper}}-{{#PrintOkHelper}}{{/PrintOkHelper}}

--- a/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/singlehelper/api.mustache
+++ b/modules/openapi-generator/src/test/resources/templating/templates/defaultgenerator/customhelpers/mustache/singlehelper/api.mustache
@@ -1,0 +1,1 @@
+{{#PrintSuccessHelper}}{{/PrintSuccessHelper}}


### PR DESCRIPTION
=================================================================================================
### Introduces support for use of custom template helpers via an option to provide a JAR path
=================================================================================================

### Rationale
* Provide support for more complex use-cases involving template logic not covered by built-in helpers
* Facilitate a way to 'inject' into the template context. Helper functions can serve as a bridge of sorts between OAG and user code

* Provide a way to mitigate certain issues without waiting for an official release or upgrading
  A real world example:

    * Descriptions may not be properly generated for some TypeScript models. This is solvable a template modification but due to what appears to be a bug in OAG the solution requires more logic than the built-in helpers provide.
This forces the user to migrate to a fixed version, if available, incurring the usual effort costs or work-around the issue otherwise.
    This is especially useful in enterprise or API-proxy scenarios where it may be difficult to upgrade OAG version due to breaking schema changes


#### Caveats
* Helpers using imports not in the classpath will fail. While a more complete solution is most likely possible,
  I believe the feature has good value regardless.

<br>

- [x] Includes tests
- [x] Includes documentation 

Closes #14868

----------------------------------------------------------------------------

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
