### PR TITLE
Autoset constants (Required fields having single valid enum value) C# Implementation of #16547

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -1102,6 +1102,9 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                     operation.vendorExtensions.put("x-not-nullable-reference-types", referenceTypes);
                     operation.vendorExtensions.put("x-has-not-nullable-reference-types", referenceTypes.size() > 0);
                     processOperation(operation);
+
+                    // Remove constant params from allParams list and add to constantParams
+                    handleConstantParams(operation);
                 }
             }
         }

--- a/modules/openapi-generator/src/main/resources/csharp/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/api.mustache
@@ -573,6 +573,12 @@ namespace {{packageName}}.{{apiPackage}}
                 localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
             }
 
+            {{#constantParams}}
+            {{#isPathParam}}
+            // Set client side default value of Path Param "{{baseName}}".
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant path parameter
+            {{/isPathParam}}
+            {{/constantParams}}
             {{#pathParams}}
             {{#required}}
             localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
@@ -584,6 +590,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
             {{/required}}
             {{/pathParams}}
+            {{#constantParams}}
+            {{#isQueryParam}}
+            // Set client side default value of Query Param "{{baseName}}".
+            localVarRequestOptions.QueryParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant query parameter
+            {{/isQueryParam}}
+            {{/constantParams}}
             {{#queryParams}}
             {{#required}}
             {{#isDeepObject}}
@@ -618,6 +630,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
             {{/required}}
             {{/queryParams}}
+            {{#constantParams}}
+            {{#isHeaderParam}}
+            // Set client side default value of Header Param "{{baseName}}".
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant header parameter
+            {{/isHeaderParam}}
+            {{/constantParams}}
             {{#headerParams}}
             {{#required}}
             localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/generichost/api.mustache
@@ -390,6 +390,12 @@ namespace {{packageName}}.{{apiPackage}}
                     uriBuilderLocalVar.Path = urlLocalVar.AbsolutePath;
                     {{/-first}}
                     {{/servers}}
+                    {{#constantParams}}
+                    {{#isPathParam}}
+                    // Set client side default value of Path Param "{{baseName}}".
+                    uriBuilderLocalVar.Path = uriBuilderLocalVar.Path.Replace("%7B{{baseName}}%7D", Uri.EscapeDataString(ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}}))); // Constant path parameter
+                    {{/isPathParam}}
+                    {{/constantParams}}
                     {{#pathParams}}
                     uriBuilderLocalVar.Path = uriBuilderLocalVar.Path.Replace("%7B{{baseName}}%7D", Uri.EscapeDataString({{paramName}}.ToString()));
                     {{#-last}}
@@ -423,6 +429,12 @@ namespace {{packageName}}.{{apiPackage}}
                     {{/required}}
                     {{/queryParams}}
 
+                    {{#constantParams}}
+                    {{#isQueryParam}}
+                    // Set client side default value of Query Param "{{baseName}}".
+                    parseQueryStringLocalVar["{{baseName}}"] = ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}}); // Constant query parameter
+                    {{/isQueryParam}}
+                    {{/constantParams}}
                     {{#queryParams}}
                     {{^required}}
                     if ({{paramName}}.IsSet)
@@ -434,6 +446,12 @@ namespace {{packageName}}.{{apiPackage}}
 
                     {{/-last}}
                     {{/queryParams}}
+                    {{#constantParams}}
+                    {{#isHeaderParam}}
+                    // Set client side default value of Header Param "{{baseName}}".
+                    httpRequestMessageLocalVar.Headers.Add("{{baseName}}", ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant header parameter
+                    {{/isHeaderParam}}
+                    {{/constantParams}}
                     {{#headerParams}}
                     {{#required}}
                     httpRequestMessageLocalVar.Headers.Add("{{baseName}}", ClientUtils.ParameterToString({{paramName}}));

--- a/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/csharp/libraries/httpclient/api.mustache
@@ -605,6 +605,12 @@ namespace {{packageName}}.{{apiPackage}}
             var localVarAccept = {{packageName}}.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
+            {{#constantParams}}
+            {{#isPathParam}}
+            // Set client side default value of Path Param "{{baseName}}".
+            localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant path parameter
+            {{/isPathParam}}
+            {{/constantParams}}
             {{#pathParams}}
             {{#required}}
             localVarRequestOptions.PathParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // path parameter
@@ -616,6 +622,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
             {{/required}}
             {{/pathParams}}
+            {{#constantParams}}
+            {{#isQueryParam}}
+            // Set client side default value of Query Param "{{baseName}}".
+            localVarRequestOptions.QueryParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant query parameter
+            {{/isQueryParam}}
+            {{/constantParams}}            
             {{#queryParams}}
             {{#required}}
             localVarRequestOptions.QueryParameters.Add({{packageName}}.Client.ClientUtils.ParameterToMultiMap("{{collectionFormat}}", "{{baseName}}", {{paramName}}));
@@ -627,6 +639,12 @@ namespace {{packageName}}.{{apiPackage}}
             }
             {{/required}}
             {{/queryParams}}
+            {{#constantParams}}
+            {{#isHeaderParam}}
+            // Set client side default value of Header Param "{{baseName}}".
+            localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{#_enum}}"{{{.}}}"{{/_enum}})); // Constant header parameter
+            {{/isHeaderParam}}
+            {{/constantParams}}
             {{#headerParams}}
             {{#required}}
             localVarRequestOptions.HeaderParameters.Add("{{baseName}}", {{packageName}}.Client.ClientUtils.ParameterToString({{paramName}})); // header parameter

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/csharpnetcore/CSharpClientCodegenTest.java
@@ -16,10 +16,26 @@
 
 package org.openapitools.codegen.csharpnetcore;
 
+import static org.junit.Assert.assertNotNull;
+import static org.openapitools.codegen.TestUtils.assertFileContains;
+import static org.openapitools.codegen.TestUtils.assertFileExists;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.CSharpClientCodegen;
 import org.openapitools.codegen.languages.JavaClientCodegen;
@@ -75,5 +91,30 @@ public class CSharpClientCodegenTest {
         Assert.assertFalse(property2.isContainer);
         Assert.assertFalse(property2.isFreeFormObject);
         Assert.assertFalse(property2.isAnyType);
+    }
+
+    @Test
+    public void testHandleConstantParams() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+        final OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/java/autoset_constant.yaml");
+        final DefaultGenerator defaultGenerator = new DefaultGenerator();
+        final ClientOptInput clientOptInput = new ClientOptInput();
+        clientOptInput.openAPI(openAPI);
+        CSharpClientCodegen cSharpClientCodegen = new CSharpClientCodegen();
+        cSharpClientCodegen.setOutputDir(output.getAbsolutePath());
+        cSharpClientCodegen.additionalProperties().put(CodegenConstants.AUTOSET_CONSTANTS, "true");
+        cSharpClientCodegen.setAutosetConstants(true);
+        clientOptInput.config(cSharpClientCodegen);
+        defaultGenerator.opts(clientOptInput);
+
+        Map<String, File> files = defaultGenerator.generate().stream()
+                .collect(Collectors.toMap(File::getPath, Function.identity()));
+
+        File apiFile = files
+                .get(Paths.get(output.getAbsolutePath(), "src", "Org.OpenAPITools", "Api", "HelloExampleApi.cs").toString());
+        assertNotNull(apiFile);
+        assertFileContains(apiFile.toPath(),
+                "localVarRequestOptions.HeaderParameters.Add(\"X-CUSTOM_CONSTANT_HEADER\", Org.OpenAPITools.Client.ClientUtils.ParameterToString(\"CONSTANT_VALUE\"));");
     }
 }


### PR DESCRIPTION
### Code Changes
Partial implementation of https://github.com/OpenAPITools/openapi-generator/issues/16547
If ``autosetConstants`` is set to True, the generated code by C# generator will hardcode values for any Header / Query Param which is marked as required and can only have a single valid enum value.
The single valued required enum i.e. The constant param will be removed from the method signature.

### Testing
A test case has been added that asserts that if ``autosetConstants`` is set to true then the constant key/value pair is being set in the generated code.
I've run ``./bin/generate-samples.sh`` and there is no change in existing code generation if the new ``autosetConstants`` property is not set, Therefore there should not be any risk in getting this change merged.