### PR TITLE
inputSpec should not be mandatory when inputSpecRootDirectory is set

### DIFF
--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -115,7 +115,7 @@ public class CodeGenMojo extends AbstractMojo {
     /**
      * Location of the OpenAPI spec, as URL or file.
      */
-    @Parameter(name = "inputSpec", property = "openapi.generator.maven.plugin.inputSpec", required = true)
+    @Parameter(name = "inputSpec", property = "openapi.generator.maven.plugin.inputSpec")
     private String inputSpec;
 
     /**
@@ -557,6 +557,11 @@ public class CodeGenMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (StringUtils.isBlank(inputSpec) && StringUtils.isBlank(inputSpecRootDirectory)) {
+            LOGGER.error("inputSpec or inputSpecRootDirectory must be specified");
+            throw new MojoExecutionException("inputSpec or inputSpecRootDirectory must be specified");
+        }
+
         if (StringUtils.isNotBlank(inputSpecRootDirectory)) {
             inputSpec = new MergedSpecBuilder(inputSpecRootDirectory, mergedFileName)
                 .buildMergedSpec();

--- a/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
+++ b/modules/openapi-generator-maven-plugin/src/main/java/org/openapitools/codegen/plugin/CodeGenMojo.java
@@ -116,13 +116,13 @@ public class CodeGenMojo extends AbstractMojo {
      * Location of the OpenAPI spec, as URL or file.
      */
     @Parameter(name = "inputSpec", property = "openapi.generator.maven.plugin.inputSpec")
-    private String inputSpec;
+    protected String inputSpec;
 
     /**
      * Local root folder with spec files
      */
     @Parameter(name = "inputSpecRootDirectory", property = "openapi.generator.maven.plugin.inputSpecRootDirectory")
-    private String inputSpecRootDirectory;
+    protected String inputSpecRootDirectory;
 
     /**
      * Name of the file that will contain all merged specs

--- a/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
+++ b/modules/openapi-generator-maven-plugin/src/test/java/org/openapitools/codegen/plugin/CodeGenMojoTest.java
@@ -16,6 +16,8 @@
 
 package org.openapitools.codegen.plugin;
 
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,6 +33,7 @@ import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -179,6 +182,36 @@ public class CodeGenMojoTest extends BaseTestCase {
             .filter(artifact -> artifact.getFile().getName().equals("petstore-full-spec.yaml"))
             .collect(Collectors.toList());
         assertEquals(1, matchingArtifacts.size());
+    }
+
+    public void testAnyInputSpecMustBeProvided() throws Exception {
+        // GIVEN
+        Path folder = Files.createTempDirectory("test");
+        CodeGenMojo mojo = loadMojo(folder.toFile(), "src/test/resources/default", "executionId");
+        mojo.inputSpec = null;
+        mojo.inputSpecRootDirectory = null;
+
+        // WHEN
+        MojoExecutionException e = assertThrows(MojoExecutionException.class, mojo::execute);
+
+        // THEN
+        assertEquals("inputSpec or inputSpecRootDirectory must be specified", e.getMessage());
+    }
+
+    public void testInputSpecRootDirectoryDoesNotRequireInputSpec() throws Exception {
+        // GIVEN
+        Path folder = Files.createTempDirectory("test");
+        CodeGenMojo mojo = loadMojo(folder.toFile(), "src/test/resources/default", "executionId");
+        mojo.inputSpec = null;
+        mojo.inputSpecRootDirectory = "src/test/resources/default";
+
+        // WHEN
+        mojo.execute();
+
+        // THEN
+        /* Check the hash file was created */
+        final Path hashFolder = folder.resolve("target/generated-sources/common-maven/remote-openapi/.openapi-generator");
+        assertTrue(hashFolder.resolve("_merged_spec.yaml-executionId.sha256").toFile().exists());
     }
 
     protected CodeGenMojo loadMojo(File temporaryFolder, String projectRoot) throws Exception {


### PR DESCRIPTION
Fix #16955 : inputSpec should not be mandatory if inputSpecRootDirectory is set
(@borsch @wing328 )

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
