### PR TITLE
Fix TS Axios echo client github workflow

### DIFF
--- a/.github/workflows/samples-typescript-axios-echo-api.yaml
+++ b/.github/workflows/samples-typescript-axios-echo-api.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run echo server
         run: |
           git clone https://github.com/wing328/http-echo-server -b openapi-generator-test-server
-          (cd http-echo-server && git checkout 5d79b77055ec593681b65a968986925e98991f71 && npm install && npm start &)
+          (cd http-echo-server && git checkout 15a684c41d4de692878636f47fcc1670af309a0f && npm install && npm start &)
 
       - name: Install
         working-directory: ${{ matrix.sample }}

--- a/.github/workflows/samples-typescript-axios-echo-api.yaml
+++ b/.github/workflows/samples-typescript-axios-echo-api.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Run echo server
         run: |
           git clone https://github.com/wing328/http-echo-server -b openapi-generator-test-server
-          (cd http-echo-server && npm install && npm start &)
+          (cd http-echo-server && git checkout 5d79b77055ec593681b65a968986925e98991f71 && npm install && npm start &)
 
       - name: Install
         working-directory: ${{ matrix.sample }}

--- a/samples/client/echo_api/typescript-axios/build/.openapi-generator-ignore
+++ b/samples/client/echo_api/typescript-axios/build/.openapi-generator-ignore
@@ -21,3 +21,5 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+#
+#


### PR DESCRIPTION
Fix TS Axios client github workflow by using an old version of the http echo server

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
