### PR TITLE
feat(rust): implement from trait on enum variants

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -77,6 +77,14 @@ impl Default for {{classname}} {
         }{{/-first}}{{/mappedModels}}{{/oneOf}}{{#oneOf}}{{#-first}}Self::{{{.}}}(Box::default()){{/-first}}{{/oneOf}}
     }
 }
+{{#oneOf}}
+
+impl From<{{{.}}}> for {{classname}} {
+    fn from(model: {{{.}}}) -> Self {
+        Self::{{{.}}}(Box::new(model))
+    }
+}
+{{/oneOf}}
 
 {{/discriminator}}
 
@@ -109,7 +117,6 @@ impl {{{classname}}} {
 }
 {{/oneOf.isEmpty}}
 {{^oneOf.isEmpty}}
-{{! TODO: add other vars that are not part of the oneOf}}
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum {{classname}} {
@@ -126,6 +133,14 @@ impl Default for {{classname}} {
         {{#oneOf}}{{#-first}}Self::{{{.}}}(Box::default()){{/-first}}{{/oneOf}}
     }
 }
+{{#oneOf}}
+
+impl From<{{{.}}}> for {{classname}} {
+    fn from(model: {{{.}}}) -> Self {
+        Self::{{{.}}}(Box::new(model))
+    }
+}
+{{/oneOf}}
 {{/oneOf.isEmpty}}
 {{/discriminator}}
 {{/isEnum}}

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/create_state_request.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/create_state_request.rs
@@ -25,6 +25,18 @@ impl Default for CreateStateRequest {
     }
 }
 
+impl From<ObjA> for CreateStateRequest {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CreateStateRequest {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
@@ -27,6 +27,24 @@ impl Default for CustomOneOfArraySchemaInner {
     }
 }
 
+impl From<ObjA> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
+impl From<ObjC> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjC) -> Self {
+        Self::ObjC(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_schema.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_schema.rs
@@ -25,6 +25,18 @@ impl Default for CustomOneOfSchema {
     }
 }
 
+impl From<ObjA> for CustomOneOfSchema {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CustomOneOfSchema {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/get_state_200_response.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/get_state_200_response.rs
@@ -27,6 +27,24 @@ impl Default for GetState200Response {
     }
 }
 
+impl From<ObjA> for GetState200Response {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for GetState200Response {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
+impl From<ObjD> for GetState200Response {
+    fn from(model: ObjD) -> Self {
+        Self::ObjD(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/hyper/oneOf/src/models/bar_ref_or_value.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/models/bar_ref_or_value.rs
@@ -26,4 +26,16 @@ impl Default for BarRefOrValue {
     }
 }
 
+impl From<Bar> for BarRefOrValue {
+    fn from(model: Bar) -> Self {
+        Self::Bar(Box::new(model))
+    }
+}
+
+impl From<BarRef> for BarRefOrValue {
+    fn from(model: BarRef) -> Self {
+        Self::BarRef(Box::new(model))
+    }
+}
+
 

--- a/samples/client/others/rust/hyper/oneOf/src/models/foo_ref_or_value.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/models/foo_ref_or_value.rs
@@ -25,6 +25,18 @@ impl Default for FooRefOrValue {
     }
 }
 
+impl From<Foo> for FooRefOrValue {
+    fn from(model: Foo) -> Self {
+        Self::Foo(Box::new(model))
+    }
+}
+
+impl From<FooRef> for FooRefOrValue {
+    fn from(model: FooRef) -> Self {
+        Self::FooRef(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/hyper/oneOf/src/models/fruit.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/models/fruit.rs
@@ -25,6 +25,18 @@ impl Default for Fruit {
     }
 }
 
+impl From<Apple> for Fruit {
+    fn from(model: Apple) -> Self {
+        Self::Apple(Box::new(model))
+    }
+}
+
+impl From<Banana> for Fruit {
+    fn from(model: Banana) -> Self {
+        Self::Banana(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/create_state_request.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/create_state_request.rs
@@ -25,6 +25,18 @@ impl Default for CreateStateRequest {
     }
 }
 
+impl From<ObjA> for CreateStateRequest {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CreateStateRequest {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
@@ -27,6 +27,24 @@ impl Default for CustomOneOfArraySchemaInner {
     }
 }
 
+impl From<ObjA> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
+impl From<ObjC> for CustomOneOfArraySchemaInner {
+    fn from(model: ObjC) -> Self {
+        Self::ObjC(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_schema.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_schema.rs
@@ -25,6 +25,18 @@ impl Default for CustomOneOfSchema {
     }
 }
 
+impl From<ObjA> for CustomOneOfSchema {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for CustomOneOfSchema {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/get_state_200_response.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/get_state_200_response.rs
@@ -27,6 +27,24 @@ impl Default for GetState200Response {
     }
 }
 
+impl From<ObjA> for GetState200Response {
+    fn from(model: ObjA) -> Self {
+        Self::ObjA(Box::new(model))
+    }
+}
+
+impl From<ObjB> for GetState200Response {
+    fn from(model: ObjB) -> Self {
+        Self::ObjB(Box::new(model))
+    }
+}
+
+impl From<ObjD> for GetState200Response {
+    fn from(model: ObjD) -> Self {
+        Self::ObjD(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/oneOf/src/models/bar_ref_or_value.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/models/bar_ref_or_value.rs
@@ -26,4 +26,16 @@ impl Default for BarRefOrValue {
     }
 }
 
+impl From<Bar> for BarRefOrValue {
+    fn from(model: Bar) -> Self {
+        Self::Bar(Box::new(model))
+    }
+}
+
+impl From<BarRef> for BarRefOrValue {
+    fn from(model: BarRef) -> Self {
+        Self::BarRef(Box::new(model))
+    }
+}
+
 

--- a/samples/client/others/rust/reqwest/oneOf/src/models/foo_ref_or_value.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/models/foo_ref_or_value.rs
@@ -25,6 +25,18 @@ impl Default for FooRefOrValue {
     }
 }
 
+impl From<Foo> for FooRefOrValue {
+    fn from(model: Foo) -> Self {
+        Self::Foo(Box::new(model))
+    }
+}
+
+impl From<FooRef> for FooRefOrValue {
+    fn from(model: FooRef) -> Self {
+        Self::FooRef(Box::new(model))
+    }
+}
+
 
 
 

--- a/samples/client/others/rust/reqwest/oneOf/src/models/fruit.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/models/fruit.rs
@@ -25,6 +25,18 @@ impl Default for Fruit {
     }
 }
 
+impl From<Apple> for Fruit {
+    fn from(model: Apple) -> Self {
+        Self::Apple(Box::new(model))
+    }
+}
+
+impl From<Banana> for Fruit {
+    fn from(model: Banana) -> Self {
+        Self::Banana(Box::new(model))
+    }
+}
+
 
 
 


### PR DESCRIPTION
Helpful Quality of Life to reduce verbosity.

Before PR:
```rust
let apple_fruit = Fruit::Apple(Box::new(Apple {
  seeds: 5
}));
```

After PR additional option is added:
```rust
let apple_fruit: Fruit = Apple {
  seeds: 5
}.into();
```

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
- 
@frol @farcaller @richardwhiuk @paladinzh @jacob-pro @wing328