### PR TITLE
[go-gin-server]  add a new function to the router to pass the gin context

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
+++ b/modules/openapi-generator/src/main/resources/go-gin-server/routers.mustache
@@ -21,26 +21,30 @@ type Route struct {
 
 // NewRouter returns a new router.
 func NewRouter(handleFunctions ApiHandleFunctions) *gin.Engine {
-	router := gin.Default()
-	for _, route := range getRoutes(handleFunctions) {
-		if route.HandlerFunc == nil {
-			route.HandlerFunc = DefaultHandleFunc
-		}
-		switch route.Method {
-		case http.MethodGet:
-			router.GET(route.Pattern, route.HandlerFunc)
-		case http.MethodPost:
-			router.POST(route.Pattern, route.HandlerFunc)
-		case http.MethodPut:
-			router.PUT(route.Pattern, route.HandlerFunc)
-		case http.MethodPatch:
-			router.PATCH(route.Pattern, route.HandlerFunc)
-		case http.MethodDelete:
-			router.DELETE(route.Pattern, route.HandlerFunc)
-		}
-	}
+	return NewRouterWithGinEngine(gin.Default(), handleFunctions)
+}
 
-	return router
+// NewRouter add routes to existing gin engine.
+func NewRouterWithGinEngine(router *gin.Engine, handleFunctions ApiHandleFunctions) *gin.Engine {
+        for _, route := range getRoutes(handleFunctions) {
+            if route.HandlerFunc == nil {
+                route.HandlerFunc = DefaultHandleFunc
+            }
+            switch route.Method {
+            case http.MethodGet:
+                router.GET(route.Pattern, route.HandlerFunc)
+            case http.MethodPost:
+                router.POST(route.Pattern, route.HandlerFunc)
+            case http.MethodPut:
+                router.PUT(route.Pattern, route.HandlerFunc)
+            case http.MethodPatch:
+                router.PATCH(route.Pattern, route.HandlerFunc)
+            case http.MethodDelete:
+                router.DELETE(route.Pattern, route.HandlerFunc)
+            }
+        }
+
+        return router
 }
 
 // Default handler for not yet implemented routes

--- a/samples/server/petstore/go-gin-api-server/go/routers.go
+++ b/samples/server/petstore/go-gin-api-server/go/routers.go
@@ -29,26 +29,30 @@ type Route struct {
 
 // NewRouter returns a new router.
 func NewRouter(handleFunctions ApiHandleFunctions) *gin.Engine {
-	router := gin.Default()
-	for _, route := range getRoutes(handleFunctions) {
-		if route.HandlerFunc == nil {
-			route.HandlerFunc = DefaultHandleFunc
-		}
-		switch route.Method {
-		case http.MethodGet:
-			router.GET(route.Pattern, route.HandlerFunc)
-		case http.MethodPost:
-			router.POST(route.Pattern, route.HandlerFunc)
-		case http.MethodPut:
-			router.PUT(route.Pattern, route.HandlerFunc)
-		case http.MethodPatch:
-			router.PATCH(route.Pattern, route.HandlerFunc)
-		case http.MethodDelete:
-			router.DELETE(route.Pattern, route.HandlerFunc)
-		}
-	}
+	return NewRouterWithGinEngine(gin.Default(), handleFunctions)
+}
 
-	return router
+// NewRouter add routes to existing gin engine.
+func NewRouterWithGinEngine(router *gin.Engine, handleFunctions ApiHandleFunctions) *gin.Engine {
+        for _, route := range getRoutes(handleFunctions) {
+            if route.HandlerFunc == nil {
+                route.HandlerFunc = DefaultHandleFunc
+            }
+            switch route.Method {
+            case http.MethodGet:
+                router.GET(route.Pattern, route.HandlerFunc)
+            case http.MethodPost:
+                router.POST(route.Pattern, route.HandlerFunc)
+            case http.MethodPut:
+                router.PUT(route.Pattern, route.HandlerFunc)
+            case http.MethodPatch:
+                router.PATCH(route.Pattern, route.HandlerFunc)
+            case http.MethodDelete:
+                router.DELETE(route.Pattern, route.HandlerFunc)
+            }
+        }
+
+        return router
 }
 
 // Default handler for not yet implemented routes


### PR DESCRIPTION
Currently, the GIN engine is directly created in the `NewRouter` function. so it is not possible to set middleware before the registration of routers.

I added a new function in the router so we can use the existing Gin Engine object.

```
func NewRouterWithGinEngine(router *gin.Engine, handleFunctions ApiHandleFunctions) *gin.Engine {
...
}
```

FYI: @antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5


<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
