### PR TITLE
[cpp-qt-client]Allow nullable parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/api-body.mustache
@@ -397,7 +397,7 @@ void {{classname}}::{{nickname}}({{#allParams}}{{#required}}const {{{dataType}}}
         }
         fullPath.append(paramString);
         {{/isPrimitiveType}}{{#isPrimitiveType}}
-        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding(::{{cppNamespace}}::toStringValue({{paramName}}{{^required}}.value(){{/required}})));
+        fullPath.append(QUrl::toPercentEncoding("{{baseName}}")).append(querySuffix).append(QUrl::toPercentEncoding({{paramName}}{{^required}}.stringValue(){{/required}}));
 {{/isPrimitiveType}}
 {{/collectionFormat}}
 {{#collectionFormat}}

--- a/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-header.mustache
+++ b/modules/openapi-generator/src/main/resources/cpp-qt-client/helpers-header.mustache
@@ -21,27 +21,6 @@
 namespace {{this}} {
 {{/cppNamespaceDeclarations}}
 
-template <typename T>
-class OptionalParam {
-public:
-    T m_Value;
-    bool m_hasValue;
-public:
-    OptionalParam(){
-        m_hasValue = false;
-    }
-    OptionalParam(const T &val){
-        m_hasValue = true;
-        m_Value = val;
-    }
-    bool hasValue() const {
-        return m_hasValue;
-    }
-    T value() const{
-        return m_Value;
-    }
-};
-
 bool setDateTimeFormat(const QString &format);
 bool setDateTimeFormat(const Qt::DateFormat &format);
 
@@ -263,6 +242,37 @@ bool fromJsonValue(QMap<QString, T> &val, const QJsonValue &jval) {
     }
     return ok;
 }
+
+template <typename T>
+class OptionalParam {
+public:
+    T m_Value;
+    bool m_isNull = false;
+    bool m_hasValue;
+public:
+    OptionalParam(){
+        m_hasValue = false;
+    }
+    OptionalParam(const T &val, bool isNull = false){
+        m_hasValue = true;
+        m_Value = val;
+        m_isNull = isNull;
+    }
+    bool hasValue() const {
+        return m_hasValue;
+    }
+    T value() const{
+        return m_Value;
+    }
+
+    QString stringValue() const {
+        if (m_isNull) {
+            return QStringLiteral("");
+        } else {
+            return toStringValue(value());
+        }
+    }
+};
 
 {{#cppNamespaceDeclarations}}
 } // namespace {{this}}


### PR DESCRIPTION
Fixes #17756

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Summon @etherealjoy for a review as you are the author of the Qt templates.