### PR TITLE
fix(rust): discriminator mapping to serde rename

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -60,12 +60,20 @@ pub enum {{{classname}}} {
     },
     {{/mappedModels}}
     {{/oneOf}}
-    {{#oneOf}}
+    {{^oneOf.isEmpty}}
     {{#description}}
     /// {{{.}}}
     {{/description}}
+    {{#mappedModels}}
+    #[serde(rename="{{mappingName}}")]
+    {{{modelName}}}(Box<{{{modelName}}}>),
+    {{/mappedModels}}
+    {{^mappedModels}}
+    {{#oneOf}}
     {{{.}}}(Box<{{{.}}}>),
     {{/oneOf}}
+    {{/mappedModels}}
+    {{/oneOf.isEmpty}}
 }
 
 impl Default for {{classname}} {

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/create_state_request.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/create_state_request.rs
@@ -15,7 +15,9 @@ use super::ObjB;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CreateStateRequest {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
 }
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
@@ -16,8 +16,11 @@ use super::ObjC;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CustomOneOfArraySchemaInner {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
+    #[serde(rename="c-type")]
     ObjC(Box<ObjC>),
 }
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_schema.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/custom_one_of_schema.rs
@@ -15,7 +15,9 @@ use super::ObjB;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CustomOneOfSchema {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
 }
 

--- a/samples/client/others/rust/hyper/composed-oneof/src/models/get_state_200_response.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/models/get_state_200_response.rs
@@ -16,8 +16,11 @@ use super::ObjD;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum GetState200Response {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
+    #[serde(rename="d-type")]
     ObjD(Box<ObjD>),
 }
 

--- a/samples/client/others/rust/hyper/oneOf/src/models/fruit.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/models/fruit.rs
@@ -15,7 +15,9 @@ use super::Banana;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "fruitType")]
 pub enum Fruit {
+    #[serde(rename="APPLE")]
     Apple(Box<Apple>),
+    #[serde(rename="BANANA")]
     Banana(Box<Banana>),
 }
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/create_state_request.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/create_state_request.rs
@@ -15,7 +15,9 @@ use super::ObjB;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CreateStateRequest {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
 }
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_array_schema_inner.rs
@@ -16,8 +16,11 @@ use super::ObjC;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CustomOneOfArraySchemaInner {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
+    #[serde(rename="c-type")]
     ObjC(Box<ObjC>),
 }
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_schema.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/custom_one_of_schema.rs
@@ -15,7 +15,9 @@ use super::ObjB;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum CustomOneOfSchema {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
 }
 

--- a/samples/client/others/rust/reqwest/composed-oneof/src/models/get_state_200_response.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/models/get_state_200_response.rs
@@ -16,8 +16,11 @@ use super::ObjD;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "realtype")]
 pub enum GetState200Response {
+    #[serde(rename="a-type")]
     ObjA(Box<ObjA>),
+    #[serde(rename="b-type")]
     ObjB(Box<ObjB>),
+    #[serde(rename="d-type")]
     ObjD(Box<ObjD>),
 }
 

--- a/samples/client/others/rust/reqwest/oneOf/src/models/fruit.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/models/fruit.rs
@@ -15,7 +15,9 @@ use super::Banana;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "fruitType")]
 pub enum Fruit {
+    #[serde(rename="APPLE")]
     Apple(Box<Apple>),
+    #[serde(rename="BANANA")]
     Banana(Box<Banana>),
 }
 


### PR DESCRIPTION
Discriminator mapping has been ignored in some cases and `serde(rename = "..")` wasn't applied. 
Even existing samples had wrong definition in some cases. 

This PR addresses this behavior 

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol @farcaller @richardwhiuk @paladinzh @jacob-pro
