### PR TITLE
[Swift] fix(#18074): correctly map OpenAPIDateWithoutTime to string in path

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/APIHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/APIHelper.mustache
@@ -62,6 +62,8 @@ import Vapor{{/useVapor}}
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/modules/openapi-generator/src/main/resources/swift5/OpenAPIDateWithoutTime.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/OpenAPIDateWithoutTime.mustache
@@ -81,3 +81,18 @@ extension OpenAPIDateWithoutTime: JSONEncodable {
         return OpenISO8601DateFormatter.withoutTime.string(from: self.normalizedWrappedDate())
     }
 }
+
+extension OpenAPIDateWithoutTime: RawRepresentable {
+    public typealias RawValue = String
+    public init?(rawValue: String) {
+        if let date = OpenISO8601DateFormatter.withoutTime.date(from: rawValue) {
+            self.init(wrappedDate: date)
+        } else {
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        OpenISO8601DateFormatter.withoutTime.string(from: normalizedWrappedDate())
+    }
+}

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/OpenAPIDateWithoutTime.swift
@@ -81,3 +81,18 @@ extension OpenAPIDateWithoutTime: JSONEncodable {
         return OpenISO8601DateFormatter.withoutTime.string(from: self.normalizedWrappedDate())
     }
 }
+
+extension OpenAPIDateWithoutTime: RawRepresentable {
+    public typealias RawValue = String
+    public init?(rawValue: String) {
+        if let date = OpenISO8601DateFormatter.withoutTime.date(from: rawValue) {
+            self.init(wrappedDate: date)
+        } else {
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        OpenISO8601DateFormatter.withoutTime.string(from: normalizedWrappedDate())
+    }
+}

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ internal struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIHelper.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -61,6 +61,8 @@ public struct APIHelper {
             return collection
                 .compactMap { value in convertAnyToString(value) }
                 .joined(separator: ",")
+        } else if let value = source as? any RawRepresentable {
+            return "\(value.rawValue)"
         }
         return source
     }


### PR DESCRIPTION
This fixes #18074, OpenAPIDateWithoutTime handling when a date is part of the uri path (parameter).
There are several options to fix the issue, this is just one suggestion.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
