### PR TITLE
Adds field:Email to provide bean validation for email adresses

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/beanValidationModel.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/libraries/jaxrs-spec/beanValidationModel.mustache
@@ -18,3 +18,5 @@ isLong set
 }}{{#isLong}}{{#minimum}} @field:Min({{.}}L){{/minimum}}{{#maximum}} @field:Max({{.}}L){{/maximum}}{{/isLong}}{{!
 Not Integer, not Long => we have a decimal value!
 }}{{^isInteger}}{{^isLong}}{{#minimum}} @field:DecimalMin({{#exclusiveMinimum}}value={{/exclusiveMinimum}}"{{minimum}}"{{#exclusiveMinimum}},inclusive=false{{/exclusiveMinimum}}){{/minimum}}{{#maximum}} @field:DecimalMax({{#exclusiveMaximum}}value={{/exclusiveMaximum}}"{{maximum}}"{{#exclusiveMaximum}},inclusive=false{{/exclusiveMaximum}}){{/maximum}}{{/isLong}}{{/isInteger}}
+{{#isEmail}} @field:Email{{! adds email validation}}
+{{/isEmail}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/kotlin/KotlinServerCodegenTest.java
@@ -166,6 +166,30 @@ public class KotlinServerCodegenTest {
         );
     }
 
+    @Test
+    public void beanValidationWithEmail() throws IOException {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        KotlinServerCodegen codegen = new KotlinServerCodegen();
+        codegen.setOutputDir(output.getAbsolutePath());
+        codegen.additionalProperties().put(USE_JAKARTA_EE, true);
+        codegen.additionalProperties().put(LIBRARY, JAXRS_SPEC);
+        codegen.additionalProperties().put(USE_BEANVALIDATION, true);
+
+        new DefaultGenerator().opts(new ClientOptInput()
+                        .openAPI(TestUtils.parseSpec("src/test/resources/3_0/kotlin/api-email.yaml"))
+                        .config(codegen))
+                .generate();
+
+        String outputPath = output.getAbsolutePath() + "/src/main/kotlin/org/openapitools/server";
+        Path emailModel = Paths.get(outputPath + "/models/Email.kt");
+        assertFileContains(
+                emailModel,
+                "field:Email"
+        );
+    }
+
     // to test attributes in the $ref (OpenAPI 3.1 spec)
     @Test
     public void attributesInRef() throws IOException {

--- a/modules/openapi-generator/src/test/resources/3_0/kotlin/api-email.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/kotlin/api-email.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.3
+info:
+  title: Email api
+  description: Email api
+  version: 1.0.0
+servers:
+  - url: 'https://email.mydomain.com'
+    description: 'Production server'
+tags:
+  - name: email
+    description: Operations about email
+paths:
+  /email:
+    post:
+      summary: Send an email
+      operationId: sendEmail
+      tags:
+        - email
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Email'
+      responses:
+        '204':
+          description: Email was sent
+        '400':
+          description: Invalid input
+components:
+  schemas:
+    Email:
+      type: object
+      properties:
+        to:
+          type: string
+          format: email
+          description: The email address of the recipient
+          example: my@email.com
+        cc:
+          type: string
+          format: email
+          description: The email address of the cc
+          example: copy@email.com
+        subject:
+          type: string
+          description: The subject of the email
+          minLength: 1
+          maxLength: 256
+          example: Hello
+        body:
+          type: string
+          description: The body of the email
+          example: Hello, how are you?
+      required:
+        - to
+        - subject
+        - body


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Added support for generating model classes that validates email fields using bean validation (if specified)

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
