### PR TITLE
#18031 Fix: added middleware adding for authorization methods [php-slim4]

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -107,12 +107,22 @@ $ composer phplint
 
 ## Show errors
 
-Switch your app environment to development in `public/.htaccess` file:
+Switch your app environment to development
+- When using with some webserver => in `public/.htaccess` file:
 ```ini
 ## .htaccess
 <IfModule mod_env.c>
     SetEnv APP_ENV 'development'
 </IfModule>
+```
+
+- Or when using whatever else, set `APP_ENV` environment variable like this:
+```bash
+export APP_ENV=development
+```
+or simply
+```bash
+export APP_ENV=dev
 ```
 
 ## Mock Server

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/README.mustache
@@ -214,6 +214,11 @@ Scope list:
 {{/scopes}}
 
 {{/isOAuth}}
+{{#isBasicBearer}}
+### Security schema `{{name}}`
+> Important! To make Bearer authentication work you need to extend [\{{authPackage}}\{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}]({{#lambda.forwardslash}}{{authSrcPath}}{{/lambda.forwardslash}}/{{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}.php) class by [\{{authPackage}}\BearerAuthenticator](./src/Auth/BearerAuthenticator.php) class.
+
+{{/isBasicBearer}}
 {{/authMethods}}
 ### Advanced middleware configuration
 Ref to used Slim Token Middleware [dyorg/slim-token-authentication](https://github.com/dyorg/slim-token-authentication/tree/1.x#readme)

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
@@ -10,6 +10,7 @@
 namespace {{authPackage}};
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Dyorg\TokenAuthentication;
 use Dyorg\TokenAuthentication\TokenSearch;
 use Dyorg\TokenAuthentication\Exceptions\UnauthorizedExceptionInterface;
@@ -38,6 +39,30 @@ abstract class {{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}
      * @throws UnauthorizedExceptionInterface on invalid token
      */
     abstract protected function getUserByToken(string $token);
+
+    /**
+     * Handles the response for unauthorized access attempts.
+     * 
+     * This method is called when an access token is either not provided, invalid, or expired.
+     * It constructs a response that includes an error message, the status code, and any other relevant information.
+     * 
+     * @param ServerRequestInterface $request   The HTTP request that led to the unauthorized access attempt.
+     * @param ResponseInterface      $response  The response object that will be modified to reflect the unauthorized status.
+     * @param TokenAuthentication    $tokenAuth The instance of TokenAuthentication that attempted to validate the token.
+     *
+     * @return ResponseInterface The modified response object with the unauthorized access error information.
+     */
+    public function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, TokenAuthentication $tokenAuth)
+    {
+        $output = [];
+        $output['error'] = [
+            'msg' => $tokenAuth->getResponseMessage(),
+            'token' => $tokenAuth->getResponseToken(),
+            'status' => 401,
+            'error' => true
+        ];
+        return $response->withJson($output, 401);
+    }
 
     /**
      * Authenticator constructor

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
@@ -46,22 +46,24 @@ abstract class {{abstractNamePrefix}}Authenticator{{abstractNameSuffix}}
      * This method is called when an access token is either not provided, invalid, or expired.
      * It constructs a response that includes an error message, the status code, and any other relevant information.
      * 
-     * @param ServerRequestInterface $request   The HTTP request that led to the unauthorized access attempt.
-     * @param ResponseInterface      $response  The response object that will be modified to reflect the unauthorized status.
-     * @param TokenAuthentication    $tokenAuth The instance of TokenAuthentication that attempted to validate the token.
+     * @param ServerRequestInterface         $request The HTTP request that led to the unauthorized access attempt.
+     * @param ResponseInterface              $response The response object that will be modified to reflect the unauthorized status.
+     * @param UnauthorizedExceptionInterface $exception The exception triggered due to unauthorized access, containing details such as the error message.
      *
-     * @return ResponseInterface The modified response object with the unauthorized access error information.
+     * @return ResponseInterface The modified response object with the unauthorized access error information, including a 401 status code and a JSON body with the error message and token information.
      */
-    public function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, TokenAuthentication $tokenAuth)
+    public static function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, UnauthorizedExceptionInterface $exception)
     {
-        $output = [];
-        $output['error'] = [
-            'msg' => $tokenAuth->getResponseMessage(),
-            'token' => $tokenAuth->getResponseToken(),
-            'status' => 401,
-            'error' => true
+        $output = [
+            'message' => $exception->getMessage(),
+            'token' => $request->getAttribute('authorization_token'),
+            'success' => false
         ];
-        return $response->withJson($output, 401);
+    
+        $response->getBody()->write(json_encode($output));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(401);
     }
 
     /**

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/abstract_authenticator.mustache
@@ -11,7 +11,6 @@ namespace {{authPackage}};
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Dyorg\TokenAuthentication;
 use Dyorg\TokenAuthentication\TokenSearch;
 use Dyorg\TokenAuthentication\Exceptions\UnauthorizedExceptionInterface;
 

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/index.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/index.mustache
@@ -25,7 +25,7 @@ $builder = new ContainerBuilder();
 
 // consider prod by default
 $env;
-switch (strtolower($_SERVER['APP_ENV'] ?? 'prod')) {
+switch (strtolower($_SERVER['APP_ENV'] ?? getenv('APP_ENV') ?? 'prod')) {
     case 'development':
     case 'dev':
         $env = 'dev';

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
@@ -179,25 +179,27 @@ class RegisterRoutes
                         {{#isBasicBasic}}
                     if ($authMethod['isBasic']) {
                         $route->add(new TokenAuthentication([
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new BasicAuthenticator,
                             'regex' => '/Basic\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,
                             'argument' => null,
-                            'error' => BasicAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['{{authPackage}}\BasicAuthenticator', 'handleUnauthorized'],
                         ]));
                     }
                         {{/isBasicBasic}}
                         {{#isApiKey}}
                     if ($authMethod['isApiKey']) {
                         $authenticatorConfig = [
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new ApiKeyAuthenticator,
                             'regex' => '/\s+(.*)$/i',
                             'argument' => null,
-                            'error' => ApiKeyAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['{{authPackage}}\ApiKeyAuthenticator', 'handleUnauthorized'],
                         ];
                         if ($authMethod['isKeyInHeader']) {
                             $authenticatorConfig = [
@@ -224,28 +226,30 @@ class RegisterRoutes
                         {{#isBasicBearer}}
                     if ($authMethod['isBearer']) {
                         $route->add(new TokenAuthentication([
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new BearerAuthenticator,
                             'regex' => '/Bearer\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,
                             'argument' => null,
-                            'error' => BearerAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['{{authPackage}}\BearerAuthenticator', 'handleUnauthorized'],
                         ]));
                     }
                         {{/isBasicBearer}}
                         {{#isOAuth}}
                     if ($authMethod['isOAuth']) {
                         $route->add(new TokenAuthentication([
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new OAuthAuthenticator($authMethod['scopes']),
                             'regex' => '/Bearer\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,
                             'argument' => null,
-                            'error' => OAuthAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['{{authPackage}}\OAuthAuthenticator', 'handleUnauthorized'],
                         ]));
                     }
                         {{/isOAuth}}

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/register_routes.mustache
@@ -14,6 +14,23 @@ namespace {{appPackage}};
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\HttpNotImplementedException;
+{{#hasAuthMethods}}
+use Dyorg\TokenAuthentication;
+    {{#authMethods}}
+        {{#isBasicBasic}}
+use {{authPackage}}\BasicAuthenticator;
+        {{/isBasicBasic}}
+        {{#isApiKey}}
+use {{authPackage}}\ApiKeyAuthenticator;
+        {{/isApiKey}}
+        {{#isOAuth}}
+use {{authPackage}}\OAuthAuthenticator;
+        {{/isOAuth}}
+        {{#isBasicBearer}}
+use {{authPackage}}\BearerAuthenticator;
+        {{/isBasicBearer}}
+    {{/authMethods}}
+{{/hasAuthMethods}}
 
 /**
  * RegisterRoutes Class Doc Comment
@@ -60,7 +77,9 @@ class RegisterRoutes
                 {{#isBasicBearer}}
                 [
                     'type' => '{{type}}',
-                    'isBasic' => true,
+                    'scheme' => '{{scheme}}',
+                    'bearerFormat' => '{{bearerFormat}}',
+                    'isBasic' => false,
                     'isBearer' => true,
                     'isApiKey' => false,
                     'isOAuth' => false,
@@ -151,6 +170,89 @@ class RegisterRoutes
                 "{$operation['basePathWithoutHost']}{$operation['path']}",
                 $callback
             )->setName($operation['operationId']);
+
+            {{#hasAuthMethods}}
+            // Add authentication middleware based on the operation's authMethods
+            if ($operation['authMethods']) {
+                foreach ($operation['authMethods'] as $authMethod) {
+                    {{#authMethods}}
+                        {{#isBasicBasic}}
+                    if ($authMethod['isBasic']) {
+                        $route->add(new TokenAuthentication([
+                            'path' => $operation['path'],
+                            'authenticator' => new BasicAuthenticator,
+                            'regex' => '/Basic\s+(.*)$/i',
+                            'header' => 'Authorization',
+                            'parameter' => null,
+                            'cookie' => null,
+                            'argument' => null,
+                            'error' => BasicAuthenticator::handleUnauthorized,
+                        ]));
+                    }
+                        {{/isBasicBasic}}
+                        {{#isApiKey}}
+                    if ($authMethod['isApiKey']) {
+                        $authenticatorConfig = [
+                            'path' => $operation['path'],
+                            'authenticator' => new ApiKeyAuthenticator,
+                            'regex' => '/\s+(.*)$/i',
+                            'argument' => null,
+                            'error' => ApiKeyAuthenticator::handleUnauthorized,
+                        ];
+                        if ($authMethod['isKeyInHeader']) {
+                            $authenticatorConfig = [
+                                'header' => $authMethod['keyParamName'],
+                                'parameter' => null,
+                                'cookie' => null,
+                            ]
+                        } else if ($authMethod['isKeyInQuery']) {
+                            $authenticatorConfig = [
+                                'header' => null,
+                                'parameter' => $authMethod['keyParamName'],
+                                'cookie' => null,
+                            ]
+                        } else if ($authMethod['isKeyInCookie']) {
+                            $authenticatorConfig = [
+                                'header' => null,
+                                'parameter' => null,
+                                'cookie' => $authMethod['keyParamName'],
+                            ]
+                        }
+                        $route->add(new TokenAuthentication($authenticatorConfig));
+                    }
+                        {{/isApiKey}}
+                        {{#isBasicBearer}}
+                    if ($authMethod['isBearer']) {
+                        $route->add(new TokenAuthentication([
+                            'path' => $operation['path'],
+                            'authenticator' => new BearerAuthenticator,
+                            'regex' => '/Bearer\s+(.*)$/i',
+                            'header' => 'Authorization',
+                            'parameter' => null,
+                            'cookie' => null,
+                            'argument' => null,
+                            'error' => BearerAuthenticator::handleUnauthorized,
+                        ]));
+                    }
+                        {{/isBasicBearer}}
+                        {{#isOAuth}}
+                    if ($authMethod['isOAuth']) {
+                        $route->add(new TokenAuthentication([
+                            'path' => $operation['path'],
+                            'authenticator' => new OAuthAuthenticator($authMethod['scopes']),
+                            'regex' => '/Bearer\s+(.*)$/i',
+                            'header' => 'Authorization',
+                            'parameter' => null,
+                            'cookie' => null,
+                            'argument' => null,
+                            'error' => OAuthAuthenticator::handleUnauthorized,
+                        ]));
+                    }
+                        {{/isOAuth}}
+                    {{/authMethods}}
+                }
+            }
+            {{/hasAuthMethods}}
 
             foreach ($middlewares as $middleware) {
                 $route->add($middleware);

--- a/samples/server/petstore/php-slim4/README.md
+++ b/samples/server/petstore/php-slim4/README.md
@@ -90,12 +90,22 @@ $ composer phplint
 
 ## Show errors
 
-Switch your app environment to development in `public/.htaccess` file:
+Switch your app environment to development
+- When using with some webserver => in `public/.htaccess` file:
 ```ini
 ## .htaccess
 <IfModule mod_env.c>
     SetEnv APP_ENV 'development'
 </IfModule>
+```
+
+- Or when using whatever else, set `APP_ENV` environment variable like this:
+```bash
+export APP_ENV=development
+```
+or simply
+```bash
+export APP_ENV=dev
 ```
 
 ## Mock Server

--- a/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
+++ b/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
@@ -27,6 +27,9 @@ namespace OpenAPIServer\App;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\HttpNotImplementedException;
+use Dyorg\TokenAuthentication;
+use OpenAPIServer\Auth\OAuthAuthenticator;
+use OpenAPIServer\Auth\ApiKeyAuthenticator;
 
 /**
  * RegisterRoutes Class Doc Comment
@@ -880,6 +883,53 @@ class RegisterRoutes
                 "{$operation['basePathWithoutHost']}{$operation['path']}",
                 $callback
             )->setName($operation['operationId']);
+
+            // Add authentication middleware based on the operation's authMethods
+            if ($operation['authMethods']) {
+                foreach ($operation['authMethods'] as $authMethod) {
+                    if ($authMethod['isOAuth']) {
+                        $route->add(new TokenAuthentication([
+                            'path' => $operation['path'],
+                            'authenticator' => new OAuthAuthenticator($authMethod['scopes']),
+                            'regex' => '/Bearer\s+(.*)$/i',
+                            'header' => 'Authorization',
+                            'parameter' => null,
+                            'cookie' => null,
+                            'argument' => null,
+                            'error' => OAuthAuthenticator::handleUnauthorized,
+                        ]));
+                    }
+                    if ($authMethod['isApiKey']) {
+                        $authenticatorConfig = [
+                            'path' => $operation['path'],
+                            'authenticator' => new ApiKeyAuthenticator,
+                            'regex' => '/\s+(.*)$/i',
+                            'argument' => null,
+                            'error' => ApiKeyAuthenticator::handleUnauthorized,
+                        ];
+                        if ($authMethod['isKeyInHeader']) {
+                            $authenticatorConfig = [
+                                'header' => $authMethod['keyParamName'],
+                                'parameter' => null,
+                                'cookie' => null,
+                            ]
+                        } else if ($authMethod['isKeyInQuery']) {
+                            $authenticatorConfig = [
+                                'header' => null,
+                                'parameter' => $authMethod['keyParamName'],
+                                'cookie' => null,
+                            ]
+                        } else if ($authMethod['isKeyInCookie']) {
+                            $authenticatorConfig = [
+                                'header' => null,
+                                'parameter' => null,
+                                'cookie' => $authMethod['keyParamName'],
+                            ]
+                        }
+                        $route->add(new TokenAuthentication($authenticatorConfig));
+                    }
+                }
+            }
 
             foreach ($middlewares as $middleware) {
                 $route->add($middleware);

--- a/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
+++ b/samples/server/petstore/php-slim4/lib/App/RegisterRoutes.php
@@ -889,23 +889,25 @@ class RegisterRoutes
                 foreach ($operation['authMethods'] as $authMethod) {
                     if ($authMethod['isOAuth']) {
                         $route->add(new TokenAuthentication([
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new OAuthAuthenticator($authMethod['scopes']),
                             'regex' => '/Bearer\s+(.*)$/i',
                             'header' => 'Authorization',
                             'parameter' => null,
                             'cookie' => null,
                             'argument' => null,
-                            'error' => OAuthAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['OpenAPIServer\Auth\OAuthAuthenticator', 'handleUnauthorized'],
                         ]));
                     }
                     if ($authMethod['isApiKey']) {
                         $authenticatorConfig = [
-                            'path' => $operation['path'],
+                            'path' => '/',
                             'authenticator' => new ApiKeyAuthenticator,
                             'regex' => '/\s+(.*)$/i',
                             'argument' => null,
-                            'error' => ApiKeyAuthenticator::handleUnauthorized,
+                            'attribute' => 'authorization_token',
+                            'error' => ['OpenAPIServer\Auth\ApiKeyAuthenticator', 'handleUnauthorized'],
                         ];
                         if ($authMethod['isKeyInHeader']) {
                             $authenticatorConfig = [

--- a/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
+++ b/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
@@ -59,22 +59,24 @@ abstract class AbstractAuthenticator
      * This method is called when an access token is either not provided, invalid, or expired.
      * It constructs a response that includes an error message, the status code, and any other relevant information.
      * 
-     * @param ServerRequestInterface $request   The HTTP request that led to the unauthorized access attempt.
-     * @param ResponseInterface      $response  The response object that will be modified to reflect the unauthorized status.
-     * @param TokenAuthentication    $tokenAuth The instance of TokenAuthentication that attempted to validate the token.
+     * @param ServerRequestInterface         $request The HTTP request that led to the unauthorized access attempt.
+     * @param ResponseInterface              $response The response object that will be modified to reflect the unauthorized status.
+     * @param UnauthorizedExceptionInterface $exception The exception triggered due to unauthorized access, containing details such as the error message.
      *
-     * @return ResponseInterface The modified response object with the unauthorized access error information.
+     * @return ResponseInterface The modified response object with the unauthorized access error information, including a 401 status code and a JSON body with the error message and token information.
      */
-    public function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, TokenAuthentication $tokenAuth)
+    public static function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, UnauthorizedExceptionInterface $exception)
     {
-        $output = [];
-        $output['error'] = [
-            'msg' => $tokenAuth->getResponseMessage(),
-            'token' => $tokenAuth->getResponseToken(),
-            'status' => 401,
-            'error' => true
+        $output = [
+            'message' => $exception->getMessage(),
+            'token' => $request->getAttribute('authorization_token'),
+            'success' => false
         ];
-        return $response->withJson($output, 401);
+    
+        $response->getBody()->write(json_encode($output));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus(401);
     }
 
     /**

--- a/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
+++ b/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
@@ -23,6 +23,7 @@
 namespace OpenAPIServer\Auth;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Dyorg\TokenAuthentication;
 use Dyorg\TokenAuthentication\TokenSearch;
 use Dyorg\TokenAuthentication\Exceptions\UnauthorizedExceptionInterface;
@@ -51,6 +52,30 @@ abstract class AbstractAuthenticator
      * @throws UnauthorizedExceptionInterface on invalid token
      */
     abstract protected function getUserByToken(string $token);
+
+    /**
+     * Handles the response for unauthorized access attempts.
+     * 
+     * This method is called when an access token is either not provided, invalid, or expired.
+     * It constructs a response that includes an error message, the status code, and any other relevant information.
+     * 
+     * @param ServerRequestInterface $request   The HTTP request that led to the unauthorized access attempt.
+     * @param ResponseInterface      $response  The response object that will be modified to reflect the unauthorized status.
+     * @param TokenAuthentication    $tokenAuth The instance of TokenAuthentication that attempted to validate the token.
+     *
+     * @return ResponseInterface The modified response object with the unauthorized access error information.
+     */
+    public function handleUnauthorized(ServerRequestInterface $request, ResponseInterface $response, TokenAuthentication $tokenAuth)
+    {
+        $output = [];
+        $output['error'] = [
+            'msg' => $tokenAuth->getResponseMessage(),
+            'token' => $tokenAuth->getResponseToken(),
+            'status' => 401,
+            'error' => true
+        ];
+        return $response->withJson($output, 401);
+    }
 
     /**
      * Authenticator constructor

--- a/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
+++ b/samples/server/petstore/php-slim4/lib/Auth/AbstractAuthenticator.php
@@ -24,7 +24,6 @@ namespace OpenAPIServer\Auth;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Dyorg\TokenAuthentication;
 use Dyorg\TokenAuthentication\TokenSearch;
 use Dyorg\TokenAuthentication\Exceptions\UnauthorizedExceptionInterface;
 

--- a/samples/server/petstore/php-slim4/public/index.php
+++ b/samples/server/petstore/php-slim4/public/index.php
@@ -37,7 +37,7 @@ $builder = new ContainerBuilder();
 
 // consider prod by default
 $env;
-switch (strtolower($_SERVER['APP_ENV'] ?? 'prod')) {
+switch (strtolower($_SERVER['APP_ENV'] ?? getenv('APP_ENV') ?? 'prod')) {
     case 'development':
     case 'dev':
         $env = 'dev';


### PR DESCRIPTION
In php-slim4 - The authorization types are picked, just they are not added to routes middlewares, this PR fixes that.
fix: added middleware adding for authorization methods, added unauthorized handler to authorization abstract, fixes #18031

Tested with real application, working.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
