### PR TITLE
[RUST] Implement escape reserved word for Rust Client codegen.

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/RustClientCodegen.java
@@ -140,8 +140,6 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
         );
 
         instantiationTypes.clear();
-        /*instantiationTypes.put("array", "GoArray");
-        instantiationTypes.put("map", "GoMap");*/
 
         typeMapping.clear();
         typeMapping.put("integer", "i32");
@@ -532,56 +530,6 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
             if (!operation.vendorExtensions.containsKey("x-group-parameters") && useSingleRequestParameter) {
                 operation.vendorExtensions.put("x-group-parameters", Boolean.TRUE);
             }
-
-            // update return type to conform to rust standard
-            /*
-            if (operation.returnType != null) {
-                if ( operation.returnType.startsWith("Vec") && !languageSpecificPrimitives.contains(operation.returnBaseType)) {
-                    // array of model
-                    String rt = operation.returnType;
-                    int end = rt.lastIndexOf(">");
-                    if ( end > 0 ) {
-                        operation.vendorExtensions.put("x-returnTypeInMethod", "Vec<super::" + rt.substring("Vec<".length(), end).trim() + ">");
-                        operation.returnContainer = "List";
-                    }
-                } else if (operation.returnType.startsWith("::std::collections::HashMap<String, ") && !languageSpecificPrimitives.contains(operation.returnBaseType)) {
-                    LOGGER.info("return base type:" + operation.returnBaseType);
-                    // map of model
-                    String rt = operation.returnType;
-                    int end = rt.lastIndexOf(">");
-                    if ( end > 0 ) {
-                        operation.vendorExtensions.put("x-returnTypeInMethod", "::std::collections::HashMap<String, super::" + rt.substring("::std::collections::HashMap<String, ".length(), end).trim() + ">");
-                        operation.returnContainer = "Map";
-                    }
-                } else if (!languageSpecificPrimitives.contains(operation.returnType)) {
-                    // add super:: to model, e.g. super::pet
-                    operation.vendorExtensions.put("x-returnTypeInMethod", "super::" + operation.returnType);
-                } else {
-                    // primitive type or array/map of primitive type
-                    operation.vendorExtensions.put("x-returnTypeInMethod", operation.returnType);
-                }
-            }
-
-            for (CodegenParameter p : operation.allParams) {
-                if (p.isArray && !languageSpecificPrimitives.contains(p.dataType)) {
-                    // array of model
-                    String rt = p.dataType;
-                    int end = rt.lastIndexOf(">");
-                    if ( end > 0 ) {
-                        p.dataType = "Vec<" + rt.substring("Vec<".length(), end).trim() + ">";
-                    }
-                } else if (p.isMap && !languageSpecificPrimitives.contains(p.dataType)) {
-                    // map of model
-                    String rt = p.dataType;
-                    int end = rt.lastIndexOf(">");
-                    if ( end > 0 ) {
-                        p.dataType = "::std::collections::HashMap<String, super::" + rt.substring("::std::collections::HashMap<String, ".length(), end).trim() + ">";
-                    }
-                } else if (!languageSpecificPrimitives.contains(p.dataType)) {
-                    // add super:: to model, e.g. super::pet
-                    p.dataType = "super::" + p.dataType;
-                }
-            }*/
         }
 
         return objs;
@@ -604,4 +552,11 @@ public class RustClientCodegen extends AbstractRustCodegen implements CodegenCon
         }
     }
 
+    @Override
+    public String escapeReservedWord(String name) {
+        if (this.reservedWordsMappings().containsKey(name)) {
+            return this.reservedWordsMappings().get(name);
+        }
+        return "_" + name;
+    }
 }


### PR DESCRIPTION
The Bitbucket Cloud API has "ref" as a swagger symbol. Thus on master it fails with a reserved word error. After this change, this should work:

```
$ ./run-in-docker.sh generate -i https://dac-static.atlassian.com/cloud/bitbucket/swagger.v3.json?_v=2.300.22-0.1297.0 -g rust -o /gen/out/
```
@frol @farcaller @richardwhiuk @paladinzh @jacob-pro

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
