### PR TITLE
Properties with custom types inheritance fix

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -17,7 +17,6 @@
 
 package org.openapitools.codegen;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
@@ -26,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Mustache.Compiler;
 import com.samskivert.mustache.Mustache.Lambda;
-import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -66,6 +64,7 @@ import org.openapitools.codegen.templating.MustacheEngineAdapter;
 import org.openapitools.codegen.templating.mustache.*;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.openapitools.codegen.utils.OneOfImplementorAdditionalData;
+import org.openapitools.codegen.utils.SchemaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -2939,11 +2938,7 @@ public class DefaultCodegen implements CodegenConfig {
         if (null != existingProperties && null != newProperties) {
             Schema existingType = existingProperties.get("type");
             Schema newType = newProperties.get("type");
-            newProperties.forEach((key, value) ->
-                    existingProperties.put(
-                            key,
-                            AnnotationsUtils.clone(value, specVersionGreaterThanOrEqualTo310(openAPI))
-                    ));
+            newProperties.forEach((key, value) -> existingProperties.put(key, SchemaUtils.cloneSchema(value)));
             if (null != existingType && null != newType && null != newType.getEnum() && !newType.getEnum().isEmpty()) {
                 for (Object e : newType.getEnum()) {
                     // ensure all interface enum types are added to schema

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/SchemaUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/SchemaUtils.java
@@ -1,0 +1,32 @@
+package org.openapitools.codegen.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import io.swagger.v3.oas.models.media.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaUtils.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    static {
+        BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
+                .build();
+        OBJECT_MAPPER.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING);
+    }
+
+    public static Schema cloneSchema(Schema schema) {
+        try {
+            String json = OBJECT_MAPPER.writeValueAsString(schema);
+            return OBJECT_MAPPER.readValue(json, schema.getClass());
+        } catch (JsonProcessingException ex) {
+            LOGGER.error("Can't clone schema {}", schema, ex);
+            return schema;
+        }
+    }
+}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaInheritanceTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 
 public class JavaInheritanceTest {
 
-
     @Test(description = "convert a composed model with parent")
     public void javaInheritanceTest() {
         final Schema parentModel = new Schema().name("Base");
@@ -180,5 +179,33 @@ public class JavaInheritanceTest {
         Assert.assertEquals(propertyCD.name, "d");
         Assert.assertFalse(propertyCD.required);
         Assert.assertEquals(cm.requiredVars.size() + cm.optionalVars.size(), cm.allVars.size());
+    }
+
+    @Test(description = "convert a composed model with parent with custom schema param")
+    public void javaInheritanceWithCustomSchemaTest() {
+        Schema custom = new Schema()
+                .name("Custom")
+                .addProperty("value", new StringSchema());
+        Schema parentModel = new Schema()
+                .name("Base")
+                .addProperty("customProperty", new Schema().type("custom"));
+        Schema schema = new ComposedSchema()
+                .name("Composed")
+                .addAllOfItem(new Schema().$ref("Base"));
+
+        OpenAPI openAPI = TestUtils.createOpenAPI();
+        openAPI.setComponents(new Components()
+                .addSchemas(custom.getName(), custom)
+                .addSchemas(parentModel.getName(), parentModel)
+                .addSchemas(schema.getName(), schema)
+        );
+
+        JavaClientCodegen codegen = new JavaClientCodegen();
+        codegen.setOpenAPI(openAPI);
+        codegen.schemaMapping()
+                .put("custom", custom.getName());
+        CodegenModel model = codegen.fromModel("sample", schema);
+
+        Assert.assertTrue(model.imports.contains(custom.getName()));
     }
 }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/SchemaUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/utils/SchemaUtilsTest.java
@@ -1,0 +1,53 @@
+package org.openapitools.codegen.utils;
+
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SchemaUtilsTest {
+
+    @Test
+    public void cloneNumberSchema() {
+        Schema schema = new NumberSchema()
+                .name("test-schema")
+                .minimum(new BigDecimal(100));
+
+        Schema deepCopy = SchemaUtils.cloneSchema(schema);
+
+        assertEquals(schema, deepCopy);
+    }
+
+    @Test
+    public void cloneCustomSchema() {
+        Schema schema = new Schema().type("money");
+
+        Schema deepCopy = SchemaUtils.cloneSchema(schema);
+
+        assertEquals(schema, deepCopy);
+    }
+
+    @Test
+    public void cloneComposedSchema() {
+        Schema base1 = new Schema()
+                .name("Base1")
+                .addProperty("foo", new StringSchema());
+        Schema base2 = new Schema()
+                .name("Base2")
+                .addProperty("bar", new StringSchema());
+        Schema composedSchema = new ComposedSchema()
+                .name("Composed")
+                .allOf(List.of(base1, base2))
+                .addProperty("baz", new StringSchema());
+
+        var deepCopy = SchemaUtils.cloneSchema(composedSchema);
+
+        assertEquals(composedSchema, deepCopy);
+    }
+}

--- a/samples/client/echo_api/r/R/data_query.R
+++ b/samples/client/echo_api/r/R/data_query.R
@@ -30,13 +30,13 @@ DataQuery <- R6::R6Class(
     #' Initialize a new DataQuery class.
     #'
     #' @param id Query
-    #' @param outcomes outcomes. Default to [SUCCESS, FAILURE].
+    #' @param outcomes outcomes. Default to ["SUCCESS","FAILURE"].
     #' @param suffix test suffix
     #' @param text Some text containing white spaces
     #' @param date A date
     #' @param ... Other optional arguments.
     #' @export
-    initialize = function(`id` = NULL, `outcomes` = [SUCCESS, FAILURE], `suffix` = NULL, `text` = NULL, `date` = NULL, ...) {
+    initialize = function(`id` = NULL, `outcomes` = ["SUCCESS","FAILURE"], `suffix` = NULL, `text` = NULL, `date` = NULL, ...) {
       if (!is.null(`id`)) {
         if (!(is.numeric(`id`) && length(`id`) == 1)) {
           stop(paste("Error! Invalid data for `id`. Must be an integer:", `id`))

--- a/samples/client/echo_api/r/docs/DataQuery.md
+++ b/samples/client/echo_api/r/docs/DataQuery.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **integer** | Query | [optional] 
-**outcomes** | **array[character]** |  | [optional] [default to [SUCCESS, FAILURE]] [Enum: ] 
+**outcomes** | **array[character]** |  | [optional] [default to [&quot;SUCCESS&quot;,&quot;FAILURE&quot;]] [Enum: ] 
 **suffix** | **character** | test suffix | [optional] 
 **text** | **character** | Some text containing white spaces | [optional] 
 **date** | **character** | A date | [optional] 


### PR DESCRIPTION
Approach to deep clone Schema's introduced in https://github.com/OpenAPITools/openapi-generator/pull/16992 breaks support for properties with custom types (added using schemaMappings or type/importMappings) when such properties are inherited using allOf. AnnotationsUtils#clone returns null for them. I've replaced AnnotationsUtils#clone with ObjectMapper's typed serialization/deserialization.

@OpenAPITools/generator-core-team

### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
