### PR TITLE
[Java][okhttp-gson] Redact authorization header and makes logging testable

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/okhttp-gson/ApiClient.mustache
@@ -73,6 +73,7 @@ import {{invokerPackage}}.auth.AWS4Auth;
 /**
  * <p>ApiClient class.</p>
  */
+{{>generatedAnnotation}}
 public class ApiClient {
 
     private String basePath = "{{{basePath}}}";
@@ -122,6 +123,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     {{#dynamicOperations}}
@@ -705,7 +710,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -59,6 +59,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://localhost:3000";
@@ -90,6 +91,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -544,7 +549,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-oneOf/src/main/java/org/openapitools/client/ApiClient.java
@@ -59,6 +59,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://localhost";
@@ -90,6 +91,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -518,7 +523,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/ApiClient.java
@@ -59,6 +59,7 @@ import org.openapitools.client.auth.ApiKeyAuth;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://localhost:8082";
@@ -90,6 +91,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -518,7 +523,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -600,7 +605,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-awsv4signature/src/main/java/org/openapitools/client/ApiClient.java
@@ -65,6 +65,7 @@ import org.openapitools.client.auth.AWS4Auth;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -96,6 +97,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -612,7 +617,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-dynamicOperations/src/main/java/org/openapitools/client/ApiClient.java
@@ -70,6 +70,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io:80/v2";
@@ -101,6 +102,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     private Map<String, ApiOperation> operationLookupMap = new HashMap<>();
@@ -617,7 +622,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-group-parameter/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -600,7 +605,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-nullable-required/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -603,7 +608,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-parcelableModel/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io:80/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -606,7 +611,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -600,7 +605,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io/v2";
@@ -95,6 +96,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -600,7 +605,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {

--- a/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/okhttp-gson/src/main/java/org/openapitools/client/ApiClient.java
@@ -64,6 +64,7 @@ import org.openapitools.client.auth.OAuthFlow;
 /**
  * <p>ApiClient class.</p>
  */
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class ApiClient {
 
     private String basePath = "http://petstore.swagger.io:80/v2";
@@ -138,6 +139,10 @@ public class ApiClient {
     private OkHttpClient httpClient;
     private JSON json;
 
+    /**
+     * Visible so that unit tests don't have to mock java.util.logging.
+     */
+    HttpLoggingInterceptor.Logger debugLogger = HttpLoggingInterceptor.Logger.DEFAULT;
     private HttpLoggingInterceptor loggingInterceptor;
 
     /**
@@ -674,7 +679,8 @@ public class ApiClient {
     public ApiClient setDebugging(boolean debugging) {
         if (debugging != this.debugging) {
             if (debugging) {
-                loggingInterceptor = new HttpLoggingInterceptor();
+                loggingInterceptor = new HttpLoggingInterceptor(debugLogger);
+                loggingInterceptor.redactHeader("authorization");
                 loggingInterceptor.setLevel(Level.BODY);
                 httpClient = httpClient.newBuilder().addInterceptor(loggingInterceptor).build();
             } else {


### PR DESCRIPTION
To [Java technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee): @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)

Right now, if you apply `.setDebugging(true)` on an okhttp-gson client with authentication, the "authorization" header ends up in the logs. When this is a token (as in the case of kubernetes), it fills up logs with distracting, and possibly sensitive info.

This redacts the "authorization" header by default, and makes the logging interceptor testable. This also adds the generated annotation, as at first we forgot this was generated code. While okhttp treats headers case-insensitively, those writing tests in the same package can verify log output via the package-accessible `debugLogger`.

Here's an example test, using wiremock though I personally prefer using okhttp's mockserver to test okhttp
```java
  @Test
  public void testRedactsBearerAuthorizationHeader() throws Exception {
    // Set up the client with an API key
    ApiClient apiClient = new ApiClient().setBasePath(server.baseUrl());
    apiClient.setApiKey(TEST_API_KEY);

    // Setup debug logging, taking care to capture logs instead of propagating to Java logging
    StringBuilder logs = new StringBuilder();
    apiClient.debugLogger = l -> logs.append(l).append('\n');
    apiClient.setDebugging(true);

    // Make a request in the same fashion openapi generated code does
    List<Pair> queryParams =
        Arrays.asList(new Pair("resourceVersion", "1"), new Pair("watch", "false"));
    Map<String, String> headers = new HashMap<>();
    headers.put("Accept", "application/json");
    Call testCall =
        apiClient.buildCall(
            null,
            TEST_PATH,
            "GET",
            queryParams,
            Collections.emptyList(),
            null,
            headers,
            Collections.emptyMap(),
            Collections.emptyMap(),
            new String[] {"BearerToken"},
            null);

    // Enqueue a response on the mock server
    server.stubFor(
        get(urlEqualTo(TEST_PATH + "?resourceVersion=1&watch=false"))
            // Verify the server saw the API key
            .withHeader(AUTHORIZATION_NAME, new EqualToPattern(TEST_API_KEY))
            .willReturn(
                aResponse()
                    .withStatus(200)
                    .withHeader("Content-Type", "application/json")
                    .withBody(TEST_RESPONSE_BODY)));

    // Ensure the request completes, by verifying it received the expected response
    try (Response response = testCall.execute()) {
      assertThat(response.body().string(), equalTo(TEST_RESPONSE_BODY));
    }

    // Verify the logs never saw the API key
    assertThat(logs.toString(), containsString(AUTHORIZATION_NAME + ": ██"));
    assertThat(logs.toString(), not(containsString(AUTHORIZATION_NAME + ": " + TEST_API_KEY)));
  }
```

Note: I [raised this for kubernetes](https://github.com/kubernetes-client/java/pull/3116), and raising also here so we don't need to apply a diff permanently

cc @brendandburns @yue9944882

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
