### PR TITLE
Make Schema type retrieval and checks 3.1 compatible

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -818,7 +818,7 @@ public class OpenAPINormalizer {
             }
         }
 
-        if (!(schema instanceof JsonSchema) && (schema.getType() == null || schema.getType().equals("null")) && schema.get$ref() == null) {
+        if (!(schema instanceof JsonSchema) && (ModelUtils.getSchemaType(schema) == null || ModelUtils.isNullType(schema)) && schema.get$ref() == null) {
             return true;
         }
 
@@ -1000,7 +1000,7 @@ public class OpenAPINormalizer {
 
         if (schema instanceof JsonSchema &&
                 schema.get$schema() == null &&
-                schema.getTypes() == null && schema.getType() == null) {
+                ModelUtils.getSchemaType(schema) == null) {
             // convert any type in v3.1 to empty schema (any type in v3.0 spec), any type example:
             // components:
             //  schemas:

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -409,6 +409,23 @@ public class ModelUtils {
     }
 
     /**
+     * Return the type of the specified schema
+     *
+     * @param schema the OAS schema
+     * @return the type of the specified schema
+     */
+    public static String getSchemaType(Schema schema) {
+        if (schema.getType() != null) {
+            // 3.0.x or 2.0 spec
+            return schema.getType();
+        } else if (schema.getTypes() != null && schema.getTypes().size() == 1) {
+            // 3.1 spec
+            return (String) schema.getTypes().iterator().next();
+        }
+        return null;
+    }
+
+    /**
      * Return true if the specified schema is type object
      * We can't use isObjectSchema because it requires properties to exist which is not required
      * We can't use isMap because it is true for AnyType use cases
@@ -417,16 +434,7 @@ public class ModelUtils {
      * @return true if the specified schema is an Object schema.
      */
     public static boolean isTypeObjectSchema(Schema schema) {
-        if (schema instanceof JsonSchema) { // 3.1 spec
-            if (schema.getTypes() != null && schema.getTypes().size() == 1) {
-                return SchemaTypeUtil.OBJECT_TYPE.equals(schema.getTypes().iterator().next());
-            } else {
-                // null type or  multiple types, e.g. [string, integer]
-                return false;
-            }
-        } else { // 3.0.x or 2.0 spec
-            return SchemaTypeUtil.OBJECT_TYPE.equals(schema.getType());
-        }
+        return SchemaTypeUtil.OBJECT_TYPE.equals(getSchemaType(schema));
     }
 
     /**
@@ -458,9 +466,9 @@ public class ModelUtils {
 
         return (schema instanceof ObjectSchema) ||
                 // must not be a map
-                (SchemaTypeUtil.OBJECT_TYPE.equals(schema.getType()) && !(schema instanceof MapSchema)) ||
+                (isTypeObjectSchema(schema) && !(schema instanceof MapSchema)) ||
                 // must have at least one property
-                (schema.getType() == null && schema.getProperties() != null && !schema.getProperties().isEmpty());
+                (getSchemaType(schema) == null && schema.getProperties() != null && !schema.getProperties().isEmpty());
     }
 
     /**
@@ -597,93 +605,93 @@ public class ModelUtils {
     }
 
     public static boolean isSet(Schema schema) {
-        return ModelUtils.isArraySchema(schema) && Boolean.TRUE.equals(schema.getUniqueItems());
+        return isArraySchema(schema) && Boolean.TRUE.equals(schema.getUniqueItems());
     }
 
     public static boolean isStringSchema(Schema schema) {
-        return schema instanceof StringSchema || SchemaTypeUtil.STRING_TYPE.equals(schema.getType());
+        return schema instanceof StringSchema || SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema));
     }
 
     public static boolean isIntegerSchema(Schema schema) {
-        return schema instanceof IntegerSchema || SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType());
+        return schema instanceof IntegerSchema || SchemaTypeUtil.INTEGER_TYPE.equals(getSchemaType(schema));
     }
 
     public static boolean isShortSchema(Schema schema) {
         // format: short (int32)
-        return SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType()) // type: integer
+        return SchemaTypeUtil.INTEGER_TYPE.equals(getSchemaType(schema)) // type: integer
                 && SchemaTypeUtil.INTEGER32_FORMAT.equals(schema.getFormat());
     }
 
     public static boolean isUnsignedIntegerSchema(Schema schema) {
-        return SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType()) && // type: integer
+        return SchemaTypeUtil.INTEGER_TYPE.equals(getSchemaType(schema)) && // type: integer
                 ("int32".equals(schema.getFormat()) || schema.getFormat() == null) && // format: int32
                 (schema.getExtensions() != null && (Boolean) schema.getExtensions().getOrDefault("x-unsigned", Boolean.FALSE));
     }
 
     public static boolean isLongSchema(Schema schema) {
         // format: long (int64)
-        return SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType()) // type: integer
+        return SchemaTypeUtil.INTEGER_TYPE.equals(getSchemaType(schema)) // type: integer
                 && SchemaTypeUtil.INTEGER64_FORMAT.equals(schema.getFormat());
     }
 
     public static boolean isUnsignedLongSchema(Schema schema) {
-        return SchemaTypeUtil.INTEGER_TYPE.equals(schema.getType()) && // type: integer
+        return SchemaTypeUtil.INTEGER_TYPE.equals(getSchemaType(schema)) && // type: integer
                 "int64".equals(schema.getFormat()) && // format: int64
                 (schema.getExtensions() != null && (Boolean) schema.getExtensions().getOrDefault("x-unsigned", Boolean.FALSE));
     }
 
     public static boolean isBooleanSchema(Schema schema) {
-        return schema instanceof BooleanSchema || SchemaTypeUtil.BOOLEAN_TYPE.equals(schema.getType());
+        return schema instanceof BooleanSchema || SchemaTypeUtil.BOOLEAN_TYPE.equals(getSchemaType(schema));
     }
 
     public static boolean isNumberSchema(Schema schema) {
-        return schema instanceof NumberSchema || SchemaTypeUtil.NUMBER_TYPE.equals(schema.getType());
+        return schema instanceof NumberSchema || SchemaTypeUtil.NUMBER_TYPE.equals(getSchemaType(schema));
     }
 
     public static boolean isFloatSchema(Schema schema) {
         // format: float
-        return SchemaTypeUtil.NUMBER_TYPE.equals(schema.getType())
+        return SchemaTypeUtil.NUMBER_TYPE.equals(getSchemaType(schema))
                 && SchemaTypeUtil.FLOAT_FORMAT.equals(schema.getFormat());
     }
 
     public static boolean isDoubleSchema(Schema schema) {
         // format: double
-        return SchemaTypeUtil.NUMBER_TYPE.equals(schema.getType())
+        return SchemaTypeUtil.NUMBER_TYPE.equals(getSchemaType(schema))
                 && SchemaTypeUtil.DOUBLE_FORMAT.equals(schema.getFormat());
     }
 
     public static boolean isDateSchema(Schema schema) {
         return (schema instanceof DateSchema) ||
                 // format: date
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.DATE_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isDateTimeSchema(Schema schema) {
         return (schema instanceof DateTimeSchema) ||
                 // format: date-time
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.DATE_TIME_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isPasswordSchema(Schema schema) {
         return (schema instanceof PasswordSchema) ||
                 // double
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.PASSWORD_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isByteArraySchema(Schema schema) {
         return (schema instanceof ByteArraySchema) ||
                 // format: byte
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.BYTE_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isBinarySchema(Schema schema) {
         return (schema instanceof BinarySchema) ||
                 // format: binary
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.BINARY_FORMAT.equals(schema.getFormat()));
     }
 
@@ -696,26 +704,26 @@ public class ModelUtils {
     public static boolean isUUIDSchema(Schema schema) {
         return (schema instanceof UUIDSchema) ||
                 // format: uuid
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.UUID_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isURISchema(Schema schema) {
         // format: uri
-        return SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+        return SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                 && URI_FORMAT.equals(schema.getFormat());
     }
 
     public static boolean isEmailSchema(Schema schema) {
         return (schema instanceof EmailSchema) ||
                 // format: email
-                (SchemaTypeUtil.STRING_TYPE.equals(schema.getType())
+                (SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema))
                         && SchemaTypeUtil.EMAIL_FORMAT.equals(schema.getFormat()));
     }
 
     public static boolean isDecimalSchema(Schema schema) {
         // format: number
-        return SchemaTypeUtil.STRING_TYPE.equals(schema.getType()) // type: string
+        return SchemaTypeUtil.STRING_TYPE.equals(getSchemaType(schema)) // type: string
                 && "number".equals(schema.getFormat());
     }
 
@@ -817,31 +825,24 @@ public class ModelUtils {
                 return true;
             } else if (schema.getAdditionalProperties() instanceof JsonSchema) {
                 return true;
-            } else if (schema.getTypes() != null) {
-                if (schema.getTypes().size() == 1) { // types = [object]
-                    return SchemaTypeUtil.OBJECT_TYPE.equals(schema.getTypes().iterator().next());
-                } else { // has more than 1 type, e.g. types = [integer, string]
-                    return false;
-                }
             }
-
-            return false;
+            return isTypeObjectSchema(schema);
         }
 
         // 3.0.x spec or 2.x spec
         // not free-form if allOf, anyOf, oneOf is not empty
         if (isComposedSchema(schema)) {
-            List<Schema> interfaces = ModelUtils.getInterfaces(schema);
+            List<Schema> interfaces = getInterfaces(schema);
             if (interfaces != null && !interfaces.isEmpty()) {
                 return false;
             }
         }
 
         // has at least one property
-        if ("object".equals(schema.getType())) {
+        if (isTypeObjectSchema(schema)) {
             // no properties
             if ((schema.getProperties() == null || schema.getProperties().isEmpty())) {
-                Schema addlProps = ModelUtils.getAdditionalProperties(schema);
+                Schema addlProps = getAdditionalProperties(schema);
 
                 if (schema.getExtensions() != null && schema.getExtensions().containsKey(freeFormExplicit)) {
                     // User has hard-coded vendor extension to handle free-form evaluation.
@@ -862,7 +863,7 @@ public class ModelUtils {
                         return objSchema.getProperties() == null || objSchema.getProperties().isEmpty();
                     } else if (addlProps instanceof Schema) {
                         // additionalProperties defined as {}
-                        return addlProps.getType() == null && addlProps.get$ref() == null && (addlProps.getProperties() == null || addlProps.getProperties().isEmpty());
+                        return getSchemaType(addlProps) == null && addlProps.get$ref() == null && (addlProps.getProperties() == null || addlProps.getProperties().isEmpty());
                     }
                 }
             }
@@ -888,11 +889,11 @@ public class ModelUtils {
         // A composed schema (allOf, oneOf, anyOf) is considered a Map schema if the additionalproperties attribute is set
         // for that composed schema. However, in the case of a composed schema, the properties are defined or referenced
         // in the inner schemas, and the outer schema does not have properties.
-        return ModelUtils.isGenerateAliasAsModel(schema) || ModelUtils.isComposedSchema(schema) || !(schema.getProperties() == null || schema.getProperties().isEmpty());
+        return isGenerateAliasAsModel(schema) || isComposedSchema(schema) || !(schema.getProperties() == null || schema.getProperties().isEmpty());
     }
 
     public static boolean shouldGenerateArrayModel(Schema schema) {
-        return ModelUtils.isGenerateAliasAsModel(schema) || !(schema.getProperties() == null || schema.getProperties().isEmpty());
+        return isGenerateAliasAsModel(schema) || !(schema.getProperties() == null || schema.getProperties().isEmpty());
     }
 
     /**
@@ -1239,7 +1240,7 @@ public class ModelUtils {
         }
 
         if (schema != null && StringUtils.isNotEmpty(schema.get$ref())) {
-            String simpleRef = ModelUtils.getSimpleRef(schema.get$ref());
+            String simpleRef = getSimpleRef(schema.get$ref());
             if (schemaMappings.containsKey(simpleRef)) {
                 LOGGER.debug("Schema unaliasing of {} omitted because aliased class is to be mapped to {}", simpleRef, schemaMappings.get(simpleRef));
                 return schema;
@@ -1255,7 +1256,7 @@ public class ModelUtils {
                 if (isGenerateAliasAsModel(ref)) {
                     return schema; // generate a model extending array
                 } else {
-                    return unaliasSchema(openAPI, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())),
+                    return unaliasSchema(openAPI, allSchemas.get(getSimpleRef(schema.get$ref())),
                             schemaMappings);
                 }
             } else if (isComposedSchema(ref)) {
@@ -1268,7 +1269,7 @@ public class ModelUtils {
                         return schema; // generate a model extending map
                     } else {
                         // treat it as a typical map
-                        return unaliasSchema(openAPI, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())),
+                        return unaliasSchema(openAPI, allSchemas.get(getSimpleRef(schema.get$ref())),
                                 schemaMappings);
                     }
                 }
@@ -1279,11 +1280,11 @@ public class ModelUtils {
                     // which is the last reference to the actual model/object
                     return schema;
                 } else { // free form object (type: object)
-                    return unaliasSchema(openAPI, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())),
+                    return unaliasSchema(openAPI, allSchemas.get(getSimpleRef(schema.get$ref())),
                             schemaMappings);
                 }
             } else {
-                return unaliasSchema(openAPI, allSchemas.get(ModelUtils.getSimpleRef(schema.get$ref())), schemaMappings);
+                return unaliasSchema(openAPI, allSchemas.get(getSimpleRef(schema.get$ref())), schemaMappings);
             }
         }
         return schema;
@@ -1457,7 +1458,7 @@ public class ModelUtils {
                 } else {
                     // not a ref, doing nothing, except counting the number of times the 'null' type
                     // is listed as composed element.
-                    if (ModelUtils.isNullType(schema)) {
+                    if (isNullType(schema)) {
                         // If there are two interfaces, and one of them is the 'null' type,
                         // then the parent is obvious and there is no need to warn about specifying
                         // a determinator.
@@ -1660,7 +1661,7 @@ public class ModelUtils {
      * @return true if the schema is the 'null' type
      */
     public static boolean isNullType(Schema schema) {
-        return "null".equals(schema.getType());
+        return "null".equals(getSchemaType(schema));
     }
 
     /**
@@ -1676,7 +1677,7 @@ public class ModelUtils {
         // TODO remove the ref check here, or pass in the spec version
         // openapi 3.1.0 specs allow ref to be adjacent to any keyword
         // openapi 3.0.3 and earlier do not allow adjacent keywords to refs
-        return (schema.get$ref() == null && schema.getType() == null);
+        return (schema.get$ref() == null && getSchemaType(schema) == null);
     }
 
     public static void syncValidationProperties(Schema schema, IJsonSchemaValidationProperties target) {
@@ -1808,7 +1809,7 @@ public class ModelUtils {
     private static void logWarnMessagesForIneffectiveValidations(Set<String> setValidations, Schema schema, Set<String> effectiveValidations) {
         setValidations.removeAll(effectiveValidations);
         setValidations.stream().forEach(validation -> {
-            LOGGER.warn("Validation '" + validation + "' has no effect on schema '" + schema.getType() +"'. Ignoring!");
+            LOGGER.warn("Validation '" + validation + "' has no effect on schema '" + getSchemaType(schema) +"'. Ignoring!");
         });
     }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/validations/oas/OpenApiSchemaValidations.java
@@ -161,7 +161,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
     private static ValidationRule.Result checkInvalidType(SchemaWrapper schemaWrapper) {
         Schema schema = schemaWrapper.getSchema();
         ValidationRule.Result result = ValidationRule.Pass.empty();
-        if (schema.getType() != null && !validTypes.contains(schema.getType())) {
+        if (ModelUtils.getSchemaType(schema) != null && !validTypes.contains(ModelUtils.getSchemaType(schema))) {
             result = new ValidationRule.Fail();
             String name = schema.getName();
             if (name == null) {
@@ -169,7 +169,7 @@ class OpenApiSchemaValidations extends GenericValidator<SchemaWrapper> {
             }
             result.setDetails(String.format(Locale.ROOT,
                 "Schema '%s' uses the '%s' type, which is not a valid type.",
-                name, schema.getType()));
+                name, ModelUtils.getSchemaType(schema)));
             return result;
         }
         return result;

--- a/samples/client/petstore/java/okhttp-gson-3.1/.openapi-generator/FILES
+++ b/samples/client/petstore/java/okhttp-gson-3.1/.openapi-generator/FILES
@@ -18,7 +18,6 @@ docs/Order.md
 docs/Pet.md
 docs/PetApi.md
 docs/StoreApi.md
-docs/StringOrInt.md
 docs/Tag.md
 docs/User.md
 docs/UserApi.md
@@ -67,6 +66,5 @@ src/main/java/org/openapitools/client/model/ModelApiResponse.java
 src/main/java/org/openapitools/client/model/OneOfStringOrInt.java
 src/main/java/org/openapitools/client/model/Order.java
 src/main/java/org/openapitools/client/model/Pet.java
-src/main/java/org/openapitools/client/model/StringOrInt.java
 src/main/java/org/openapitools/client/model/Tag.java
 src/main/java/org/openapitools/client/model/User.java

--- a/samples/client/petstore/java/okhttp-gson-3.1/README.md
+++ b/samples/client/petstore/java/okhttp-gson-3.1/README.md
@@ -152,7 +152,6 @@ Class | Method | HTTP request | Description
  - [OneOfStringOrInt](docs/OneOfStringOrInt.md)
  - [Order](docs/Order.md)
  - [Pet](docs/Pet.md)
- - [StringOrInt](docs/StringOrInt.md)
  - [Tag](docs/Tag.md)
  - [User](docs/User.md)
 

--- a/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
+++ b/samples/client/petstore/java/okhttp-gson-3.1/api/openapi.yaml
@@ -908,12 +908,7 @@ components:
         message:
           type: string
       title: An uploaded response
-    StringOrInt:
-      anyOf:
-      - type: string
-      - format: int32
-        type: integer
-      description: string or int
+    StringOrInt: {}
     OneOfStringOrInt:
       description: string or int (onefOf)
       oneOf:

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/JSON.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/JSON.java
@@ -138,7 +138,6 @@ public class JSON {
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.OneOfStringOrInt.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Order.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Pet.CustomTypeAdapterFactory());
-        gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.StringOrInt.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.Tag.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new org.openapitools.client.model.User.CustomTypeAdapterFactory());
         gson = gsonBuilder.create();

--- a/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyOfArray.java
+++ b/samples/client/petstore/java/okhttp-gson-3.1/src/main/java/org/openapitools/client/model/AnyOfArray.java
@@ -14,6 +14,7 @@
 package org.openapitools.client.model;
 
 import java.util.Objects;
+import java.util.List;
 
 
 
@@ -62,7 +63,7 @@ public class AnyOfArray extends AbstractOpenApiSchema {
                 return null; // this class only serializes 'AnyOfArray' and its subtypes
             }
             final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
-            final TypeAdapter<Object> adapterObject = gson.getDelegateAdapter(this, TypeToken.get(Object.class));
+            final TypeAdapter<List> adapterList = gson.getDelegateAdapter(this, TypeToken.get(List.class));
 
             return (TypeAdapter<T>) new TypeAdapter<AnyOfArray>() {
                 @Override
@@ -72,13 +73,13 @@ public class AnyOfArray extends AbstractOpenApiSchema {
                         return;
                     }
 
-                    // check if the actual instance is of the type `Object`
-                    if (value.getActualInstance() instanceof Object) {
-                      JsonPrimitive primitive = adapterObject.toJsonTree((Object)value.getActualInstance()).getAsJsonPrimitive();
-                      elementAdapter.write(out, primitive);
+                    // check if the actual instance is of the type `List`
+                    if (value.getActualInstance() instanceof List) {
+                      JsonElement element = adapterList.toJsonTree((List)value.getActualInstance());
+                      elementAdapter.write(out, element);
                       return;
                     }
-                    throw new IOException("Failed to serialize as the type doesn't match anyOf schemae: Object");
+                    throw new IOException("Failed to serialize as the type doesn't match anyOf schemae: List");
                 }
 
                 @Override
@@ -89,20 +90,18 @@ public class AnyOfArray extends AbstractOpenApiSchema {
                     ArrayList<String> errorMessages = new ArrayList<>();
                     TypeAdapter actualAdapter = elementAdapter;
 
-                    // deserialize Object
+                    // deserialize List
                     try {
                       // validate the JSON object to see if any exception is thrown
-                      if(!jsonElement.getAsJsonPrimitive().isNumber()) {
-                        throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
-                      }
-                      actualAdapter = adapterObject;
+                      List.validateJsonElement(jsonElement);
+                      actualAdapter = adapterList;
                       AnyOfArray ret = new AnyOfArray();
                       ret.setActualInstance(actualAdapter.fromJsonTree(jsonElement));
                       return ret;
                     } catch (Exception e) {
                       // deserialization failed, continue
-                      errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
-                      log.log(Level.FINER, "Input data does not match schema 'Object'", e);
+                      errorMessages.add(String.format("Deserialization for List failed with `%s`.", e.getMessage()));
+                      log.log(Level.FINER, "Input data does not match schema 'List'", e);
                     }
 
                     throw new IOException(String.format("Failed deserialization for AnyOfArray: no class matches result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
@@ -118,13 +117,13 @@ public class AnyOfArray extends AbstractOpenApiSchema {
         super("anyOf", Boolean.FALSE);
     }
 
-    public AnyOfArray(Object o) {
+    public AnyOfArray(List o) {
         super("anyOf", Boolean.FALSE);
         setActualInstance(o);
     }
 
     static {
-        schemas.put("Object", Object.class);
+        schemas.put("List", List.class);
     }
 
     @Override
@@ -135,25 +134,25 @@ public class AnyOfArray extends AbstractOpenApiSchema {
     /**
      * Set the instance that matches the anyOf child schema, check
      * the instance parameter is valid against the anyOf child schemas:
-     * Object
+     * List
      *
      * It could be an instance of the 'anyOf' schemas.
      */
     @Override
     public void setActualInstance(Object instance) {
-        if (instance instanceof Object) {
+        if (instance instanceof List) {
             super.setActualInstance(instance);
             return;
         }
 
-        throw new RuntimeException("Invalid instance type. Must be Object");
+        throw new RuntimeException("Invalid instance type. Must be List");
     }
 
     /**
      * Get the actual instance, which can be the following:
-     * Object
+     * List
      *
-     * @return The actual instance (Object)
+     * @return The actual instance (List)
      */
     @Override
     public Object getActualInstance() {
@@ -161,14 +160,14 @@ public class AnyOfArray extends AbstractOpenApiSchema {
     }
 
     /**
-     * Get the actual instance of `Object`. If the actual instance is not `Object`,
+     * Get the actual instance of `List`. If the actual instance is not `List`,
      * the ClassCastException will be thrown.
      *
-     * @return The actual instance of `Object`
-     * @throws ClassCastException if the instance is not `Object`
+     * @return The actual instance of `List`
+     * @throws ClassCastException if the instance is not `List`
      */
-    public Object getObject() throws ClassCastException {
-        return (Object)super.getActualInstance();
+    public List getList() throws ClassCastException {
+        return (List)super.getActualInstance();
     }
 
  /**
@@ -180,17 +179,15 @@ public class AnyOfArray extends AbstractOpenApiSchema {
   public static void validateJsonElement(JsonElement jsonElement) throws IOException {
     // validate anyOf schemas one by one
     ArrayList<String> errorMessages = new ArrayList<>();
-    // validate the json string with Object
+    // validate the json string with List
     try {
-      if(!jsonElement.getAsJsonPrimitive().isNumber()) {
-        throw new IllegalArgumentException(String.format("Expected json element to be of type Number in the JSON string but got `%s`", jsonElement.toString()));
-      }
+      List.validateJsonElement(jsonElement);
       return;
     } catch (Exception e) {
-      errorMessages.add(String.format("Deserialization for Object failed with `%s`.", e.getMessage()));
+      errorMessages.add(String.format("Deserialization for List failed with `%s`.", e.getMessage()));
       // continue to the next one
     }
-    throw new IOException(String.format("The JSON string is invalid for AnyOfArray with anyOf schemas: Object. no class match the result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
+    throw new IOException(String.format("The JSON string is invalid for AnyOfArray with anyOf schemas: List. no class match the result, expected at least 1. Detailed failure message for anyOf schemas: %s. JSON: %s", errorMessages, jsonElement.toString()));
     
   }
 


### PR DESCRIPTION
Swagger Parser only populates the Schema's `type` field for OAS `3.0.X` and under. For schemas versioned `3.1.0` and above the type will be populated in the `types` field instead ([reference](https://github.com/swagger-api/swagger-parser/issues/1821#issuecomment-1300918559)).

The solution proposed by swagger-parser is to set the System property `bind-type` which will ensure that the `getType()` method of the `Schema` object will perform the same process of extracting the type as the `ModelUtils.getSchemaType()` function that I've implemented in this MR. 

I believe that using the proposed `ModelUtils.getSchemaType()` function will allow for more flexibility when writing logic for backward compatibility that might require a distinction of the origin of the `type` field.

This MR makes almost all `type` checks spec version agnostic which should hopefully resolve a good chunk edge cases for `3.1.0` generations.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
