### PR TITLE
[java][native] Fix missing imports when using list validation

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -13,6 +13,10 @@ import {{import}};
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+{{/useBeanValidation}}
 {{#hasFormParamsInSpec}}
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -615,6 +615,34 @@ public class JavaClientCodegenTest {
     }
 
     @Test
+    public void testJdkHttpClientWithUseBeanValidationEnabled() throws IOException {
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+        properties.put(JavaClientCodegen.USE_BEANVALIDATION, true);
+        properties.put(JavaClientCodegen.USE_JAKARTA_EE, true);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("java")
+                .setLibrary(JavaClientCodegen.NATIVE)
+                .setAdditionalProperties(properties)
+                .setInputSpec("src/test/resources/3_1/issue-17485.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        validateJavaSourceFiles(files);
+
+        TestUtils.assertFileContains(Paths.get(output + "/src/main/java/xyz/abcdef/api/UserApi.java"),
+                "@Pattern", "import jakarta.validation.constraints.*");
+    }
+
+    @Test
     public void testJdkHttpClientWithAndWithoutDiscriminator() throws Exception {
         Map<String, Object> properties = new HashMap<>();
         properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");

--- a/modules/openapi-generator/src/test/resources/3_1/issue-17485.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue-17485.yaml
@@ -1,0 +1,25 @@
+# OAS document that tests for a regression when useBeanValidation=true and lists with a pattern.
+openapi: 3.1.0
+info:
+  title: issue-17485
+  version: 0.1.0
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /user:
+    get:
+      tags:
+        - user
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: The name of the user
+          schema:
+            type: array
+            items:
+              type: string
+              pattern: "^[a-zA-Z0-9]$"
+      responses:
+        "200":
+          description: OK


### PR DESCRIPTION
Fixes #17485 which was a regression in 7.2.0 after #17165 was merged. That change did not add the necessary imports to the generated API when bean validation was enabled and the schema contained an array that had item level validation.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg @wing328 