### PR TITLE
refactor(php): unify $hostSettings variable name

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/Configuration.mustache
@@ -493,23 +493,23 @@ class Configuration
     /**
     * Returns URL based on host settings, index and variables
     *
-    * @param array      $hostsSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
+    * @param array      $hostSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
     * @param int        $hostIndex    index of the host settings
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];
         }
 
         // check array index out of bound
-        if ($hostIndex < 0 || $hostIndex >= count($hostsSettings)) {
-            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
+        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostSettings));
         }
 
-        $host = $hostsSettings[$hostIndex];
+        $host = $hostSettings[$hostIndex];
         $url = $host["url"];
 
         // go through variable and assign a value

--- a/samples/client/echo_api/php-nextgen/src/Configuration.php
+++ b/samples/client/echo_api/php-nextgen/src/Configuration.php
@@ -477,23 +477,23 @@ class Configuration
     /**
     * Returns URL based on host settings, index and variables
     *
-    * @param array      $hostsSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
+    * @param array      $hostSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
     * @param int        $hostIndex    index of the host settings
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];
         }
 
         // check array index out of bound
-        if ($hostIndex < 0 || $hostIndex >= count($hostsSettings)) {
-            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
+        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostSettings));
         }
 
-        $host = $hostsSettings[$hostIndex];
+        $host = $hostSettings[$hostIndex];
         $url = $host["url"];
 
         // go through variable and assign a value

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Configuration.php
@@ -513,23 +513,23 @@ class Configuration
     /**
     * Returns URL based on host settings, index and variables
     *
-    * @param array      $hostsSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
+    * @param array      $hostSettings array of host settings, generated from getHostSettings() or equivalent from the API clients
     * @param int        $hostIndex    index of the host settings
     * @param array|null $variables    hash of variable and the corresponding value (optional)
     * @return string URL based on host settings
     */
-    public static function getHostString(array $hostsSettings, int $hostIndex, array $variables = null): string
+    public static function getHostString(array $hostSettings, int $hostIndex, array $variables = null): string
     {
         if (null === $variables) {
             $variables = [];
         }
 
         // check array index out of bound
-        if ($hostIndex < 0 || $hostIndex >= count($hostsSettings)) {
-            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostsSettings));
+        if ($hostIndex < 0 || $hostIndex >= count($hostSettings)) {
+            throw new InvalidArgumentException("Invalid index $hostIndex when selecting the host. Must be less than ".count($hostSettings));
         }
 
-        $host = $hostsSettings[$hostIndex];
+        $host = $hostSettings[$hostIndex];
         $url = $host["url"];
 
         // go through variable and assign a value


### PR DESCRIPTION
`hostSettings` is used everywhere else so I consider `hostsSettings` a typo

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
