### PR TITLE
fix(java):  resolve feign ambiguity in ApiErrorDecoder fix(#17842)

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/ApiErrorDecoder.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/auth/ApiErrorDecoder.mustache
@@ -1,5 +1,7 @@
 package {{invokerPackage}}.auth;
 
+import java.util.Date;
+
 import feign.Response;
 import feign.RetryableException;
 import feign.codec.ErrorDecoder;
@@ -18,7 +20,7 @@ public class ApiErrorDecoder implements ErrorDecoder {
         Exception httpException = defaultErrorDecoder.decode(methodKey, response);
         if (response.status() == 401 || response.status() == 403) {
             return new RetryableException(response.status(), "Received status " + response.status() + " trying to renew access token",
-                    response.request().httpMethod(), httpException, null, response.request());
+                    response.request().httpMethod(), httpException, (Date) null, response.request());
         }
         return httpException;
     }

--- a/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/auth/ApiErrorDecoder.java
+++ b/samples/client/petstore/java/feign-no-nullable/src/main/java/org/openapitools/client/auth/ApiErrorDecoder.java
@@ -1,5 +1,7 @@
 package org.openapitools.client.auth;
 
+import java.util.Date;
+
 import feign.Response;
 import feign.RetryableException;
 import feign.codec.ErrorDecoder;
@@ -18,7 +20,7 @@ public class ApiErrorDecoder implements ErrorDecoder {
         Exception httpException = defaultErrorDecoder.decode(methodKey, response);
         if (response.status() == 401 || response.status() == 403) {
             return new RetryableException(response.status(), "Received status " + response.status() + " trying to renew access token",
-                    response.request().httpMethod(), httpException, null, response.request());
+                    response.request().httpMethod(), httpException, (Date) null, response.request());
         }
         return httpException;
     }

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/ApiErrorDecoder.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/auth/ApiErrorDecoder.java
@@ -1,5 +1,7 @@
 package org.openapitools.client.auth;
 
+import java.util.Date;
+
 import feign.Response;
 import feign.RetryableException;
 import feign.codec.ErrorDecoder;
@@ -18,7 +20,7 @@ public class ApiErrorDecoder implements ErrorDecoder {
         Exception httpException = defaultErrorDecoder.decode(methodKey, response);
         if (response.status() == 401 || response.status() == 403) {
             return new RetryableException(response.status(), "Received status " + response.status() + " trying to renew access token",
-                    response.request().httpMethod(), httpException, null, response.request());
+                    response.request().httpMethod(), httpException, (Date) null, response.request());
         }
         return httpException;
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @martin-mfg 