### PR TITLE
Fix recursion in discriminatorFound

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -3305,10 +3305,12 @@ public class DefaultCodegen implements CodegenConfig {
      *
      */
     private CodegenProperty discriminatorFound(String composedSchemaName, Schema sc, String discPropName, Set<String> visitedSchemas) {
-        if (visitedSchemas.contains(composedSchemaName)) { // recursive schema definition found
-            return null;
-        } else {
-            visitedSchemas.add(composedSchemaName);
+        if (composedSchemaName != null) {
+            if (visitedSchemas.contains(composedSchemaName)) { // recursive schema definition found
+                return null;
+            } else {
+                visitedSchemas.add(composedSchemaName);
+            }
         }
 
         Schema refSchema = ModelUtils.getReferencedSchema(openAPI, sc);
@@ -3329,7 +3331,8 @@ public class DefaultCodegen implements CodegenConfig {
             if (composedSchema.getAllOf() != null) {
                 // If our discriminator is in one of the allOf schemas break when we find it
                 for (Object allOf : composedSchema.getAllOf()) {
-                    CodegenProperty cp = discriminatorFound(composedSchemaName, (Schema) allOf, discPropName, visitedSchemas);
+                    Schema allOfSchema = (Schema) allOf;
+                    CodegenProperty cp = discriminatorFound(allOfSchema.getName(), allOfSchema, discPropName, visitedSchemas);
                     if (cp != null) {
                         return cp;
                     }
@@ -3339,12 +3342,13 @@ public class DefaultCodegen implements CodegenConfig {
                 // All oneOf definitions must contain the discriminator
                 CodegenProperty cp = new CodegenProperty();
                 for (Object oneOf : composedSchema.getOneOf()) {
-                    String modelName = ModelUtils.getSimpleRef(((Schema) oneOf).get$ref());
-                    CodegenProperty thisCp = discriminatorFound(composedSchemaName, (Schema) oneOf, discPropName, visitedSchemas);
+                    Schema oneOfSchema = (Schema) oneOf;
+                    String modelName = ModelUtils.getSimpleRef(oneOfSchema.get$ref());
+                    CodegenProperty thisCp = discriminatorFound(oneOfSchema.getName(), (Schema) oneOf, discPropName, visitedSchemas);
                     if (thisCp == null) {
                         LOGGER.warn(
-                                "'{}' defines discriminator '{}', but the referenced OneOf schema '{}' is missing {}",
-                                composedSchemaName, discPropName, modelName, discPropName);
+                            "'{}' defines discriminator '{}', but the referenced OneOf schema '{}' is missing {}",
+                            composedSchemaName, discPropName, modelName, discPropName);
                     }
                     if (cp != null && cp.dataType == null) {
                         cp = thisCp;
@@ -3352,8 +3356,8 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     if (cp != thisCp) {
                         LOGGER.warn(
-                                "'{}' defines discriminator '{}', but the OneOf schema '{}' has a different {} definition than the prior OneOf schema's. Make sure the {} type and required values are the same",
-                                composedSchemaName, discPropName, modelName, discPropName, discPropName);
+                            "'{}' defines discriminator '{}', but the OneOf schema '{}' has a different {} definition than the prior OneOf schema's. Make sure the {} type and required values are the same",
+                            composedSchemaName, discPropName, modelName, discPropName, discPropName);
                     }
                 }
                 return cp;
@@ -3362,12 +3366,13 @@ public class DefaultCodegen implements CodegenConfig {
                 // All anyOf definitions must contain the discriminator because a min of one must be selected
                 CodegenProperty cp = new CodegenProperty();
                 for (Object anyOf : composedSchema.getAnyOf()) {
-                    String modelName = ModelUtils.getSimpleRef(((Schema) anyOf).get$ref());
-                    CodegenProperty thisCp = discriminatorFound(composedSchemaName, (Schema) anyOf, discPropName, visitedSchemas);
+                    Schema anOfSchema = (Schema) anyOf;
+                    String modelName = ModelUtils.getSimpleRef(anOfSchema.get$ref());
+                    CodegenProperty thisCp = discriminatorFound(anOfSchema.getName(), anOfSchema, discPropName, visitedSchemas);
                     if (thisCp == null) {
                         LOGGER.warn(
-                                "'{}' defines discriminator '{}', but the referenced AnyOf schema '{}' is missing {}",
-                                composedSchemaName, discPropName, modelName, discPropName);
+                            "'{}' defines discriminator '{}', but the referenced AnyOf schema '{}' is missing {}",
+                            composedSchemaName, discPropName, modelName, discPropName);
                     }
                     if (cp != null && cp.dataType == null) {
                         cp = thisCp;
@@ -3375,8 +3380,8 @@ public class DefaultCodegen implements CodegenConfig {
                     }
                     if (cp != thisCp) {
                         LOGGER.warn(
-                                "'{}' defines discriminator '{}', but the AnyOf schema '{}' has a different {} definition than the prior AnyOf schema's. Make sure the {} type and required values are the same",
-                                composedSchemaName, discPropName, modelName, discPropName, discPropName);
+                            "'{}' defines discriminator '{}', but the AnyOf schema '{}' has a different {} definition than the prior AnyOf schema's. Make sure the {} type and required values are the same",
+                            composedSchemaName, discPropName, modelName, discPropName, discPropName);
                     }
                 }
                 return cp;


### PR DESCRIPTION
Fix #17893 remove incorrect warning about missing discriminator.
Allow recursion in children allOf/oneOf/anyOf

<!-- Please check the completed items below -->
### PR checklist
 
- [x  Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [c] File the PR against the [master branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-

> committee

) members, so they are more likely to review the pull request.
