### PR TITLE
[R][Client] Allow api responses to be NULL or invalid JSON and fix file_params for file upload

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -50,6 +50,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -515,7 +515,7 @@
       file_params["{{baseName}}"] <- httr::upload_file(`{{paramName}}`)
       {{/isHttr2}}
       {{#isHttr2}}
-      file_params["{{baseName}}"] <- curl::form_file(`{{paramName}}`)
+      file_params[["{{baseName}}"]] <- curl::form_file(`{{paramName}}`)
       {{/isHttr2}}
       {{/isFile}}
       {{/formParams}}

--- a/modules/openapi-generator/src/main/resources/r/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api_client.mustache
@@ -335,7 +335,11 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/libraries/httr2/api_client.mustache
@@ -344,7 +344,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/echo_api/r/R/api_client.R
+++ b/samples/client/echo_api/r/R/api_client.R
@@ -287,7 +287,11 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/samples/client/echo_api/r/R/api_response.R
+++ b/samples/client/echo_api/r/R/api_response.R
@@ -57,6 +57,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R-httr2-wrapper/R/api_client.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_client.R
@@ -333,7 +333,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -1807,7 +1807,7 @@ PetApi <- R6::R6Class(
 
 
       form_params["additionalMetadata"] <- `additional_metadata`
-      file_params["file"] <- curl::form_file(`file`)
+      file_params[["file"]] <- curl::form_file(`file`)
       local_var_url_path <- "/pet/{petId}/uploadImage"
       if (!missing(`pet_id`)) {
         local_var_url_path <- gsub("\\{petId\\}", URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)

--- a/samples/client/petstore/R-httr2/R/api_client.R
+++ b/samples/client/petstore/R-httr2/R/api_client.R
@@ -333,7 +333,11 @@ ApiClient  <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type.

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -1807,7 +1807,7 @@ PetApi <- R6::R6Class(
 
 
       form_params["additionalMetadata"] <- `additional_metadata`
-      file_params["file"] <- curl::form_file(`file`)
+      file_params[["file"]] <- curl::form_file(`file`)
       local_var_url_path <- "/pet/{petId}/uploadImage"
       if (!missing(`pet_id`)) {
         local_var_url_path <- gsub("\\{petId\\}", URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)

--- a/samples/client/petstore/R/R/api_client.R
+++ b/samples/client/petstore/R/R/api_client.R
@@ -316,7 +316,11 @@ ApiClient <- R6::R6Class(
     #' @return Deserialized object.
     #' @export
     deserialize = function(raw_response, return_type, pkg_env) {
-      resp_obj <- jsonlite::fromJSON(raw_response)
+      if (jsonlite::validate(raw_response)) {
+        resp_obj <- jsonlite::fromJSON(raw_response)
+      } else {
+        resp_obj <- raw_response
+      }
       self$deserializeObj(resp_obj, return_type, pkg_env)
     },
     #' Deserialize the response from jsonlite object based on the given type

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


Introduces changes:
**ApiResponse** now deserializes NULL values instead of producing errors by turning them into strings "NULL"
```
if (is.null(self$response)) {
  self$response <- charToRaw(jsonlite::toJSON("NULL"))
}
```
**ApiClient** now allows to deserialize responses not conforming to JSON, i.e. a simple string would normally produce an error in `jsonlite::fromJSON` but will now be passed on unchanged.
```
if (jsonlite::validate(raw_response)) {
  resp_obj <- jsonlite::fromJSON(raw_response)
} else {
  resp_obj <- raw_response
}
```
**api.mustache** `file_params["{{baseName}}"]` has been changed to `file_params[["{{baseName}}"]]` in order to function as intended when a file path is given as `paramName` in ```file_params[["{{baseName}}"]] <- curl::form_file(`{{paramName}}`)```

Technical committee @Ramanth @saigiridhar21 