### PR TITLE
[dart2] [client] Adds correct code generation for enums

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/dart_constructor.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/dart_constructor.mustache
@@ -5,6 +5,6 @@
         A field is required in Dart when it is
         required && !defaultValue in OAS
     }}
-    {{#required}}{{^defaultValue}}required {{/defaultValue}}{{/required}}this.{{{name}}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}},
+    {{#required}}{{^defaultValue}}required {{/defaultValue}}{{/required}}this.{{{name}}}{{#defaultValue}} = {{#isEnum}}{{^isContainer}}{{^isNumeric}}const {{{enumName}}}._({{/isNumeric}}{{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}{{^isNumeric}}){{/isNumeric}}{{/isContainer}}{{/isEnum}}{{/defaultValue}},
   {{/vars}}
   });

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_class.mustache
@@ -220,7 +220,7 @@ class {{{classname}}} {
         {{{name}}}: mapValueOfType<{{{datatypeWithEnum}}}>(json, r'{{{baseName}}}'){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
                 {{#isEnum}}
-        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{{.}}}{{/defaultValue}}{{/required}},
+        {{{name}}}: {{{enumName}}}.fromJson(json[r'{{{baseName}}}']){{#required}}{{^isNullable}}!{{/isNullable}}{{/required}}{{^required}}{{#defaultValue}} ?? {{#isEnum}}{{^isContainer}}const {{{enumName}}}._({{/isContainer}}{{/isEnum}}{{{.}}}{{#isEnum}}{{^isContainer}}){{/isContainer}}{{/isEnum}}{{/defaultValue}}{{/required}},
                 {{/isEnum}}
               {{/isNumber}}
             {{/isMap}}

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum.mustache
@@ -40,6 +40,13 @@ class {{{classname}}} {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is {{{classname}}} && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [{{{classname}}}] to {{{dataType}}},

--- a/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum_inline.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/serialization/native/native_enum_inline.mustache
@@ -40,6 +40,12 @@ class {{{enumName}}} {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is {{{enumName}}} && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [{{{enumName}}}] to {{{dataType}}},

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ApiResponse {
   /// Returns a new [ApiResponse] instance.
   ApiResponse({
-    this.code,
-    this.type,
-    this.message,
+     this.code,
+     this.type,
+     this.message,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Category {
   /// Returns a new [Category] instance.
   Category({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Order {
   /// Returns a new [Order] instance.
   Order({
-    this.id,
-    this.petId,
-    this.quantity,
-    this.shipDate,
-    this.status,
-    this.complete = false,
+     this.id,
+     this.petId,
+     this.quantity,
+     this.shipDate,
+     this.status,
+     this.complete = false,
   });
 
   ///
@@ -224,6 +224,12 @@ class OrderStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OrderStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OrderStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Pet {
   /// Returns a new [Pet] instance.
   Pet({
-    this.id,
-    this.category,
-    required this.name,
-    this.photoUrls = const [],
-    this.tags = const [],
-    this.status,
+     this.id,
+     this.category,
+     required this.name,
+     this.photoUrls = const [],
+     this.tags = const [],
+     this.status,
   });
 
   ///
@@ -208,6 +208,12 @@ class PetStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PetStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [PetStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Tag {
   /// Returns a new [Tag] instance.
   Tag({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class User {
   /// Returns a new [User] instance.
   User({
-    this.id,
-    this.username,
-    this.firstName,
-    this.lastName,
-    this.email,
-    this.password,
-    this.phone,
-    this.userStatus,
+     this.id,
+     this.username,
+     this.firstName,
+     this.lastName,
+     this.email,
+     this.password,
+     this.phone,
+     this.userStatus,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class AdditionalPropertiesClass {
   /// Returns a new [AdditionalPropertiesClass] instance.
   AdditionalPropertiesClass({
-    this.mapProperty = const {},
-    this.mapOfMapProperty = const {},
+     this.mapProperty = const {},
+     this.mapOfMapProperty = const {},
   });
 
   Map<String, String> mapProperty;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class AllOfWithSingleRef {
   /// Returns a new [AllOfWithSingleRef] instance.
   AllOfWithSingleRef({
-    this.username,
-    this.singleRefType,
+     this.username,
+     this.singleRefType,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Animal {
   /// Returns a new [Animal] instance.
   Animal({
-    required this.className,
-    this.color = 'red',
+     required this.className,
+     this.color = 'red',
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ApiResponse {
   /// Returns a new [ApiResponse] instance.
   ApiResponse({
-    this.code,
-    this.type,
-    this.message,
+     this.code,
+     this.type,
+     this.message,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ArrayOfArrayOfNumberOnly {
   /// Returns a new [ArrayOfArrayOfNumberOnly] instance.
   ArrayOfArrayOfNumberOnly({
-    this.arrayArrayNumber = const [],
+     this.arrayArrayNumber = const [],
   });
 
   List<List<num>> arrayArrayNumber;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ArrayOfNumberOnly {
   /// Returns a new [ArrayOfNumberOnly] instance.
   ArrayOfNumberOnly({
-    this.arrayNumber = const [],
+     this.arrayNumber = const [],
   });
 
   List<num> arrayNumber;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ArrayTest {
   /// Returns a new [ArrayTest] instance.
   ArrayTest({
-    this.arrayOfString = const [],
-    this.arrayArrayOfInteger = const [],
-    this.arrayArrayOfModel = const [],
+     this.arrayOfString = const [],
+     this.arrayArrayOfInteger = const [],
+     this.arrayArrayOfModel = const [],
   });
 
   List<String> arrayOfString;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Capitalization {
   /// Returns a new [Capitalization] instance.
   Capitalization({
-    this.smallCamel,
-    this.capitalCamel,
-    this.smallSnake,
-    this.capitalSnake,
-    this.sCAETHFlowPoints,
-    this.ATT_NAME,
+     this.smallCamel,
+     this.capitalCamel,
+     this.smallSnake,
+     this.capitalSnake,
+     this.sCAETHFlowPoints,
+     this.ATT_NAME,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class Cat {
   /// Returns a new [Cat] instance.
   Cat({
-    required this.className,
-    this.color = 'red',
-    this.declawed,
+     required this.className,
+     this.color = 'red',
+     this.declawed,
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Category {
   /// Returns a new [Category] instance.
   Category({
-    this.id,
-    this.name = 'default-name',
+     this.id,
+     this.name = 'default-name',
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class ChildWithNullable {
   /// Returns a new [ChildWithNullable] instance.
   ChildWithNullable({
-    this.type,
-    this.nullableProperty,
-    this.otherProperty,
+     this.type,
+     this.nullableProperty,
+     this.otherProperty,
   });
 
   ChildWithNullableTypeEnum? type;
@@ -172,6 +172,12 @@ class ChildWithNullableTypeEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is ChildWithNullableTypeEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [ChildWithNullableTypeEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ClassModel {
   /// Returns a new [ClassModel] instance.
   ClassModel({
-    this.class_,
+     this.class_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class DeprecatedObject {
   /// Returns a new [DeprecatedObject] instance.
   DeprecatedObject({
-    this.name,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class Dog {
   /// Returns a new [Dog] instance.
   Dog({
-    required this.className,
-    this.color = 'red',
-    this.breed,
+     required this.className,
+     this.color = 'red',
+     this.breed,
   });
 
   String className;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class EnumArrays {
   /// Returns a new [EnumArrays] instance.
   EnumArrays({
-    this.justSymbol,
-    this.arrayEnum = const [],
+     this.justSymbol,
+     this.arrayEnum = const [],
   });
 
   EnumArraysJustSymbolEnum? justSymbol;
@@ -153,6 +153,12 @@ class EnumArraysJustSymbolEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumArraysJustSymbolEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumArraysJustSymbolEnum] to String,
@@ -227,6 +233,12 @@ class EnumArraysArrayEnumEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumArraysArrayEnumEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumArraysArrayEnumEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
@@ -48,6 +48,13 @@ class EnumClass {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumClass && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumClass] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class EnumTest {
   /// Returns a new [EnumTest] instance.
   EnumTest({
-    this.enumString,
-    required this.enumStringRequired,
-    this.enumInteger,
-    this.enumNumber,
-    this.outerEnum,
-    this.outerEnumInteger,
-    this.outerEnumDefaultValue,
-    this.outerEnumIntegerDefaultValue,
+     this.enumString,
+     required this.enumStringRequired,
+     this.enumInteger,
+     this.enumNumber,
+     this.outerEnum,
+     this.outerEnumInteger,
+     this.outerEnumDefaultValue,
+     this.outerEnumIntegerDefaultValue,
   });
 
   EnumTestEnumStringEnum? enumString;
@@ -240,6 +240,12 @@ class EnumTestEnumStringEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumStringEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumStringEnum] to String,
@@ -317,6 +323,12 @@ class EnumTestEnumStringRequiredEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumStringRequiredEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumStringRequiredEnum] to String,
@@ -392,6 +404,12 @@ class EnumTestEnumIntegerEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumIntegerEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumIntegerEnum] to int,
@@ -466,6 +484,12 @@ class EnumTestEnumNumberEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is EnumTestEnumNumberEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [EnumTestEnumNumberEnum] to double,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class FakeBigDecimalMap200Response {
   /// Returns a new [FakeBigDecimalMap200Response] instance.
   FakeBigDecimalMap200Response({
-    this.someId,
-    this.someMap = const {},
+     this.someId,
+     this.someMap = const {},
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class FileSchemaTestClass {
   /// Returns a new [FileSchemaTestClass] instance.
   FileSchemaTestClass({
-    this.file,
-    this.files = const [],
+     this.file,
+     this.files = const [],
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class Foo {
   /// Returns a new [Foo] instance.
   Foo({
-    this.bar = 'bar',
+     this.bar = 'bar',
   });
 
   String bar;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class FooGetDefaultResponse {
   /// Returns a new [FooGetDefaultResponse] instance.
   FooGetDefaultResponse({
-    this.string,
+     this.string,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -13,22 +13,22 @@ part of openapi.api;
 class FormatTest {
   /// Returns a new [FormatTest] instance.
   FormatTest({
-    this.integer,
-    this.int32,
-    this.int64,
-    required this.number,
-    this.float,
-    this.double_,
-    this.decimal,
-    this.string,
-    required this.byte,
-    this.binary,
-    required this.date,
-    this.dateTime,
-    this.uuid,
-    required this.password,
-    this.patternWithDigits,
-    this.patternWithDigitsAndDelimiter,
+     this.integer,
+     this.int32,
+     this.int64,
+     required this.number,
+     this.float,
+     this.double_,
+     this.decimal,
+     this.string,
+     required this.byte,
+     this.binary,
+     required this.date,
+     this.dateTime,
+     this.uuid,
+     required this.password,
+     this.patternWithDigits,
+     this.patternWithDigitsAndDelimiter,
   });
 
   /// Minimum value: 10

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class HasOnlyReadOnly {
   /// Returns a new [HasOnlyReadOnly] instance.
   HasOnlyReadOnly({
-    this.bar,
-    this.foo,
+     this.bar,
+     this.foo,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class HealthCheckResult {
   /// Returns a new [HealthCheckResult] instance.
   HealthCheckResult({
-    this.nullableMessage,
+     this.nullableMessage,
   });
 
   String? nullableMessage;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class MapTest {
   /// Returns a new [MapTest] instance.
   MapTest({
-    this.mapMapOfString = const {},
-    this.mapOfEnumString = const {},
-    this.directMap = const {},
-    this.indirectMap = const {},
+     this.mapMapOfString = const {},
+     this.mapOfEnumString = const {},
+     this.directMap = const {},
+     this.indirectMap = const {},
   });
 
   Map<String, Map<String, String>> mapMapOfString;
@@ -163,6 +163,12 @@ class MapTestMapOfEnumStringEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is MapTestMapOfEnumStringEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [MapTestMapOfEnumStringEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class MixedPropertiesAndAdditionalPropertiesClass {
   /// Returns a new [MixedPropertiesAndAdditionalPropertiesClass] instance.
   MixedPropertiesAndAdditionalPropertiesClass({
-    this.uuid,
-    this.dateTime,
-    this.map = const {},
+     this.uuid,
+     this.dateTime,
+     this.map = const {},
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Model200Response {
   /// Returns a new [Model200Response] instance.
   Model200Response({
-    this.name,
-    this.class_,
+     this.name,
+     this.class_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelClient {
   /// Returns a new [ModelClient] instance.
   ModelClient({
-    this.client,
+     this.client,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelFile {
   /// Returns a new [ModelFile] instance.
   ModelFile({
-    this.sourceURI,
+     this.sourceURI,
   });
 
   /// Test capitalization

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelList {
   /// Returns a new [ModelList] instance.
   ModelList({
-    this.n123list,
+     this.n123list,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class ModelReturn {
   /// Returns a new [ModelReturn] instance.
   ModelReturn({
-    this.return_,
+     this.return_,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class Name {
   /// Returns a new [Name] instance.
   Name({
-    required this.name,
-    this.snakeCase,
-    this.property,
-    this.n123number,
+     required this.name,
+     this.snakeCase,
+     this.property,
+     this.n123number,
   });
 
   int name;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -13,18 +13,18 @@ part of openapi.api;
 class NullableClass {
   /// Returns a new [NullableClass] instance.
   NullableClass({
-    this.integerProp,
-    this.numberProp,
-    this.booleanProp,
-    this.stringProp,
-    this.dateProp,
-    this.datetimeProp,
-    this.arrayNullableProp = const [],
-    this.arrayAndItemsNullableProp = const [],
-    this.arrayItemsNullable = const [],
-    this.objectNullableProp = const {},
-    this.objectAndItemsNullableProp = const {},
-    this.objectItemsNullable = const {},
+     this.integerProp,
+     this.numberProp,
+     this.booleanProp,
+     this.stringProp,
+     this.dateProp,
+     this.datetimeProp,
+     this.arrayNullableProp = const [],
+     this.arrayAndItemsNullableProp = const [],
+     this.arrayItemsNullable = const [],
+     this.objectNullableProp = const {},
+     this.objectAndItemsNullableProp = const {},
+     this.objectItemsNullable = const {},
   });
 
   int? integerProp;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class NumberOnly {
   /// Returns a new [NumberOnly] instance.
   NumberOnly({
-    this.justNumber,
+     this.justNumber,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -13,10 +13,10 @@ part of openapi.api;
 class ObjectWithDeprecatedFields {
   /// Returns a new [ObjectWithDeprecatedFields] instance.
   ObjectWithDeprecatedFields({
-    this.uuid,
-    this.id,
-    this.deprecatedRef,
-    this.bars = const [],
+     this.uuid,
+     this.id,
+     this.deprecatedRef,
+     this.bars = const [],
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Order {
   /// Returns a new [Order] instance.
   Order({
-    this.id,
-    this.petId,
-    this.quantity,
-    this.shipDate,
-    this.status,
-    this.complete = false,
+     this.id,
+     this.petId,
+     this.quantity,
+     this.shipDate,
+     this.status,
+     this.complete = false,
   });
 
   ///
@@ -224,6 +224,12 @@ class OrderStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OrderStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OrderStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -13,9 +13,9 @@ part of openapi.api;
 class OuterComposite {
   /// Returns a new [OuterComposite] instance.
   OuterComposite({
-    this.myNumber,
-    this.myString,
-    this.myBoolean,
+     this.myNumber,
+     this.myString,
+     this.myBoolean,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
@@ -48,6 +48,13 @@ class OuterEnum {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
@@ -48,6 +48,13 @@ class OuterEnumDefaultValue {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumDefaultValue && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumDefaultValue] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
@@ -48,6 +48,13 @@ class OuterEnumInteger {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumInteger && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumInteger] to int,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
@@ -48,6 +48,13 @@ class OuterEnumIntegerDefaultValue {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is OuterEnumIntegerDefaultValue && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [OuterEnumIntegerDefaultValue] to int,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class OuterObjectWithEnumProperty {
   /// Returns a new [OuterObjectWithEnumProperty] instance.
   OuterObjectWithEnumProperty({
-    required this.value,
+     required this.value,
   });
 
   OuterEnumInteger value;

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class ParentWithNullable {
   /// Returns a new [ParentWithNullable] instance.
   ParentWithNullable({
-    this.type,
-    this.nullableProperty,
+     this.type,
+     this.nullableProperty,
   });
 
   ParentWithNullableTypeEnum? type;
@@ -155,6 +155,12 @@ class ParentWithNullableTypeEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is ParentWithNullableTypeEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [ParentWithNullableTypeEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -13,12 +13,12 @@ part of openapi.api;
 class Pet {
   /// Returns a new [Pet] instance.
   Pet({
-    this.id,
-    this.category,
-    required this.name,
-    this.photoUrls = const {},
-    this.tags = const [],
-    this.status,
+     this.id,
+     this.category,
+     required this.name,
+     this.photoUrls = const {},
+     this.tags = const [],
+     this.status,
   });
 
   ///
@@ -208,6 +208,12 @@ class PetStatusEnum {
     }
     return result.toList(growable: growable);
   }
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is PetStatusEnum && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [PetStatusEnum] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class ReadOnlyFirst {
   /// Returns a new [ReadOnlyFirst] instance.
   ReadOnlyFirst({
-    this.bar,
-    this.baz,
+     this.bar,
+     this.baz,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
@@ -46,6 +46,13 @@ class SingleRefType {
     }
     return result.toList(growable: growable);
   }
+
+  
+  @override
+  bool operator ==(Object other) => identical(this, other) || other is SingleRefType && other.value == value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// Transformation class that can [encode] an instance of [SingleRefType] to String,

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class SpecialModelName {
   /// Returns a new [SpecialModelName] instance.
   SpecialModelName({
-    this.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket,
+     this.dollarSpecialLeftSquareBracketPropertyPeriodNameRightSquareBracket,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -13,8 +13,8 @@ part of openapi.api;
 class Tag {
   /// Returns a new [Tag] instance.
   Tag({
-    this.id,
-    this.name,
+     this.id,
+     this.name,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
@@ -13,7 +13,7 @@ part of openapi.api;
 class TestInlineFreeformAdditionalPropertiesRequest {
   /// Returns a new [TestInlineFreeformAdditionalPropertiesRequest] instance.
   TestInlineFreeformAdditionalPropertiesRequest({
-    this.someProperty,
+     this.someProperty,
   });
 
   ///

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -13,14 +13,14 @@ part of openapi.api;
 class User {
   /// Returns a new [User] instance.
   User({
-    this.id,
-    this.username,
-    this.firstName,
-    this.lastName,
-    this.email,
-    this.password,
-    this.phone,
-    this.userStatus,
+     this.id,
+     this.username,
+     this.firstName,
+     this.lastName,
+     this.email,
+     this.password,
+     this.phone,
+     this.userStatus,
   });
 
   ///


### PR DESCRIPTION
fix #17547 
fix #13459 

This PR is part of the effort to split PR https://github.com/OpenAPITools/openapi-generator/pull/17548

Numeric enums of the form:
```yaml
some_enum:
  type: integer
  enum:
    - 1
    - 2
```

will now generate correct code, instead of invalid, non compile-able dart code.

Enums with a default choice will now also generate valid dart code for instantiating that default:

```yaml
some_enum2:
  type: string
  enum:
    - "x"
    - "y"
  default: "x"
```


@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)