### PR TITLE
Fix `ClassCastException` in `OpenAPINormalizer` on composed schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -458,33 +458,31 @@ public class OpenAPINormalizer {
         } else if (ModelUtils.isAllOf(schema)) { // allOf
             return normalizeAllOf(schema, visitedSchemas);
         } else if (ModelUtils.isComposedSchema(schema)) { // composed schema
-            ComposedSchema cs = (ComposedSchema) schema;
-
-            if (ModelUtils.isComplexComposedSchema(cs)) {
-                cs = (ComposedSchema) normalizeComplexComposedSchema(cs, visitedSchemas);
+            if (ModelUtils.isComplexComposedSchema(schema)) {
+                schema = normalizeComplexComposedSchema(schema, visitedSchemas);
             }
 
-            if (cs.getAllOf() != null && !cs.getAllOf().isEmpty()) {
-                return normalizeAllOf(cs, visitedSchemas);
+            if (schema.getAllOf() != null && !schema.getAllOf().isEmpty()) {
+                return normalizeAllOf(schema, visitedSchemas);
             }
 
-            if (cs.getOneOf() != null && !cs.getOneOf().isEmpty()) {
-                return normalizeOneOf(cs, visitedSchemas);
+            if (schema.getOneOf() != null && !schema.getOneOf().isEmpty()) {
+                return normalizeOneOf(schema, visitedSchemas);
             }
 
-            if (cs.getAnyOf() != null && !cs.getAnyOf().isEmpty()) {
-                return normalizeAnyOf(cs, visitedSchemas);
+            if (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty()) {
+                return normalizeAnyOf(schema, visitedSchemas);
             }
 
-            if (cs.getProperties() != null && !cs.getProperties().isEmpty()) {
-                normalizeProperties(cs.getProperties(), visitedSchemas);
+            if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+                normalizeProperties(schema.getProperties(), visitedSchemas);
             }
 
-            if (cs.getAdditionalProperties() != null) {
+            if (schema.getAdditionalProperties() != null) {
                 // normalizeAdditionalProperties(m);
             }
 
-            return cs;
+            return schema;
         } else if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
             normalizeProperties(schema.getProperties(), visitedSchemas);
         } else if (schema instanceof BooleanSchema) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -467,4 +467,12 @@ public class OpenAPINormalizerTest {
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getDelete().getExtensions().get("x-internal"), false);
         assertEquals(openAPI.getPaths().get("/person/display/{personId}").getPut().getExtensions().get("x-internal"), true);
     }
+
+    @Test
+    public void testComposedSchemaDoesNotThrow() {
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/composed-schema.yaml");
+
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, Collections.emptyMap());
+        openAPINormalizer.normalize();
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/composed-schema.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/composed-schema.yaml
@@ -1,0 +1,36 @@
+openapi: 3.1.0
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /payment:
+    post:
+      operationId: payment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Payment"
+
+components:
+  schemas:
+    Payment:
+      type: object
+      properties:
+        label:
+          type: string
+        otherLabel:
+          type: string
+        amount:
+          type: number
+      oneOf:
+        - required:
+            - label
+            - amount
+        - required:
+            - otherLabel
+            - amount


### PR DESCRIPTION
A `ClassCastException` can happen on OpenAPI 3.1 schemas when they declare both `properties` and `oneOf`, for example:
```yaml
components:
  schemas:
    Payment:
      type: object
      properties:
        label:
          type: string
        otherLabel:
          type: string
        amount:
          type: number
      oneOf:
        - required:
            - label
            - amount
        - required:
            - otherLabel
            - amount
```

This raises the following exception:

```
java.lang.ClassCastException: class io.swagger.v3.oas.models.media.JsonSchema cannot be cast to class io.swagger.v3.oas.models.media.ComposedSchema (io.swagger.v3.oas.models.media.JsonSchema and io.swagger.v3.oas.models.media.ComposedSchema are in unnamed module of loader 'app')

	at org.openapitools.codegen.OpenAPINormalizer.normalizeSchema(OpenAPINormalizer.java:461)
	at org.openapitools.codegen.OpenAPINormalizer.normalizeComponentsSchemas(OpenAPINormalizer.java:419)
	at org.openapitools.codegen.OpenAPINormalizer.normalize(OpenAPINormalizer.java:222)
```

This cast is not necessary, and should even be avoided because in 3.1 `ComposeSchema` is not used as suggested in a comment in `org.openapitools.codegen.utils.ModelUtils#isComposedSchema`:

>         // in 3.0, ComposeSchema is used for anyOf/oneOf/allOf
>         // in 3.1, it's not the case so we need more checks below

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
