### PR TITLE
[dart2] [client] Bump test package version to >=1.21.6 for dart3 compatability

### DIFF
--- a/modules/openapi-generator/src/main/resources/dart2/header.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/header.mustache
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
+++ b/modules/openapi-generator/src/main/resources/dart2/pubspec.mustache
@@ -20,7 +20,7 @@ dependencies:
   intl: '^0.18.0'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '>=1.16.0 <1.18.0'
+  test: '>=1.21.6 <1.22.0'
 {{#json_serializable}}
   build_runner: '^1.10.9'
   json_serializable: '^3.5.1'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/pet_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/store_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api/user_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_client.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_exception.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_exception.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/api_helper.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/api_key_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/api_key_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/authentication.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/authentication.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/http_basic_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/http_basic_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/http_bearer_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/http_bearer_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/oauth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/auth/oauth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/api_response.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/category.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/order.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/pet.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/tag.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/lib/model/user.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   intl: '^0.18.0'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '>=1.16.0 <1.18.0'
+  test: '>=1.21.6 <1.22.0'

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/another_fake_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/default_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/fake_classname_tags123_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/pet_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/store_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api/user_api.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_client.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_exception.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_exception.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/api_helper.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/api_key_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/api_key_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/authentication.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/authentication.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/http_basic_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/http_basic_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/http_bearer_auth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/http_bearer_auth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/oauth.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/auth/oauth.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/additional_properties_class.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/all_of_with_single_ref.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/animal.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/api_response.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_array_of_number_only.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_of_number_only.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/array_test.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/capitalization.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/cat.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/category.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/child_with_nullable.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/class_model.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/deprecated_object.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/dog.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_arrays.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_class.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/enum_test.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/fake_big_decimal_map200_response.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/file_schema_test_class.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/foo_get_default_response.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/format_test.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/has_only_read_only.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/health_check_result.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/map_test.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/mixed_properties_and_additional_properties_class.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model200_response.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_client.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_file.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_list.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/model_return.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/name.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/nullable_class.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/number_only.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/object_with_deprecated_fields.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/order.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_composite.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_default_value.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_enum_integer_default_value.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/outer_object_with_enum_property.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/parent_with_nullable.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/pet.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/read_only_first.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/single_ref_type.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/special_model_name.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/tag.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/test_inline_freeform_additional_properties_request.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/lib/model/user.dart
@@ -1,7 +1,7 @@
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
-// @dart=2.12
+// @dart=2.18
 
 // ignore_for_file: unused_element, unused_import
 // ignore_for_file: always_put_required_named_parameters_first

--- a/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
+++ b/samples/openapi3/client/petstore/dart2/petstore_client_lib_fake/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
   intl: '^0.18.0'
   meta: '^1.1.8'
 dev_dependencies:
-  test: '>=1.16.0 <1.18.0'
+  test: '>=1.21.6 <1.22.0'


### PR DESCRIPTION
fix #17563 

The test runner is too outdated to be used for Dart 3 projects. This change updates the test runner to be constrained to `>=1.21.6 <1.22.0`. 

Since this change implies a minimum of Dart 2.18, the header.mustache file is now also bumped from `// @dart=2.12` to `// @dart=2.18`.

I think this is a not inappropriate version update for Dart, since 2.18 has been out for 1.5 years now ([August 30, 2022](https://dart.dev/guides/whats-new#august-30-2022-2-18-release))

@jaumard (2018/09) @josh-burton (2019/12) @amondnet (2019/12) @sbu-WBT (2020/12) @kuhnroyal (2020/12) @agilob (2020/12) @ahmednfwela (2021/08)