### PR TITLE
Update 2018 Blog Post broken link

### DIFF
--- a/website/blog/2018-12-24-new-website.md
+++ b/website/blog/2018-12-24-new-website.md
@@ -10,4 +10,4 @@ That's why we're proud to announce that we've adopted a new website and design f
 
 <!--truncate-->
 
-We will still continue to maintain the documentation on our GitHub repository. In fact, our website will be generated with [Docusaurus](https://docusaurus.io/en), so our docs on GitHub will still be incorporated into this site!
+We will still continue to maintain the documentation on our GitHub repository. In fact, our website will be generated with [Docusaurus](https://docusaurus.io), so our docs on GitHub will still be incorporated into this site!


### PR DESCRIPTION
https://docusaurus.io/en returns 404, removing `/en` fixes it.

