### PR TITLE
Fix: Always serialise Map and Set to object and array in typescript-axios

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/common.mustache
@@ -118,8 +118,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/echo_api/typescript-axios/build/common.ts
+++ b/samples/client/echo_api/typescript-axios/build/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/common.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/composed-schemas/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/default/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/default/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/es6-target/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/test-petstore/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-complex-headers/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-fake-endpoints-models-for-testing-with-http-signature/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-interfaces/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-node-imports/common.ts
@@ -127,8 +127,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-single-request-parameters/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**

--- a/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-string-enums/common.ts
@@ -126,8 +126,48 @@ export const serializeDataIfNeeded = function (value: any, requestOptions: any, 
         ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
         : nonString;
     return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
+        ? JSON.stringify(value !== undefined ? convertMapsAndSetsToPlain(value) : {})
         : (value || "");
+}
+
+function convertMapsAndSetsToPlain(value: any): any {
+    if (typeof Set === "undefined") return value;
+    if (typeof Map === "undefined") return value;
+    if (typeof value !== "object" || !value) {
+        return value;
+    }
+    if (value instanceof Set) {
+        return Array.from(value).map(item => convertMapsAndSetsToPlain(item));
+    }
+    if (value instanceof Map) {
+        const entries: Array<[string, any]> = [];
+        value.forEach((value: any, key: any) => {
+            entries.push([key, convertMapsAndSetsToPlain(value)])
+        });
+        return objectFromEntries(entries);
+    }
+    if (Array.isArray(value)) {
+        return value.map(it => convertMapsAndSetsToPlain(it));
+    }
+    return objectFromEntries(objectEntries(value)
+        .map(([k, v]) => [k, convertMapsAndSetsToPlain(v)]));
+}
+
+/**
+ * Ponyfill for Object.entries
+ */
+function objectEntries(object: Record<string, any>): Array<[string, any]> {
+    return Object.keys(object).map(key => [key, object[key]]);
+}
+
+/**
+ * Ponyfill for Object.fromEntries
+ */
+function objectFromEntries(entries: any): Record<string, any> {
+    return [...entries].reduce((object, [key, val]) => {
+        object[key] = val;
+        return object;
+    }, {});
 }
 
 /**


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This produces type definitions that aren't compatible with the typescript-axios client:

```openapi
        someField:
          uniqueItems: true
          type: array
          items:
            type: string
```

My fix serialises of `Set`s into arrays and `Map`s into objects, since otherwise they are not serialized with JSON.stringify, see https://stackoverflow.com/questions/31190885/json-stringify-a-set

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka