### PR TITLE
fix KotlinServerCodegenTest and PostmanCollectionCodegenTest

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -715,6 +715,8 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             JsonNode actualObj = objectMapper.readTree(json);
             json = Json.pretty(actualObj);
             json = json.replace("\"", JSON_ESCAPE_DOUBLE_QUOTE);
+            json = json.replace("\r\n", JSON_ESCAPE_NEW_LINE);
+            json = json.replace("\r", JSON_ESCAPE_NEW_LINE);
             json = json.replace("\n", JSON_ESCAPE_NEW_LINE);
 
         } catch (JsonProcessingException e) {

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -1,11 +1,11 @@
 package org.openapitools.codegen.kotlin;
 
-import org.junit.Test;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.KotlinServerCodegen;
 import org.openapitools.codegen.languages.KotlinSpringServerCodegen;
+import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -180,7 +180,7 @@ public class KotlinServerCodegenTest {
                         .config(codegen))
                 .generate();
 
-        String outputPath = output.getAbsolutePath() + "src/main/kotlin/org/openapitools";
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools";
         Path order = Paths.get(outputPath + "/model/Order.kt");
         assertFileContains(
                 order,

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.models.tags.Tag;
 import org.junit.Assert;
-import org.junit.Test;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.openapitools.codegen.languages.PostmanCollectionCodegen;
+import org.testng.annotations.Test;
 
 import java.io.File;
 


### PR DESCRIPTION
- use correct `@Test` import - from TestNG instead of JUnit - in `KotlinServerCodegenTest` and `PostmanCollectionCodegenTest`
   Previously, tests in these two classes were not run by TestNG.
- add missing slash to file path in `KotlinServerCodegenTest`
- use "\n" line endings in `PostmanCollectionCodegen`, regardless of operating system

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
   Kotlin: @jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)