### PR TITLE
Migrate to Develocity Build Cache connector

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,7 +3,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20</version>
+        <version>1.20.1</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -37,17 +37,9 @@
       <enabled>false</enabled>
     </local>
     <remote>
-      <server>
-        <url>https://ge.openapi-generator.tech/cache/exp3/</url>           <!-- adjust to your GE hostname, and note the trailing slash -->
-        <allowUntrusted>true</allowUntrusted>                   <!-- set to false if a trusted certificate is configured for the GE server -->
-        <credentials>
-          <username>${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
-          <password>${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
-        </credentials>
-      </server>
-      <enabled>true</enabled>                                   <!-- must be true for this experiment -->
+      <enabled>true</enabled>
       <!-- Check credentials presence to avoid build cache errors on PR builds when credentials are not present -->
-      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['GRADLE_ENTERPRISE_CACHE_USERNAME']) and isTrue(env['GRADLE_ENTERPRISE_CACHE_PASSWORD'])}</storeEnabled>
+      <storeEnabled>#{isTrue(env['CI']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
 </gradleEnterprise>


### PR DESCRIPTION
Simplify Develocity configuration by using the [Develocity build cache connector](https://docs.gradle.com/enterprise/maven-extension/#configuring_the_remote_cache).
Cache URL and credentials are not required anymore, the permissions will be checked on the access key provided in the environment

This contributes to fixing the Develocity remote build cache entries not being stored:
https://ge.openapi-generator.tech/scans/performance?performance.metric=avoidanceSavings,avoidanceSavingsRemoteBuildCache&performance.offset=2692&performance.pageSize=256&search.relativeStartTime=P90D&search.timeZoneId=Europe%2FParis

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
