### PR TITLE
Provide rust-server `swagger/multipart_form`

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/Cargo.mustache
@@ -57,7 +57,7 @@ server = [
     "mime_0_2",
 {{/apiUsesMultipart}}
 {{#apiUsesMultipartFormData}}
-    "multipart", "multipart/server",
+    "multipart", "multipart/server", "swagger/multipart_form",
 {{/apiUsesMultipartFormData}}
 {{#apiUsesMultipartRelated}}
     "hyper_0_10", "mime_multipart",

--- a/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/multipart-v3/Cargo.toml
@@ -17,7 +17,7 @@ client = [
 ]
 server = [
     "mime_0_2",
-    "multipart", "multipart/server",
+    "multipart", "multipart/server", "swagger/multipart_form",
     "hyper_0_10", "mime_multipart",
    "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
 ]

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/Cargo.toml
@@ -17,7 +17,7 @@ client = [
 ]
 server = [
     "mime_0_2",
-    "multipart", "multipart/server",
+    "multipart", "multipart/server", "swagger/multipart_form",
    "serde_ignored", "hyper", "regex", "percent-encoding", "url", "lazy_static"
 ]
 conversion = ["frunk", "frunk_derives", "frunk_core", "frunk-enum-core", "frunk-enum-derive"]


### PR DESCRIPTION
This PR grants the rust-server server feature `swagger/multipart_form`.

Currently, if you generate the rust-server, and then include it in another cargo project and only enable the `server` feature (as I was doing for a server specific workload), you will get the following error:

```sh
error[E0433]: failed to resolve: could not find `form` in `multipart`
   --> lib/__omit__/src/server/mod.rs:917:58
    |
917 |                 let boundary = match swagger::multipart::form::boundary(&headers) {
    |                                                          ^^^^ could not find `form` in `multipart`
```
 
this is because with default features turned on, the server dependencies are able to piggy-back off of the client enabling `swagger/multipart_form`. Resolving this by enabled it for the server as well.

@jacob-pro

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
