### PR TITLE
[java] Update feign to newer version: 13.2.1

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/feign/pom.mustache
@@ -380,7 +380,7 @@
         {{#swagger2AnnotationLibrary}}
         <swagger-annotations-version>2.2.15</swagger-annotations-version>
         {{/swagger2AnnotationLibrary}}
-        <feign-version>12.5</feign-version>
+        <feign-version>13.2.1</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         {{#jackson}}
         <jackson-version>2.15.2</jackson-version>

--- a/samples/client/echo_api/java/feign-gson/pom.xml
+++ b/samples/client/echo_api/java/feign-gson/pom.xml
@@ -300,7 +300,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <feign-version>12.5</feign-version>
+        <feign-version>13.2.1</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         <gson-version>2.10.1</gson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>

--- a/samples/client/petstore/java/feign-no-nullable/pom.xml
+++ b/samples/client/petstore/java/feign-no-nullable/pom.xml
@@ -311,7 +311,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <feign-version>12.5</feign-version>
+        <feign-version>13.2.1</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         <jackson-version>2.15.2</jackson-version>
         <jackson-databind-version>2.15.2</jackson-databind-version>

--- a/samples/client/petstore/java/feign/pom.xml
+++ b/samples/client/petstore/java/feign/pom.xml
@@ -316,7 +316,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <feign-version>12.5</feign-version>
+        <feign-version>13.2.1</feign-version>
         <feign-form-version>3.8.0</feign-form-version>
         <jackson-version>2.15.2</jackson-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>


### PR DESCRIPTION
update feign to `13.2.1`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


cc
@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
