### PR TITLE
[typescript-fetch] Use `==` to check property is null or undefined

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -107,7 +107,7 @@ export class {{classname}} extends runtime.BaseAPI {
     async {{nickname}}Raw({{#allParams.0}}requestParameters: {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request, {{/allParams.0}}initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<{{{returnType}}}{{^returnType}}void{{/returnType}}>> {
         {{#allParams}}
         {{#required}}
-        if (!runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] == null) {
             throw new runtime.RequiredError(
                 '{{paramName}}',
                 'Required parameter "{{paramName}}" was null or undefined when calling {{nickname}}().'
@@ -120,7 +120,7 @@ export class {{classname}} extends runtime.BaseAPI {
 
         {{#queryParams}}
         {{#isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             {{#isCollectionFormatMulti}}
             queryParameters['{{baseName}}'] = requestParameters['{{paramName}}'];
             {{/isCollectionFormatMulti}}
@@ -131,7 +131,7 @@ export class {{classname}} extends runtime.BaseAPI {
 
         {{/isArray}}
         {{^isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             {{#isDateTimeType}}
             queryParameters['{{baseName}}'] = (requestParameters['{{paramName}}'] as any).toISOString();
             {{/isDateTimeType}}
@@ -161,13 +161,13 @@ export class {{classname}} extends runtime.BaseAPI {
         {{/bodyParam}}
         {{#headerParams}}
         {{#isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             headerParameters['{{baseName}}'] = {{#uniqueItems}}Array.from({{/uniqueItems}}requestParameters['{{paramName}}']{{#uniqueItems}}){{/uniqueItems}}!.join(runtime.COLLECTION_FORMATS["{{collectionFormat}}"]);
         }
 
         {{/isArray}}
         {{^isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             headerParameters['{{baseName}}'] = String(requestParameters['{{paramName}}']);
         }
 
@@ -238,7 +238,7 @@ export class {{classname}} extends runtime.BaseAPI {
 
         {{#formParams}}
         {{#isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             {{#isCollectionFormatMulti}}
             requestParameters['{{paramName}}'].forEach((element) => {
                 formParams.append('{{baseName}}', element as any);
@@ -251,7 +251,7 @@ export class {{classname}} extends runtime.BaseAPI {
 
         {{/isArray}}
         {{^isArray}}
-        if (runtime.exists(requestParameters, '{{paramName}}')) {
+        if (requestParameters['{{paramName}}'] != null) {
             {{#isPrimitiveType}}
             formParams.append('{{baseName}}', requestParameters['{{paramName}}'] as any);
             {{/isPrimitiveType}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -1,4 +1,4 @@
-import { exists, mapValues } from '../runtime{{importFileExtension}}';
+import { mapValues } from '../runtime{{importFileExtension}}';
 {{#hasImports}}
 {{#imports}}
 import type { {{{.}}} } from './{{.}}{{importFileExtension}}';
@@ -38,7 +38,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
 
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
     {{#hasVars}}
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
 {{#discriminator}}
@@ -58,36 +58,36 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
         {{#vars}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(json, '{{baseName}}') ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(json, '{{baseName}}') ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Date(json['{{baseName}}'])),
         {{/isDateTimeType}}
         {{^isDateType}}
         {{^isDateTimeType}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}json['{{baseName}}'],
         {{/isDateTimeType}}
         {{/isDateType}}
         {{/isPrimitiveType}}
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}{{#required}}({{#isNullable}}!exists(json, '{{baseName}}') ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{#required}}({{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}new Set((json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON))),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(json, '{{baseName}}') ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}(json['{{baseName}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(json, '{{baseName}}') ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}json['{{baseName}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(json['{{baseName}}'], {{#items}}{{datatype}}{{/items}}FromJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}
         {{^isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}{{datatype}}FromJSON(json['{{baseName}}']),
         {{/isFreeFormObject}}
         {{#isFreeFormObject}}
-        '{{name}}': {{^required}}!exists(json, '{{baseName}}') ? undefined : {{/required}}json['{{baseName}}'],
+        '{{name}}': {{^required}}json['{{baseName}}'] == null ? undefined : {{/required}}json['{{baseName}}'],
         {{/isFreeFormObject}}
         {{/isMap}}
         {{/isArray}}
@@ -102,11 +102,8 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 
 export function {{classname}}ToJSON(value?: {{classname}} | null): any {
     {{#hasVars}}
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         {{#parent}}...{{{.}}}ToJSON(value),{{/parent}}
@@ -117,13 +114,13 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{^isReadOnly}}
         {{#isPrimitiveType}}
         {{#isDateType}}
-        '{{baseName}}': {{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}(value['{{name}}']{{#isNullable}} as any{{/isNullable}}).toISOString().substring(0,10)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}']{{#isNullable}} as any{{/isNullable}}).toISOString().substring(0,10)),
         {{/isDateType}}
         {{#isDateTimeType}}
-        '{{baseName}}': {{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}(value['{{name}}']{{#isNullable}} as any{{/isNullable}}).toISOString()),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}']{{#isNullable}} as any{{/isNullable}}).toISOString()),
         {{/isDateTimeType}}
         {{#isArray}}
-        '{{baseName}}': {{#uniqueItems}}{{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}{{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>){{/uniqueItems}}{{^uniqueItems}}value['{{name}}']{{/uniqueItems}},
+        '{{baseName}}': {{#uniqueItems}}{{^required}}value['{{name}}'] == null ? undefined : {{/required}}{{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>){{/uniqueItems}}{{^uniqueItems}}value['{{name}}']{{/uniqueItems}},
         {{/isArray}}
         {{^isDateType}}
         {{^isDateTimeType}}
@@ -136,14 +133,14 @@ export function {{classname}}ToJSON(value?: {{classname}} | null): any {
         {{^isPrimitiveType}}
         {{#isArray}}
         {{#uniqueItems}}
-        '{{baseName}}': {{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}Array.from(value['{{name}}'] as Set<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/uniqueItems}}
         {{^uniqueItems}}
-        '{{baseName}}': {{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}(value['{{name}}'] as Array<any>).map({{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/uniqueItems}}
         {{/isArray}}
         {{#isMap}}
-        '{{baseName}}': {{^required}}!exists(value, '{{name}}') ? undefined : {{/required}}({{#required}}{{#isNullable}}!exists(value, '{{name}}') ? null : {{/isNullable}}{{/required}}mapValues(value['{{name}}'], {{#items}}{{datatype}}{{/items}}ToJSON)),
+        '{{baseName}}': {{^required}}value['{{name}}'] == null ? undefined : {{/required}}({{#required}}{{#isNullable}}value['{{name}}'] == null ? null : {{/isNullable}}{{/required}}mapValues(value['{{name}}'], {{#items}}{{datatype}}{{/items}}ToJSON)),
         {{/isMap}}
         {{^isArray}}
         {{^isMap}}

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -17,7 +17,7 @@ export function {{classname}}FromJSON(json: any): {{classname}} {
 }
 
 export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boolean): {{classname}} {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
 {{#discriminator}}
@@ -36,11 +36,8 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function {{classname}}ToJSON(value?: {{classname}} | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
 {{#discriminator}}
     switch (value['{{discriminator.propertyName}}']) {

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/runtime.mustache
@@ -299,13 +299,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-{{^withoutRuntimeChecks}}
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-{{/withoutRuntimeChecks}}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/apis/DefaultApi.ts
@@ -34,7 +34,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async listRaw(requestParameters: ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Club>> {
-        if (!runtime.exists(requestParameters, 'personId')) {
+        if (requestParameters['personId'] == null) {
             throw new runtime.RequiredError(
                 'personId',
                 'Required parameter "personId" was null or undefined when calling list().'

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Owner } from './Owner';
 import {
     OwnerFromJSON,
@@ -46,21 +46,18 @@ export function ClubFromJSON(json: any): Club {
 }
 
 export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'owner': !exists(json, 'owner') ? undefined : OwnerFromJSON(json['owner']),
+        'owner': json['owner'] == null ? undefined : OwnerFromJSON(json['owner']),
     };
 }
 
 export function ClubToJSON(value?: Club | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function OwnerFromJSON(json: any): Owner {
 }
 
 export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Owner {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function OwnerToJSON(value?: Owner | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/apis/DefaultApi.ts
@@ -34,7 +34,7 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      */
     async listRaw(requestParameters: ListRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Club>> {
-        if (!runtime.exists(requestParameters, 'personId')) {
+        if (requestParameters['personId'] == null) {
             throw new runtime.RequiredError(
                 'personId',
                 'Required parameter "personId" was null or undefined when calling list().'

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Owner } from './Owner';
 import {
     OwnerFromJSON,
@@ -46,21 +46,18 @@ export function ClubFromJSON(json: any): Club {
 }
 
 export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'owner': !exists(json, 'owner') ? undefined : OwnerFromJSON(json['owner']),
+        'owner': json['owner'] == null ? undefined : OwnerFromJSON(json['owner']),
     };
 }
 
 export function ClubToJSON(value?: Club | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function OwnerFromJSON(json: any): Owner {
 }
 
 export function OwnerFromJSONTyped(json: any, ignoreDiscriminator: boolean): Owner {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function OwnerToJSON(value?: Owner | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/AnotherFakeApi.ts
@@ -36,7 +36,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags
      */
     async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling _123testSpecialTags().'

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeApi.ts
@@ -229,7 +229,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test http signature authentication
      */
     async fakeHttpSignatureTestRaw(requestParameters: FakeHttpSignatureTestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling fakeHttpSignatureTest().'
@@ -238,7 +238,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'query1')) {
+        if (requestParameters['query1'] != null) {
             queryParameters['query_1'] = requestParameters['query1'];
         }
 
@@ -246,7 +246,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (runtime.exists(requestParameters, 'header1')) {
+        if (requestParameters['header1'] != null) {
             headerParameters['header_1'] = String(requestParameters['header1']);
         }
 
@@ -400,7 +400,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of enum (int) properties with examples
      */
     async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
-        if (!runtime.exists(requestParameters, 'outerObjectWithEnumProperty')) {
+        if (requestParameters['outerObjectWithEnumProperty'] == null) {
             throw new runtime.RequiredError(
                 'outerObjectWithEnumProperty',
                 'Required parameter "outerObjectWithEnumProperty" was null or undefined when calling fakePropertyEnumIntegerSerialize().'
@@ -437,7 +437,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test referenced additionalProperties
      */
     async testAdditionalPropertiesReferenceRaw(requestParameters: TestAdditionalPropertiesReferenceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requestBody')) {
+        if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
                 'Required parameter "requestBody" was null or undefined when calling testAdditionalPropertiesReference().'
@@ -473,7 +473,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body has to be a binary file.
      */
     async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling testBodyWithBinary().'
@@ -508,7 +508,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body for this request must reference a schema named `File`.
      */
     async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'fileSchemaTestClass')) {
+        if (requestParameters['fileSchemaTestClass'] == null) {
             throw new runtime.RequiredError(
                 'fileSchemaTestClass',
                 'Required parameter "fileSchemaTestClass" was null or undefined when calling testBodyWithFileSchema().'
@@ -542,14 +542,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      */
     async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'query')) {
+        if (requestParameters['query'] == null) {
             throw new runtime.RequiredError(
                 'query',
                 'Required parameter "query" was null or undefined when calling testBodyWithQueryParams().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling testBodyWithQueryParams().'
@@ -558,7 +558,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'query')) {
+        if (requestParameters['query'] != null) {
             queryParameters['query'] = requestParameters['query'];
         }
 
@@ -588,7 +588,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test \"client\" model
      */
     async testClientModelRaw(requestParameters: TestClientModelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling testClientModel().'
@@ -626,28 +626,28 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      */
     async testEndpointParametersRaw(requestParameters: TestEndpointParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'number')) {
+        if (requestParameters['number'] == null) {
             throw new runtime.RequiredError(
                 'number',
                 'Required parameter "number" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_double')) {
+        if (requestParameters['_double'] == null) {
             throw new runtime.RequiredError(
                 '_double',
                 'Required parameter "_double" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'patternWithoutDelimiter')) {
+        if (requestParameters['patternWithoutDelimiter'] == null) {
             throw new runtime.RequiredError(
                 'patternWithoutDelimiter',
                 'Required parameter "patternWithoutDelimiter" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_byte')) {
+        if (requestParameters['_byte'] == null) {
             throw new runtime.RequiredError(
                 '_byte',
                 'Required parameter "_byte" was null or undefined when calling testEndpointParameters().'
@@ -677,59 +677,59 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'integer')) {
+        if (requestParameters['integer'] != null) {
             formParams.append('integer', requestParameters['integer'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'int32')) {
+        if (requestParameters['int32'] != null) {
             formParams.append('int32', requestParameters['int32'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'int64')) {
+        if (requestParameters['int64'] != null) {
             formParams.append('int64', requestParameters['int64'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'number')) {
+        if (requestParameters['number'] != null) {
             formParams.append('number', requestParameters['number'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_float')) {
+        if (requestParameters['_float'] != null) {
             formParams.append('float', requestParameters['_float'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_double')) {
+        if (requestParameters['_double'] != null) {
             formParams.append('double', requestParameters['_double'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'string')) {
+        if (requestParameters['string'] != null) {
             formParams.append('string', requestParameters['string'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'patternWithoutDelimiter')) {
+        if (requestParameters['patternWithoutDelimiter'] != null) {
             formParams.append('pattern_without_delimiter', requestParameters['patternWithoutDelimiter'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_byte')) {
+        if (requestParameters['_byte'] != null) {
             formParams.append('byte', requestParameters['_byte'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'binary')) {
+        if (requestParameters['binary'] != null) {
             formParams.append('binary', requestParameters['binary'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'date')) {
+        if (requestParameters['date'] != null) {
             formParams.append('date', requestParameters['date'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'dateTime')) {
+        if (requestParameters['dateTime'] != null) {
             formParams.append('dateTime', requestParameters['dateTime'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             formParams.append('password', requestParameters['password'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'callback')) {
+        if (requestParameters['callback'] != null) {
             formParams.append('callback', requestParameters['callback'] as any);
         }
 
@@ -759,33 +759,33 @@ export class FakeApi extends runtime.BaseAPI {
     async testEnumParametersRaw(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'enumQueryStringArray')) {
+        if (requestParameters['enumQueryStringArray'] != null) {
             queryParameters['enum_query_string_array'] = requestParameters['enumQueryStringArray'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryString')) {
+        if (requestParameters['enumQueryString'] != null) {
             queryParameters['enum_query_string'] = requestParameters['enumQueryString'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryInteger')) {
+        if (requestParameters['enumQueryInteger'] != null) {
             queryParameters['enum_query_integer'] = requestParameters['enumQueryInteger'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryDouble')) {
+        if (requestParameters['enumQueryDouble'] != null) {
             queryParameters['enum_query_double'] = requestParameters['enumQueryDouble'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryModelArray')) {
+        if (requestParameters['enumQueryModelArray'] != null) {
             queryParameters['enum_query_model_array'] = requestParameters['enumQueryModelArray'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'enumHeaderStringArray')) {
+        if (requestParameters['enumHeaderStringArray'] != null) {
             headerParameters['enum_header_string_array'] = requestParameters['enumHeaderStringArray']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'enumHeaderString')) {
+        if (requestParameters['enumHeaderString'] != null) {
             headerParameters['enum_header_string'] = String(requestParameters['enumHeaderString']);
         }
 
@@ -803,11 +803,11 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'enumFormStringArray')) {
+        if (requestParameters['enumFormStringArray'] != null) {
             formParams.append('enum_form_string_array', requestParameters['enumFormStringArray']!.join(runtime.COLLECTION_FORMATS["csv"]));
         }
 
-        if (runtime.exists(requestParameters, 'enumFormString')) {
+        if (requestParameters['enumFormString'] != null) {
             formParams.append('enum_form_string', requestParameters['enumFormString'] as any);
         }
 
@@ -835,21 +835,21 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint to test group parameters (optional)
      */
     async testGroupParametersRaw(requestParameters: TestGroupParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requiredStringGroup')) {
+        if (requestParameters['requiredStringGroup'] == null) {
             throw new runtime.RequiredError(
                 'requiredStringGroup',
                 'Required parameter "requiredStringGroup" was null or undefined when calling testGroupParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredBooleanGroup')) {
+        if (requestParameters['requiredBooleanGroup'] == null) {
             throw new runtime.RequiredError(
                 'requiredBooleanGroup',
                 'Required parameter "requiredBooleanGroup" was null or undefined when calling testGroupParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredInt64Group')) {
+        if (requestParameters['requiredInt64Group'] == null) {
             throw new runtime.RequiredError(
                 'requiredInt64Group',
                 'Required parameter "requiredInt64Group" was null or undefined when calling testGroupParameters().'
@@ -858,29 +858,29 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'requiredStringGroup')) {
+        if (requestParameters['requiredStringGroup'] != null) {
             queryParameters['required_string_group'] = requestParameters['requiredStringGroup'];
         }
 
-        if (runtime.exists(requestParameters, 'requiredInt64Group')) {
+        if (requestParameters['requiredInt64Group'] != null) {
             queryParameters['required_int64_group'] = requestParameters['requiredInt64Group'];
         }
 
-        if (runtime.exists(requestParameters, 'stringGroup')) {
+        if (requestParameters['stringGroup'] != null) {
             queryParameters['string_group'] = requestParameters['stringGroup'];
         }
 
-        if (runtime.exists(requestParameters, 'int64Group')) {
+        if (requestParameters['int64Group'] != null) {
             queryParameters['int64_group'] = requestParameters['int64Group'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'requiredBooleanGroup')) {
+        if (requestParameters['requiredBooleanGroup'] != null) {
             headerParameters['required_boolean_group'] = String(requestParameters['requiredBooleanGroup']);
         }
 
-        if (runtime.exists(requestParameters, 'booleanGroup')) {
+        if (requestParameters['booleanGroup'] != null) {
             headerParameters['boolean_group'] = String(requestParameters['booleanGroup']);
         }
 
@@ -915,7 +915,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline additionalProperties
      */
     async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requestBody')) {
+        if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
                 'Required parameter "requestBody" was null or undefined when calling testInlineAdditionalProperties().'
@@ -952,7 +952,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline free-form additionalProperties
      */
     async testInlineFreeformAdditionalPropertiesRaw(requestParameters: TestInlineFreeformAdditionalPropertiesOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'testInlineFreeformAdditionalPropertiesRequest')) {
+        if (requestParameters['testInlineFreeformAdditionalPropertiesRequest'] == null) {
             throw new runtime.RequiredError(
                 'testInlineFreeformAdditionalPropertiesRequest',
                 'Required parameter "testInlineFreeformAdditionalPropertiesRequest" was null or undefined when calling testInlineFreeformAdditionalProperties().'
@@ -989,14 +989,14 @@ export class FakeApi extends runtime.BaseAPI {
      * test json serialization of form data
      */
     async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'param')) {
+        if (requestParameters['param'] == null) {
             throw new runtime.RequiredError(
                 'param',
                 'Required parameter "param" was null or undefined when calling testJsonFormData().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'param2')) {
+        if (requestParameters['param2'] == null) {
             throw new runtime.RequiredError(
                 'param2',
                 'Required parameter "param2" was null or undefined when calling testJsonFormData().'
@@ -1021,11 +1021,11 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'param')) {
+        if (requestParameters['param'] != null) {
             formParams.append('param', requestParameters['param'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'param2')) {
+        if (requestParameters['param2'] != null) {
             formParams.append('param2', requestParameters['param2'] as any);
         }
 
@@ -1053,7 +1053,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test nullable parent property
      */
     async testNullableRaw(requestParameters: TestNullableRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'childWithNullable')) {
+        if (requestParameters['childWithNullable'] == null) {
             throw new runtime.RequiredError(
                 'childWithNullable',
                 'Required parameter "childWithNullable" was null or undefined when calling testNullable().'
@@ -1089,42 +1089,42 @@ export class FakeApi extends runtime.BaseAPI {
      * To test the collection format in query parameters
      */
     async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pipe')) {
+        if (requestParameters['pipe'] == null) {
             throw new runtime.RequiredError(
                 'pipe',
                 'Required parameter "pipe" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'ioutil')) {
+        if (requestParameters['ioutil'] == null) {
             throw new runtime.RequiredError(
                 'ioutil',
                 'Required parameter "ioutil" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'http')) {
+        if (requestParameters['http'] == null) {
             throw new runtime.RequiredError(
                 'http',
                 'Required parameter "http" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'url')) {
+        if (requestParameters['url'] == null) {
             throw new runtime.RequiredError(
                 'url',
                 'Required parameter "url" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'context')) {
+        if (requestParameters['context'] == null) {
             throw new runtime.RequiredError(
                 'context',
                 'Required parameter "context" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'allowEmpty')) {
+        if (requestParameters['allowEmpty'] == null) {
             throw new runtime.RequiredError(
                 'allowEmpty',
                 'Required parameter "allowEmpty" was null or undefined when calling testQueryParameterCollectionFormat().'
@@ -1133,31 +1133,31 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'pipe')) {
+        if (requestParameters['pipe'] != null) {
             queryParameters['pipe'] = requestParameters['pipe']!.join(runtime.COLLECTION_FORMATS["pipes"]);
         }
 
-        if (runtime.exists(requestParameters, 'ioutil')) {
+        if (requestParameters['ioutil'] != null) {
             queryParameters['ioutil'] = requestParameters['ioutil']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'http')) {
+        if (requestParameters['http'] != null) {
             queryParameters['http'] = requestParameters['http']!.join(runtime.COLLECTION_FORMATS["ssv"]);
         }
 
-        if (runtime.exists(requestParameters, 'url')) {
+        if (requestParameters['url'] != null) {
             queryParameters['url'] = requestParameters['url']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'context')) {
+        if (requestParameters['context'] != null) {
             queryParameters['context'] = requestParameters['context'];
         }
 
-        if (runtime.exists(requestParameters, 'language')) {
+        if (requestParameters['language'] != null) {
             queryParameters['language'] = requestParameters['language'];
         }
 
-        if (runtime.exists(requestParameters, 'allowEmpty')) {
+        if (requestParameters['allowEmpty'] != null) {
             queryParameters['allowEmpty'] = requestParameters['allowEmpty'];
         }
 
@@ -1185,7 +1185,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test referenced string map
      */
     async testStringMapReferenceRaw(requestParameters: TestStringMapReferenceRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requestBody')) {
+        if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
                 'Required parameter "requestBody" was null or undefined when calling testStringMapReference().'

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/FakeClassnameTags123Api.ts
@@ -36,7 +36,7 @@ export class FakeClassnameTags123Api extends runtime.BaseAPI {
      * To test class name in snake case
      */
     async testClassnameRaw(requestParameters: TestClassnameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling testClassname().'

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/PetApi.ts
@@ -78,7 +78,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling addPet().'
@@ -120,7 +120,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -131,7 +131,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -163,7 +163,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -172,7 +172,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Set<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -217,7 +217,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = Array.from(requestParameters['tags'])!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -253,7 +253,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -292,7 +292,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling updatePet().'
@@ -334,7 +334,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -364,11 +364,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -396,7 +396,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -428,11 +428,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 
@@ -461,14 +461,14 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image (required)
      */
     async uploadFileWithRequiredFileRaw(requestParameters: UploadFileWithRequiredFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFileWithRequiredFile().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredFile')) {
+        if (requestParameters['requiredFile'] == null) {
             throw new runtime.RequiredError(
                 'requiredFile',
                 'Required parameter "requiredFile" was null or undefined when calling uploadFileWithRequiredFile().'
@@ -500,11 +500,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'requiredFile')) {
+        if (requestParameters['requiredFile'] != null) {
             formParams.append('requiredFile', requestParameters['requiredFile'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -145,7 +145,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'order')) {
+        if (requestParameters['order'] == null) {
             throw new runtime.RequiredError(
                 'order',
                 'Required parameter "order" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUser().'
@@ -99,7 +99,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUsersWithArrayInput().'
@@ -136,7 +136,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUsersWithListInput().'
@@ -173,7 +173,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -207,7 +207,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -242,14 +242,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -258,11 +258,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -323,14 +323,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function AdditionalPropertiesClassFromJSON(json: any): AdditionalProperti
 }
 
 export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): AdditionalPropertiesClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'mapProperty': !exists(json, 'map_property') ? undefined : json['map_property'],
-        'mapOfMapProperty': !exists(json, 'map_of_map_property') ? undefined : json['map_of_map_property'],
+        'mapProperty': json['map_property'] == null ? undefined : json['map_property'],
+        'mapOfMapProperty': json['map_of_map_property'] == null ? undefined : json['map_of_map_property'],
     };
 }
 
 export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { SingleRefType } from './SingleRefType';
 import {
     SingleRefTypeFromJSON,
@@ -52,22 +52,19 @@ export function AllOfWithSingleRefFromJSON(json: any): AllOfWithSingleRef {
 }
 
 export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: boolean): AllOfWithSingleRef {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'singleRefType': !exists(json, 'SingleRefType') ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
+        'username': json['username'] == null ? undefined : json['username'],
+        'singleRefType': json['SingleRefType'] == null ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
     };
 }
 
 export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import {
      CatFromJSONTyped,
      DogFromJSONTyped
@@ -51,7 +51,7 @@ export function AnimalFromJSON(json: any): Animal {
 }
 
 export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): Animal {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     if (!ignoreDiscriminator) {
@@ -65,16 +65,13 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     return {
         
         'className': json['className'],
-        'color': !exists(json, 'color') ? undefined : json['color'],
+        'color': json['color'] == null ? undefined : json['color'],
     };
 }
 
 export function AnimalToJSON(value?: Animal | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ArrayOfArrayOfNumberOnlyFromJSON(json: any): ArrayOfArrayOfNumbe
 }
 
 export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfArrayOfNumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayArrayNumber': !exists(json, 'ArrayArrayNumber') ? undefined : json['ArrayArrayNumber'],
+        'arrayArrayNumber': json['ArrayArrayNumber'] == null ? undefined : json['ArrayArrayNumber'],
     };
 }
 
 export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ArrayOfNumberOnlyFromJSON(json: any): ArrayOfNumberOnly {
 }
 
 export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfNumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayNumber': !exists(json, 'ArrayNumber') ? undefined : json['ArrayNumber'],
+        'arrayNumber': json['ArrayNumber'] == null ? undefined : json['ArrayNumber'],
     };
 }
 
 export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ReadOnlyFirst } from './ReadOnlyFirst';
 import {
     ReadOnlyFirstFromJSON,
@@ -58,23 +58,20 @@ export function ArrayTestFromJSON(json: any): ArrayTest {
 }
 
 export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayOfString': !exists(json, 'array_of_string') ? undefined : json['array_of_string'],
-        'arrayArrayOfInteger': !exists(json, 'array_array_of_integer') ? undefined : json['array_array_of_integer'],
-        'arrayArrayOfModel': !exists(json, 'array_array_of_model') ? undefined : json['array_array_of_model'],
+        'arrayOfString': json['array_of_string'] == null ? undefined : json['array_of_string'],
+        'arrayArrayOfInteger': json['array_array_of_integer'] == null ? undefined : json['array_array_of_integer'],
+        'arrayArrayOfModel': json['array_array_of_model'] == null ? undefined : json['array_array_of_model'],
     };
 }
 
 export function ArrayTestToJSON(value?: ArrayTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -70,26 +70,23 @@ export function CapitalizationFromJSON(json: any): Capitalization {
 }
 
 export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: boolean): Capitalization {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'smallCamel': !exists(json, 'smallCamel') ? undefined : json['smallCamel'],
-        'capitalCamel': !exists(json, 'CapitalCamel') ? undefined : json['CapitalCamel'],
-        'smallSnake': !exists(json, 'small_Snake') ? undefined : json['small_Snake'],
-        'capitalSnake': !exists(json, 'Capital_Snake') ? undefined : json['Capital_Snake'],
-        'sCAETHFlowPoints': !exists(json, 'SCA_ETH_Flow_Points') ? undefined : json['SCA_ETH_Flow_Points'],
-        'aTTNAME': !exists(json, 'ATT_NAME') ? undefined : json['ATT_NAME'],
+        'smallCamel': json['smallCamel'] == null ? undefined : json['smallCamel'],
+        'capitalCamel': json['CapitalCamel'] == null ? undefined : json['CapitalCamel'],
+        'smallSnake': json['small_Snake'] == null ? undefined : json['small_Snake'],
+        'capitalSnake': json['Capital_Snake'] == null ? undefined : json['Capital_Snake'],
+        'sCAETHFlowPoints': json['SCA_ETH_Flow_Points'] == null ? undefined : json['SCA_ETH_Flow_Points'],
+        'aTTNAME': json['ATT_NAME'] == null ? undefined : json['ATT_NAME'],
     };
 }
 
 export function CapitalizationToJSON(value?: Capitalization | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -46,21 +46,18 @@ export function CatFromJSON(json: any): Cat {
 }
 
 export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         ...AnimalFromJSONTyped(json, ignoreDiscriminator),
-        'declawed': !exists(json, 'declawed') ? undefined : json['declawed'],
+        'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
 
 export function CatToJSON(value?: Cat | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         ...AnimalToJSON(value),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -46,22 +46,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
+        'id': json['id'] == null ? undefined : json['id'],
         'name': json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ParentWithNullable } from './ParentWithNullable';
 import {
     ParentWithNullableFromJSON,
@@ -48,21 +48,18 @@ export function ChildWithNullableFromJSON(json: any): ChildWithNullable {
 }
 
 export function ChildWithNullableFromJSONTyped(json: any, ignoreDiscriminator: boolean): ChildWithNullable {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         ...ParentWithNullableFromJSONTyped(json, ignoreDiscriminator),
-        'otherProperty': !exists(json, 'otherProperty') ? undefined : json['otherProperty'],
+        'otherProperty': json['otherProperty'] == null ? undefined : json['otherProperty'],
     };
 }
 
 export function ChildWithNullableToJSON(value?: ChildWithNullable | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         ...ParentWithNullableToJSON(value),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model with "_class" property
  * @export
@@ -39,21 +39,18 @@ export function ClassModelFromJSON(json: any): ClassModel {
 }
 
 export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): ClassModel {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_class': !exists(json, '_class') ? undefined : json['_class'],
+        '_class': json['_class'] == null ? undefined : json['_class'],
     };
 }
 
 export function ClassModelToJSON(value?: ClassModel | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ClientFromJSON(json: any): Client {
 }
 
 export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Client {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'client': !exists(json, 'client') ? undefined : json['client'],
+        'client': json['client'] == null ? undefined : json['client'],
     };
 }
 
 export function ClientToJSON(value?: Client | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function DeprecatedObjectFromJSON(json: any): DeprecatedObject {
 }
 
 export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): DeprecatedObject {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -46,21 +46,18 @@ export function DogFromJSON(json: any): Dog {
 }
 
 export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         ...AnimalFromJSONTyped(json, ignoreDiscriminator),
-        'breed': !exists(json, 'breed') ? undefined : json['breed'],
+        'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
 
 export function DogToJSON(value?: Dog | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         ...AnimalToJSON(value),

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -65,22 +65,19 @@ export function EnumArraysFromJSON(json: any): EnumArrays {
 }
 
 export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumArrays {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'justSymbol': !exists(json, 'just_symbol') ? undefined : json['just_symbol'],
-        'arrayEnum': !exists(json, 'array_enum') ? undefined : json['array_enum'],
+        'justSymbol': json['just_symbol'] == null ? undefined : json['just_symbol'],
+        'arrayEnum': json['array_enum'] == null ? undefined : json['array_enum'],
     };
 }
 
 export function EnumArraysToJSON(value?: EnumArrays | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { OuterEnum } from './OuterEnum';
 import {
     OuterEnumFromJSON,
@@ -147,28 +147,25 @@ export function EnumTestFromJSON(json: any): EnumTest {
 }
 
 export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'enumString': !exists(json, 'enum_string') ? undefined : json['enum_string'],
+        'enumString': json['enum_string'] == null ? undefined : json['enum_string'],
         'enumStringRequired': json['enum_string_required'],
-        'enumInteger': !exists(json, 'enum_integer') ? undefined : json['enum_integer'],
-        'enumNumber': !exists(json, 'enum_number') ? undefined : json['enum_number'],
-        'outerEnum': !exists(json, 'outerEnum') ? undefined : OuterEnumFromJSON(json['outerEnum']),
-        'outerEnumInteger': !exists(json, 'outerEnumInteger') ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
-        'outerEnumDefaultValue': !exists(json, 'outerEnumDefaultValue') ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
-        'outerEnumIntegerDefaultValue': !exists(json, 'outerEnumIntegerDefaultValue') ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
+        'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
+        'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
+        'outerEnum': json['outerEnum'] == null ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
+        'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
+        'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
     };
 }
 
 export function EnumTestToJSON(value?: EnumTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function FakeBigDecimalMap200ResponseFromJSON(json: any): FakeBigDecimalM
 }
 
 export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FakeBigDecimalMap200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'someId': !exists(json, 'someId') ? undefined : json['someId'],
-        'someMap': !exists(json, 'someMap') ? undefined : json['someMap'],
+        'someId': json['someId'] == null ? undefined : json['someId'],
+        'someMap': json['someMap'] == null ? undefined : json['someMap'],
     };
 }
 
 export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function FileSchemaTestClassFromJSON(json: any): FileSchemaTestClass {
 }
 
 export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): FileSchemaTestClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'file': !exists(json, 'file') ? undefined : json['file'],
-        'files': !exists(json, 'files') ? undefined : json['files'],
+        'file': json['file'] == null ? undefined : json['file'],
+        'files': json['files'] == null ? undefined : json['files'],
     };
 }
 
 export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function FooFromJSON(json: any): Foo {
 }
 
 export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
     };
 }
 
 export function FooToJSON(value?: Foo | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Foo } from './Foo';
 import {
     FooFromJSON,
@@ -46,21 +46,18 @@ export function FooGetDefaultResponseFromJSON(json: any): FooGetDefaultResponse 
 }
 
 export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FooGetDefaultResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'string': !exists(json, 'string') ? undefined : FooFromJSON(json['string']),
+        'string': json['string'] == null ? undefined : FooFromJSON(json['string']),
     };
 }
 
 export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Decimal } from './Decimal';
 import {
     DecimalFromJSON,
@@ -140,36 +140,33 @@ export function FormatTestFromJSON(json: any): FormatTest {
 }
 
 export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): FormatTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'integer': !exists(json, 'integer') ? undefined : json['integer'],
-        'int32': !exists(json, 'int32') ? undefined : json['int32'],
-        'int64': !exists(json, 'int64') ? undefined : json['int64'],
+        'integer': json['integer'] == null ? undefined : json['integer'],
+        'int32': json['int32'] == null ? undefined : json['int32'],
+        'int64': json['int64'] == null ? undefined : json['int64'],
         'number': json['number'],
-        '_float': !exists(json, 'float') ? undefined : json['float'],
-        '_double': !exists(json, 'double') ? undefined : json['double'],
-        'decimal': !exists(json, 'decimal') ? undefined : DecimalFromJSON(json['decimal']),
-        'string': !exists(json, 'string') ? undefined : json['string'],
+        '_float': json['float'] == null ? undefined : json['float'],
+        '_double': json['double'] == null ? undefined : json['double'],
+        'decimal': json['decimal'] == null ? undefined : DecimalFromJSON(json['decimal']),
+        'string': json['string'] == null ? undefined : json['string'],
         '_byte': json['byte'],
-        'binary': !exists(json, 'binary') ? undefined : json['binary'],
+        'binary': json['binary'] == null ? undefined : json['binary'],
         'date': (new Date(json['date'])),
-        'dateTime': !exists(json, 'dateTime') ? undefined : (new Date(json['dateTime'])),
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
+        'dateTime': json['dateTime'] == null ? undefined : (new Date(json['dateTime'])),
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
         'password': json['password'],
-        'patternWithDigits': !exists(json, 'pattern_with_digits') ? undefined : json['pattern_with_digits'],
-        'patternWithDigitsAndDelimiter': !exists(json, 'pattern_with_digits_and_delimiter') ? undefined : json['pattern_with_digits_and_delimiter'],
+        'patternWithDigits': json['pattern_with_digits'] == null ? undefined : json['pattern_with_digits'],
+        'patternWithDigitsAndDelimiter': json['pattern_with_digits_and_delimiter'] == null ? undefined : json['pattern_with_digits_and_delimiter'],
     };
 }
 
 export function FormatTestToJSON(value?: FormatTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -184,7 +181,7 @@ export function FormatTestToJSON(value?: FormatTest | null): any {
         'byte': value['_byte'],
         'binary': value['binary'],
         'date': ((value['date']).toISOString().substring(0,10)),
-        'dateTime': !exists(value, 'dateTime') ? undefined : ((value['dateTime']).toISOString()),
+        'dateTime': value['dateTime'] == null ? undefined : ((value['dateTime']).toISOString()),
         'uuid': value['uuid'],
         'password': value['password'],
         'pattern_with_digits': value['patternWithDigits'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function HasOnlyReadOnlyFromJSON(json: any): HasOnlyReadOnly {
 }
 
 export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): HasOnlyReadOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
-        'foo': !exists(json, 'foo') ? undefined : json['foo'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
+        'foo': json['foo'] == null ? undefined : json['foo'],
     };
 }
 
 export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
  * @export
@@ -39,21 +39,18 @@ export function HealthCheckResultFromJSON(json: any): HealthCheckResult {
 }
 
 export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: boolean): HealthCheckResult {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'nullableMessage': !exists(json, 'NullableMessage') ? undefined : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
     };
 }
 
 export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ListFromJSON(json: any): List {
 }
 
 export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_123list': !exists(json, '123-list') ? undefined : json['123-list'],
+        '_123list': json['123-list'] == null ? undefined : json['123-list'],
     };
 }
 
 export function ListToJSON(value?: List | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -68,24 +68,21 @@ export function MapTestFromJSON(json: any): MapTest {
 }
 
 export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'mapMapOfString': !exists(json, 'map_map_of_string') ? undefined : json['map_map_of_string'],
-        'mapOfEnumString': !exists(json, 'map_of_enum_string') ? undefined : json['map_of_enum_string'],
-        'directMap': !exists(json, 'direct_map') ? undefined : json['direct_map'],
-        'indirectMap': !exists(json, 'indirect_map') ? undefined : json['indirect_map'],
+        'mapMapOfString': json['map_map_of_string'] == null ? undefined : json['map_map_of_string'],
+        'mapOfEnumString': json['map_of_enum_string'] == null ? undefined : json['map_of_enum_string'],
+        'directMap': json['direct_map'] == null ? undefined : json['direct_map'],
+        'indirectMap': json['indirect_map'] == null ? undefined : json['indirect_map'],
     };
 }
 
 export function MapTestToJSON(value?: MapTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -58,29 +58,26 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSON(json: any): 
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): MixedPropertiesAndAdditionalPropertiesClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
-        'dateTime': !exists(json, 'dateTime') ? undefined : (new Date(json['dateTime'])),
-        'map': !exists(json, 'map') ? undefined : (mapValues(json['map'], AnimalFromJSON)),
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
+        'dateTime': json['dateTime'] == null ? undefined : (new Date(json['dateTime'])),
+        'map': json['map'] == null ? undefined : (mapValues(json['map'], AnimalFromJSON)),
     };
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'uuid': value['uuid'],
-        'dateTime': !exists(value, 'dateTime') ? undefined : ((value['dateTime']).toISOString()),
-        'map': !exists(value, 'map') ? undefined : (mapValues(value['map'], AnimalToJSON)),
+        'dateTime': value['dateTime'] == null ? undefined : ((value['dateTime']).toISOString()),
+        'map': value['map'] == null ? undefined : (mapValues(value['map'], AnimalToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model name starting with number
  * @export
@@ -45,22 +45,19 @@ export function Model200ResponseFromJSON(json: any): Model200Response {
 }
 
 export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): Model200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
-        '_class': !exists(json, 'class') ? undefined : json['class'],
+        'name': json['name'] == null ? undefined : json['name'],
+        '_class': json['class'] == null ? undefined : json['class'],
     };
 }
 
 export function Model200ResponseToJSON(value?: Model200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Must be named `File` for test.
  * @export
@@ -39,21 +39,18 @@ export function ModelFileFromJSON(json: any): ModelFile {
 }
 
 export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelFile {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'sourceURI': !exists(json, 'sourceURI') ? undefined : json['sourceURI'],
+        'sourceURI': json['sourceURI'] == null ? undefined : json['sourceURI'],
     };
 }
 
 export function ModelFileToJSON(value?: ModelFile | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model name same as property name
  * @export
@@ -58,24 +58,21 @@ export function NameFromJSON(json: any): Name {
 }
 
 export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'name': json['name'],
-        'snakeCase': !exists(json, 'snake_case') ? undefined : json['snake_case'],
-        'property': !exists(json, 'property') ? undefined : json['property'],
-        '_123number': !exists(json, '123Number') ? undefined : json['123Number'],
+        'snakeCase': json['snake_case'] == null ? undefined : json['snake_case'],
+        'property': json['property'] == null ? undefined : json['property'],
+        '_123number': json['123Number'] == null ? undefined : json['123Number'],
     };
 }
 
 export function NameToJSON(value?: Name | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -106,33 +106,30 @@ export function NullableClassFromJSON(json: any): NullableClass {
 }
 
 export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): NullableClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
             ...json,
-        'integerProp': !exists(json, 'integer_prop') ? undefined : json['integer_prop'],
-        'numberProp': !exists(json, 'number_prop') ? undefined : json['number_prop'],
-        'booleanProp': !exists(json, 'boolean_prop') ? undefined : json['boolean_prop'],
-        'stringProp': !exists(json, 'string_prop') ? undefined : json['string_prop'],
-        'dateProp': !exists(json, 'date_prop') ? undefined : (new Date(json['date_prop'])),
-        'datetimeProp': !exists(json, 'datetime_prop') ? undefined : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': !exists(json, 'array_nullable_prop') ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop') ? undefined : json['array_and_items_nullable_prop'],
-        'arrayItemsNullable': !exists(json, 'array_items_nullable') ? undefined : json['array_items_nullable'],
-        'objectNullableProp': !exists(json, 'object_nullable_prop') ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop') ? undefined : json['object_and_items_nullable_prop'],
-        'objectItemsNullable': !exists(json, 'object_items_nullable') ? undefined : json['object_items_nullable'],
+        'integerProp': json['integer_prop'] == null ? undefined : json['integer_prop'],
+        'numberProp': json['number_prop'] == null ? undefined : json['number_prop'],
+        'booleanProp': json['boolean_prop'] == null ? undefined : json['boolean_prop'],
+        'stringProp': json['string_prop'] == null ? undefined : json['string_prop'],
+        'dateProp': json['date_prop'] == null ? undefined : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] == null ? undefined : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] == null ? undefined : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? undefined : json['array_and_items_nullable_prop'],
+        'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
+        'objectNullableProp': json['object_nullable_prop'] == null ? undefined : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? undefined : json['object_and_items_nullable_prop'],
+        'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }
 
 export function NullableClassToJSON(value?: NullableClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -141,8 +138,8 @@ export function NullableClassToJSON(value?: NullableClass | null): any {
         'number_prop': value['numberProp'],
         'boolean_prop': value['booleanProp'],
         'string_prop': value['stringProp'],
-        'date_prop': !exists(value, 'dateProp') ? undefined : ((value['dateProp'] as any).toISOString().substring(0,10)),
-        'datetime_prop': !exists(value, 'datetimeProp') ? undefined : ((value['datetimeProp'] as any).toISOString()),
+        'date_prop': value['dateProp'] == null ? undefined : ((value['dateProp'] as any).toISOString().substring(0,10)),
+        'datetime_prop': value['datetimeProp'] == null ? undefined : ((value['datetimeProp'] as any).toISOString()),
         'array_nullable_prop': value['arrayNullableProp'],
         'array_and_items_nullable_prop': value['arrayAndItemsNullableProp'],
         'array_items_nullable': value['arrayItemsNullable'],

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function NumberOnlyFromJSON(json: any): NumberOnly {
 }
 
 export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): NumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'justNumber': !exists(json, 'JustNumber') ? undefined : json['JustNumber'],
+        'justNumber': json['JustNumber'] == null ? undefined : json['JustNumber'],
     };
 }
 
 export function NumberOnlyToJSON(value?: NumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { DeprecatedObject } from './DeprecatedObject';
 import {
     DeprecatedObjectFromJSON,
@@ -67,24 +67,21 @@ export function ObjectWithDeprecatedFieldsFromJSON(json: any): ObjectWithDepreca
 }
 
 export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscriminator: boolean): ObjectWithDeprecatedFields {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'deprecatedRef': !exists(json, 'deprecatedRef') ? undefined : DeprecatedObjectFromJSON(json['deprecatedRef']),
-        'bars': !exists(json, 'bars') ? undefined : json['bars'],
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'deprecatedRef': json['deprecatedRef'] == null ? undefined : DeprecatedObjectFromJSON(json['deprecatedRef']),
+        'bars': json['bars'] == null ? undefined : json['bars'],
     };
 }
 
 export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -51,23 +51,20 @@ export function OuterCompositeFromJSON(json: any): OuterComposite {
 }
 
 export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterComposite {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'myNumber': !exists(json, 'my_number') ? undefined : json['my_number'],
-        'myString': !exists(json, 'my_string') ? undefined : json['my_string'],
-        'myBoolean': !exists(json, 'my_boolean') ? undefined : json['my_boolean'],
+        'myNumber': json['my_number'] == null ? undefined : json['my_number'],
+        'myString': json['my_string'] == null ? undefined : json['my_string'],
+        'myBoolean': json['my_boolean'] == null ? undefined : json['my_boolean'],
     };
 }
 
 export function OuterCompositeToJSON(value?: OuterComposite | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
@@ -47,7 +47,7 @@ export function OuterObjectWithEnumPropertyFromJSON(json: any): OuterObjectWithE
 }
 
 export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterObjectWithEnumProperty {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -57,11 +57,8 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
 }
 
 export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import {
      ChildWithNullableFromJSONTyped
 } from './index';
@@ -59,7 +59,7 @@ export function ParentWithNullableFromJSON(json: any): ParentWithNullable {
 }
 
 export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: boolean): ParentWithNullable {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     if (!ignoreDiscriminator) {
@@ -69,17 +69,14 @@ export function ParentWithNullableFromJSONTyped(json: any, ignoreDiscriminator: 
     }
     return {
         
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'nullableProperty': !exists(json, 'nullableProperty') ? undefined : json['nullableProperty'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'nullableProperty': json['nullableProperty'] == null ? undefined : json['nullableProperty'],
     };
 }
 
 export function ParentWithNullableToJSON(value?: ParentWithNullable | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function ReadOnlyFirstFromJSON(json: any): ReadOnlyFirst {
 }
 
 export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boolean): ReadOnlyFirst {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
-        'baz': !exists(json, 'baz') ? undefined : json['baz'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
+        'baz': json['baz'] == null ? undefined : json['baz'],
     };
 }
 
 export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing reserved words
  * @export
@@ -39,21 +39,18 @@ export function ReturnFromJSON(json: any): Return {
 }
 
 export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Return {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_return': !exists(json, 'return') ? undefined : json['return'],
+        '_return': json['return'] == null ? undefined : json['return'],
     };
 }
 
 export function ReturnToJSON(value?: Return | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function SpecialModelNameFromJSON(json: any): SpecialModelName {
 }
 
 export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: boolean): SpecialModelName {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '$specialPropertyName': !exists(json, '$special[property.name]') ? undefined : json['$special[property.name]'],
+        '$specialPropertyName': json['$special[property.name]'] == null ? undefined : json['$special[property.name]'],
     };
 }
 
 export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -40,22 +40,19 @@ export function TestInlineFreeformAdditionalPropertiesRequestFromJSON(json: any)
 }
 
 export function TestInlineFreeformAdditionalPropertiesRequestFromJSONTyped(json: any, ignoreDiscriminator: boolean): TestInlineFreeformAdditionalPropertiesRequest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
             ...json,
-        'someProperty': !exists(json, 'someProperty') ? undefined : json['someProperty'],
+        'someProperty': json['someProperty'] == null ? undefined : json['someProperty'],
     };
 }
 
 export function TestInlineFreeformAdditionalPropertiesRequestToJSON(value?: TestInlineFreeformAdditionalPropertiesRequest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/PetApi.ts
@@ -71,7 +71,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -111,7 +111,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -122,7 +122,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -162,7 +162,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -198,7 +198,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -207,7 +207,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -281,7 +281,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -321,7 +321,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -351,11 +351,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -413,11 +413,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -98,7 +98,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -133,7 +133,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -202,7 +202,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -235,14 +235,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -251,11 +251,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/apis/DefaultApi.ts
@@ -63,19 +63,19 @@ export class DefaultApi extends runtime.BaseAPI {
     async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'stringEnum')) {
+        if (requestParameters['stringEnum'] != null) {
             queryParameters['string-enum'] = requestParameters['stringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableStringEnum')) {
+        if (requestParameters['nullableStringEnum'] != null) {
             queryParameters['nullable-string-enum'] = requestParameters['nullableStringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'numberEnum')) {
+        if (requestParameters['numberEnum'] != null) {
             queryParameters['number-enum'] = requestParameters['numberEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableNumberEnum')) {
+        if (requestParameters['nullableNumberEnum'] != null) {
             queryParameters['nullable-number-enum'] = requestParameters['nullableNumberEnum'];
         }
 
@@ -103,19 +103,19 @@ export class DefaultApi extends runtime.BaseAPI {
     async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'stringEnum')) {
+        if (requestParameters['stringEnum'] != null) {
             queryParameters['string-enum'] = requestParameters['stringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableStringEnum')) {
+        if (requestParameters['nullableStringEnum'] != null) {
             queryParameters['nullable-string-enum'] = requestParameters['nullableStringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'numberEnum')) {
+        if (requestParameters['numberEnum'] != null) {
             queryParameters['number-enum'] = requestParameters['numberEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableNumberEnum')) {
+        if (requestParameters['nullableNumberEnum'] != null) {
             queryParameters['nullable-number-enum'] = requestParameters['nullableNumberEnum'];
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { NumberEnum } from './NumberEnum';
 import {
     NumberEnumFromJSON,
@@ -70,24 +70,21 @@ export function EnumPatternObjectFromJSON(json: any): EnumPatternObject {
 }
 
 export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumPatternObject {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'stringEnum': !exists(json, 'string-enum') ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
-        'numberEnum': !exists(json, 'number-enum') ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 
 export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -99,24 +99,21 @@ export function FakeEnumRequestGetInline200ResponseFromJSON(json: any): FakeEnum
 }
 
 export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FakeEnumRequestGetInline200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'stringEnum': !exists(json, 'string-enum') ? undefined : json['string-enum'],
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : json['nullable-string-enum'],
-        'numberEnum': !exists(json, 'number-enum') ? undefined : json['number-enum'],
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : json['nullable-number-enum'],
+        'stringEnum': json['string-enum'] == null ? undefined : json['string-enum'],
+        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : json['nullable-string-enum'],
+        'numberEnum': json['number-enum'] == null ? undefined : json['number-enum'],
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : json['nullable-number-enum'],
     };
 }
 
 export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/PetApi.ts
@@ -71,7 +71,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -111,7 +111,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -122,7 +122,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -162,7 +162,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -198,7 +198,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -207,7 +207,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -281,7 +281,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -321,7 +321,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -351,11 +351,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -413,11 +413,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -98,7 +98,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -133,7 +133,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -202,7 +202,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -235,14 +235,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -251,11 +251,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/PetApi.ts
@@ -71,7 +71,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -111,7 +111,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -122,7 +122,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -162,7 +162,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -198,7 +198,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -207,7 +207,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -281,7 +281,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -321,7 +321,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -351,11 +351,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -413,11 +413,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -98,7 +98,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -133,7 +133,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -202,7 +202,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -235,14 +235,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -251,11 +251,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/PetApi.ts
@@ -71,7 +71,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: PetApiAddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -111,7 +111,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: PetApiDeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -122,7 +122,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: PetApiFindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -162,7 +162,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -198,7 +198,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: PetApiFindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -207,7 +207,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: PetApiGetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -281,7 +281,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: PetApiUpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -321,7 +321,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: PetApiUpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -351,11 +351,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: PetApiUploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -413,11 +413,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: StoreApiDeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: StoreApiGetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: StoreApiPlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: UserApiCreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -98,7 +98,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: UserApiCreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -133,7 +133,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: UserApiCreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: UserApiDeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -202,7 +202,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: UserApiGetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -235,14 +235,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: UserApiLoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -251,11 +251,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UserApiUpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/BehaviorApi.ts
@@ -42,7 +42,7 @@ export class BehaviorApi extends runtime.BaseAPI {
      * Get permissions for the behavior
      */
     async getBehaviorPermissionsRaw(requestParameters: GetBehaviorPermissionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetBehaviorPermissionsResponse>> {
-        if (!runtime.exists(requestParameters, 'behaviorId')) {
+        if (requestParameters['behaviorId'] == null) {
             throw new runtime.RequiredError(
                 'behaviorId',
                 'Required parameter "behaviorId" was null or undefined when calling getBehaviorPermissions().'
@@ -75,7 +75,7 @@ export class BehaviorApi extends runtime.BaseAPI {
      * Get the type of behavior
      */
     async getBehaviorTypeRaw(requestParameters: GetBehaviorTypeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetBehaviorTypeResponse>> {
-        if (!runtime.exists(requestParameters, 'behaviorId')) {
+        if (requestParameters['behaviorId'] == null) {
             throw new runtime.RequiredError(
                 'behaviorId',
                 'Required parameter "behaviorId" was null or undefined when calling getBehaviorType().'

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetApi.ts
@@ -100,7 +100,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'dummyCat')) {
+        if (requestParameters['dummyCat'] == null) {
             throw new runtime.RequiredError(
                 'dummyCat',
                 'Required parameter "dummyCat" was null or undefined when calling addPet().'
@@ -140,7 +140,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -151,7 +151,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -183,7 +183,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByIdsRaw(requestParameters: FindPetsByIdsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'ids')) {
+        if (requestParameters['ids'] == null) {
             throw new runtime.RequiredError(
                 'ids',
                 'Required parameter "ids" was null or undefined when calling findPetsByIds().'
@@ -192,7 +192,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'ids')) {
+        if (requestParameters['ids'] != null) {
             queryParameters['ids'] = requestParameters['ids']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -228,7 +228,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FindPetsByStatusResponse>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -237,7 +237,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -273,7 +273,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -282,7 +282,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -319,7 +319,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByUserIdsRaw(requestParameters: FindPetsByUserIdsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FindPetsByUserResponse>> {
-        if (!runtime.exists(requestParameters, 'ids')) {
+        if (requestParameters['ids'] == null) {
             throw new runtime.RequiredError(
                 'ids',
                 'Required parameter "ids" was null or undefined when calling findPetsByUserIds().'
@@ -328,7 +328,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'ids')) {
+        if (requestParameters['ids'] != null) {
             queryParameters['ids'] = requestParameters['ids']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -364,7 +364,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -402,7 +402,7 @@ export class PetApi extends runtime.BaseAPI {
      * Gets regions for a single pet.
      */
     async getPetRegionsRaw(requestParameters: GetPetRegionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PetRegionsResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetRegions().'
@@ -435,7 +435,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -475,14 +475,14 @@ export class PetApi extends runtime.BaseAPI {
      * Updates the pet regions.
      */
     async updatePetRegionsRaw(requestParameters: UpdatePetRegionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<PetRegionsResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetRegions().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'newRegions')) {
+        if (requestParameters['newRegions'] == null) {
             throw new runtime.RequiredError(
                 'newRegions',
                 'Required parameter "newRegions" was null or undefined when calling updatePetRegions().'
@@ -518,7 +518,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -548,11 +548,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -578,7 +578,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -610,11 +610,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/PetPartApi.ts
@@ -47,7 +47,7 @@ export class PetPartApi extends runtime.BaseAPI {
      * Returns single pet part type for the petPart id.
      */
     async getFakePetPartTypeRaw(requestParameters: GetFakePetPartTypeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetPetPartTypeResponse>> {
-        if (!runtime.exists(requestParameters, 'fakePetPartId')) {
+        if (requestParameters['fakePetPartId'] == null) {
             throw new runtime.RequiredError(
                 'fakePetPartId',
                 'Required parameter "fakePetPartId" was null or undefined when calling getFakePetPartType().'
@@ -80,28 +80,28 @@ export class PetPartApi extends runtime.BaseAPI {
      * Get the matching parts for the given pet part.
      */
     async getMatchingPartsRaw(requestParameters: GetMatchingPartsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<GetMatchingPartsResponse>> {
-        if (!runtime.exists(requestParameters, 'fakePetPartId')) {
+        if (requestParameters['fakePetPartId'] == null) {
             throw new runtime.RequiredError(
                 'fakePetPartId',
                 'Required parameter "fakePetPartId" was null or undefined when calling getMatchingParts().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_long')) {
+        if (requestParameters['_long'] == null) {
             throw new runtime.RequiredError(
                 '_long',
                 'Required parameter "_long" was null or undefined when calling getMatchingParts().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'smooth')) {
+        if (requestParameters['smooth'] == null) {
             throw new runtime.RequiredError(
                 'smooth',
                 'Required parameter "smooth" was null or undefined when calling getMatchingParts().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_short')) {
+        if (requestParameters['_short'] == null) {
             throw new runtime.RequiredError(
                 '_short',
                 'Required parameter "_short" was null or undefined when calling getMatchingParts().'
@@ -110,23 +110,23 @@ export class PetPartApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, '_long')) {
+        if (requestParameters['_long'] != null) {
             queryParameters['long'] = requestParameters['_long'];
         }
 
-        if (runtime.exists(requestParameters, 'smooth')) {
+        if (requestParameters['smooth'] != null) {
             queryParameters['smooth'] = requestParameters['smooth'];
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             queryParameters['name'] = requestParameters['name'];
         }
 
-        if (runtime.exists(requestParameters, 'connectedPart')) {
+        if (requestParameters['connectedPart'] != null) {
             queryParameters['connected-part'] = requestParameters['connectedPart'];
         }
 
-        if (runtime.exists(requestParameters, '_short')) {
+        if (requestParameters['_short'] != null) {
             queryParameters['short'] = requestParameters['_short'];
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/apis/UserApi.ts
@@ -65,7 +65,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -101,7 +101,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -136,7 +136,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -172,7 +172,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -205,7 +205,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -238,14 +238,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -254,11 +254,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -316,14 +316,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<DefaultMetaOnlyResponse>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
@@ -47,7 +47,7 @@ export function DefaultMetaOnlyResponseFromJSON(json: any): DefaultMetaOnlyRespo
 }
 
 export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): DefaultMetaOnlyResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -57,11 +57,8 @@ export function DefaultMetaOnlyResponseFromJSONTyped(json: any, ignoreDiscrimina
 }
 
 export function DefaultMetaOnlyResponseToJSON(value?: DefaultMetaOnlyResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Pet } from './Pet';
 import {
     PetFromJSON,
@@ -59,27 +59,24 @@ export function FindPetsByStatusResponseFromJSON(json: any): FindPetsByStatusRes
 }
 
 export function FindPetsByStatusResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FindPetsByStatusResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : ((json['data'] as Array<any>).map(PetFromJSON)),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(PetFromJSON)),
     };
 }
 
 export function FindPetsByStatusResponseToJSON(value?: FindPetsByStatusResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': !exists(value, 'data') ? undefined : ((value['data'] as Array<any>).map(PetToJSON)),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(PetToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
@@ -59,27 +59,24 @@ export function FindPetsByUserResponseFromJSON(json: any): FindPetsByUserRespons
 }
 
 export function FindPetsByUserResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FindPetsByUserResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : ((json['data'] as Array<any>).map(UserFromJSON)),
+        'data': json['data'] == null ? undefined : ((json['data'] as Array<any>).map(UserFromJSON)),
     };
 }
 
 export function FindPetsByUserResponseToJSON(value?: FindPetsByUserResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'meta': ResponseMetaToJSON(value['meta']),
-        'data': !exists(value, 'data') ? undefined : ((value['data'] as Array<any>).map(UserToJSON)),
+        'data': value['data'] == null ? undefined : ((value['data'] as Array<any>).map(UserToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
@@ -53,22 +53,19 @@ export function GetBehaviorPermissionsResponseFromJSON(json: any): GetBehaviorPe
 }
 
 export function GetBehaviorPermissionsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetBehaviorPermissionsResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : json['data'],
+        'data': json['data'] == null ? undefined : json['data'],
     };
 }
 
 export function GetBehaviorPermissionsResponseToJSON(value?: GetBehaviorPermissionsResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { BehaviorType } from './BehaviorType';
 import {
     BehaviorTypeFromJSON,
@@ -59,22 +59,19 @@ export function GetBehaviorTypeResponseFromJSON(json: any): GetBehaviorTypeRespo
 }
 
 export function GetBehaviorTypeResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetBehaviorTypeResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : BehaviorTypeFromJSON(json['data']),
+        'data': json['data'] == null ? undefined : BehaviorTypeFromJSON(json['data']),
     };
 }
 
 export function GetBehaviorTypeResponseToJSON(value?: GetBehaviorTypeResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { MatchingParts } from './MatchingParts';
 import {
     MatchingPartsFromJSON,
@@ -59,22 +59,19 @@ export function GetMatchingPartsResponseFromJSON(json: any): GetMatchingPartsRes
 }
 
 export function GetMatchingPartsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetMatchingPartsResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : MatchingPartsFromJSON(json['data']),
+        'data': json['data'] == null ? undefined : MatchingPartsFromJSON(json['data']),
     };
 }
 
 export function GetMatchingPartsResponseToJSON(value?: GetMatchingPartsResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { PetPartType } from './PetPartType';
 import {
     PetPartTypeFromJSON,
@@ -59,22 +59,19 @@ export function GetPetPartTypeResponseFromJSON(json: any): GetPetPartTypeRespons
 }
 
 export function GetPetPartTypeResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): GetPetPartTypeResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : PetPartTypeFromJSON(json['data']),
+        'data': json['data'] == null ? undefined : PetPartTypeFromJSON(json['data']),
     };
 }
 
 export function GetPetPartTypeResponseToJSON(value?: GetPetPartTypeResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Simplified identifier of an item
  * @export
@@ -47,7 +47,7 @@ export function ItemIdFromJSON(json: any): ItemId {
 }
 
 export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): ItemId {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -58,11 +58,8 @@ export function ItemIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): It
 }
 
 export function ItemIdToJSON(value?: ItemId | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Part } from './Part';
 import {
     PartFromJSON,
@@ -54,7 +54,7 @@ export function MatchingPartsFromJSON(json: any): MatchingParts {
 }
 
 export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boolean): MatchingParts {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -65,11 +65,8 @@ export function MatchingPartsFromJSONTyped(json: any, ignoreDiscriminator: boole
 }
 
 export function MatchingPartsToJSON(value?: MatchingParts | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ItemId } from './ItemId';
 import {
     ItemIdFromJSON,
@@ -65,24 +65,21 @@ export function ModelErrorFromJSON(json: any): ModelError {
 }
 
 export function ModelErrorFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelError {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'type': json['type'],
-        'itemInfo': !exists(json, 'itemInfo') ? undefined : ItemIdFromJSON(json['itemInfo']),
-        'details': !exists(json, 'details') ? undefined : json['details'],
-        'exception': !exists(json, 'exception') ? undefined : json['exception'],
+        'itemInfo': json['itemInfo'] == null ? undefined : ItemIdFromJSON(json['itemInfo']),
+        'details': json['details'] == null ? undefined : json['details'],
+        'exception': json['exception'] == null ? undefined : json['exception'],
     };
 }
 
 export function ModelErrorToJSON(value?: ModelError | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Contains all the info about a pet part
  * @export
@@ -47,7 +47,7 @@ export function PartFromJSON(json: any): Part {
 }
 
 export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -58,11 +58,8 @@ export function PartFromJSONTyped(json: any, ignoreDiscriminator: boolean): Part
 }
 
 export function PartToJSON(value?: Part | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -210,41 +210,38 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'id': json['id'],
-        'friendId': !exists(json, 'friendId') ? undefined : json['friendId'],
+        'friendId': json['friendId'] == null ? undefined : json['friendId'],
         'otherFriendIds': json['otherFriendIds'],
         'friendAge': json['friendAge'],
         'age': json['age'],
         'isHappy': json['isHappy'],
         'isTall': json['isTall'],
         'category': CategoryFromJSON(json['category']),
-        'optionalCategory': !exists(json, 'optionalCategory') ? undefined : CategoryFromJSON(json['optionalCategory']),
+        'optionalCategory': json['optionalCategory'] == null ? undefined : CategoryFromJSON(json['optionalCategory']),
         'name': json['name'],
-        '_entries': !exists(json, 'entries') ? undefined : ((json['entries'] as Array<any>).map(CategoryFromJSON)),
-        'surname': !exists(json, 'surname') ? undefined : json['surname'],
+        '_entries': json['entries'] == null ? undefined : ((json['entries'] as Array<any>).map(CategoryFromJSON)),
+        'surname': json['surname'] == null ? undefined : json['surname'],
         'photoUrls': json['photoUrls'],
         'warningStatus': WarningCodeFromJSON(json['warningStatus']),
-        'depStatus': !exists(json, 'depStatus') ? undefined : DeploymentRequestStatusFromJSON(json['depStatus']),
+        'depStatus': json['depStatus'] == null ? undefined : DeploymentRequestStatusFromJSON(json['depStatus']),
         'alternateStatus': DeploymentRequestStatusFromJSON(json['alternateStatus']),
         'otherDepStatuses': ((json['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusFromJSON)),
         'tags': ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'optionalTags': !exists(json, 'optionalTags') ? undefined : ((json['optionalTags'] as Array<any>).map(TagFromJSON)),
+        'optionalTags': json['optionalTags'] == null ? undefined : ((json['optionalTags'] as Array<any>).map(TagFromJSON)),
         'status': json['status'],
-        'regions': !exists(json, 'regions') ? undefined : json['regions'],
+        'regions': json['regions'] == null ? undefined : json['regions'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -258,7 +255,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'optionalCategory': CategoryToJSON(value['optionalCategory']),
         'name': value['name'],
-        'entries': !exists(value, '_entries') ? undefined : ((value['_entries'] as Array<any>).map(CategoryToJSON)),
+        'entries': value['_entries'] == null ? undefined : ((value['_entries'] as Array<any>).map(CategoryToJSON)),
         'surname': value['surname'],
         'photoUrls': value['photoUrls'],
         'warningStatus': WarningCodeToJSON(value['warningStatus']),
@@ -266,7 +263,7 @@ export function PetToJSON(value?: Pet | null): any {
         'alternateStatus': DeploymentRequestStatusToJSON(value['alternateStatus']),
         'otherDepStatuses': ((value['otherDepStatuses'] as Array<any>).map(DeploymentRequestStatusToJSON)),
         'tags': ((value['tags'] as Array<any>).map(TagToJSON)),
-        'optionalTags': !exists(value, 'optionalTags') ? undefined : ((value['optionalTags'] as Array<any>).map(TagToJSON)),
+        'optionalTags': value['optionalTags'] == null ? undefined : ((value['optionalTags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
         'regions': value['regions'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ResponseMeta } from './ResponseMeta';
 import {
     ResponseMetaFromJSON,
@@ -53,22 +53,19 @@ export function PetRegionsResponseFromJSON(json: any): PetRegionsResponse {
 }
 
 export function PetRegionsResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): PetRegionsResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'meta': ResponseMetaFromJSON(json['meta']),
-        'data': !exists(json, 'data') ? undefined : json['data'],
+        'data': json['data'] == null ? undefined : json['data'],
     };
 }
 
 export function PetRegionsResponseToJSON(value?: PetRegionsResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ErrorCode } from './ErrorCode';
 import {
     ErrorCodeFromJSON,
@@ -109,26 +109,23 @@ export function ResponseMetaFromJSON(json: any): ResponseMeta {
 }
 
 export function ResponseMetaFromJSONTyped(json: any, ignoreDiscriminator: boolean): ResponseMeta {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'code': json['code'],
-        'detail': !exists(json, 'detail') ? undefined : json['detail'],
-        'exception': !exists(json, 'exception') ? undefined : json['exception'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'errorCode': !exists(json, 'errorCode') ? undefined : ErrorCodeFromJSON(json['errorCode']),
-        'errors': !exists(json, 'errors') ? undefined : json['errors'],
+        'detail': json['detail'] == null ? undefined : json['detail'],
+        'exception': json['exception'] == null ? undefined : json['exception'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'errorCode': json['errorCode'] == null ? undefined : ErrorCodeFromJSON(json['errorCode']),
+        'errors': json['errors'] == null ? undefined : json['errors'],
     };
 }
 
 export function ResponseMetaToJSON(value?: ResponseMeta | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -95,30 +95,27 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'id': json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
-        'subUser': !exists(json, 'subUser') ? undefined : UserFromJSON(json['subUser']),
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
+        'subUser': json['subUser'] == null ? undefined : UserFromJSON(json['subUser']),
         'subUser2': UserFromJSON(json['subUser2']),
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/AnotherFakeApi.ts
@@ -36,7 +36,7 @@ export class AnotherFakeApi extends runtime.BaseAPI {
      * To test special tags
      */
     async _123testSpecialTagsRaw(requestParameters: 123testSpecialTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling _123testSpecialTags().'

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeApi.ts
@@ -207,7 +207,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test http signature authentication
      */
     async fakeHttpSignatureTestRaw(requestParameters: FakeHttpSignatureTestRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling fakeHttpSignatureTest().'
@@ -216,7 +216,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'query1')) {
+        if (requestParameters['query1'] != null) {
             queryParameters['query_1'] = requestParameters['query1'];
         }
 
@@ -224,7 +224,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         headerParameters['Content-Type'] = 'application/json';
 
-        if (runtime.exists(requestParameters, 'header1')) {
+        if (requestParameters['header1'] != null) {
             headerParameters['header_1'] = String(requestParameters['header1']);
         }
 
@@ -378,7 +378,7 @@ export class FakeApi extends runtime.BaseAPI {
      * Test serialization of enum (int) properties with examples
      */
     async fakePropertyEnumIntegerSerializeRaw(requestParameters: FakePropertyEnumIntegerSerializeRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<OuterObjectWithEnumProperty>> {
-        if (!runtime.exists(requestParameters, 'outerObjectWithEnumProperty')) {
+        if (requestParameters['outerObjectWithEnumProperty'] == null) {
             throw new runtime.RequiredError(
                 'outerObjectWithEnumProperty',
                 'Required parameter "outerObjectWithEnumProperty" was null or undefined when calling fakePropertyEnumIntegerSerialize().'
@@ -414,7 +414,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body has to be a binary file.
      */
     async testBodyWithBinaryRaw(requestParameters: TestBodyWithBinaryRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling testBodyWithBinary().'
@@ -449,7 +449,7 @@ export class FakeApi extends runtime.BaseAPI {
      * For this test, the body for this request must reference a schema named `File`.
      */
     async testBodyWithFileSchemaRaw(requestParameters: TestBodyWithFileSchemaRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'fileSchemaTestClass')) {
+        if (requestParameters['fileSchemaTestClass'] == null) {
             throw new runtime.RequiredError(
                 'fileSchemaTestClass',
                 'Required parameter "fileSchemaTestClass" was null or undefined when calling testBodyWithFileSchema().'
@@ -483,14 +483,14 @@ export class FakeApi extends runtime.BaseAPI {
     /**
      */
     async testBodyWithQueryParamsRaw(requestParameters: TestBodyWithQueryParamsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'query')) {
+        if (requestParameters['query'] == null) {
             throw new runtime.RequiredError(
                 'query',
                 'Required parameter "query" was null or undefined when calling testBodyWithQueryParams().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling testBodyWithQueryParams().'
@@ -499,7 +499,7 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'query')) {
+        if (requestParameters['query'] != null) {
             queryParameters['query'] = requestParameters['query'];
         }
 
@@ -529,7 +529,7 @@ export class FakeApi extends runtime.BaseAPI {
      * To test \"client\" model
      */
     async testClientModelRaw(requestParameters: TestClientModelRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling testClientModel().'
@@ -567,28 +567,28 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint for testing various parameters 假端點 偽のエンドポイント 가짜 엔드 포인트 
      */
     async testEndpointParametersRaw(requestParameters: TestEndpointParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'number')) {
+        if (requestParameters['number'] == null) {
             throw new runtime.RequiredError(
                 'number',
                 'Required parameter "number" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_double')) {
+        if (requestParameters['_double'] == null) {
             throw new runtime.RequiredError(
                 '_double',
                 'Required parameter "_double" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'patternWithoutDelimiter')) {
+        if (requestParameters['patternWithoutDelimiter'] == null) {
             throw new runtime.RequiredError(
                 'patternWithoutDelimiter',
                 'Required parameter "patternWithoutDelimiter" was null or undefined when calling testEndpointParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, '_byte')) {
+        if (requestParameters['_byte'] == null) {
             throw new runtime.RequiredError(
                 '_byte',
                 'Required parameter "_byte" was null or undefined when calling testEndpointParameters().'
@@ -618,59 +618,59 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'integer')) {
+        if (requestParameters['integer'] != null) {
             formParams.append('integer', requestParameters['integer'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'int32')) {
+        if (requestParameters['int32'] != null) {
             formParams.append('int32', requestParameters['int32'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'int64')) {
+        if (requestParameters['int64'] != null) {
             formParams.append('int64', requestParameters['int64'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'number')) {
+        if (requestParameters['number'] != null) {
             formParams.append('number', requestParameters['number'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_float')) {
+        if (requestParameters['_float'] != null) {
             formParams.append('float', requestParameters['_float'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_double')) {
+        if (requestParameters['_double'] != null) {
             formParams.append('double', requestParameters['_double'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'string')) {
+        if (requestParameters['string'] != null) {
             formParams.append('string', requestParameters['string'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'patternWithoutDelimiter')) {
+        if (requestParameters['patternWithoutDelimiter'] != null) {
             formParams.append('pattern_without_delimiter', requestParameters['patternWithoutDelimiter'] as any);
         }
 
-        if (runtime.exists(requestParameters, '_byte')) {
+        if (requestParameters['_byte'] != null) {
             formParams.append('byte', requestParameters['_byte'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'binary')) {
+        if (requestParameters['binary'] != null) {
             formParams.append('binary', requestParameters['binary'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'date')) {
+        if (requestParameters['date'] != null) {
             formParams.append('date', requestParameters['date'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'dateTime')) {
+        if (requestParameters['dateTime'] != null) {
             formParams.append('dateTime', requestParameters['dateTime'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             formParams.append('password', requestParameters['password'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'callback')) {
+        if (requestParameters['callback'] != null) {
             formParams.append('callback', requestParameters['callback'] as any);
         }
 
@@ -700,33 +700,33 @@ export class FakeApi extends runtime.BaseAPI {
     async testEnumParametersRaw(requestParameters: TestEnumParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'enumQueryStringArray')) {
+        if (requestParameters['enumQueryStringArray'] != null) {
             queryParameters['enum_query_string_array'] = requestParameters['enumQueryStringArray'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryString')) {
+        if (requestParameters['enumQueryString'] != null) {
             queryParameters['enum_query_string'] = requestParameters['enumQueryString'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryInteger')) {
+        if (requestParameters['enumQueryInteger'] != null) {
             queryParameters['enum_query_integer'] = requestParameters['enumQueryInteger'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryDouble')) {
+        if (requestParameters['enumQueryDouble'] != null) {
             queryParameters['enum_query_double'] = requestParameters['enumQueryDouble'];
         }
 
-        if (runtime.exists(requestParameters, 'enumQueryModelArray')) {
+        if (requestParameters['enumQueryModelArray'] != null) {
             queryParameters['enum_query_model_array'] = requestParameters['enumQueryModelArray'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'enumHeaderStringArray')) {
+        if (requestParameters['enumHeaderStringArray'] != null) {
             headerParameters['enum_header_string_array'] = requestParameters['enumHeaderStringArray']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'enumHeaderString')) {
+        if (requestParameters['enumHeaderString'] != null) {
             headerParameters['enum_header_string'] = String(requestParameters['enumHeaderString']);
         }
 
@@ -744,11 +744,11 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'enumFormStringArray')) {
+        if (requestParameters['enumFormStringArray'] != null) {
             formParams.append('enum_form_string_array', requestParameters['enumFormStringArray']!.join(runtime.COLLECTION_FORMATS["csv"]));
         }
 
-        if (runtime.exists(requestParameters, 'enumFormString')) {
+        if (requestParameters['enumFormString'] != null) {
             formParams.append('enum_form_string', requestParameters['enumFormString'] as any);
         }
 
@@ -776,21 +776,21 @@ export class FakeApi extends runtime.BaseAPI {
      * Fake endpoint to test group parameters (optional)
      */
     async testGroupParametersRaw(requestParameters: TestGroupParametersRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requiredStringGroup')) {
+        if (requestParameters['requiredStringGroup'] == null) {
             throw new runtime.RequiredError(
                 'requiredStringGroup',
                 'Required parameter "requiredStringGroup" was null or undefined when calling testGroupParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredBooleanGroup')) {
+        if (requestParameters['requiredBooleanGroup'] == null) {
             throw new runtime.RequiredError(
                 'requiredBooleanGroup',
                 'Required parameter "requiredBooleanGroup" was null or undefined when calling testGroupParameters().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredInt64Group')) {
+        if (requestParameters['requiredInt64Group'] == null) {
             throw new runtime.RequiredError(
                 'requiredInt64Group',
                 'Required parameter "requiredInt64Group" was null or undefined when calling testGroupParameters().'
@@ -799,29 +799,29 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'requiredStringGroup')) {
+        if (requestParameters['requiredStringGroup'] != null) {
             queryParameters['required_string_group'] = requestParameters['requiredStringGroup'];
         }
 
-        if (runtime.exists(requestParameters, 'requiredInt64Group')) {
+        if (requestParameters['requiredInt64Group'] != null) {
             queryParameters['required_int64_group'] = requestParameters['requiredInt64Group'];
         }
 
-        if (runtime.exists(requestParameters, 'stringGroup')) {
+        if (requestParameters['stringGroup'] != null) {
             queryParameters['string_group'] = requestParameters['stringGroup'];
         }
 
-        if (runtime.exists(requestParameters, 'int64Group')) {
+        if (requestParameters['int64Group'] != null) {
             queryParameters['int64_group'] = requestParameters['int64Group'];
         }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'requiredBooleanGroup')) {
+        if (requestParameters['requiredBooleanGroup'] != null) {
             headerParameters['required_boolean_group'] = String(requestParameters['requiredBooleanGroup']);
         }
 
-        if (runtime.exists(requestParameters, 'booleanGroup')) {
+        if (requestParameters['booleanGroup'] != null) {
             headerParameters['boolean_group'] = String(requestParameters['booleanGroup']);
         }
 
@@ -856,7 +856,7 @@ export class FakeApi extends runtime.BaseAPI {
      * test inline additionalProperties
      */
     async testInlineAdditionalPropertiesRaw(requestParameters: TestInlineAdditionalPropertiesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'requestBody')) {
+        if (requestParameters['requestBody'] == null) {
             throw new runtime.RequiredError(
                 'requestBody',
                 'Required parameter "requestBody" was null or undefined when calling testInlineAdditionalProperties().'
@@ -893,14 +893,14 @@ export class FakeApi extends runtime.BaseAPI {
      * test json serialization of form data
      */
     async testJsonFormDataRaw(requestParameters: TestJsonFormDataRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'param')) {
+        if (requestParameters['param'] == null) {
             throw new runtime.RequiredError(
                 'param',
                 'Required parameter "param" was null or undefined when calling testJsonFormData().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'param2')) {
+        if (requestParameters['param2'] == null) {
             throw new runtime.RequiredError(
                 'param2',
                 'Required parameter "param2" was null or undefined when calling testJsonFormData().'
@@ -925,11 +925,11 @@ export class FakeApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'param')) {
+        if (requestParameters['param'] != null) {
             formParams.append('param', requestParameters['param'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'param2')) {
+        if (requestParameters['param2'] != null) {
             formParams.append('param2', requestParameters['param2'] as any);
         }
 
@@ -956,42 +956,42 @@ export class FakeApi extends runtime.BaseAPI {
      * To test the collection format in query parameters
      */
     async testQueryParameterCollectionFormatRaw(requestParameters: TestQueryParameterCollectionFormatRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pipe')) {
+        if (requestParameters['pipe'] == null) {
             throw new runtime.RequiredError(
                 'pipe',
                 'Required parameter "pipe" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'ioutil')) {
+        if (requestParameters['ioutil'] == null) {
             throw new runtime.RequiredError(
                 'ioutil',
                 'Required parameter "ioutil" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'http')) {
+        if (requestParameters['http'] == null) {
             throw new runtime.RequiredError(
                 'http',
                 'Required parameter "http" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'url')) {
+        if (requestParameters['url'] == null) {
             throw new runtime.RequiredError(
                 'url',
                 'Required parameter "url" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'context')) {
+        if (requestParameters['context'] == null) {
             throw new runtime.RequiredError(
                 'context',
                 'Required parameter "context" was null or undefined when calling testQueryParameterCollectionFormat().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'allowEmpty')) {
+        if (requestParameters['allowEmpty'] == null) {
             throw new runtime.RequiredError(
                 'allowEmpty',
                 'Required parameter "allowEmpty" was null or undefined when calling testQueryParameterCollectionFormat().'
@@ -1000,31 +1000,31 @@ export class FakeApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'pipe')) {
+        if (requestParameters['pipe'] != null) {
             queryParameters['pipe'] = requestParameters['pipe']!.join(runtime.COLLECTION_FORMATS["pipes"]);
         }
 
-        if (runtime.exists(requestParameters, 'ioutil')) {
+        if (requestParameters['ioutil'] != null) {
             queryParameters['ioutil'] = requestParameters['ioutil']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'http')) {
+        if (requestParameters['http'] != null) {
             queryParameters['http'] = requestParameters['http']!.join(runtime.COLLECTION_FORMATS["ssv"]);
         }
 
-        if (runtime.exists(requestParameters, 'url')) {
+        if (requestParameters['url'] != null) {
             queryParameters['url'] = requestParameters['url']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
-        if (runtime.exists(requestParameters, 'context')) {
+        if (requestParameters['context'] != null) {
             queryParameters['context'] = requestParameters['context'];
         }
 
-        if (runtime.exists(requestParameters, 'language')) {
+        if (requestParameters['language'] != null) {
             queryParameters['language'] = requestParameters['language'];
         }
 
-        if (runtime.exists(requestParameters, 'allowEmpty')) {
+        if (requestParameters['allowEmpty'] != null) {
             queryParameters['allowEmpty'] = requestParameters['allowEmpty'];
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeClassnameTags123Api.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/FakeClassnameTags123Api.ts
@@ -36,7 +36,7 @@ export class FakeClassnameTags123Api extends runtime.BaseAPI {
      * To test class name in snake case
      */
     async testClassnameRaw(requestParameters: TestClassnameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Client>> {
-        if (!runtime.exists(requestParameters, 'client')) {
+        if (requestParameters['client'] == null) {
             throw new runtime.RequiredError(
                 'client',
                 'Required parameter "client" was null or undefined when calling testClassname().'

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/PetApi.ts
@@ -78,7 +78,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling addPet().'
@@ -120,7 +120,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -131,7 +131,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -163,7 +163,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -172,7 +172,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -208,7 +208,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Set<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -217,7 +217,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = Array.from(requestParameters['tags'])!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -253,7 +253,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -292,7 +292,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'pet')) {
+        if (requestParameters['pet'] == null) {
             throw new runtime.RequiredError(
                 'pet',
                 'Required parameter "pet" was null or undefined when calling updatePet().'
@@ -334,7 +334,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -364,11 +364,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -396,7 +396,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -428,11 +428,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 
@@ -461,14 +461,14 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image (required)
      */
     async uploadFileWithRequiredFileRaw(requestParameters: UploadFileWithRequiredFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFileWithRequiredFile().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'requiredFile')) {
+        if (requestParameters['requiredFile'] == null) {
             throw new runtime.RequiredError(
                 'requiredFile',
                 'Required parameter "requiredFile" was null or undefined when calling uploadFileWithRequiredFile().'
@@ -500,11 +500,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'requiredFile')) {
+        if (requestParameters['requiredFile'] != null) {
             formParams.append('requiredFile', requestParameters['requiredFile'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -145,7 +145,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'order')) {
+        if (requestParameters['order'] == null) {
             throw new runtime.RequiredError(
                 'order',
                 'Required parameter "order" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUser().'
@@ -99,7 +99,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUsersWithArrayInput().'
@@ -136,7 +136,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling createUsersWithListInput().'
@@ -173,7 +173,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -207,7 +207,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -242,14 +242,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -258,11 +258,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -323,14 +323,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'user')) {
+        if (requestParameters['user'] == null) {
             throw new runtime.RequiredError(
                 'user',
                 'Required parameter "user" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function AdditionalPropertiesClassFromJSON(json: any): AdditionalProperti
 }
 
 export function AdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): AdditionalPropertiesClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'mapProperty': !exists(json, 'map_property') ? undefined : json['map_property'],
-        'mapOfMapProperty': !exists(json, 'map_of_map_property') ? undefined : json['map_of_map_property'],
+        'mapProperty': json['map_property'] == null ? undefined : json['map_property'],
+        'mapOfMapProperty': json['map_of_map_property'] == null ? undefined : json['map_of_map_property'],
     };
 }
 
 export function AdditionalPropertiesClassToJSON(value?: AdditionalPropertiesClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { SingleRefType } from './SingleRefType';
 import {
     SingleRefTypeFromJSON,
@@ -52,22 +52,19 @@ export function AllOfWithSingleRefFromJSON(json: any): AllOfWithSingleRef {
 }
 
 export function AllOfWithSingleRefFromJSONTyped(json: any, ignoreDiscriminator: boolean): AllOfWithSingleRef {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'singleRefType': !exists(json, 'SingleRefType') ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
+        'username': json['username'] == null ? undefined : json['username'],
+        'singleRefType': json['SingleRefType'] == null ? undefined : SingleRefTypeFromJSON(json['SingleRefType']),
     };
 }
 
 export function AllOfWithSingleRefToJSON(value?: AllOfWithSingleRef | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import {
      CatFromJSONTyped,
      DogFromJSONTyped
@@ -51,7 +51,7 @@ export function AnimalFromJSON(json: any): Animal {
 }
 
 export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): Animal {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     if (!ignoreDiscriminator) {
@@ -65,16 +65,13 @@ export function AnimalFromJSONTyped(json: any, ignoreDiscriminator: boolean): An
     return {
         
         'className': json['class_name'],
-        'color': !exists(json, 'color') ? undefined : json['color'],
+        'color': json['color'] == null ? undefined : json['color'],
     };
 }
 
 export function AnimalToJSON(value?: Animal | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ArrayOfArrayOfNumberOnlyFromJSON(json: any): ArrayOfArrayOfNumbe
 }
 
 export function ArrayOfArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfArrayOfNumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayArrayNumber': !exists(json, 'ArrayArrayNumber') ? undefined : json['ArrayArrayNumber'],
+        'arrayArrayNumber': json['ArrayArrayNumber'] == null ? undefined : json['ArrayArrayNumber'],
     };
 }
 
 export function ArrayOfArrayOfNumberOnlyToJSON(value?: ArrayOfArrayOfNumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ArrayOfNumberOnlyFromJSON(json: any): ArrayOfNumberOnly {
 }
 
 export function ArrayOfNumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfNumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayNumber': !exists(json, 'ArrayNumber') ? undefined : json['ArrayNumber'],
+        'arrayNumber': json['ArrayNumber'] == null ? undefined : json['ArrayNumber'],
     };
 }
 
 export function ArrayOfNumberOnlyToJSON(value?: ArrayOfNumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { ReadOnlyFirst } from './ReadOnlyFirst';
 import {
     ReadOnlyFirstFromJSON,
@@ -58,23 +58,20 @@ export function ArrayTestFromJSON(json: any): ArrayTest {
 }
 
 export function ArrayTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'arrayOfString': !exists(json, 'array_of_string') ? undefined : json['array_of_string'],
-        'arrayArrayOfInteger': !exists(json, 'array_array_of_integer') ? undefined : json['array_array_of_integer'],
-        'arrayArrayOfModel': !exists(json, 'array_array_of_model') ? undefined : json['array_array_of_model'],
+        'arrayOfString': json['array_of_string'] == null ? undefined : json['array_of_string'],
+        'arrayArrayOfInteger': json['array_array_of_integer'] == null ? undefined : json['array_array_of_integer'],
+        'arrayArrayOfModel': json['array_array_of_model'] == null ? undefined : json['array_array_of_model'],
     };
 }
 
 export function ArrayTestToJSON(value?: ArrayTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -70,26 +70,23 @@ export function CapitalizationFromJSON(json: any): Capitalization {
 }
 
 export function CapitalizationFromJSONTyped(json: any, ignoreDiscriminator: boolean): Capitalization {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'smallCamel': !exists(json, 'smallCamel') ? undefined : json['smallCamel'],
-        'capitalCamel': !exists(json, 'CapitalCamel') ? undefined : json['CapitalCamel'],
-        'smallSnake': !exists(json, 'small_Snake') ? undefined : json['small_Snake'],
-        'capitalSnake': !exists(json, 'Capital_Snake') ? undefined : json['Capital_Snake'],
-        'sCAETHFlowPoints': !exists(json, 'SCA_ETH_Flow_Points') ? undefined : json['SCA_ETH_Flow_Points'],
-        'aTTNAME': !exists(json, 'ATT_NAME') ? undefined : json['ATT_NAME'],
+        'smallCamel': json['smallCamel'] == null ? undefined : json['smallCamel'],
+        'capitalCamel': json['CapitalCamel'] == null ? undefined : json['CapitalCamel'],
+        'smallSnake': json['small_Snake'] == null ? undefined : json['small_Snake'],
+        'capitalSnake': json['Capital_Snake'] == null ? undefined : json['Capital_Snake'],
+        'sCAETHFlowPoints': json['SCA_ETH_Flow_Points'] == null ? undefined : json['SCA_ETH_Flow_Points'],
+        'aTTNAME': json['ATT_NAME'] == null ? undefined : json['ATT_NAME'],
     };
 }
 
 export function CapitalizationToJSON(value?: Capitalization | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -46,21 +46,18 @@ export function CatFromJSON(json: any): Cat {
 }
 
 export function CatFromJSONTyped(json: any, ignoreDiscriminator: boolean): Cat {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         ...AnimalFromJSONTyped(json, ignoreDiscriminator),
-        'declawed': !exists(json, 'declawed') ? undefined : json['declawed'],
+        'declawed': json['declawed'] == null ? undefined : json['declawed'],
     };
 }
 
 export function CatToJSON(value?: Cat | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         ...AnimalToJSON(value),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -46,22 +46,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
+        'id': json['id'] == null ? undefined : json['id'],
         'name': json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model with "_class" property
  * @export
@@ -39,21 +39,18 @@ export function ClassModelFromJSON(json: any): ClassModel {
 }
 
 export function ClassModelFromJSONTyped(json: any, ignoreDiscriminator: boolean): ClassModel {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_class': !exists(json, '_class') ? undefined : json['_class'],
+        '_class': json['_class'] == null ? undefined : json['_class'],
     };
 }
 
 export function ClassModelToJSON(value?: ClassModel | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ClientFromJSON(json: any): Client {
 }
 
 export function ClientFromJSONTyped(json: any, ignoreDiscriminator: boolean): Client {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'client': !exists(json, 'client') ? undefined : json['client'],
+        'client': json['client'] == null ? undefined : json['client'],
     };
 }
 
 export function ClientToJSON(value?: Client | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function DeprecatedObjectFromJSON(json: any): DeprecatedObject {
 }
 
 export function DeprecatedObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): DeprecatedObject {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function DeprecatedObjectToJSON(value?: DeprecatedObject | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -46,21 +46,18 @@ export function DogFromJSON(json: any): Dog {
 }
 
 export function DogFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dog {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         ...AnimalFromJSONTyped(json, ignoreDiscriminator),
-        'breed': !exists(json, 'breed') ? undefined : json['breed'],
+        'breed': json['breed'] == null ? undefined : json['breed'],
     };
 }
 
 export function DogToJSON(value?: Dog | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         ...AnimalToJSON(value),

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -65,22 +65,19 @@ export function EnumArraysFromJSON(json: any): EnumArrays {
 }
 
 export function EnumArraysFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumArrays {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'justSymbol': !exists(json, 'just_symbol') ? undefined : json['just_symbol'],
-        'arrayEnum': !exists(json, 'array_enum') ? undefined : json['array_enum'],
+        'justSymbol': json['just_symbol'] == null ? undefined : json['just_symbol'],
+        'arrayEnum': json['array_enum'] == null ? undefined : json['array_enum'],
     };
 }
 
 export function EnumArraysToJSON(value?: EnumArrays | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { OuterEnum } from './OuterEnum';
 import {
     OuterEnumFromJSON,
@@ -147,28 +147,25 @@ export function EnumTestFromJSON(json: any): EnumTest {
 }
 
 export function EnumTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'enumString': !exists(json, 'enum_string') ? undefined : json['enum_string'],
+        'enumString': json['enum_string'] == null ? undefined : json['enum_string'],
         'enumStringRequired': json['enum_string_required'],
-        'enumInteger': !exists(json, 'enum_integer') ? undefined : json['enum_integer'],
-        'enumNumber': !exists(json, 'enum_number') ? undefined : json['enum_number'],
-        'outerEnum': !exists(json, 'outerEnum') ? undefined : OuterEnumFromJSON(json['outerEnum']),
-        'outerEnumInteger': !exists(json, 'outerEnumInteger') ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
-        'outerEnumDefaultValue': !exists(json, 'outerEnumDefaultValue') ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
-        'outerEnumIntegerDefaultValue': !exists(json, 'outerEnumIntegerDefaultValue') ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
+        'enumInteger': json['enum_integer'] == null ? undefined : json['enum_integer'],
+        'enumNumber': json['enum_number'] == null ? undefined : json['enum_number'],
+        'outerEnum': json['outerEnum'] == null ? undefined : OuterEnumFromJSON(json['outerEnum']),
+        'outerEnumInteger': json['outerEnumInteger'] == null ? undefined : OuterEnumIntegerFromJSON(json['outerEnumInteger']),
+        'outerEnumDefaultValue': json['outerEnumDefaultValue'] == null ? undefined : OuterEnumDefaultValueFromJSON(json['outerEnumDefaultValue']),
+        'outerEnumIntegerDefaultValue': json['outerEnumIntegerDefaultValue'] == null ? undefined : OuterEnumIntegerDefaultValueFromJSON(json['outerEnumIntegerDefaultValue']),
     };
 }
 
 export function EnumTestToJSON(value?: EnumTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function FakeBigDecimalMap200ResponseFromJSON(json: any): FakeBigDecimalM
 }
 
 export function FakeBigDecimalMap200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FakeBigDecimalMap200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'someId': !exists(json, 'someId') ? undefined : json['someId'],
-        'someMap': !exists(json, 'someMap') ? undefined : json['someMap'],
+        'someId': json['someId'] == null ? undefined : json['someId'],
+        'someMap': json['someMap'] == null ? undefined : json['someMap'],
     };
 }
 
 export function FakeBigDecimalMap200ResponseToJSON(value?: FakeBigDecimalMap200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function FileSchemaTestClassFromJSON(json: any): FileSchemaTestClass {
 }
 
 export function FileSchemaTestClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): FileSchemaTestClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'file': !exists(json, 'file') ? undefined : json['file'],
-        'files': !exists(json, 'files') ? undefined : json['files'],
+        'file': json['file'] == null ? undefined : json['file'],
+        'files': json['files'] == null ? undefined : json['files'],
     };
 }
 
 export function FileSchemaTestClassToJSON(value?: FileSchemaTestClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function FooFromJSON(json: any): Foo {
 }
 
 export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
     };
 }
 
 export function FooToJSON(value?: Foo | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Foo } from './Foo';
 import {
     FooFromJSON,
@@ -46,21 +46,18 @@ export function FooGetDefaultResponseFromJSON(json: any): FooGetDefaultResponse 
 }
 
 export function FooGetDefaultResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FooGetDefaultResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'string': !exists(json, 'string') ? undefined : FooFromJSON(json['string']),
+        'string': json['string'] == null ? undefined : FooFromJSON(json['string']),
     };
 }
 
 export function FooGetDefaultResponseToJSON(value?: FooGetDefaultResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Decimal } from './Decimal';
 import {
     DecimalFromJSON,
@@ -140,36 +140,33 @@ export function FormatTestFromJSON(json: any): FormatTest {
 }
 
 export function FormatTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): FormatTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'integer': !exists(json, 'integer') ? undefined : json['integer'],
-        'int32': !exists(json, 'int32') ? undefined : json['int32'],
-        'int64': !exists(json, 'int64') ? undefined : json['int64'],
+        'integer': json['integer'] == null ? undefined : json['integer'],
+        'int32': json['int32'] == null ? undefined : json['int32'],
+        'int64': json['int64'] == null ? undefined : json['int64'],
         'number': json['number'],
-        '_float': !exists(json, 'float') ? undefined : json['float'],
-        '_double': !exists(json, 'double') ? undefined : json['double'],
-        'decimal': !exists(json, 'decimal') ? undefined : DecimalFromJSON(json['decimal']),
-        'string': !exists(json, 'string') ? undefined : json['string'],
+        '_float': json['float'] == null ? undefined : json['float'],
+        '_double': json['double'] == null ? undefined : json['double'],
+        'decimal': json['decimal'] == null ? undefined : DecimalFromJSON(json['decimal']),
+        'string': json['string'] == null ? undefined : json['string'],
         '_byte': json['byte'],
-        'binary': !exists(json, 'binary') ? undefined : json['binary'],
+        'binary': json['binary'] == null ? undefined : json['binary'],
         'date': (new Date(json['date'])),
-        'dateTime': !exists(json, 'dateTime') ? undefined : (new Date(json['dateTime'])),
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
+        'dateTime': json['dateTime'] == null ? undefined : (new Date(json['dateTime'])),
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
         'password': json['password'],
-        'patternWithDigits': !exists(json, 'pattern_with_digits') ? undefined : json['pattern_with_digits'],
-        'patternWithDigitsAndDelimiter': !exists(json, 'pattern_with_digits_and_delimiter') ? undefined : json['pattern_with_digits_and_delimiter'],
+        'patternWithDigits': json['pattern_with_digits'] == null ? undefined : json['pattern_with_digits'],
+        'patternWithDigitsAndDelimiter': json['pattern_with_digits_and_delimiter'] == null ? undefined : json['pattern_with_digits_and_delimiter'],
     };
 }
 
 export function FormatTestToJSON(value?: FormatTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -184,7 +181,7 @@ export function FormatTestToJSON(value?: FormatTest | null): any {
         'byte': value['_byte'],
         'binary': value['binary'],
         'date': ((value['date']).toISOString().substring(0,10)),
-        'dateTime': !exists(value, 'dateTime') ? undefined : ((value['dateTime']).toISOString()),
+        'dateTime': value['dateTime'] == null ? undefined : ((value['dateTime']).toISOString()),
         'uuid': value['uuid'],
         'password': value['password'],
         'pattern_with_digits': value['patternWithDigits'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function HasOnlyReadOnlyFromJSON(json: any): HasOnlyReadOnly {
 }
 
 export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): HasOnlyReadOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
-        'foo': !exists(json, 'foo') ? undefined : json['foo'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
+        'foo': json['foo'] == null ? undefined : json['foo'],
     };
 }
 
 export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.
  * @export
@@ -39,21 +39,18 @@ export function HealthCheckResultFromJSON(json: any): HealthCheckResult {
 }
 
 export function HealthCheckResultFromJSONTyped(json: any, ignoreDiscriminator: boolean): HealthCheckResult {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'nullableMessage': !exists(json, 'NullableMessage') ? undefined : json['NullableMessage'],
+        'nullableMessage': json['NullableMessage'] == null ? undefined : json['NullableMessage'],
     };
 }
 
 export function HealthCheckResultToJSON(value?: HealthCheckResult | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function ListFromJSON(json: any): List {
 }
 
 export function ListFromJSONTyped(json: any, ignoreDiscriminator: boolean): List {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_123list': !exists(json, '123-list') ? undefined : json['123-list'],
+        '_123list': json['123-list'] == null ? undefined : json['123-list'],
     };
 }
 
 export function ListToJSON(value?: List | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -68,24 +68,21 @@ export function MapTestFromJSON(json: any): MapTest {
 }
 
 export function MapTestFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapTest {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'mapMapOfString': !exists(json, 'map_map_of_string') ? undefined : json['map_map_of_string'],
-        'mapOfEnumString': !exists(json, 'map_of_enum_string') ? undefined : json['map_of_enum_string'],
-        'directMap': !exists(json, 'direct_map') ? undefined : json['direct_map'],
-        'indirectMap': !exists(json, 'indirect_map') ? undefined : json['indirect_map'],
+        'mapMapOfString': json['map_map_of_string'] == null ? undefined : json['map_map_of_string'],
+        'mapOfEnumString': json['map_of_enum_string'] == null ? undefined : json['map_of_enum_string'],
+        'directMap': json['direct_map'] == null ? undefined : json['direct_map'],
+        'indirectMap': json['indirect_map'] == null ? undefined : json['indirect_map'],
     };
 }
 
 export function MapTestToJSON(value?: MapTest | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Animal } from './Animal';
 import {
     AnimalFromJSON,
@@ -58,29 +58,26 @@ export function MixedPropertiesAndAdditionalPropertiesClassFromJSON(json: any): 
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): MixedPropertiesAndAdditionalPropertiesClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
-        'dateTime': !exists(json, 'dateTime') ? undefined : (new Date(json['dateTime'])),
-        'map': !exists(json, 'map') ? undefined : (mapValues(json['map'], AnimalFromJSON)),
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
+        'dateTime': json['dateTime'] == null ? undefined : (new Date(json['dateTime'])),
+        'map': json['map'] == null ? undefined : (mapValues(json['map'], AnimalFromJSON)),
     };
 }
 
 export function MixedPropertiesAndAdditionalPropertiesClassToJSON(value?: MixedPropertiesAndAdditionalPropertiesClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'uuid': value['uuid'],
-        'dateTime': !exists(value, 'dateTime') ? undefined : ((value['dateTime']).toISOString()),
-        'map': !exists(value, 'map') ? undefined : (mapValues(value['map'], AnimalToJSON)),
+        'dateTime': value['dateTime'] == null ? undefined : ((value['dateTime']).toISOString()),
+        'map': value['map'] == null ? undefined : (mapValues(value['map'], AnimalToJSON)),
     };
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model name starting with number
  * @export
@@ -45,22 +45,19 @@ export function Model200ResponseFromJSON(json: any): Model200Response {
 }
 
 export function Model200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): Model200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'name': !exists(json, 'name') ? undefined : json['name'],
-        '_class': !exists(json, 'class') ? undefined : json['class'],
+        'name': json['name'] == null ? undefined : json['name'],
+        '_class': json['class'] == null ? undefined : json['class'],
     };
 }
 
 export function Model200ResponseToJSON(value?: Model200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Must be named `File` for test.
  * @export
@@ -39,21 +39,18 @@ export function ModelFileFromJSON(json: any): ModelFile {
 }
 
 export function ModelFileFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelFile {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'sourceURI': !exists(json, 'sourceURI') ? undefined : json['sourceURI'],
+        'sourceURI': json['sourceURI'] == null ? undefined : json['sourceURI'],
     };
 }
 
 export function ModelFileToJSON(value?: ModelFile | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing model name same as property name
  * @export
@@ -58,24 +58,21 @@ export function NameFromJSON(json: any): Name {
 }
 
 export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
         'name': json['name'],
-        'snakeCase': !exists(json, 'snake_case') ? undefined : json['snake_case'],
-        'property': !exists(json, 'property') ? undefined : json['property'],
-        '_123number': !exists(json, '123Number') ? undefined : json['123Number'],
+        'snakeCase': json['snake_case'] == null ? undefined : json['snake_case'],
+        'property': json['property'] == null ? undefined : json['property'],
+        '_123number': json['123Number'] == null ? undefined : json['123Number'],
     };
 }
 
 export function NameToJSON(value?: Name | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -106,33 +106,30 @@ export function NullableClassFromJSON(json: any): NullableClass {
 }
 
 export function NullableClassFromJSONTyped(json: any, ignoreDiscriminator: boolean): NullableClass {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
             ...json,
-        'integerProp': !exists(json, 'integer_prop') ? undefined : json['integer_prop'],
-        'numberProp': !exists(json, 'number_prop') ? undefined : json['number_prop'],
-        'booleanProp': !exists(json, 'boolean_prop') ? undefined : json['boolean_prop'],
-        'stringProp': !exists(json, 'string_prop') ? undefined : json['string_prop'],
-        'dateProp': !exists(json, 'date_prop') ? undefined : (new Date(json['date_prop'])),
-        'datetimeProp': !exists(json, 'datetime_prop') ? undefined : (new Date(json['datetime_prop'])),
-        'arrayNullableProp': !exists(json, 'array_nullable_prop') ? undefined : json['array_nullable_prop'],
-        'arrayAndItemsNullableProp': !exists(json, 'array_and_items_nullable_prop') ? undefined : json['array_and_items_nullable_prop'],
-        'arrayItemsNullable': !exists(json, 'array_items_nullable') ? undefined : json['array_items_nullable'],
-        'objectNullableProp': !exists(json, 'object_nullable_prop') ? undefined : json['object_nullable_prop'],
-        'objectAndItemsNullableProp': !exists(json, 'object_and_items_nullable_prop') ? undefined : json['object_and_items_nullable_prop'],
-        'objectItemsNullable': !exists(json, 'object_items_nullable') ? undefined : json['object_items_nullable'],
+        'integerProp': json['integer_prop'] == null ? undefined : json['integer_prop'],
+        'numberProp': json['number_prop'] == null ? undefined : json['number_prop'],
+        'booleanProp': json['boolean_prop'] == null ? undefined : json['boolean_prop'],
+        'stringProp': json['string_prop'] == null ? undefined : json['string_prop'],
+        'dateProp': json['date_prop'] == null ? undefined : (new Date(json['date_prop'])),
+        'datetimeProp': json['datetime_prop'] == null ? undefined : (new Date(json['datetime_prop'])),
+        'arrayNullableProp': json['array_nullable_prop'] == null ? undefined : json['array_nullable_prop'],
+        'arrayAndItemsNullableProp': json['array_and_items_nullable_prop'] == null ? undefined : json['array_and_items_nullable_prop'],
+        'arrayItemsNullable': json['array_items_nullable'] == null ? undefined : json['array_items_nullable'],
+        'objectNullableProp': json['object_nullable_prop'] == null ? undefined : json['object_nullable_prop'],
+        'objectAndItemsNullableProp': json['object_and_items_nullable_prop'] == null ? undefined : json['object_and_items_nullable_prop'],
+        'objectItemsNullable': json['object_items_nullable'] == null ? undefined : json['object_items_nullable'],
     };
 }
 
 export function NullableClassToJSON(value?: NullableClass | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -141,8 +138,8 @@ export function NullableClassToJSON(value?: NullableClass | null): any {
         'number_prop': value['numberProp'],
         'boolean_prop': value['booleanProp'],
         'string_prop': value['stringProp'],
-        'date_prop': !exists(value, 'dateProp') ? undefined : ((value['dateProp'] as any).toISOString().substring(0,10)),
-        'datetime_prop': !exists(value, 'datetimeProp') ? undefined : ((value['datetimeProp'] as any).toISOString()),
+        'date_prop': value['dateProp'] == null ? undefined : ((value['dateProp'] as any).toISOString().substring(0,10)),
+        'datetime_prop': value['datetimeProp'] == null ? undefined : ((value['datetimeProp'] as any).toISOString()),
         'array_nullable_prop': value['arrayNullableProp'],
         'array_and_items_nullable_prop': value['arrayAndItemsNullableProp'],
         'array_items_nullable': value['arrayItemsNullable'],

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function NumberOnlyFromJSON(json: any): NumberOnly {
 }
 
 export function NumberOnlyFromJSONTyped(json: any, ignoreDiscriminator: boolean): NumberOnly {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'justNumber': !exists(json, 'JustNumber') ? undefined : json['JustNumber'],
+        'justNumber': json['JustNumber'] == null ? undefined : json['JustNumber'],
     };
 }
 
 export function NumberOnlyToJSON(value?: NumberOnly | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { DeprecatedObject } from './DeprecatedObject';
 import {
     DeprecatedObjectFromJSON,
@@ -67,24 +67,21 @@ export function ObjectWithDeprecatedFieldsFromJSON(json: any): ObjectWithDepreca
 }
 
 export function ObjectWithDeprecatedFieldsFromJSONTyped(json: any, ignoreDiscriminator: boolean): ObjectWithDeprecatedFields {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'uuid': !exists(json, 'uuid') ? undefined : json['uuid'],
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'deprecatedRef': !exists(json, 'deprecatedRef') ? undefined : DeprecatedObjectFromJSON(json['deprecatedRef']),
-        'bars': !exists(json, 'bars') ? undefined : json['bars'],
+        'uuid': json['uuid'] == null ? undefined : json['uuid'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'deprecatedRef': json['deprecatedRef'] == null ? undefined : DeprecatedObjectFromJSON(json['deprecatedRef']),
+        'bars': json['bars'] == null ? undefined : json['bars'],
     };
 }
 
 export function ObjectWithDeprecatedFieldsToJSON(value?: ObjectWithDeprecatedFields | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -51,23 +51,20 @@ export function OuterCompositeFromJSON(json: any): OuterComposite {
 }
 
 export function OuterCompositeFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterComposite {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'myNumber': !exists(json, 'my_number') ? undefined : json['my_number'],
-        'myString': !exists(json, 'my_string') ? undefined : json['my_string'],
-        'myBoolean': !exists(json, 'my_boolean') ? undefined : json['my_boolean'],
+        'myNumber': json['my_number'] == null ? undefined : json['my_number'],
+        'myString': json['my_string'] == null ? undefined : json['my_string'],
+        'myBoolean': json['my_boolean'] == null ? undefined : json['my_boolean'],
     };
 }
 
 export function OuterCompositeToJSON(value?: OuterComposite | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { OuterEnumInteger } from './OuterEnumInteger';
 import {
     OuterEnumIntegerFromJSON,
@@ -47,7 +47,7 @@ export function OuterObjectWithEnumPropertyFromJSON(json: any): OuterObjectWithE
 }
 
 export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscriminator: boolean): OuterObjectWithEnumProperty {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
@@ -57,11 +57,8 @@ export function OuterObjectWithEnumPropertyFromJSONTyped(json: any, ignoreDiscri
 }
 
 export function OuterObjectWithEnumPropertyToJSON(value?: OuterObjectWithEnumProperty | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': Array.from(value['photoUrls'] as Set<any>),
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function ReadOnlyFirstFromJSON(json: any): ReadOnlyFirst {
 }
 
 export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boolean): ReadOnlyFirst {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'bar': !exists(json, 'bar') ? undefined : json['bar'],
-        'baz': !exists(json, 'baz') ? undefined : json['baz'],
+        'bar': json['bar'] == null ? undefined : json['bar'],
+        'baz': json['baz'] == null ? undefined : json['baz'],
     };
 }
 
 export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Model for testing reserved words
  * @export
@@ -39,21 +39,18 @@ export function ReturnFromJSON(json: any): Return {
 }
 
 export function ReturnFromJSONTyped(json: any, ignoreDiscriminator: boolean): Return {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '_return': !exists(json, 'return') ? undefined : json['return'],
+        '_return': json['return'] == null ? undefined : json['return'],
     };
 }
 
 export function ReturnToJSON(value?: Return | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -39,21 +39,18 @@ export function SpecialModelNameFromJSON(json: any): SpecialModelName {
 }
 
 export function SpecialModelNameFromJSONTyped(json: any, ignoreDiscriminator: boolean): SpecialModelName {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        '$specialPropertyName': !exists(json, '$special[property.name]') ? undefined : json['$special[property.name]'],
+        '$specialPropertyName': json['$special[property.name]'] == null ? undefined : json['$special[property.name]'],
     };
 }
 
 export function SpecialModelNameToJSON(value?: SpecialModelName | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/PetApi.ts
@@ -210,7 +210,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -250,7 +250,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -261,7 +261,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -292,7 +292,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -301,7 +301,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -337,7 +337,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -346,7 +346,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -382,7 +382,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -420,7 +420,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -460,7 +460,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -490,11 +490,11 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -520,7 +520,7 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -552,11 +552,11 @@ export class PetApi extends runtime.BaseAPI implements PetApiInterface {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/StoreApi.ts
@@ -115,7 +115,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -181,7 +181,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -215,7 +215,7 @@ export class StoreApi extends runtime.BaseAPI implements StoreApiInterface {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/apis/UserApi.ts
@@ -195,7 +195,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -231,7 +231,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -266,7 +266,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -302,7 +302,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -335,7 +335,7 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -368,14 +368,14 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -384,11 +384,11 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -446,14 +446,14 @@ export class UserApi extends runtime.BaseAPI implements UserApiInterface {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/PetApi.ts
@@ -71,7 +71,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -111,7 +111,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -122,7 +122,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -153,7 +153,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -162,7 +162,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -198,7 +198,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -207,7 +207,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -243,7 +243,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -281,7 +281,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -321,7 +321,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -351,11 +351,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -381,7 +381,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -413,11 +413,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/StoreApi.ts
@@ -44,7 +44,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -110,7 +110,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -144,7 +144,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/apis/UserApi.ts
@@ -62,7 +62,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -98,7 +98,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -133,7 +133,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -169,7 +169,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -202,7 +202,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -235,14 +235,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -251,11 +251,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -313,14 +313,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A category for a pet
  * @export
@@ -45,22 +45,19 @@ export function CategoryFromJSON(json: any): Category {
 }
 
 export function CategoryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Category {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function CategoryToJSON(value?: Category | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * Describes the result of uploading an image resource
  * @export
@@ -51,23 +51,20 @@ export function ModelApiResponseFromJSON(json: any): ModelApiResponse {
 }
 
 export function ModelApiResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): ModelApiResponse {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'code': !exists(json, 'code') ? undefined : json['code'],
-        'type': !exists(json, 'type') ? undefined : json['type'],
-        'message': !exists(json, 'message') ? undefined : json['message'],
+        'code': json['code'] == null ? undefined : json['code'],
+        'type': json['type'] == null ? undefined : json['type'],
+        'message': json['message'] == null ? undefined : json['message'],
     };
 }
 
 export function ModelApiResponseToJSON(value?: ModelApiResponse | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * An order for a pets from the pet store
  * @export
@@ -81,33 +81,30 @@ export function OrderFromJSON(json: any): Order {
 }
 
 export function OrderFromJSONTyped(json: any, ignoreDiscriminator: boolean): Order {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'petId': !exists(json, 'petId') ? undefined : json['petId'],
-        'quantity': !exists(json, 'quantity') ? undefined : json['quantity'],
-        'shipDate': !exists(json, 'shipDate') ? undefined : (new Date(json['shipDate'])),
-        'status': !exists(json, 'status') ? undefined : json['status'],
-        'complete': !exists(json, 'complete') ? undefined : json['complete'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'petId': json['petId'] == null ? undefined : json['petId'],
+        'quantity': json['quantity'] == null ? undefined : json['quantity'],
+        'shipDate': json['shipDate'] == null ? undefined : (new Date(json['shipDate'])),
+        'status': json['status'] == null ? undefined : json['status'],
+        'complete': json['complete'] == null ? undefined : json['complete'],
     };
 }
 
 export function OrderToJSON(value?: Order | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
         'id': value['id'],
         'petId': value['petId'],
         'quantity': value['quantity'],
-        'shipDate': !exists(value, 'shipDate') ? undefined : ((value['shipDate']).toISOString()),
+        'shipDate': value['shipDate'] == null ? undefined : ((value['shipDate']).toISOString()),
         'status': value['status'],
         'complete': value['complete'],
     };

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { Category } from './Category';
 import {
     CategoryFromJSON,
@@ -96,26 +96,23 @@ export function PetFromJSON(json: any): Pet {
 }
 
 export function PetFromJSONTyped(json: any, ignoreDiscriminator: boolean): Pet {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'category': !exists(json, 'category') ? undefined : CategoryFromJSON(json['category']),
+        'id': json['id'] == null ? undefined : json['id'],
+        'category': json['category'] == null ? undefined : CategoryFromJSON(json['category']),
         'name': json['name'],
         'photoUrls': json['photoUrls'],
-        'tags': !exists(json, 'tags') ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
-        'status': !exists(json, 'status') ? undefined : json['status'],
+        'tags': json['tags'] == null ? undefined : ((json['tags'] as Array<any>).map(TagFromJSON)),
+        'status': json['status'] == null ? undefined : json['status'],
     };
 }
 
 export function PetToJSON(value?: Pet | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         
@@ -123,7 +120,7 @@ export function PetToJSON(value?: Pet | null): any {
         'category': CategoryToJSON(value['category']),
         'name': value['name'],
         'photoUrls': value['photoUrls'],
-        'tags': !exists(value, 'tags') ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
+        'tags': value['tags'] == null ? undefined : ((value['tags'] as Array<any>).map(TagToJSON)),
         'status': value['status'],
     };
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A tag for a pet
  * @export
@@ -45,22 +45,19 @@ export function TagFromJSON(json: any): Tag {
 }
 
 export function TagFromJSONTyped(json: any, ignoreDiscriminator: boolean): Tag {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'name': !exists(json, 'name') ? undefined : json['name'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'name': json['name'] == null ? undefined : json['name'],
     };
 }
 
 export function TagToJSON(value?: Tag | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * A User who is purchasing from the pet store
  * @export
@@ -81,28 +81,25 @@ export function UserFromJSON(json: any): User {
 }
 
 export function UserFromJSONTyped(json: any, ignoreDiscriminator: boolean): User {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'id': !exists(json, 'id') ? undefined : json['id'],
-        'username': !exists(json, 'username') ? undefined : json['username'],
-        'firstName': !exists(json, 'firstName') ? undefined : json['firstName'],
-        'lastName': !exists(json, 'lastName') ? undefined : json['lastName'],
-        'email': !exists(json, 'email') ? undefined : json['email'],
-        'password': !exists(json, 'password') ? undefined : json['password'],
-        'phone': !exists(json, 'phone') ? undefined : json['phone'],
-        'userStatus': !exists(json, 'userStatus') ? undefined : json['userStatus'],
+        'id': json['id'] == null ? undefined : json['id'],
+        'username': json['username'] == null ? undefined : json['username'],
+        'firstName': json['firstName'] == null ? undefined : json['firstName'],
+        'lastName': json['lastName'] == null ? undefined : json['lastName'],
+        'email': json['email'] == null ? undefined : json['email'],
+        'password': json['password'] == null ? undefined : json['password'],
+        'phone': json['phone'] == null ? undefined : json['phone'],
+        'userStatus': json['userStatus'] == null ? undefined : json['userStatus'],
     };
 }
 
 export function UserToJSON(value?: User | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/apis/DefaultApi.ts
@@ -63,19 +63,19 @@ export class DefaultApi extends runtime.BaseAPI {
     async fakeEnumRequestGetInlineRaw(requestParameters: FakeEnumRequestGetInlineRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<FakeEnumRequestGetInline200Response>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'stringEnum')) {
+        if (requestParameters['stringEnum'] != null) {
             queryParameters['string-enum'] = requestParameters['stringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableStringEnum')) {
+        if (requestParameters['nullableStringEnum'] != null) {
             queryParameters['nullable-string-enum'] = requestParameters['nullableStringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'numberEnum')) {
+        if (requestParameters['numberEnum'] != null) {
             queryParameters['number-enum'] = requestParameters['numberEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableNumberEnum')) {
+        if (requestParameters['nullableNumberEnum'] != null) {
             queryParameters['nullable-number-enum'] = requestParameters['nullableNumberEnum'];
         }
 
@@ -103,19 +103,19 @@ export class DefaultApi extends runtime.BaseAPI {
     async fakeEnumRequestGetRefRaw(requestParameters: FakeEnumRequestGetRefRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<EnumPatternObject>> {
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'stringEnum')) {
+        if (requestParameters['stringEnum'] != null) {
             queryParameters['string-enum'] = requestParameters['stringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableStringEnum')) {
+        if (requestParameters['nullableStringEnum'] != null) {
             queryParameters['nullable-string-enum'] = requestParameters['nullableStringEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'numberEnum')) {
+        if (requestParameters['numberEnum'] != null) {
             queryParameters['number-enum'] = requestParameters['numberEnum'];
         }
 
-        if (runtime.exists(requestParameters, 'nullableNumberEnum')) {
+        if (requestParameters['nullableNumberEnum'] != null) {
             queryParameters['nullable-number-enum'] = requestParameters['nullableNumberEnum'];
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 import type { NumberEnum } from './NumberEnum';
 import {
     NumberEnumFromJSON,
@@ -70,24 +70,21 @@ export function EnumPatternObjectFromJSON(json: any): EnumPatternObject {
 }
 
 export function EnumPatternObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): EnumPatternObject {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'stringEnum': !exists(json, 'string-enum') ? undefined : StringEnumFromJSON(json['string-enum']),
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
-        'numberEnum': !exists(json, 'number-enum') ? undefined : NumberEnumFromJSON(json['number-enum']),
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
+        'stringEnum': json['string-enum'] == null ? undefined : StringEnumFromJSON(json['string-enum']),
+        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : StringEnumFromJSON(json['nullable-string-enum']),
+        'numberEnum': json['number-enum'] == null ? undefined : NumberEnumFromJSON(json['number-enum']),
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : NumberEnumFromJSON(json['nullable-number-enum']),
     };
 }
 
 export function EnumPatternObjectToJSON(value?: EnumPatternObject | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -12,7 +12,7 @@
  * Do not edit the class manually.
  */
 
-import { exists, mapValues } from '../runtime';
+import { mapValues } from '../runtime';
 /**
  * 
  * @export
@@ -95,24 +95,21 @@ export function FakeEnumRequestGetInline200ResponseFromJSON(json: any): FakeEnum
 }
 
 export function FakeEnumRequestGetInline200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): FakeEnumRequestGetInline200Response {
-    if (json === undefined || json === null) {
+    if (json == null) {
         return json;
     }
     return {
         
-        'stringEnum': !exists(json, 'string-enum') ? undefined : json['string-enum'],
-        'nullableStringEnum': !exists(json, 'nullable-string-enum') ? undefined : json['nullable-string-enum'],
-        'numberEnum': !exists(json, 'number-enum') ? undefined : json['number-enum'],
-        'nullableNumberEnum': !exists(json, 'nullable-number-enum') ? undefined : json['nullable-number-enum'],
+        'stringEnum': json['string-enum'] == null ? undefined : json['string-enum'],
+        'nullableStringEnum': json['nullable-string-enum'] == null ? undefined : json['nullable-string-enum'],
+        'numberEnum': json['number-enum'] == null ? undefined : json['number-enum'],
+        'nullableNumberEnum': json['nullable-number-enum'] == null ? undefined : json['nullable-number-enum'],
     };
 }
 
 export function FakeEnumRequestGetInline200ResponseToJSON(value?: FakeEnumRequestGetInline200Response | null): any {
-    if (value === undefined) {
-        return undefined;
-    }
-    if (value === null) {
-        return null;
+    if (value == null) {
+        return value;
     }
     return {
         

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/runtime.ts
@@ -310,11 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-export function exists(json: any, key: string): boolean {
-    const value = json[key];
-    return value !== undefined && value !== null;
-}
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/PetApi.ts
@@ -65,7 +65,7 @@ export class PetApi extends runtime.BaseAPI {
      * Add a new pet to the store
      */
     async addPetRaw(requestParameters: AddPetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling addPet().'
@@ -105,7 +105,7 @@ export class PetApi extends runtime.BaseAPI {
      * Deletes a pet
      */
     async deletePetRaw(requestParameters: DeletePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling deletePet().'
@@ -116,7 +116,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const headerParameters: runtime.HTTPHeaders = {};
 
-        if (runtime.exists(requestParameters, 'apiKey')) {
+        if (requestParameters['apiKey'] != null) {
             headerParameters['api_key'] = String(requestParameters['apiKey']);
         }
 
@@ -147,7 +147,7 @@ export class PetApi extends runtime.BaseAPI {
      * Finds Pets by status
      */
     async findPetsByStatusRaw(requestParameters: FindPetsByStatusRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] == null) {
             throw new runtime.RequiredError(
                 'status',
                 'Required parameter "status" was null or undefined when calling findPetsByStatus().'
@@ -156,7 +156,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             queryParameters['status'] = requestParameters['status']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -192,7 +192,7 @@ export class PetApi extends runtime.BaseAPI {
      * @deprecated
      */
     async findPetsByTagsRaw(requestParameters: FindPetsByTagsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Pet>>> {
-        if (!runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] == null) {
             throw new runtime.RequiredError(
                 'tags',
                 'Required parameter "tags" was null or undefined when calling findPetsByTags().'
@@ -201,7 +201,7 @@ export class PetApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'tags')) {
+        if (requestParameters['tags'] != null) {
             queryParameters['tags'] = requestParameters['tags']!.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
@@ -237,7 +237,7 @@ export class PetApi extends runtime.BaseAPI {
      * Find pet by ID
      */
     async getPetByIdRaw(requestParameters: GetPetByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Pet>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling getPetById().'
@@ -275,7 +275,7 @@ export class PetApi extends runtime.BaseAPI {
      * Update an existing pet
      */
     async updatePetRaw(requestParameters: UpdatePetRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updatePet().'
@@ -315,7 +315,7 @@ export class PetApi extends runtime.BaseAPI {
      * Updates a pet in the store with form data
      */
     async updatePetWithFormRaw(requestParameters: UpdatePetWithFormRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling updatePetWithForm().'
@@ -345,11 +345,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'name')) {
+        if (requestParameters['name'] != null) {
             formParams.append('name', requestParameters['name'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'status')) {
+        if (requestParameters['status'] != null) {
             formParams.append('status', requestParameters['status'] as any);
         }
 
@@ -375,7 +375,7 @@ export class PetApi extends runtime.BaseAPI {
      * uploads an image
      */
     async uploadFileRaw(requestParameters: UploadFileRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ModelApiResponse>> {
-        if (!runtime.exists(requestParameters, 'petId')) {
+        if (requestParameters['petId'] == null) {
             throw new runtime.RequiredError(
                 'petId',
                 'Required parameter "petId" was null or undefined when calling uploadFile().'
@@ -407,11 +407,11 @@ export class PetApi extends runtime.BaseAPI {
             formParams = new URLSearchParams();
         }
 
-        if (runtime.exists(requestParameters, 'additionalMetadata')) {
+        if (requestParameters['additionalMetadata'] != null) {
             formParams.append('additionalMetadata', requestParameters['additionalMetadata'] as any);
         }
 
-        if (runtime.exists(requestParameters, 'file')) {
+        if (requestParameters['file'] != null) {
             formParams.append('file', requestParameters['file'] as any);
         }
 

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/StoreApi.ts
@@ -40,7 +40,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Delete purchase order by ID
      */
     async deleteOrderRaw(requestParameters: DeleteOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling deleteOrder().'
@@ -106,7 +106,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Find purchase order by ID
      */
     async getOrderByIdRaw(requestParameters: GetOrderByIdRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'orderId')) {
+        if (requestParameters['orderId'] == null) {
             throw new runtime.RequiredError(
                 'orderId',
                 'Required parameter "orderId" was null or undefined when calling getOrderById().'
@@ -140,7 +140,7 @@ export class StoreApi extends runtime.BaseAPI {
      * Place an order for a pet
      */
     async placeOrderRaw(requestParameters: PlaceOrderRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Order>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling placeOrder().'

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/apis/UserApi.ts
@@ -58,7 +58,7 @@ export class UserApi extends runtime.BaseAPI {
      * Create user
      */
     async createUserRaw(requestParameters: CreateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUser().'
@@ -94,7 +94,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithArrayInputRaw(requestParameters: CreateUsersWithArrayInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithArrayInput().'
@@ -129,7 +129,7 @@ export class UserApi extends runtime.BaseAPI {
      * Creates list of users with given input array
      */
     async createUsersWithListInputRaw(requestParameters: CreateUsersWithListInputRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling createUsersWithListInput().'
@@ -165,7 +165,7 @@ export class UserApi extends runtime.BaseAPI {
      * Delete user
      */
     async deleteUserRaw(requestParameters: DeleteUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling deleteUser().'
@@ -198,7 +198,7 @@ export class UserApi extends runtime.BaseAPI {
      * Get user by user name
      */
     async getUserByNameRaw(requestParameters: GetUserByNameRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<User>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling getUserByName().'
@@ -231,14 +231,14 @@ export class UserApi extends runtime.BaseAPI {
      * Logs user into the system
      */
     async loginUserRaw(requestParameters: LoginUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<string>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling loginUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] == null) {
             throw new runtime.RequiredError(
                 'password',
                 'Required parameter "password" was null or undefined when calling loginUser().'
@@ -247,11 +247,11 @@ export class UserApi extends runtime.BaseAPI {
 
         const queryParameters: any = {};
 
-        if (runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] != null) {
             queryParameters['username'] = requestParameters['username'];
         }
 
-        if (runtime.exists(requestParameters, 'password')) {
+        if (requestParameters['password'] != null) {
             queryParameters['password'] = requestParameters['password'];
         }
 
@@ -309,14 +309,14 @@ export class UserApi extends runtime.BaseAPI {
      * Updated user
      */
     async updateUserRaw(requestParameters: UpdateUserRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
-        if (!runtime.exists(requestParameters, 'username')) {
+        if (requestParameters['username'] == null) {
             throw new runtime.RequiredError(
                 'username',
                 'Required parameter "username" was null or undefined when calling updateUser().'
             );
         }
 
-        if (!runtime.exists(requestParameters, 'body')) {
+        if (requestParameters['body'] == null) {
             throw new runtime.RequiredError(
                 'body',
                 'Required parameter "body" was null or undefined when calling updateUser().'

--- a/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
+++ b/samples/client/petstore/typescript-fetch/builds/without-runtime-checks/src/runtime.ts
@@ -310,7 +310,6 @@ export interface RequestOpts {
     body?: HTTPBody;
 }
 
-
 export function querystring(params: HTTPQuery, prefix: string = ''): string {
     return Object.keys(params)
         .map(key => querystringSingleKey(key, params[key], prefix))


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fix: #17970

The root cause of the issue is that Typescript compiler does not understand that the `exists()` function ensures the property is not null or undefined. This PR replaces all `exists()` with `==` operator, which is more efficient way to do the same thing.
I've also refactored some verbose code like `if (json === undefined || json === null)` to `if (json == null)`.

To committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
