### PR TITLE
make `title` available to templates for ref properties

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -4235,6 +4235,9 @@ public class DefaultCodegen implements CodegenConfig {
             if (original.getMinimum() != null) {
                 property.setMinimum(String.valueOf(original.getMinimum().doubleValue()));
             }
+            if (original.getTitle() != null) {
+                property.setTitle(original.getTitle());
+            }
         }
 
         // set the default value

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -1917,6 +1917,19 @@ public class DefaultCodegenTest {
     }
 
     @Test
+    public void testTitleProperty() {
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/property-title.yaml");
+        new InlineModelResolver().flatten(openAPI);
+        final DefaultCodegen codegen = new DefaultCodegen();
+        codegen.setOpenAPI(openAPI);
+
+        final Map testProperties = Collections.unmodifiableMap(openAPI.getComponents().getSchemas().get("ModelWithTitledProperties").getProperties());
+
+        Assert.assertEquals("Simple-Property-Title", codegen.fromProperty("simpleProperty", (Schema) testProperties.get("simpleProperty")).title);
+        Assert.assertEquals("Ref-Property-Title", codegen.fromProperty("refProperty", (Schema) testProperties.get("refProperty")).title);
+    }
+
+    @Test
     public void testDeprecatedRef() {
         final OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/model-deprecated.yaml");
         new InlineModelResolver().flatten(openAPI);

--- a/modules/openapi-generator/src/test/resources/3_0/property-title.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/property-title.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.1
+paths:
+  /foo:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/test'
+info:
+  title: Title on Properties
+  version: "1.0"
+components:
+  schemas:
+    ModelWithTitledProperties:
+      properties:
+        simpleProperty:
+          type: string
+          title: Simple-Property-Title
+        refProperty:
+          type: string
+          title: Ref-Property-Title
+          allOf:
+            - $ref: '#/components/schemas/RefObject'
+      type: object
+    RefObject:
+      type: string


### PR DESCRIPTION
Even though `title` is technically for the title of the API itself, it's possible to set it for properties as well.
Right now, the `title` property is available in templates for regular properties, but for ref-properties it gets lost right here.
This seemed rather surprising to me, so I think it's better to fix.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.4.0 minor release - breaking changes with fallbacks), ~~`8.0.x` (breaking changes without fallbacks)~~
- [x] ~~If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.~~
