### PR TITLE
Ignore _merged_spec.yaml when computing build cache key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,21 @@
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>${git-commit-id-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                            <normalization>
+                                <runtimeClassPath>
+                                    <ignoredFiles>
+                                        <ignoredFile>**/_merged_spec.yaml</ignoredFile>
+                                    </ignoredFiles>
+                                </runtimeClassPath>
+                            </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
### Issue
The build has some cache misses when run twice without any change (on a fresh clone). The cost here is 10s of wall clock time:
![Screenshot 2024-03-14 at 3 25 55 PM](https://github.com/OpenAPITools/openapi-generator/assets/10243934/2a0570de-e4d9-4355-a567-609770cdef48)

The problem is that the file `modules/openapi-generator-maven-plugin/src/test/resources/default/_merged_spec.yaml` generated by the `maven-plugin` module tests is located in the `src/test/resources` folder which is used as goal input by `compiler:testCompile` and `surefire:test` from the `maven-plugin` module.

![Screenshot 2024-03-14 at 3 22 45 PM](https://github.com/OpenAPITools/openapi-generator/assets/10243934/74cc1785-a359-4199-a0ed-c2c84d495cdd)

This means that the cache key is different, therefore the cache misses.

### Steps to reproduce
Clone the project in a new location
```
git clone git@github.com:OpenAPITools/openapi-generator.git /tmp/openapi-generator
cd /tmp/openapi-generator
./mvnw clean package
./mvnw clean package
```

### Fix
The best solution would be to generate the `_merged_spec.yaml` in the `target` directory, however I couldn't find a way to configure this.
The approach taken is to ignore the file while computing the cache key with help of [RuntimeNormalization](https://docs.gradle.com/enterprise/maven-extension/#ignoring_arbitrary_files).

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
