### PR TITLE
[Python] deserialize enum json response (fix #17789)

### DIFF
--- a/modules/openapi-generator/src/main/resources/python/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/python/api_client.mustache
@@ -4,6 +4,7 @@
 
 import datetime
 from dateutil.parser import parse
+from enum import Enum
 import json
 import mimetypes
 import os
@@ -437,6 +438,8 @@ class ApiClient:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datetime(data)
+        elif issubclass(klass, Enum):
+            return self.__deserialize_enum(data, klass)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -740,6 +743,24 @@ class ApiClient:
                 reason=(
                     "Failed to parse `{0}` as datetime object"
                     .format(string)
+                )
+            )
+
+    def __deserialize_enum(self, data, klass):
+        """Deserializes primitive type to enum.
+
+        :param data: primitive type.
+        :param klass: class literal.
+        :return: enum value.
+        """
+        try:
+            return klass(data)
+        except ValueError:
+            raise rest.ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
                 )
             )
 

--- a/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/echo_api.yaml
@@ -544,6 +544,26 @@ paths:
             text/plain:
               schema:
                 type: string
+  /echo/body/string_enum:
+    post:
+      tags:
+        - body
+      summary: Test string enum response body
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
   /binary/gif:
     post:
       tags:

--- a/samples/client/echo_api/csharp-restsharp/README.md
+++ b/samples/client/echo_api/csharp-restsharp/README.md
@@ -126,6 +126,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**TestEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testechobodyfreeformobjectresponsestring) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**TestEchoBodyPet**](docs/BodyApi.md#testechobodypet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**TestEchoBodyPetResponseString**](docs/BodyApi.md#testechobodypetresponsestring) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**TestEchoBodyStringEnum**](docs/BodyApi.md#testechobodystringenum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**TestEchoBodyTagResponseString**](docs/BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**TestFormIntegerBooleanString**](docs/FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**TestFormOneof**](docs/FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
+++ b/samples/client/echo_api/csharp-restsharp/api/openapi.yaml
@@ -519,6 +519,26 @@ paths:
       summary: Test free form object
       tags:
       - body
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/csharp-restsharp/docs/BodyApi.md
+++ b/samples/client/echo_api/csharp-restsharp/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**TestEchoBodyFreeFormObjectResponseString**](BodyApi.md#testechobodyfreeformobjectresponsestring) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**TestEchoBodyPet**](BodyApi.md#testechobodypet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**TestEchoBodyPetResponseString**](BodyApi.md#testechobodypetresponsestring) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**TestEchoBodyStringEnum**](BodyApi.md#testechobodystringenum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**TestEchoBodyTagResponseString**](BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 <a id="testbinarygif"></a>
@@ -728,6 +729,97 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="testechobodystringenum"></a>
+# **TestEchoBodyStringEnum**
+> StringEnumRef TestEchoBodyStringEnum (string? body = null)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+```csharp
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class TestEchoBodyStringEnumExample
+    {
+        public static void Main()
+        {
+            Configuration config = new Configuration();
+            config.BasePath = "http://localhost:3000";
+            var apiInstance = new BodyApi(config);
+            var body = null;  // string? | String enum (optional) 
+
+            try
+            {
+                // Test string enum response body
+                StringEnumRef result = apiInstance.TestEchoBodyStringEnum(body);
+                Debug.WriteLine(result);
+            }
+            catch (ApiException  e)
+            {
+                Debug.Print("Exception when calling BodyApi.TestEchoBodyStringEnum: " + e.Message);
+                Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print(e.StackTrace);
+            }
+        }
+    }
+}
+```
+
+#### Using the TestEchoBodyStringEnumWithHttpInfo variant
+This returns an ApiResponse object which contains the response data, status code and headers.
+
+```csharp
+try
+{
+    // Test string enum response body
+    ApiResponse<StringEnumRef> response = apiInstance.TestEchoBodyStringEnumWithHttpInfo(body);
+    Debug.Write("Status Code: " + response.StatusCode);
+    Debug.Write("Response Headers: " + response.Headers);
+    Debug.Write("Response Body: " + response.Data);
+}
+catch (ApiException e)
+{
+    Debug.Print("Exception when calling BodyApi.TestEchoBodyStringEnumWithHttpInfo: " + e.Message);
+    Debug.Print("Status Code: " + e.ErrorCode);
+    Debug.Print(e.StackTrace);
+}
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+|------|------|-------------|-------|
+| **body** | **string?** | String enum | [optional]  |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 
 ### HTTP response details

--- a/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
+++ b/samples/client/echo_api/csharp-restsharp/src/Org.OpenAPITools/Api/BodyApi.cs
@@ -210,6 +210,29 @@ namespace Org.OpenAPITools.Api
         /// <returns>ApiResponse of string</returns>
         ApiResponse<string> TestEchoBodyPetResponseStringWithHttpInfo(Pet? pet = default(Pet?), int operationIndex = 0);
         /// <summary>
+        /// Test string enum response body
+        /// </summary>
+        /// <remarks>
+        /// Test string enum response body
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>StringEnumRef</returns>
+        StringEnumRef TestEchoBodyStringEnum(string? body = default(string?), int operationIndex = 0);
+
+        /// <summary>
+        /// Test string enum response body
+        /// </summary>
+        /// <remarks>
+        /// Test string enum response body
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of StringEnumRef</returns>
+        ApiResponse<StringEnumRef> TestEchoBodyStringEnumWithHttpInfo(string? body = default(string?), int operationIndex = 0);
+        /// <summary>
         /// Test empty json (request body)
         /// </summary>
         /// <remarks>
@@ -439,6 +462,31 @@ namespace Org.OpenAPITools.Api
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (string)</returns>
         System.Threading.Tasks.Task<ApiResponse<string>> TestEchoBodyPetResponseStringWithHttpInfoAsync(Pet? pet = default(Pet?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        /// <summary>
+        /// Test string enum response body
+        /// </summary>
+        /// <remarks>
+        /// Test string enum response body
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of StringEnumRef</returns>
+        System.Threading.Tasks.Task<StringEnumRef> TestEchoBodyStringEnumAsync(string? body = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <summary>
+        /// Test string enum response body
+        /// </summary>
+        /// <remarks>
+        /// Test string enum response body
+        /// </remarks>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (StringEnumRef)</returns>
+        System.Threading.Tasks.Task<ApiResponse<StringEnumRef>> TestEchoBodyStringEnumWithHttpInfoAsync(string? body = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test empty json (request body)
         /// </summary>
@@ -1663,6 +1711,140 @@ namespace Org.OpenAPITools.Api
             if (this.ExceptionFactory != null)
             {
                 Exception _exception = this.ExceptionFactory("TestEchoBodyPetResponseString", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test string enum response body Test string enum response body
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>StringEnumRef</returns>
+        public StringEnumRef TestEchoBodyStringEnum(string? body = default(string?), int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.ApiResponse<StringEnumRef> localVarResponse = TestEchoBodyStringEnumWithHttpInfo(body);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test string enum response body Test string enum response body
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <returns>ApiResponse of StringEnumRef</returns>
+        public Org.OpenAPITools.Client.ApiResponse<StringEnumRef> TestEchoBodyStringEnumWithHttpInfo(string? body = default(string?), int operationIndex = 0)
+        {
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                "application/json"
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            localVarRequestOptions.Data = body;
+
+            localVarRequestOptions.Operation = "BodyApi.TestEchoBodyStringEnum";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = this.Client.Post<StringEnumRef>("/echo/body/string_enum", localVarRequestOptions, this.Configuration);
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestEchoBodyStringEnum", localVarResponse);
+                if (_exception != null)
+                {
+                    throw _exception;
+                }
+            }
+
+            return localVarResponse;
+        }
+
+        /// <summary>
+        /// Test string enum response body Test string enum response body
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of StringEnumRef</returns>
+        public async System.Threading.Tasks.Task<StringEnumRef> TestEchoBodyStringEnumAsync(string? body = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            Org.OpenAPITools.Client.ApiResponse<StringEnumRef> localVarResponse = await TestEchoBodyStringEnumWithHttpInfoAsync(body, operationIndex, cancellationToken).ConfigureAwait(false);
+            return localVarResponse.Data;
+        }
+
+        /// <summary>
+        /// Test string enum response body Test string enum response body
+        /// </summary>
+        /// <exception cref="Org.OpenAPITools.Client.ApiException">Thrown when fails to make API call</exception>
+        /// <param name="body">String enum (optional)</param>
+        /// <param name="operationIndex">Index associated with the operation.</param>
+        /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
+        /// <returns>Task of ApiResponse (StringEnumRef)</returns>
+        public async System.Threading.Tasks.Task<Org.OpenAPITools.Client.ApiResponse<StringEnumRef>> TestEchoBodyStringEnumWithHttpInfoAsync(string? body = default(string?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+
+            Org.OpenAPITools.Client.RequestOptions localVarRequestOptions = new Org.OpenAPITools.Client.RequestOptions();
+
+            string[] _contentTypes = new string[] {
+                "application/json"
+            };
+
+            // to determine the Accept header
+            string[] _accepts = new string[] {
+                "application/json"
+            };
+
+            var localVarContentType = Org.OpenAPITools.Client.ClientUtils.SelectHeaderContentType(_contentTypes);
+            if (localVarContentType != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Content-Type", localVarContentType);
+            }
+
+            var localVarAccept = Org.OpenAPITools.Client.ClientUtils.SelectHeaderAccept(_accepts);
+            if (localVarAccept != null)
+            {
+                localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
+            }
+
+            localVarRequestOptions.Data = body;
+
+            localVarRequestOptions.Operation = "BodyApi.TestEchoBodyStringEnum";
+            localVarRequestOptions.OperationIndex = operationIndex;
+
+
+            // make the HTTP request
+            var localVarResponse = await this.AsynchronousClient.PostAsync<StringEnumRef>("/echo/body/string_enum", localVarRequestOptions, this.Configuration, cancellationToken).ConfigureAwait(false);
+
+            if (this.ExceptionFactory != null)
+            {
+                Exception _exception = this.ExceptionFactory("TestEchoBodyStringEnum", localVarResponse);
                 if (_exception != null)
                 {
                     throw _exception;

--- a/samples/client/echo_api/go/README.md
+++ b/samples/client/echo_api/go/README.md
@@ -87,6 +87,7 @@ Class | Method | HTTP request | Description
 *BodyAPI* | [**TestEchoBodyFreeFormObjectResponseString**](docs/BodyAPI.md#testechobodyfreeformobjectresponsestring) | **Post** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyAPI* | [**TestEchoBodyPet**](docs/BodyAPI.md#testechobodypet) | **Post** /echo/body/Pet | Test body parameter(s)
 *BodyAPI* | [**TestEchoBodyPetResponseString**](docs/BodyAPI.md#testechobodypetresponsestring) | **Post** /echo/body/Pet/response_string | Test empty response body
+*BodyAPI* | [**TestEchoBodyStringEnum**](docs/BodyAPI.md#testechobodystringenum) | **Post** /echo/body/string_enum | Test string enum response body
 *BodyAPI* | [**TestEchoBodyTagResponseString**](docs/BodyAPI.md#testechobodytagresponsestring) | **Post** /echo/body/Tag/response_string | Test empty json (request body)
 *FormAPI* | [**TestFormIntegerBooleanString**](docs/FormAPI.md#testformintegerbooleanstring) | **Post** /form/integer/boolean/string | Test form parameter(s)
 *FormAPI* | [**TestFormOneof**](docs/FormAPI.md#testformoneof) | **Post** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/go/api/openapi.yaml
+++ b/samples/client/echo_api/go/api/openapi.yaml
@@ -519,6 +519,26 @@ paths:
       summary: Test free form object
       tags:
       - body
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/go/api_body.go
+++ b/samples/client/echo_api/go/api_body.go
@@ -908,6 +908,114 @@ func (a *BodyAPIService) TestEchoBodyPetResponseStringExecute(r ApiTestEchoBodyP
 	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
+type ApiTestEchoBodyStringEnumRequest struct {
+	ctx context.Context
+	ApiService *BodyAPIService
+	body *string
+}
+
+// String enum
+func (r ApiTestEchoBodyStringEnumRequest) Body(body string) ApiTestEchoBodyStringEnumRequest {
+	r.body = &body
+	return r
+}
+
+func (r ApiTestEchoBodyStringEnumRequest) Execute() (*StringEnumRef, *http.Response, error) {
+	return r.ApiService.TestEchoBodyStringEnumExecute(r)
+}
+
+/*
+TestEchoBodyStringEnum Test string enum response body
+
+Test string enum response body
+
+ @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ @return ApiTestEchoBodyStringEnumRequest
+*/
+func (a *BodyAPIService) TestEchoBodyStringEnum(ctx context.Context) ApiTestEchoBodyStringEnumRequest {
+	return ApiTestEchoBodyStringEnumRequest{
+		ApiService: a,
+		ctx: ctx,
+	}
+}
+
+// Execute executes the request
+//  @return StringEnumRef
+func (a *BodyAPIService) TestEchoBodyStringEnumExecute(r ApiTestEchoBodyStringEnumRequest) (*StringEnumRef, *http.Response, error) {
+	var (
+		localVarHTTPMethod   = http.MethodPost
+		localVarPostBody     interface{}
+		formFiles            []formFile
+		localVarReturnValue  *StringEnumRef
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BodyAPIService.TestEchoBodyStringEnum")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/echo/body/string_enum"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.body
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type ApiTestEchoBodyTagResponseStringRequest struct {
 	ctx context.Context
 	ApiService *BodyAPIService

--- a/samples/client/echo_api/go/docs/BodyAPI.md
+++ b/samples/client/echo_api/go/docs/BodyAPI.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**TestEchoBodyFreeFormObjectResponseString**](BodyAPI.md#TestEchoBodyFreeFormObjectResponseString) | **Post** /echo/body/FreeFormObject/response_string | Test free form object
 [**TestEchoBodyPet**](BodyAPI.md#TestEchoBodyPet) | **Post** /echo/body/Pet | Test body parameter(s)
 [**TestEchoBodyPetResponseString**](BodyAPI.md#TestEchoBodyPetResponseString) | **Post** /echo/body/Pet/response_string | Test empty response body
+[**TestEchoBodyStringEnum**](BodyAPI.md#TestEchoBodyStringEnum) | **Post** /echo/body/string_enum | Test string enum response body
 [**TestEchoBodyTagResponseString**](BodyAPI.md#TestEchoBodyTagResponseString) | **Post** /echo/body/Tag/response_string | Test empty json (request body)
 
 
@@ -533,6 +534,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## TestEchoBodyStringEnum
+
+> StringEnumRef TestEchoBodyStringEnum(ctx).Body(body).Execute()
+
+Test string enum response body
+
+
+
+### Example
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	openapiclient "github.com/GIT_USER_ID/GIT_REPO_ID"
+)
+
+func main() {
+	body := string(987) // string | String enum (optional)
+
+	configuration := openapiclient.NewConfiguration()
+	apiClient := openapiclient.NewAPIClient(configuration)
+	resp, r, err := apiClient.BodyAPI.TestEchoBodyStringEnum(context.Background()).Body(body).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `BodyAPI.TestEchoBodyStringEnum``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
+	// response from `TestEchoBodyStringEnum`: StringEnumRef
+	fmt.Fprintf(os.Stdout, "Response from `BodyAPI.TestEchoBodyStringEnum`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiTestEchoBodyStringEnumRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **string** | String enum | 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/samples/client/echo_api/java/apache-httpclient/README.md
+++ b/samples/client/echo_api/java/apache-httpclient/README.md
@@ -120,6 +120,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
+++ b/samples/client/echo_api/java/apache-httpclient/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
+++ b/samples/client/echo_api/java/apache-httpclient/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -532,6 +533,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyStringEnum
+
+> StringEnumRef testEchoBodyStringEnum(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        String body = "body_example"; // String | String enum
+        try {
+            StringEnumRef result = apiInstance.testEchoBodyStringEnum(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ### HTTP response details

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -21,6 +21,7 @@ import org.openapitools.client.Pair;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 
@@ -595,6 +596,75 @@ public class BodyApi {
     String[] localVarAuthNames = new String[] {  };
 
     TypeReference<String> localVarReturnType = new TypeReference<String>() {};
+    return apiClient.invokeAPI(
+        localVarPath,
+        "POST",
+        localVarQueryParams,
+        localVarCollectionQueryParams,
+        localVarQueryStringJoiner.toString(),
+        localVarPostBody,
+        localVarHeaderParams,
+        localVarCookieParams,
+        localVarFormParams,
+        localVarAccept,
+        localVarContentType,
+        localVarAuthNames,
+        localVarReturnType
+    );
+  }
+
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return StringEnumRef
+   * @throws ApiException if fails to make API call
+   */
+  public StringEnumRef testEchoBodyStringEnum(String body) throws ApiException {
+    return this.testEchoBodyStringEnum(body, Collections.emptyMap());
+  }
+
+
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @param additionalHeaders additionalHeaders for this call
+   * @return StringEnumRef
+   * @throws ApiException if fails to make API call
+   */
+  public StringEnumRef testEchoBodyStringEnum(String body, Map<String, String> additionalHeaders) throws ApiException {
+    Object localVarPostBody = body;
+    
+    // create path and map variables
+    String localVarPath = "/echo/body/string_enum";
+
+    StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+    String localVarQueryParameterBaseName;
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    
+    localVarHeaderParams.putAll(additionalHeaders);
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    TypeReference<StringEnumRef> localVarReturnType = new TypeReference<StringEnumRef>() {};
     return apiClient.invokeAPI(
         localVarPath,
         "POST",

--- a/samples/client/echo_api/java/feign-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/feign-gson/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/feign-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -6,6 +6,7 @@ import org.openapitools.client.model.ApiResponse;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 import java.util.ArrayList;
@@ -243,6 +244,35 @@ public interface BodyApi extends ApiClient.Api {
     "Accept: text/plain",
   })
   ApiResponse<String> testEchoBodyPetResponseStringWithHttpInfo(Pet pet);
+
+
+
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return StringEnumRef
+   */
+  @RequestLine("POST /echo/body/string_enum")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: application/json",
+  })
+  StringEnumRef testEchoBodyStringEnum(String body);
+
+  /**
+   * Test string enum response body
+   * Similar to <code>testEchoBodyStringEnum</code> but it also returns the http response headers .
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return A ApiResponse that wraps the response boyd and the http headers.
+   */
+  @RequestLine("POST /echo/body/string_enum")
+  @Headers({
+    "Content-Type: application/json",
+    "Accept: application/json",
+  })
+  ApiResponse<StringEnumRef> testEchoBodyStringEnumWithHttpInfo(String body);
 
 
 

--- a/samples/client/echo_api/java/native/README.md
+++ b/samples/client/echo_api/java/native/README.md
@@ -124,6 +124,8 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyPetWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**testEchoBodyPetResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyPetResponseStringWithHttpInfo) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
+*BodyApi* | [**testEchoBodyStringEnumWithHttpInfo**](docs/BodyApi.md#testEchoBodyStringEnumWithHttpInfo) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *BodyApi* | [**testEchoBodyTagResponseStringWithHttpInfo**](docs/BodyApi.md#testEchoBodyTagResponseStringWithHttpInfo) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)

--- a/samples/client/echo_api/java/native/api/openapi.yaml
+++ b/samples/client/echo_api/java/native/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/native/docs/BodyApi.md
+++ b/samples/client/echo_api/java/native/docs/BodyApi.md
@@ -20,6 +20,8 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyPetWithHttpInfo**](BodyApi.md#testEchoBodyPetWithHttpInfo) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
 | [**testEchoBodyPetResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyPetResponseStringWithHttpInfo) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
+| [**testEchoBodyStringEnumWithHttpInfo**](BodyApi.md#testEchoBodyStringEnumWithHttpInfo) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 | [**testEchoBodyTagResponseStringWithHttpInfo**](BodyApi.md#testEchoBodyTagResponseStringWithHttpInfo) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
@@ -1082,6 +1084,140 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyStringEnum
+
+> StringEnumRef testEchoBodyStringEnum(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        String body = "body_example"; // String | String enum
+        try {
+            StringEnumRef result = apiInstance.testEchoBodyStringEnum(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+## testEchoBodyStringEnumWithHttpInfo
+
+> ApiResponse<StringEnumRef> testEchoBodyStringEnum testEchoBodyStringEnumWithHttpInfo(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.ApiResponse;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        String body = "body_example"; // String | String enum
+        try {
+            ApiResponse<StringEnumRef> response = apiInstance.testEchoBodyStringEnumWithHttpInfo(body);
+            System.out.println("Status code: " + response.getStatusCode());
+            System.out.println("Response headers: " + response.getHeaders());
+            System.out.println("Response body: " + response.getData());
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            System.err.println("Reason: " + e.getResponseBody());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+ApiResponse<[**StringEnumRef**](StringEnumRef.md)>
+
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -19,6 +19,7 @@ import org.openapitools.client.Pair;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -753,6 +754,79 @@ public class BodyApi {
 
     try {
       byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(pet);
+      localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.ofByteArray(localVarPostBody));
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    if (memberVarReadTimeout != null) {
+      localVarRequestBuilder.timeout(memberVarReadTimeout);
+    }
+    if (memberVarInterceptor != null) {
+      memberVarInterceptor.accept(localVarRequestBuilder);
+    }
+    return localVarRequestBuilder;
+  }
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return StringEnumRef
+   * @throws ApiException if fails to make API call
+   */
+  public StringEnumRef testEchoBodyStringEnum(String body) throws ApiException {
+    ApiResponse<StringEnumRef> localVarResponse = testEchoBodyStringEnumWithHttpInfo(body);
+    return localVarResponse.getData();
+  }
+
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return ApiResponse&lt;StringEnumRef&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<StringEnumRef> testEchoBodyStringEnumWithHttpInfo(String body) throws ApiException {
+    HttpRequest.Builder localVarRequestBuilder = testEchoBodyStringEnumRequestBuilder(body);
+    try {
+      HttpResponse<InputStream> localVarResponse = memberVarHttpClient.send(
+          localVarRequestBuilder.build(),
+          HttpResponse.BodyHandlers.ofInputStream());
+      if (memberVarResponseInterceptor != null) {
+        memberVarResponseInterceptor.accept(localVarResponse);
+      }
+      try {
+        if (localVarResponse.statusCode()/ 100 != 2) {
+          throw getApiException("testEchoBodyStringEnum", localVarResponse);
+        }
+        return new ApiResponse<StringEnumRef>(
+          localVarResponse.statusCode(),
+          localVarResponse.headers().map(),
+          localVarResponse.body() == null ? null : memberVarObjectMapper.readValue(localVarResponse.body(), new TypeReference<StringEnumRef>() {}) // closes the InputStream
+        );
+      } finally {
+      }
+    } catch (IOException e) {
+      throw new ApiException(e);
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ApiException(e);
+    }
+  }
+
+  private HttpRequest.Builder testEchoBodyStringEnumRequestBuilder(String body) throws ApiException {
+
+    HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
+
+    String localVarPath = "/echo/body/string_enum";
+
+    localVarRequestBuilder.uri(URI.create(memberVarBaseUri + localVarPath));
+
+    localVarRequestBuilder.header("Content-Type", "application/json");
+    localVarRequestBuilder.header("Accept", "application/json");
+
+    try {
+      byte[] localVarPostBody = memberVarObjectMapper.writeValueAsBytes(body);
       localVarRequestBuilder.method("POST", HttpRequest.BodyPublishers.ofByteArray(localVarPostBody));
     } catch (IOException e) {
       throw new ApiException(e);

--- a/samples/client/echo_api/java/okhttp-gson/README.md
+++ b/samples/client/echo_api/java/okhttp-gson/README.md
@@ -128,6 +128,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
+++ b/samples/client/echo_api/java/okhttp-gson/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
+++ b/samples/client/echo_api/java/okhttp-gson/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -501,6 +502,68 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+<a id="testEchoBodyStringEnum"></a>
+# **testEchoBodyStringEnum**
+> StringEnumRef testEchoBodyStringEnum(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost:3000");
+
+    BodyApi apiInstance = new BodyApi(defaultClient);
+    String body = "body_example"; // String | String enum
+    try {
+      StringEnumRef result = apiInstance.testEchoBodyStringEnum(body);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 import java.lang.reflect.Type;
@@ -1023,6 +1024,124 @@ public class BodyApi {
 
         okhttp3.Call localVarCall = testEchoBodyPetResponseStringValidateBeforeCall(pet, _callback);
         Type localVarReturnType = new TypeToken<String>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
+     * Build call for testEchoBodyStringEnum
+     * @param body String enum (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyStringEnumCall(String body, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = body;
+
+        // create path and map variables
+        String localVarPath = "/echo/body/string_enum";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            "application/json"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call testEchoBodyStringEnumValidateBeforeCall(String body, final ApiCallback _callback) throws ApiException {
+        return testEchoBodyStringEnumCall(body, _callback);
+
+    }
+
+    /**
+     * Test string enum response body
+     * Test string enum response body
+     * @param body String enum (optional)
+     * @return StringEnumRef
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public StringEnumRef testEchoBodyStringEnum(String body) throws ApiException {
+        ApiResponse<StringEnumRef> localVarResp = testEchoBodyStringEnumWithHttpInfo(body);
+        return localVarResp.getData();
+    }
+
+    /**
+     * Test string enum response body
+     * Test string enum response body
+     * @param body String enum (optional)
+     * @return ApiResponse&lt;StringEnumRef&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<StringEnumRef> testEchoBodyStringEnumWithHttpInfo(String body) throws ApiException {
+        okhttp3.Call localVarCall = testEchoBodyStringEnumValidateBeforeCall(body, null);
+        Type localVarReturnType = new TypeToken<StringEnumRef>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * Test string enum response body (asynchronously)
+     * Test string enum response body
+     * @param body String enum (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Successful operation </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call testEchoBodyStringEnumAsync(String body, final ApiCallback<StringEnumRef> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = testEchoBodyStringEnumValidateBeforeCall(body, _callback);
+        Type localVarReturnType = new TypeToken<StringEnumRef>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }

--- a/samples/client/echo_api/java/resteasy/README.md
+++ b/samples/client/echo_api/java/resteasy/README.md
@@ -127,6 +127,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/java/resteasy/api/openapi.yaml
+++ b/samples/client/echo_api/java/resteasy/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/resteasy/docs/BodyApi.md
+++ b/samples/client/echo_api/java/resteasy/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -532,6 +533,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyStringEnum
+
+> StringEnumRef testEchoBodyStringEnum(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        String body = "body_example"; // String | String enum
+        try {
+            StringEnumRef result = apiInstance.testEchoBodyStringEnum(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ### HTTP response details

--- a/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/resteasy/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.GenericType;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 import java.util.ArrayList;
@@ -346,6 +347,44 @@ public class BodyApi {
     String[] localVarAuthNames = new String[] {  };
 
     GenericType<String> localVarReturnType = new GenericType<String>() {};
+    return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+      }
+  /**
+   * Test string enum response body
+   * Test string enum response body
+   * @param body String enum (optional)
+   * @return a {@code StringEnumRef}
+   * @throws ApiException if fails to make API call
+   */
+  public StringEnumRef testEchoBodyStringEnum(String body) throws ApiException {
+    Object localVarPostBody = body;
+    
+    // create path and map variables
+    String localVarPath = "/echo/body/string_enum".replaceAll("\\{format\\}","json");
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, String> localVarCookieParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+
+    
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] {  };
+
+    GenericType<StringEnumRef> localVarReturnType = new GenericType<StringEnumRef>() {};
     return apiClient.invokeAPI(localVarPath, "POST", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
       }
   /**

--- a/samples/client/echo_api/java/resttemplate/README.md
+++ b/samples/client/echo_api/java/resttemplate/README.md
@@ -127,6 +127,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/FormApi.md#testFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/FormApi.md#testFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/java/resttemplate/api/openapi.yaml
+++ b/samples/client/echo_api/java/resttemplate/api/openapi.yaml
@@ -547,6 +547,28 @@ paths:
       - body
       x-content-type: application/json
       x-accepts: text/plain
+  /echo/body/string_enum:
+    post:
+      description: Test string enum response body
+      operationId: test/echo/body/string_enum
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringEnumRef'
+        description: String enum
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringEnumRef'
+          description: Successful operation
+      summary: Test string enum response body
+      tags:
+      - body
+      x-content-type: application/json
+      x-accepts: application/json
   /binary/gif:
     post:
       description: Test binary (gif) response body

--- a/samples/client/echo_api/java/resttemplate/docs/BodyApi.md
+++ b/samples/client/echo_api/java/resttemplate/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**testEchoBodyFreeFormObjectResponseString**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -532,6 +533,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+
+## testEchoBodyStringEnum
+
+> StringEnumRef testEchoBodyStringEnum(body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```java
+// Import classes:
+import org.openapitools.client.ApiClient;
+import org.openapitools.client.ApiException;
+import org.openapitools.client.Configuration;
+import org.openapitools.client.models.*;
+import org.openapitools.client.api.BodyApi;
+
+public class Example {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        defaultClient.setBasePath("http://localhost:3000");
+
+        BodyApi apiInstance = new BodyApi(defaultClient);
+        String body = "body_example"; // String | String enum
+        try {
+            StringEnumRef result = apiInstance.testEchoBodyStringEnum(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling BodyApi#testEchoBodyStringEnum");
+            System.err.println("Status code: " + e.getCode());
+            System.err.println("Reason: " + e.getResponseBody());
+            System.err.println("Response headers: " + e.getResponseHeaders());
+            e.printStackTrace();
+        }
+    }
+}
+```
+
+### Parameters
+
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **String**| String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ### HTTP response details

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/api/BodyApi.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/api/BodyApi.java
@@ -4,6 +4,7 @@ import org.openapitools.client.ApiClient;
 
 import java.io.File;
 import org.openapitools.client.model.Pet;
+import org.openapitools.client.model.StringEnumRef;
 import org.openapitools.client.model.Tag;
 
 import java.util.Collections;
@@ -397,6 +398,49 @@ public class BodyApi {
 
         ParameterizedTypeReference<String> localReturnType = new ParameterizedTypeReference<String>() {};
         return apiClient.invokeAPI("/echo/body/Pet/response_string", HttpMethod.POST, Collections.<String, Object>emptyMap(), localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
+    }
+    /**
+     * Test string enum response body
+     * Test string enum response body
+     * <p><b>200</b> - Successful operation
+     * @param body String enum (optional)
+     * @return StringEnumRef
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public StringEnumRef testEchoBodyStringEnum(String body) throws RestClientException {
+        return testEchoBodyStringEnumWithHttpInfo(body).getBody();
+    }
+
+    /**
+     * Test string enum response body
+     * Test string enum response body
+     * <p><b>200</b> - Successful operation
+     * @param body String enum (optional)
+     * @return ResponseEntity&lt;StringEnumRef&gt;
+     * @throws RestClientException if an error occurs while attempting to invoke the API
+     */
+    public ResponseEntity<StringEnumRef> testEchoBodyStringEnumWithHttpInfo(String body) throws RestClientException {
+        Object localVarPostBody = body;
+        
+
+        final MultiValueMap<String, String> localVarQueryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders localVarHeaderParams = new HttpHeaders();
+        final MultiValueMap<String, String> localVarCookieParams = new LinkedMultiValueMap<String, String>();
+        final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
+
+        final String[] localVarAccepts = { 
+            "application/json"
+         };
+        final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = { 
+            "application/json"
+         };
+        final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+        String[] localVarAuthNames = new String[] {  };
+
+        ParameterizedTypeReference<StringEnumRef> localReturnType = new ParameterizedTypeReference<StringEnumRef>() {};
+        return apiClient.invokeAPI("/echo/body/string_enum", HttpMethod.POST, Collections.<String, Object>emptyMap(), localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localReturnType);
     }
     /**
      * Test empty json (request body)

--- a/samples/client/echo_api/php-nextgen/README.md
+++ b/samples/client/echo_api/php-nextgen/README.md
@@ -86,6 +86,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**testEchoBodyFreeFormObjectResponseString**](docs/Api/BodyApi.md#testechobodyfreeformobjectresponsestring) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**testEchoBodyPet**](docs/Api/BodyApi.md#testechobodypet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**testEchoBodyPetResponseString**](docs/Api/BodyApi.md#testechobodypetresponsestring) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**testEchoBodyStringEnum**](docs/Api/BodyApi.md#testechobodystringenum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**testEchoBodyTagResponseString**](docs/Api/BodyApi.md#testechobodytagresponsestring) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**testFormIntegerBooleanString**](docs/Api/FormApi.md#testformintegerbooleanstring) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**testFormOneof**](docs/Api/FormApi.md#testformoneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/php-nextgen/docs/Api/BodyApi.md
+++ b/samples/client/echo_api/php-nextgen/docs/Api/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to http://localhost:3000, except if the operation defines 
 | [**testEchoBodyFreeFormObjectResponseString()**](BodyApi.md#testEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**testEchoBodyPet()**](BodyApi.md#testEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**testEchoBodyPetResponseString()**](BodyApi.md#testEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**testEchoBodyStringEnum()**](BodyApi.md#testEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**testEchoBodyTagResponseString()**](BodyApi.md#testEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -455,6 +456,62 @@ No authorization required
 
 - **Content-Type**: `application/json`
 - **Accept**: `text/plain`
+
+[[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
+[[Back to Model list]](../../README.md#models)
+[[Back to README]](../../README.md)
+
+## `testEchoBodyStringEnum()`
+
+```php
+testEchoBodyStringEnum($body): \OpenAPI\Client\Model\StringEnumRef
+```
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```php
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+
+$apiInstance = new OpenAPI\Client\Api\BodyApi(
+    // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+    // This is optional, `GuzzleHttp\Client` will be used as default.
+    new GuzzleHttp\Client()
+);
+$body = 'body_example'; // string | String enum
+
+try {
+    $result = $apiInstance->testEchoBodyStringEnum($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling BodyApi->testEchoBodyStringEnum: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **body** | **string**| String enum | [optional] |
+
+### Return type
+
+[**\OpenAPI\Client\Model\StringEnumRef**](../Model/StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: `application/json`
+- **Accept**: `application/json`
 
 [[Back to top]](#) [[Back to API list]](../../README.md#endpoints)
 [[Back to Model list]](../../README.md#models)

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -96,6 +96,9 @@ class BodyApi
         'testEchoBodyPetResponseString' => [
             'application/json',
         ],
+        'testEchoBodyStringEnum' => [
+            'application/json',
+        ],
         'testEchoBodyTagResponseString' => [
             'application/json',
         ],
@@ -2618,6 +2621,321 @@ class BodyApi
                 $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($pet));
             } else {
                 $httpBody = $pet;
+            }
+        } elseif (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the form parameters
+                $httpBody = \GuzzleHttp\Utils::jsonEncode($formParams);
+            } else {
+                // for HTTP post (form)
+                $httpBody = ObjectSerializer::buildQuery($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $operationHost = $this->config->getHost();
+        $query = ObjectSerializer::buildQuery($queryParams);
+        return new Request(
+            'POST',
+            $operationHost . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation testEchoBodyStringEnum
+     *
+     * Test string enum response body
+     *
+     * @param  string|null $body String enum (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEchoBodyStringEnum'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return \OpenAPI\Client\Model\StringEnumRef
+     */
+    public function testEchoBodyStringEnum(
+        ?string $body = null,
+        string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
+    ): \OpenAPI\Client\Model\StringEnumRef
+    {
+        list($response) = $this->testEchoBodyStringEnumWithHttpInfo($body, $contentType);
+        return $response;
+    }
+
+    /**
+     * Operation testEchoBodyStringEnumWithHttpInfo
+     *
+     * Test string enum response body
+     *
+     * @param  string|null $body String enum (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEchoBodyStringEnum'] to see the possible values for this operation
+     *
+     * @throws ApiException on non-2xx response or if the response body is not in the expected format
+     * @throws InvalidArgumentException
+     * @return array of \OpenAPI\Client\Model\StringEnumRef, HTTP status code, HTTP response headers (array of strings)
+     */
+    public function testEchoBodyStringEnumWithHttpInfo(
+        ?string $body = null,
+        string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
+    ): array
+    {
+        $request = $this->testEchoBodyStringEnumRequest($body, $contentType);
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($request, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody() : null
+                );
+            } catch (ConnectException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getMessage()}",
+                    (int) $e->getCode(),
+                    null,
+                    null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        (string) $request->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    (string) $response->getBody()
+                );
+            }
+
+            switch($statusCode) {
+                case 200:
+                    if ('\OpenAPI\Client\Model\StringEnumRef' === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ('\OpenAPI\Client\Model\StringEnumRef' !== 'string') {
+                            try {
+                                $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                            } catch (\JsonException $exception) {
+                                throw new ApiException(
+                                    sprintf(
+                                        'Error JSON decoding server response (%s)',
+                                        $request->getUri()
+                                    ),
+                                    $statusCode,
+                                    $response->getHeaders(),
+                                    $content
+                                );
+                            }
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\OpenAPI\Client\Model\StringEnumRef', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\OpenAPI\Client\Model\StringEnumRef';
+            if ($returnType === '\SplFileObject') {
+                $content = $response->getBody(); //stream goes to serializer
+            } else {
+                $content = (string) $response->getBody();
+                if ($returnType !== 'string') {
+                    try {
+                        $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+                    } catch (\JsonException $exception) {
+                        throw new ApiException(
+                            sprintf(
+                                'Error JSON decoding server response (%s)',
+                                $request->getUri()
+                            ),
+                            $statusCode,
+                            $response->getHeaders(),
+                            $content
+                        );
+                    }
+                }
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\OpenAPI\Client\Model\StringEnumRef',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Operation testEchoBodyStringEnumAsync
+     *
+     * Test string enum response body
+     *
+     * @param  string|null $body String enum (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEchoBodyStringEnum'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testEchoBodyStringEnumAsync(
+        ?string $body = null,
+        string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
+    ): PromiseInterface
+    {
+        return $this->testEchoBodyStringEnumAsyncWithHttpInfo($body, $contentType)
+            ->then(
+                function ($response) {
+                    return $response[0];
+                }
+            );
+    }
+
+    /**
+     * Operation testEchoBodyStringEnumAsyncWithHttpInfo
+     *
+     * Test string enum response body
+     *
+     * @param  string|null $body String enum (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEchoBodyStringEnum'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return PromiseInterface
+     */
+    public function testEchoBodyStringEnumAsyncWithHttpInfo(
+        $body = null,
+        string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
+    ): PromiseInterface
+    {
+        $returnType = '\OpenAPI\Client\Model\StringEnumRef';
+        $request = $this->testEchoBodyStringEnumRequest($body, $contentType);
+
+        return $this->client
+            ->sendAsync($request, $this->createHttpClientOption())
+            ->then(
+                function ($response) use ($returnType) {
+                    if ($returnType === '\SplFileObject') {
+                        $content = $response->getBody(); //stream goes to serializer
+                    } else {
+                        $content = (string) $response->getBody();
+                        if ($returnType !== 'string') {
+                            $content = json_decode($content);
+                        }
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, $returnType, []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                },
+                function ($exception) {
+                    $response = $exception->getResponse();
+                    $statusCode = $response->getStatusCode();
+                    throw new ApiException(
+                        sprintf(
+                            '[%d] Error connecting to the API (%s)',
+                            $statusCode,
+                            $exception->getRequest()->getUri()
+                        ),
+                        $statusCode,
+                        $response->getHeaders(),
+                        (string) $response->getBody()
+                    );
+                }
+            );
+    }
+
+    /**
+     * Create request for operation 'testEchoBodyStringEnum'
+     *
+     * @param  string|null $body String enum (optional)
+     * @param  string $contentType The value for the Content-Type header. Check self::contentTypes['testEchoBodyStringEnum'] to see the possible values for this operation
+     *
+     * @throws InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function testEchoBodyStringEnumRequest(
+        $body = null,
+        string $contentType = self::contentTypes['testEchoBodyStringEnum'][0]
+    ): Request
+    {
+
+
+
+        $resourcePath = '/echo/body/string_enum';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+
+
+
+        $headers = $this->headerSelector->selectHeaders(
+            ['application/json', ],
+            $contentType,
+            $multipart
+        );
+
+        // for model (json/xml)
+        if (isset($body)) {
+            if (stripos($headers['Content-Type'], 'application/json') !== false) {
+                # if Content-Type contains "application/json", json_encode the body
+                $httpBody = \GuzzleHttp\Utils::jsonEncode(ObjectSerializer::sanitizeForSerialization($body));
+            } else {
+                $httpBody = $body;
             }
         } elseif (count($formParams) > 0) {
             if ($multipart) {

--- a/samples/client/echo_api/powershell/README.md
+++ b/samples/client/echo_api/powershell/README.md
@@ -62,6 +62,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**Test-EchoBodyPetResponseString**](docs/BodyApi.md#Test-EchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 *BodyApi* | [**Test-EchoBodyTagResponseString**](docs/BodyApi.md#Test-EchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *BodyApi* | [**Test-EchoBodyAllOfPet**](docs/BodyApi.md#Test-EchoBodyAllOfPet) | **POST** /echo/body/allOf/Pet | Test body parameter(s)
+*BodyApi* | [**Test-EchoBodyStringEnum**](docs/BodyApi.md#Test-EchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *FormApi* | [**Test-FormIntegerBooleanString**](docs/FormApi.md#Test-FormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**Test-FormOneof**](docs/FormApi.md#Test-FormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema
 *HeaderApi* | [**Test-HeaderIntegerBooleanStringEnums**](docs/HeaderApi.md#Test-HeaderIntegerBooleanStringEnums) | **GET** /header/integer/boolean/string/enums | Test header parameter(s)

--- a/samples/client/echo_api/powershell/docs/BodyApi.md
+++ b/samples/client/echo_api/powershell/docs/BodyApi.md
@@ -13,6 +13,7 @@ Method | HTTP request | Description
 [**Test-EchoBodyPetResponseString**](BodyApi.md#Test-EchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
 [**Test-EchoBodyTagResponseString**](BodyApi.md#Test-EchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 [**Test-EchoBodyAllOfPet**](BodyApi.md#Test-EchoBodyAllOfPet) | **POST** /echo/body/allOf/Pet | Test body parameter(s)
+[**Test-EchoBodyStringEnum**](BodyApi.md#Test-EchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 
 
 <a id="Test-BinaryGif"></a>
@@ -391,6 +392,49 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**Pet**](Pet.md) (PSCustomObject)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+<a id="Test-EchoBodyStringEnum"></a>
+# **Test-EchoBodyStringEnum**
+> StringEnumRef Test-EchoBodyStringEnum<br>
+> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[-Body] <System.Nullable[String]><br>
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+```powershell
+$Body = 0 # String | String enum (optional)
+
+# Test string enum response body
+try {
+    $Result = Test-EchoBodyStringEnum -Body $Body
+} catch {
+    Write-Host ("Exception occurred when calling Test-EchoBodyStringEnum: {0}" -f ($_.ErrorDetails | ConvertFrom-Json))
+    Write-Host ("Response headers: {0}" -f ($_.Exception.Response.Headers | ConvertTo-Json))
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **Body** | **String**| String enum | [optional] 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md) (PSCustomObject)
 
 ### Authorization
 

--- a/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/BodyApi.ps1
+++ b/samples/client/echo_api/powershell/src/PSOpenAPITools/Api/BodyApi.ps1
@@ -666,3 +666,77 @@ function Test-EchoBodyAllOfPet {
     }
 }
 
+<#
+.SYNOPSIS
+
+Test string enum response body
+
+.DESCRIPTION
+
+No description available.
+
+.PARAMETER Body
+String enum
+
+.PARAMETER WithHttpInfo
+
+A switch when turned on will return a hash table of Response, StatusCode and Headers instead of just the Response
+
+.OUTPUTS
+
+StringEnumRef
+#>
+function Test-EchoBodyStringEnum {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Position = 0, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Mandatory = $false)]
+        [System.Nullable[String]]
+        ${Body},
+        [Switch]
+        $WithHttpInfo
+    )
+
+    Process {
+        'Calling method: Test-EchoBodyStringEnum' | Write-Debug
+        $PSBoundParameters | Out-DebugParameter | Write-Debug
+
+        $LocalVarAccepts = @()
+        $LocalVarContentTypes = @()
+        $LocalVarQueryParameters = @{}
+        $LocalVarHeaderParameters = @{}
+        $LocalVarFormParameters = @{}
+        $LocalVarPathParameters = @{}
+        $LocalVarCookieParameters = @{}
+        $LocalVarBodyParameter = $null
+
+        $Configuration = Get-Configuration
+        # HTTP header 'Accept' (if needed)
+        $LocalVarAccepts = @('application/json')
+
+        # HTTP header 'Content-Type'
+        $LocalVarContentTypes = @('application/json')
+
+        $LocalVarUri = '/echo/body/string_enum'
+
+        $LocalVarBodyParameter = $Body | ConvertTo-Json -Depth 100
+
+        $LocalVarResult = Invoke-ApiClient -Method 'POST' `
+                                -Uri $LocalVarUri `
+                                -Accepts $LocalVarAccepts `
+                                -ContentTypes $LocalVarContentTypes `
+                                -Body $LocalVarBodyParameter `
+                                -HeaderParameters $LocalVarHeaderParameters `
+                                -QueryParameters $LocalVarQueryParameters `
+                                -FormParameters $LocalVarFormParameters `
+                                -CookieParameters $LocalVarCookieParameters `
+                                -ReturnType "StringEnumRef" `
+                                -IsBodyNullable $false
+
+        if ($WithHttpInfo.IsPresent) {
+            return $LocalVarResult
+        } else {
+            return $LocalVarResult["Response"]
+        }
+    }
+}
+

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/README.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/README.md
@@ -103,6 +103,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/docs/BodyApi.md
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/docs/BodyApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+[**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 
 
@@ -541,6 +542,74 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_echo_body_string_enum**
+> StringEnumRef test_echo_body_string_enum(body=body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+
+```python
+import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+    body = 'body_example' # str | String enum (optional)
+
+    try:
+        # Test string enum response body
+        api_response = api_instance.test_echo_body_string_enum(body=body)
+        print("The response of BodyApi->test_echo_body_string_enum:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_echo_body_string_enum: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **str**| String enum | [optional] 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 ### HTTP response details
 

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/body_api.py
@@ -21,6 +21,7 @@ from pydantic import Field, StrictBytes, StrictStr
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Annotated
 from openapi_client.models.pet import Pet
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.tag import Tag
 
 from openapi_client.api_client import ApiClient, RequestSerialized
@@ -2164,6 +2165,276 @@ class BodyApi:
         return self.api_client.param_serialize(
             method='POST',
             resource_path='/echo/body/Pet/response_string',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def test_echo_body_string_enum(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> StringEnumRef:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def test_echo_body_string_enum_with_http_info(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[StringEnumRef]:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def test_echo_body_string_enum_without_preload_content(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _test_echo_body_string_enum_serialize(
+        self,
+        body,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if body is not None:
+            _body_params = body
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'application/json'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/echo/body/string_enum',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api_client.py
@@ -15,6 +15,7 @@
 
 import datetime
 from dateutil.parser import parse
+from enum import Enum
 import json
 import mimetypes
 import os
@@ -430,6 +431,8 @@ class ApiClient:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datetime(data)
+        elif issubclass(klass, Enum):
+            return self.__deserialize_enum(data, klass)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -724,6 +727,24 @@ class ApiClient:
                 reason=(
                     "Failed to parse `{0}` as datetime object"
                     .format(string)
+                )
+            )
+
+    def __deserialize_enum(self, data, klass):
+        """Deserializes primitive type to enum.
+
+        :param data: primitive type.
+        :param klass: class literal.
+        :return: enum value.
+        """
+        try:
+            return klass(data)
+        except ValueError:
+            raise rest.ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
                 )
             )
 

--- a/samples/client/echo_api/python-pydantic-v1/README.md
+++ b/samples/client/echo_api/python-pydantic-v1/README.md
@@ -104,6 +104,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/python-pydantic-v1/docs/BodyApi.md
+++ b/samples/client/echo_api/python-pydantic-v1/docs/BodyApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+[**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 
 
@@ -534,6 +535,73 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_echo_body_string_enum**
+> StringEnumRef test_echo_body_string_enum(body=body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+```python
+import time
+import os
+import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+    body = 'body_example' # str | String enum (optional)
+
+    try:
+        # Test string enum response body
+        api_response = api_instance.test_echo_body_string_enum(body=body)
+        print("The response of BodyApi->test_echo_body_string_enum:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_echo_body_string_enum: %s\n" % e)
+```
+
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **str**| String enum | [optional] 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/api/body_api.py
@@ -25,6 +25,7 @@ from pydantic import Field, StrictBytes, StrictStr, conlist
 from typing import Any, Dict, Optional, Union
 
 from openapi_client.models.pet import Pet
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.tag import Tag
 
 from openapi_client.api_client import ApiClient
@@ -1199,6 +1200,153 @@ class BodyApi:
 
         return self.api_client.call_api(
             '/echo/body/Pet/response_string', 'POST',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def test_echo_body_string_enum(self, body : Annotated[Optional[StringEnumRef], Field(description="String enum")] = None, **kwargs) -> StringEnumRef:  # noqa: E501
+        """Test string enum response body  # noqa: E501
+
+        Test string enum response body  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_string_enum(body, async_req=True)
+        >>> result = thread.get()
+
+        :param body: String enum
+        :type body: str
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request.
+               If one number provided, it will be total request
+               timeout. It can also be a pair (tuple) of
+               (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: StringEnumRef
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            message = "Error! Please call the test_echo_body_string_enum_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
+            raise ValueError(message)
+        return self.test_echo_body_string_enum_with_http_info(body, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def test_echo_body_string_enum_with_http_info(self, body : Annotated[Optional[StringEnumRef], Field(description="String enum")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        """Test string enum response body  # noqa: E501
+
+        Test string enum response body  # noqa: E501
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.test_echo_body_string_enum_with_http_info(body, async_req=True)
+        >>> result = thread.get()
+
+        :param body: String enum
+        :type body: str
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(StringEnumRef, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'body'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method test_echo_body_string_enum" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+
+        # process the query parameters
+        _query_params = []
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        if _params['body'] is not None:
+            _body_params = _params['body']
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/json'])  # noqa: E501
+
+        # set the HTTP header `Content-Type`
+        _content_types_list = _params.get('_content_type',
+            self.api_client.select_header_content_type(
+                ['application/json']))
+        if _content_types_list:
+                _header_params['Content-Type'] = _content_types_list
+
+        # authentication setting
+        _auth_settings = []  # noqa: E501
+
+        _response_types_map = {
+            '200': "StringEnumRef",
+        }
+
+        return self.api_client.call_api(
+            '/echo/body/string_enum', 'POST',
             _path_params,
             _query_params,
             _header_params,

--- a/samples/client/echo_api/python/README.md
+++ b/samples/client/echo_api/python/README.md
@@ -103,6 +103,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/python/docs/BodyApi.md
+++ b/samples/client/echo_api/python/docs/BodyApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+[**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 
 
@@ -541,6 +542,74 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **test_echo_body_string_enum**
+> StringEnumRef test_echo_body_string_enum(body=body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+
+
+```python
+import openapi_client
+from openapi_client.models.string_enum_ref import StringEnumRef
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost:3000
+# See configuration.py for a list of all supported configuration parameters.
+configuration = openapi_client.Configuration(
+    host = "http://localhost:3000"
+)
+
+
+# Enter a context with an instance of the API client
+with openapi_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = openapi_client.BodyApi(api_client)
+    body = 'body_example' # str | String enum (optional)
+
+    try:
+        # Test string enum response body
+        api_response = api_instance.test_echo_body_string_enum(body=body)
+        print("The response of BodyApi->test_echo_body_string_enum:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling BodyApi->test_echo_body_string_enum: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **str**| String enum | [optional] 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 ### HTTP response details
 

--- a/samples/client/echo_api/python/openapi_client/api/body_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/body_api.py
@@ -21,6 +21,7 @@ from pydantic import Field, StrictBytes, StrictStr
 from typing import Any, Dict, List, Optional, Union
 from typing_extensions import Annotated
 from openapi_client.models.pet import Pet
+from openapi_client.models.string_enum_ref import StringEnumRef
 from openapi_client.models.tag import Tag
 
 from openapi_client.api_client import ApiClient, RequestSerialized
@@ -2164,6 +2165,276 @@ class BodyApi:
         return self.api_client.param_serialize(
             method='POST',
             resource_path='/echo/body/Pet/response_string',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+
+    @validate_call
+    def test_echo_body_string_enum(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> StringEnumRef:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def test_echo_body_string_enum_with_http_info(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[StringEnumRef]:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def test_echo_body_string_enum_without_preload_content(
+        self,
+        body: Annotated[Optional[StringEnumRef], Field(description="String enum")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Test string enum response body
+
+        Test string enum response body
+
+        :param body: String enum
+        :type body: str
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._test_echo_body_string_enum_serialize(
+            body=body,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "StringEnumRef",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _test_echo_body_string_enum_serialize(
+        self,
+        body,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if body is not None:
+            _body_params = body
+
+
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'application/json'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/echo/body/string_enum',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/samples/client/echo_api/python/openapi_client/api_client.py
+++ b/samples/client/echo_api/python/openapi_client/api_client.py
@@ -15,6 +15,7 @@
 
 import datetime
 from dateutil.parser import parse
+from enum import Enum
 import json
 import mimetypes
 import os
@@ -430,6 +431,8 @@ class ApiClient:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datetime(data)
+        elif issubclass(klass, Enum):
+            return self.__deserialize_enum(data, klass)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -724,6 +727,24 @@ class ApiClient:
                 reason=(
                     "Failed to parse `{0}` as datetime object"
                     .format(string)
+                )
+            )
+
+    def __deserialize_enum(self, data, klass):
+        """Deserializes primitive type to enum.
+
+        :param data: primitive type.
+        :param klass: class literal.
+        :return: enum value.
+        """
+        try:
+            return klass(data)
+        except ValueError:
+            raise rest.ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
                 )
             )
 

--- a/samples/client/echo_api/python/tests/test_manual.py
+++ b/samples/client/echo_api/python/tests/test_manual.py
@@ -18,6 +18,7 @@ import base64
 import os
 
 import openapi_client
+from openapi_client import StringEnumRef
 from openapi_client.api.query_api import QueryApi # noqa: E501
 from openapi_client.rest import ApiException
 
@@ -117,6 +118,13 @@ class TestManual(unittest.TestCase):
         api_response = api_instance.test_query_datetime_date_string(datetime_query=datetime_query, date_query=date_query, string_query=string_query)
         e = EchoServerResponseParser(api_response)
         self.assertEqual(e.path, "/query/datetime/date/string?datetime_query=2013-10-20T19%3A20%3A30.000000-0500&date_query=2013-10-20&string_query=string_query_example")
+
+    def testStringEnum(self):
+        api_instance = openapi_client.BodyApi()
+
+        # Test string enum response
+        api_response = api_instance.test_echo_body_string_enum(StringEnumRef.SUCCESS)
+        self.assertEqual(api_response, StringEnumRef.SUCCESS)
 
     def testBinaryGif(self):
         api_instance = openapi_client.BodyApi()

--- a/samples/client/echo_api/r/R/body_api.R
+++ b/samples/client/echo_api/r/R/body_api.R
@@ -143,6 +143,23 @@
 #' }
 #' }
 #'
+#' \strong{ TestEchoBodyStringEnum } \emph{ Test string enum response body }
+#' Test string enum response body
+#'
+#' \itemize{
+#' \item \emph{ @param } body character
+#' \item \emph{ @returnType } \link{StringEnumRef} \cr
+#'
+#'
+#' \item status code : 200 | Successful operation
+#'
+#' \item return type : StringEnumRef
+#' \item response headers :
+#'
+#' \tabular{ll}{
+#' }
+#' }
+#'
 #' \strong{ TestEchoBodyTagResponseString } \emph{ Test empty json (request body) }
 #' Test empty json (request body)
 #'
@@ -272,6 +289,20 @@
 #' # to save the result into a file, simply add the optional `data_file` parameter, e.g.
 #' # result <- api_instance$TestEchoBodyPetResponseString(pet = var_petdata_file = "result.txt")
 #' result <- api_instance$TestEchoBodyPetResponseString(pet = var_pet)
+#' dput(result)
+#'
+#'
+#' ####################  TestEchoBodyStringEnum  ####################
+#'
+#' library(openapi)
+#' var_body <- "body_example" # character | String enum (Optional)
+#'
+#' #Test string enum response body
+#' api_instance <- BodyApi$new()
+#'
+#' # to save the result into a file, simply add the optional `data_file` parameter, e.g.
+#' # result <- api_instance$TestEchoBodyStringEnum(body = var_bodydata_file = "result.txt")
+#' result <- api_instance$TestEchoBodyStringEnum(body = var_body)
 #' dput(result)
 #'
 #'
@@ -1039,6 +1070,101 @@ BodyApi <- R6::R6Class(
 
         deserialized_resp_obj <- tryCatch(
           self$api_client$deserialize(local_var_resp$response_as_text(), "character", loadNamespace("openapi")),
+          error = function(e) {
+            stop("Failed to deserialize response")
+          }
+        )
+        local_var_resp$content <- deserialized_resp_obj
+        local_var_resp
+      } else if (local_var_resp$status_code >= 300 && local_var_resp$status_code <= 399) {
+        ApiResponse$new(paste("Server returned ", local_var_resp$status_code, " response status code."), local_var_resp)
+      } else if (local_var_resp$status_code >= 400 && local_var_resp$status_code <= 499) {
+        ApiResponse$new("API client error", local_var_resp)
+      } else if (local_var_resp$status_code >= 500 && local_var_resp$status_code <= 599) {
+        if (is.null(local_var_resp$response) || local_var_resp$response == "") {
+          local_var_resp$response <- "API server error"
+        }
+        local_var_resp
+      }
+    },
+    #' Test string enum response body
+    #'
+    #' @description
+    #' Test string enum response body
+    #'
+    #' @param body (optional) String enum
+    #' @param data_file (optional) name of the data file to save the result
+    #' @param ... Other optional arguments
+    #' @return StringEnumRef
+    #' @export
+    TestEchoBodyStringEnum = function(body = NULL, data_file = NULL, ...) {
+      local_var_response <- self$TestEchoBodyStringEnumWithHttpInfo(body, data_file = data_file, ...)
+      if (local_var_response$status_code >= 200 && local_var_response$status_code <= 299) {
+        local_var_response$content
+      } else if (local_var_response$status_code >= 300 && local_var_response$status_code <= 399) {
+        local_var_response
+      } else if (local_var_response$status_code >= 400 && local_var_response$status_code <= 499) {
+        local_var_response
+      } else if (local_var_response$status_code >= 500 && local_var_response$status_code <= 599) {
+        local_var_response
+      }
+    },
+    #' Test string enum response body
+    #'
+    #' @description
+    #' Test string enum response body
+    #'
+    #' @param body (optional) String enum
+    #' @param data_file (optional) name of the data file to save the result
+    #' @param ... Other optional arguments
+    #' @return API response (StringEnumRef) with additional information such as HTTP status code, headers
+    #' @export
+    TestEchoBodyStringEnumWithHttpInfo = function(body = NULL, data_file = NULL, ...) {
+      args <- list(...)
+      query_params <- list()
+      header_params <- c()
+      form_params <- list()
+      file_params <- list()
+      local_var_body <- NULL
+      oauth_scopes <- NULL
+      is_oauth <- FALSE
+
+
+      if (!is.null(`body`)) {
+        local_var_body <- `body`$toJSONString()
+      } else {
+        body <- NULL
+      }
+
+      local_var_url_path <- "/echo/body/string_enum"
+
+      # The Accept request HTTP header
+      local_var_accepts <- list("application/json")
+
+      # The Content-Type representation header
+      local_var_content_types <- list("application/json")
+
+      local_var_resp <- self$api_client$CallApi(url = paste0(self$api_client$base_path, local_var_url_path),
+                                 method = "POST",
+                                 query_params = query_params,
+                                 header_params = header_params,
+                                 form_params = form_params,
+                                 file_params = file_params,
+                                 accepts = local_var_accepts,
+                                 content_types = local_var_content_types,
+                                 body = local_var_body,
+                                 is_oauth = is_oauth,
+                                 oauth_scopes = oauth_scopes,
+                                 ...)
+
+      if (local_var_resp$status_code >= 200 && local_var_resp$status_code <= 299) {
+        # save response in a file
+        if (!is.null(data_file)) {
+          write(local_var_resp$response, data_file)
+        }
+
+        deserialized_resp_obj <- tryCatch(
+          self$api_client$deserialize(local_var_resp$response_as_text(), "StringEnumRef", loadNamespace("openapi")),
           error = function(e) {
             stop("Failed to deserialize response")
           }

--- a/samples/client/echo_api/r/README.md
+++ b/samples/client/echo_api/r/README.md
@@ -82,6 +82,7 @@ Class | Method | HTTP request | Description
 *BodyApi* | [**TestEchoBodyFreeFormObjectResponseString**](docs/BodyApi.md#TestEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *BodyApi* | [**TestEchoBodyPet**](docs/BodyApi.md#TestEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 *BodyApi* | [**TestEchoBodyPetResponseString**](docs/BodyApi.md#TestEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+*BodyApi* | [**TestEchoBodyStringEnum**](docs/BodyApi.md#TestEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 *BodyApi* | [**TestEchoBodyTagResponseString**](docs/BodyApi.md#TestEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *FormApi* | [**TestFormIntegerBooleanString**](docs/FormApi.md#TestFormIntegerBooleanString) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *FormApi* | [**TestFormOneof**](docs/FormApi.md#TestFormOneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/r/docs/BodyApi.md
+++ b/samples/client/echo_api/r/docs/BodyApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**TestEchoBodyFreeFormObjectResponseString**](BodyApi.md#TestEchoBodyFreeFormObjectResponseString) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 [**TestEchoBodyPet**](BodyApi.md#TestEchoBodyPet) | **POST** /echo/body/Pet | Test body parameter(s)
 [**TestEchoBodyPetResponseString**](BodyApi.md#TestEchoBodyPetResponseString) | **POST** /echo/body/Pet/response_string | Test empty response body
+[**TestEchoBodyStringEnum**](BodyApi.md#TestEchoBodyStringEnum) | **POST** /echo/body/string_enum | Test string enum response body
 [**TestEchoBodyTagResponseString**](BodyApi.md#TestEchoBodyTagResponseString) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 
 
@@ -380,6 +381,53 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: text/plain
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Successful operation |  -  |
+
+# **TestEchoBodyStringEnum**
+> StringEnumRef TestEchoBodyStringEnum(body = var.body)
+
+Test string enum response body
+
+Test string enum response body
+
+### Example
+```R
+library(openapi)
+
+# Test string enum response body
+#
+# prepare function argument(s)
+var_body <- "body_example" # character | String enum (Optional)
+
+api_instance <- BodyApi$new()
+# to save the result into a file, simply add the optional `data_file` parameter, e.g.
+# result <- api_instance$TestEchoBodyStringEnum(body = var_bodydata_file = "result.txt")
+result <- api_instance$TestEchoBodyStringEnum(body = var_body)
+dput(result)
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **body** | **character**| String enum | [optional] 
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 ### HTTP response details
 | Status code | Description | Response headers |

--- a/samples/client/echo_api/ruby-faraday/README.md
+++ b/samples/client/echo_api/ruby-faraday/README.md
@@ -93,6 +93,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *OpenapiClient::BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *OpenapiClient::BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*OpenapiClient::BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *OpenapiClient::BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *OpenapiClient::FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *OpenapiClient::FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/ruby-faraday/docs/BodyApi.md
+++ b/samples/client/echo_api/ruby-faraday/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -534,6 +535,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+## test_echo_body_string_enum
+
+> <StringEnumRef> test_echo_body_string_enum(opts)
+
+Test string enum response body
+
+Test string enum response body
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::BodyApi.new
+opts = {
+  body: 'body_example' # String | String enum
+}
+
+begin
+  # Test string enum response body
+  result = api_instance.test_echo_body_string_enum(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum: #{e}"
+end
+```
+
+#### Using the test_echo_body_string_enum_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<StringEnumRef>, Integer, Hash)> test_echo_body_string_enum_with_http_info(opts)
+
+```ruby
+begin
+  # Test string enum response body
+  data, status_code, headers = api_instance.test_echo_body_string_enum_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <StringEnumRef>
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **String** | String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ## test_echo_body_tag_response_string

--- a/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-faraday/lib/openapi_client/api/body_api.rb
@@ -530,6 +530,70 @@ module OpenapiClient
       return data, status_code, headers
     end
 
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [StringEnumRef]
+    def test_echo_body_string_enum(opts = {})
+      data, _status_code, _headers = test_echo_body_string_enum_with_http_info(opts)
+      data
+    end
+
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [Array<(StringEnumRef, Integer, Hash)>] StringEnumRef data, response status code and response headers
+    def test_echo_body_string_enum_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: BodyApi.test_echo_body_string_enum ...'
+      end
+      # resource path
+      local_var_path = '/echo/body/string_enum'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      content_type = @api_client.select_header_content_type(['application/json'])
+      if !content_type.nil?
+          header_params['Content-Type'] = content_type
+      end
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'StringEnumRef'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"BodyApi.test_echo_body_string_enum",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: BodyApi#test_echo_body_string_enum\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Test empty json (request body)
     # Test empty json (request body)
     # @param [Hash] opts the optional parameters

--- a/samples/client/echo_api/ruby-httpx/README.md
+++ b/samples/client/echo_api/ruby-httpx/README.md
@@ -93,6 +93,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *OpenapiClient::BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *OpenapiClient::BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*OpenapiClient::BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *OpenapiClient::BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *OpenapiClient::FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *OpenapiClient::FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/ruby-httpx/docs/BodyApi.md
+++ b/samples/client/echo_api/ruby-httpx/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -534,6 +535,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+## test_echo_body_string_enum
+
+> <StringEnumRef> test_echo_body_string_enum(opts)
+
+Test string enum response body
+
+Test string enum response body
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::BodyApi.new
+opts = {
+  body: 'body_example' # String | String enum
+}
+
+begin
+  # Test string enum response body
+  result = api_instance.test_echo_body_string_enum(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum: #{e}"
+end
+```
+
+#### Using the test_echo_body_string_enum_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<StringEnumRef>, Integer, Hash)> test_echo_body_string_enum_with_http_info(opts)
+
+```ruby
+begin
+  # Test string enum response body
+  data, status_code, headers = api_instance.test_echo_body_string_enum_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <StringEnumRef>
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **String** | String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ## test_echo_body_tag_response_string

--- a/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-httpx/lib/openapi_client/api/body_api.rb
@@ -530,6 +530,70 @@ module OpenapiClient
       return data, status_code, headers
     end
 
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [StringEnumRef]
+    def test_echo_body_string_enum(opts = {})
+      data, _status_code, _headers = test_echo_body_string_enum_with_http_info(opts)
+      data
+    end
+
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [Array<(StringEnumRef, Integer, Hash)>] StringEnumRef data, response status code and response headers
+    def test_echo_body_string_enum_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: BodyApi.test_echo_body_string_enum ...'
+      end
+      # resource path
+      local_var_path = '/echo/body/string_enum'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      content_type = @api_client.select_header_content_type(['application/json'])
+      if !content_type.nil?
+          header_params['Content-Type'] = content_type
+      end
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'StringEnumRef'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"BodyApi.test_echo_body_string_enum",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: BodyApi#test_echo_body_string_enum\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Test empty json (request body)
     # Test empty json (request body)
     # @param [Hash] opts the optional parameters

--- a/samples/client/echo_api/ruby-typhoeus/README.md
+++ b/samples/client/echo_api/ruby-typhoeus/README.md
@@ -91,6 +91,7 @@ Class | Method | HTTP request | Description
 *OpenapiClient::BodyApi* | [**test_echo_body_free_form_object_response_string**](docs/BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object
 *OpenapiClient::BodyApi* | [**test_echo_body_pet**](docs/BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s)
 *OpenapiClient::BodyApi* | [**test_echo_body_pet_response_string**](docs/BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body
+*OpenapiClient::BodyApi* | [**test_echo_body_string_enum**](docs/BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body
 *OpenapiClient::BodyApi* | [**test_echo_body_tag_response_string**](docs/BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body)
 *OpenapiClient::FormApi* | [**test_form_integer_boolean_string**](docs/FormApi.md#test_form_integer_boolean_string) | **POST** /form/integer/boolean/string | Test form parameter(s)
 *OpenapiClient::FormApi* | [**test_form_oneof**](docs/FormApi.md#test_form_oneof) | **POST** /form/oneof | Test form parameter(s) for oneOf schema

--- a/samples/client/echo_api/ruby-typhoeus/docs/BodyApi.md
+++ b/samples/client/echo_api/ruby-typhoeus/docs/BodyApi.md
@@ -12,6 +12,7 @@ All URIs are relative to *http://localhost:3000*
 | [**test_echo_body_free_form_object_response_string**](BodyApi.md#test_echo_body_free_form_object_response_string) | **POST** /echo/body/FreeFormObject/response_string | Test free form object |
 | [**test_echo_body_pet**](BodyApi.md#test_echo_body_pet) | **POST** /echo/body/Pet | Test body parameter(s) |
 | [**test_echo_body_pet_response_string**](BodyApi.md#test_echo_body_pet_response_string) | **POST** /echo/body/Pet/response_string | Test empty response body |
+| [**test_echo_body_string_enum**](BodyApi.md#test_echo_body_string_enum) | **POST** /echo/body/string_enum | Test string enum response body |
 | [**test_echo_body_tag_response_string**](BodyApi.md#test_echo_body_tag_response_string) | **POST** /echo/body/Tag/response_string | Test empty json (request body) |
 
 
@@ -534,6 +535,72 @@ No authorization required
 
 - **Content-Type**: application/json
 - **Accept**: text/plain
+
+
+## test_echo_body_string_enum
+
+> <StringEnumRef> test_echo_body_string_enum(opts)
+
+Test string enum response body
+
+Test string enum response body
+
+### Examples
+
+```ruby
+require 'time'
+require 'openapi_client'
+
+api_instance = OpenapiClient::BodyApi.new
+opts = {
+  body: 'body_example' # String | String enum
+}
+
+begin
+  # Test string enum response body
+  result = api_instance.test_echo_body_string_enum(opts)
+  p result
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum: #{e}"
+end
+```
+
+#### Using the test_echo_body_string_enum_with_http_info variant
+
+This returns an Array which contains the response data, status code and headers.
+
+> <Array(<StringEnumRef>, Integer, Hash)> test_echo_body_string_enum_with_http_info(opts)
+
+```ruby
+begin
+  # Test string enum response body
+  data, status_code, headers = api_instance.test_echo_body_string_enum_with_http_info(opts)
+  p status_code # => 2xx
+  p headers # => { ... }
+  p data # => <StringEnumRef>
+rescue OpenapiClient::ApiError => e
+  puts "Error when calling BodyApi->test_echo_body_string_enum_with_http_info: #{e}"
+end
+```
+
+### Parameters
+
+| Name | Type | Description | Notes |
+| ---- | ---- | ----------- | ----- |
+| **body** | **String** | String enum | [optional] |
+
+### Return type
+
+[**StringEnumRef**](StringEnumRef.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 
 ## test_echo_body_tag_response_string

--- a/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/body_api.rb
+++ b/samples/client/echo_api/ruby-typhoeus/lib/openapi_client/api/body_api.rb
@@ -530,6 +530,70 @@ module OpenapiClient
       return data, status_code, headers
     end
 
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [StringEnumRef]
+    def test_echo_body_string_enum(opts = {})
+      data, _status_code, _headers = test_echo_body_string_enum_with_http_info(opts)
+      data
+    end
+
+    # Test string enum response body
+    # Test string enum response body
+    # @param [Hash] opts the optional parameters
+    # @option opts [String] :body String enum
+    # @return [Array<(StringEnumRef, Integer, Hash)>] StringEnumRef data, response status code and response headers
+    def test_echo_body_string_enum_with_http_info(opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: BodyApi.test_echo_body_string_enum ...'
+      end
+      # resource path
+      local_var_path = '/echo/body/string_enum'
+
+      # query parameters
+      query_params = opts[:query_params] || {}
+
+      # header parameters
+      header_params = opts[:header_params] || {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      content_type = @api_client.select_header_content_type(['application/json'])
+      if !content_type.nil?
+          header_params['Content-Type'] = content_type
+      end
+
+      # form parameters
+      form_params = opts[:form_params] || {}
+
+      # http body (model)
+      post_body = opts[:debug_body] || @api_client.object_to_http_body(opts[:'body'])
+
+      # return_type
+      return_type = opts[:debug_return_type] || 'StringEnumRef'
+
+      # auth_names
+      auth_names = opts[:debug_auth_names] || []
+
+      new_options = opts.merge(
+        :operation => :"BodyApi.test_echo_body_string_enum",
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names,
+        :return_type => return_type
+      )
+
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path, new_options)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: BodyApi#test_echo_body_string_enum\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
+
     # Test empty json (request body)
     # Test empty json (request body)
     # @param [Hash] opts the optional parameters

--- a/samples/client/echo_api/typescript-axios/build/api.ts
+++ b/samples/client/echo_api/typescript-axios/build/api.ts
@@ -796,6 +796,40 @@ export const BodyApiAxiosParamCreator = function (configuration?: Configuration)
             };
         },
         /**
+         * Test string enum response body
+         * @summary Test string enum response body
+         * @param {string} [body] String enum
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testEchoBodyStringEnum: async (body?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/echo/body/string_enum`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(body, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Test empty json (request body)
          * @summary Test empty json (request body)
          * @param {Tag} [tag] Tag object
@@ -943,6 +977,19 @@ export const BodyApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Test string enum response body
+         * @summary Test string enum response body
+         * @param {string} [body] String enum
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async testEchoBodyStringEnum(body?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StringEnumRef>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.testEchoBodyStringEnum(body, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['BodyApi.testEchoBodyStringEnum']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Test empty json (request body)
          * @summary Test empty json (request body)
          * @param {Tag} [tag] Tag object
@@ -1043,6 +1090,16 @@ export const BodyApiFactory = function (configuration?: Configuration, basePath?
          */
         testEchoBodyPetResponseString(pet?: Pet, options?: any): AxiosPromise<string> {
             return localVarFp.testEchoBodyPetResponseString(pet, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Test string enum response body
+         * @summary Test string enum response body
+         * @param {string} [body] String enum
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        testEchoBodyStringEnum(body?: string, options?: any): AxiosPromise<StringEnumRef> {
+            return localVarFp.testEchoBodyStringEnum(body, options).then((request) => request(axios, basePath));
         },
         /**
          * Test empty json (request body)
@@ -1157,6 +1214,18 @@ export class BodyApi extends BaseAPI {
      */
     public testEchoBodyPetResponseString(pet?: Pet, options?: RawAxiosRequestConfig) {
         return BodyApiFp(this.configuration).testEchoBodyPetResponseString(pet, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Test string enum response body
+     * @summary Test string enum response body
+     * @param {string} [body] String enum
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof BodyApi
+     */
+    public testEchoBodyStringEnum(body?: string, options?: RawAxiosRequestConfig) {
+        return BodyApiFp(this.configuration).testEchoBodyStringEnum(body, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api_client.py
@@ -14,6 +14,7 @@
 
 import datetime
 from dateutil.parser import parse
+from enum import Enum
 import json
 import mimetypes
 import os
@@ -432,6 +433,8 @@ class ApiClient:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datetime(data)
+        elif issubclass(klass, Enum):
+            return self.__deserialize_enum(data, klass)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -733,6 +736,24 @@ class ApiClient:
                 reason=(
                     "Failed to parse `{0}` as datetime object"
                     .format(string)
+                )
+            )
+
+    def __deserialize_enum(self, data, klass):
+        """Deserializes primitive type to enum.
+
+        :param data: primitive type.
+        :param klass: class literal.
+        :return: enum value.
+        """
+        try:
+            return klass(data)
+        except ValueError:
+            raise rest.ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
                 )
             )
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api_client.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api_client.py
@@ -14,6 +14,7 @@
 
 import datetime
 from dateutil.parser import parse
+from enum import Enum
 import json
 import mimetypes
 import os
@@ -429,6 +430,8 @@ class ApiClient:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
             return self.__deserialize_datetime(data)
+        elif issubclass(klass, Enum):
+            return self.__deserialize_enum(data, klass)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -730,6 +733,24 @@ class ApiClient:
                 reason=(
                     "Failed to parse `{0}` as datetime object"
                     .format(string)
+                )
+            )
+
+    def __deserialize_enum(self, data, klass):
+        """Deserializes primitive type to enum.
+
+        :param data: primitive type.
+        :param klass: class literal.
+        :return: enum value.
+        """
+        try:
+            return klass(data)
+        except ValueError:
+            raise rest.ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
                 )
             )
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #17789

Added deserialization of enums for json responses in the python api_client template.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@tomplus @krjakbrjak @fa0311 @multani