### PR TITLE
Add new uncamelize lambda (#18097)

### DIFF
--- a/docs/templating.md
+++ b/docs/templating.md
@@ -822,6 +822,7 @@ Many generators (*those extending DefaultCodegen*) come with a small set of lamb
 - `uppercase` - Converts all of the characters in this fragment to upper case using the rules of the `ROOT` locale.
 - `titlecase` - Converts text in a fragment to title case. For example `once upon a time` to `Once Upon A Time`.
 - `camelcase` - Converts text in a fragment to camelCase. For example `Input-text` to `inputText`.
+- `uncamelize` - Converts text in a fragment from camelCase or PascalCase to a string of words separated by whitespaces. For example `inputText` to `Input Text`.
 - `indented` - Prepends 4 spaces indention from second line of a fragment on. First line will be indented by Mustache.
 - `indented_8` - Prepends 8 spaces indention from second line of a fragment on. First line will be indented by Mustache.
 - `indented_12` - Prepends 12 spaces indention from second line of a fragment on. First line will be indented by Mustache.

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -465,6 +465,7 @@ public class DefaultCodegen implements CodegenConfig {
                 .put("kebabcase", new KebabCaseLambda())
                 .put("camelcase", new CamelCaseLambda(true).generator(this))
                 .put("pascalcase", new CamelCaseLambda(false).generator(this))
+                .put("uncamelize", new UncamelizeLambda())
                 .put("forwardslash", new ForwardSlashLambda())
                 .put("backslash", new BackSlashLambda())
                 .put("doublequote", new DoubleQuoteLambda())

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/UncamelizeLambda.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/templating/mustache/UncamelizeLambda.java
@@ -1,0 +1,53 @@
+
+/*
+ * Copyright 2018 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ * Copyright 2018 SmartBear Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openapitools.codegen.templating.mustache;
+
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.Template;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import static org.openapitools.codegen.utils.StringUtils.camelize;
+
+/**
+ * Converts text in a fragment from camelCase or PascalCase to a space separated string
+ *
+ * Register:
+ * <pre>
+ * additionalProperties.put("uncamelize", new UncamelizeLambda());
+ * </pre>
+ *
+ * Use:
+ * <pre>
+ * {{#uncamelize}}{{name}}{{/uncamelize}}
+ * </pre>
+ */
+public class UncamelizeLambda implements Mustache.Lambda {
+
+    public UncamelizeLambda() {}
+    @Override
+    public void execute(Template.Fragment fragment, Writer writer) throws IOException {
+        String input = fragment.execute();
+        String text = StringUtils.capitalize(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase(input.trim()), StringUtils.SPACE));
+        writer.write(text.trim().replaceAll(" +", " "));
+    }
+}
+

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/UncamelizeLambdaTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/templating/mustache/UncamelizeLambdaTest.java
@@ -1,0 +1,50 @@
+package org.openapitools.codegen.templating.mustache;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class UncamelizeLambdaTest extends LambdaTest {
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void camelCaseTest() {
+        // Given
+        Map<String, Object> ctx = context("uncamelize", new UncamelizeLambda());
+
+        // When & Then
+        test("Input Text", "{{#uncamelize}}inputText{{/uncamelize}}", ctx);
+    }
+
+    @Test
+    public void pascalCaseTest() {
+        // Given
+        Map<String, Object> ctx = context("uncamelize", new UncamelizeLambda());
+
+        // When & Then
+        test("Input Text", "{{#uncamelize}}InputText{{/uncamelize}}", ctx);
+    }
+
+
+    @Test
+    public void emptyStringTest() {
+        // Given
+        Map<String, Object> ctx = context("uncamelize", new UncamelizeLambda());
+
+        // When & Then
+        test("", "{{#uncamelize}}{{/uncamelize}}", ctx);
+    }
+
+    @Test
+    public void nonCamelCaseStringTest() {
+        // Given
+        Map<String, Object> ctx = context("uncamelize", new UncamelizeLambda());
+
+        // When & Then
+        test("Input Text", "{{#uncamelize}}Input Text{{/uncamelize}}", ctx);
+    }
+}


### PR DESCRIPTION
New `uncamelize` lambda that converts the input string from camelCase/PascalCase to a string of whitespace separated words. For example `inputText` to `Input Text`.


### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
