### PR TITLE
[Java] Fix default values of array-type parameters in a referenced file

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -1289,6 +1289,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
             return localDate.toString();
         }
         if (ModelUtils.isArraySchema(schema)) {
+            // swagger-parser parses the default value differently depending on whether it's in a referenced file or not.
+            // cf. https://github.com/swagger-api/swagger-parser/issues/1958
+            // ArrayList if in the referenced file, ArrayNode if not.
             if (defaultValue instanceof ArrayNode) {
                 ArrayNode array = (ArrayNode) defaultValue;
                 return StreamSupport.stream(array.spliterator(), false)
@@ -1296,6 +1299,11 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                         // remove wrapper quotes
                         .map(item -> StringUtils.removeStart(item, "\""))
                         .map(item -> StringUtils.removeEnd(item, "\""))
+                        .collect(Collectors.joining(","));
+            } else if (defaultValue instanceof ArrayList) {
+                ArrayList<?> array = (ArrayList<?>) defaultValue;
+                return array.stream()
+                        .map(Object::toString)
                         .collect(Collectors.joining(","));
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -17,14 +17,18 @@
 
 package org.openapitools.codegen.java;
 
+import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.*;
 
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import java.util.stream.Collectors;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -871,6 +875,26 @@ public class AbstractJavaCodegenTest {
         Assert.assertTrue(cm.imports.contains("BigDecimal"));
         Assert.assertTrue(cm.imports.contains("Date"));
         Assert.assertTrue(cm.imports.contains("UUID"));
+    }
+
+    @Test
+    public void arrayParameterDefaultValueDoesNotNeedBraces() throws Exception {
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+        final OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_16223.yaml", null, parseOptions)
+                .getOpenAPI();
+        final P_AbstractJavaCodegen codegen = new P_AbstractJavaCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        Map<String, Schema> schemas = openAPI.getPaths().get("/test").getGet().getParameters().stream()
+                .collect(Collectors.toMap(
+                        Parameter::getName,
+                        p -> ModelUtils.getReferencedSchema(openAPI, p.getSchema())));
+        Assert.assertEquals(codegen.toDefaultParameterValue(schemas.get("fileEnumWithDefault")), "A,B");
+        Assert.assertEquals(codegen.toDefaultParameterValue(schemas.get("fileEnumWithDefaultEmpty")), "");
+        Assert.assertEquals(codegen.toDefaultParameterValue(schemas.get("inlineEnumWithDefault")), "A,B");
+        Assert.assertEquals(codegen.toDefaultParameterValue(schemas.get("inlineEnumWithDefaultEmpty")), "");
     }
 
     private static Schema<?> createObjectSchemaWithMinItems() {

--- a/modules/openapi-generator/src/test/resources/3_0/issue_16223.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_16223.yaml
@@ -1,0 +1,54 @@
+---
+openapi: 3.0.3
+info:
+  title: Test
+  version: 1.0.0-SNAPSHOT
+paths:
+  /test:
+    get:
+      parameters:
+        - name: fileEnumWithDefault
+          in: query
+          schema:
+            $ref: './issue_16223_enum_with_default.yaml'
+        - name: fileEnumWithDefaultEmpty
+          in: query
+          schema:
+            $ref: './issue_16223_enum_with_default_empty.yaml'
+        - name: inlineEnumWithDefault
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - A
+                - B
+                - C
+            default:
+              - A
+              - B
+        - name: inlineEnumWithDefaultEmpty
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - A
+                - B
+                - C
+            default: []
+      responses:
+        "200":
+          description: OK
+
+components:
+  schemas:
+    Test:
+      type: object
+      properties:
+        withDefault:
+          $ref: './issue_16223_enum_with_default.yaml'
+        withEmptyDefault:
+          $ref: './issue_16223_enum_with_default_empty.yaml'

--- a/modules/openapi-generator/src/test/resources/3_0/issue_16223_enum_with_default.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_16223_enum_with_default.yaml
@@ -1,0 +1,10 @@
+type: array
+items:
+  type: string
+  enum:
+    - A
+    - B
+    - C
+default:
+  - A
+  - B

--- a/modules/openapi-generator/src/test/resources/3_0/issue_16223_enum_with_default_empty.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_16223_enum_with_default_empty.yaml
@@ -1,0 +1,8 @@
+type: array
+items:
+  type: string
+  enum:
+    - A
+    - B
+    - C
+default: []


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
fix: #16223

If a parameter is referencing an array-type schema in an external file using `$ref`, its default value will be rendered with unneeded square braces like `[foo, bar]`. This PR removes them.

To [Java technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee): @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
