### PR TITLE
feat(cpp-ue4): additionalproperties modelNameCamelize, modelFilenameCamelize

### DIFF
--- a/docs/generators/cpp-ue4.md
+++ b/docs/generators/cpp-ue4.md
@@ -31,6 +31,8 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |sortParamsByRequiredFlag|Sort method arguments to place required parameters before optional parameters.| |true|
 |unrealModuleName|Name of the generated unreal module (optional)| |OpenAPI|
 |variableNameFirstCharacterUppercase|Make first character of variable name uppercase (eg. value -&gt; Value)| |true|
+|modelNameCamelize|Do not camelize model name|<dl><dt>**true**</dt><dd>Schema name `FT1Model_HelloWorldRequest` uses the class name `FT1ModelHelloWorldRequest`.</dd><dt>**false**</dt><dd>Schema name `FT1Model_HelloWorldRequest` uses the class name `FT1Model_HelloWorldRequest`.</dd></dl>|true|
+|modelFilenameCamelize|Do not camelize model filename|<dl><dt>**true**</dt><dd>Schema name `FT1Model_HelloWorldRequest` uses the filename `FT1ModelHelloWorldRequest`.</dd><dt>**false**</dt><dd>Schema name `FT1Model_HelloWorldRequest` uses the filename `FT1Model_HelloWorldRequest`.</dd></dl>|true|
 
 ## IMPORT MAPPING
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
@@ -49,8 +49,8 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
     protected Set<String> systemIncludes = new HashSet<>();
     protected String cppNamespace = unrealModuleName;
     protected boolean optionalProjectFileFlag = true;
-    private boolean modelNameCamelize = true;
-    private boolean modelFilenameCamelize = true;
+    protected boolean modelNameCamelize = true;
+    protected boolean modelFilenameCamelize = true;
 
     public CppUE4ClientCodegen() {
         super();
@@ -221,13 +221,11 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
             updateSupportingFiles = true;
         }
 
-        if (additionalProperties.containsKey("modelNameCamelize"))
-        {
+        if (additionalProperties.containsKey("modelNameCamelize")) {
             modelNameCamelize = (boolean) additionalProperties.get("modelNameCamelize");
         }
 
-        if (additionalProperties.containsKey("modelFilenameCamelize"))
-        {
+        if (additionalProperties.containsKey("modelFilenameCamelize")) {
             modelFilenameCamelize = (boolean) additionalProperties.get("modelFilenameCamelize");
         }
 
@@ -515,7 +513,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
         String camelCaseName = camelize(name);
 
         //Avoid empty variable name at all costs
-        if(!camelCaseName.isEmpty()) {
+        if (!camelCaseName.isEmpty()) {
             name = camelCaseName;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/CppUE4ClientCodegen.java
@@ -49,6 +49,8 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
     protected Set<String> systemIncludes = new HashSet<>();
     protected String cppNamespace = unrealModuleName;
     protected boolean optionalProjectFileFlag = true;
+    private boolean modelNameCamelize = true;
+    private boolean modelFilenameCamelize = true;
 
     public CppUE4ClientCodegen() {
         super();
@@ -219,6 +221,16 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
             updateSupportingFiles = true;
         }
 
+        if (additionalProperties.containsKey("modelNameCamelize"))
+        {
+            modelNameCamelize = (boolean) additionalProperties.get("modelNameCamelize");
+        }
+
+        if (additionalProperties.containsKey("modelFilenameCamelize"))
+        {
+            modelFilenameCamelize = (boolean) additionalProperties.get("modelFilenameCamelize");
+        }
+
         if (additionalProperties.containsKey(CodegenConstants.OPTIONAL_PROJECT_FILE)) {
             setOptionalProjectFileFlag(convertPropertyToBooleanAndWriteBack(CodegenConstants.OPTIONAL_PROJECT_FILE));
         } else {
@@ -349,7 +361,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
     @Override
     public String toModelFilename(String name) {
         name = sanitizeName(name);
-        return modelNamePrefix + camelize(name);
+        return modelNamePrefix + (modelFilenameCamelize ? camelize(name) : name);
     }
 
     @Override
@@ -485,7 +497,7 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
                 languageSpecificPrimitives.contains(type)) {
             return type;
         } else {
-            return modelNamePrefix + camelize(sanitizeName(type));
+            return modelNamePrefix + (modelNameCamelize ? camelize(sanitizeName(type)) : sanitizeName(type));
         }
     }
 
@@ -554,5 +566,21 @@ public class CppUE4ClientCodegen extends AbstractCppCodegen {
     @Override
     public String toSetter(String name) {
         return "Set" + getterAndSetterCapitalize(name);
+    }
+
+    public boolean getModelNameCamelize() {
+        return modelNameCamelize;
+    }
+
+    public void setModelNameCamelize(boolean isCamelize) {
+        modelNameCamelize = isCamelize;
+    }
+
+    public boolean getModelFilenameCamelize() {
+        return modelFilenameCamelize;
+    }
+
+    public void setModelFilenameCamelize(boolean isCamelize) {
+        modelFilenameCamelize = isCamelize;
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/cppue4/CppUE4AdditionalPropertiesTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/cppue4/CppUE4AdditionalPropertiesTest.java
@@ -1,0 +1,42 @@
+package org.openapitools.codegen.cppue4;
+
+import org.openapitools.codegen.languages.CppUE4ClientCodegen;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CppUE4AdditionalPropertiesTest {
+    protected CppUE4ClientCodegen codegen = new CppUE4ClientCodegen();
+
+    @Test(description = "When set modelNameCamelize is true, then modelName 'Model_HelloRequest' should be 'ModelHelloRequest'")
+    public void shouldModelNameCamelize() {
+        // Arrange
+        String packageName = "OpenAPI";
+        String modelName = "Model_HelloRequest";
+        String expectedModelName = modelName.replace("_", "");
+        boolean isCamelize = true;
+
+        codegen.setModelNameCamelize(isCamelize);
+
+        // Act
+        String actualModelName = codegen.toModelName("Model_HelloRequest");
+
+        // Assert
+        Assert.assertEquals(actualModelName, packageName + expectedModelName);
+    }
+
+    @Test(description = "When set modelNameCamelize is false, then modelName 'Model_HelloRequest' should be 'Model_HelloRequest'")
+    public void shouldNotModelNameCamelize() {
+        // Arrange
+        String packageName = "OpenAPI";
+        String modelName = "Model_HelloRequest";
+        boolean isCamelize = false;
+
+        codegen.setModelNameCamelize(isCamelize);
+
+        // Act
+        String actualModelName = codegen.toModelName("Model_HelloRequest");
+
+        // Assert
+        Assert.assertEquals(actualModelName, packageName + modelName);
+    }
+}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Issue #17981 
Following @wing328 

I added additionalProperties of `modelNameCamelize` and `modelFilenameCamelize`.

If you set `modelNameCamelize` to true, `FT1Model_HelloWorldRequest -> FT1ModelHelloWorldRequest`.
And you set `modelNameCamelize` to false, `FT1Model_HelloWorldRequest -> FT1Model_HelloWorldRequest`.

Also `modelFilenameCamelize` is similar.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
