### PR TITLE
[typescript-fetch] Omit readOnly properties from request models

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -26,12 +26,12 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.parser.util.SchemaTypeUtil;
+import java.util.stream.Collectors;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.meta.features.DocumentationFeature;
 import org.openapitools.codegen.meta.features.SecurityFeature;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.ModelsMap;
-import org.openapitools.codegen.model.OperationMap;
 import org.openapitools.codegen.model.OperationsMap;
 import org.openapitools.codegen.templating.mustache.IndentedLambda;
 import org.openapitools.codegen.utils.ModelUtils;
@@ -986,6 +986,8 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
     class ExtendedCodegenParameter extends CodegenParameter {
         public String dataTypeAlternate;
         public boolean isUniqueId; // this parameter represents a unique id (x-isUniqueId: true)
+        public List<CodegenProperty> readOnlyVars; // a list of read-only properties
+        public boolean hasReadOnly = false; // indicates the type has at least one read-only property
 
         public boolean itemsAreUniqueId() {
             return TypeScriptFetchClientCodegen.itemsAreUniqueId(this.items);
@@ -1081,8 +1083,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.minItems = cp.minItems;
             this.uniqueItems = cp.uniqueItems;
             this.multipleOf = cp.multipleOf;
+            this.setHasVars(cp.getHasVars());
+            this.setHasRequired(cp.getHasRequired());
             this.setMaxProperties(cp.getMaxProperties());
             this.setMinProperties(cp.getMinProperties());
+            setReadOnlyVars();
         }
 
         @Override
@@ -1122,6 +1127,11 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             sb.append(", isUniqueId=").append(isUniqueId);
             sb.append(", dataTypeAlternate='").append(dataTypeAlternate).append('\'');
             return sb.toString();
+        }
+
+        private void setReadOnlyVars() {
+            readOnlyVars = vars.stream().filter(v -> v.isReadOnly).collect(Collectors.toList());
+            hasReadOnly = !readOnlyVars.isEmpty();
         }
     }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/apis.mustache
@@ -24,7 +24,7 @@ import {
 {{#allParams.0}}
 export interface {{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request {
 {{#allParams}}
-    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}}{{#required}} | null{{/required}}{{/isNullable}}{{/isEnum}};
+    {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{#hasReadOnly}}Omit<{{{dataType}}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{{dataType}}}{{/hasReadOnly}}{{#isNullable}}{{#required}} | null{{/required}}{{/isNullable}}{{/isEnum}};
 {{/allParams}}
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -100,7 +100,7 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     {{/hasVars}}
 }
 
-export function {{classname}}ToJSON(value?: {{classname}} | null): any {
+export function {{classname}}ToJSON(value?: {{#hasReadOnly}}Omit<{{classname}}, {{#readOnlyVars}}'{{baseName}}'{{^-last}}|{{/-last}}{{/readOnlyVars}}>{{/hasReadOnly}}{{^hasReadOnly}}{{classname}}{{/hasReadOnly}} | null): any {
     {{#hasVars}}
     if (value == null) {
         return value;

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -55,7 +55,7 @@ export function ClubFromJSONTyped(json: any, ignoreDiscriminator: boolean): Club
     };
 }
 
-export function ClubToJSON(value?: Club | null): any {
+export function ClubToJSON(value?: Omit<Club, 'owner'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -55,7 +55,7 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
+export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -70,7 +70,7 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Name | null): any {
+export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -55,7 +55,7 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
+export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -55,7 +55,7 @@ export function HasOnlyReadOnlyFromJSONTyped(json: any, ignoreDiscriminator: boo
     };
 }
 
-export function HasOnlyReadOnlyToJSON(value?: HasOnlyReadOnly | null): any {
+export function HasOnlyReadOnlyToJSON(value?: Omit<HasOnlyReadOnly, 'bar'|'foo'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -70,7 +70,7 @@ export function NameFromJSONTyped(json: any, ignoreDiscriminator: boolean): Name
     };
 }
 
-export function NameToJSON(value?: Name | null): any {
+export function NameToJSON(value?: Omit<Name, 'snake_case'|'123Number'> | null): any {
     if (value == null) {
         return value;
     }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -55,7 +55,7 @@ export function ReadOnlyFirstFromJSONTyped(json: any, ignoreDiscriminator: boole
     };
 }
 
-export function ReadOnlyFirstToJSON(value?: ReadOnlyFirst | null): any {
+export function ReadOnlyFirstToJSON(value?: Omit<ReadOnlyFirst, 'bar'> | null): any {
     if (value == null) {
         return value;
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Related to:  #4190  

This PR omits readOnly properties from request models. Given the following OpenAPI schema and operation.

```yaml
title: Task
type: object
properties:
  id:
    type: integer
    readOnly: true
  title:
    type: string
```

```yaml
post:
  operationId: createTask
  requestBody:
    required: true
    content:
      application/json:
        schema:
          $ref: Task.yml
...
```

The current generated request models require the unneeded `id` property.

```js
export interface CreateTaskRequest {
    task: Task;
}
```

This PR changes them to:

```js
export interface CreateTaskRequest {
    task: Omit<Task, 'id'>;
}
```

To technical committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
