### PR TITLE
[Python-pydantic-v1] Only call to_dict when available

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
@@ -152,9 +152,14 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         if self.{{{name}}}:
             for _item in self.{{{name}}}:
                 if _item:
-                    _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
-                    )
+                    _inner_items = []
+                    for _inner_item in _item:
+                        if _inner_item is not None:
+                            if hasattr(_inner_item, "to_dict") and callable(_inner_item.to_dict):
+                                _inner_items.append(_inner_item.to_dict())
+                            else:
+                                _inner_items.append(_inner_item)
+                    _items.append(_inner_items)
             _dict['{{{baseName}}}'] = _items
         {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
@@ -166,7 +171,10 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         if self.{{{name}}}:
             for _item in self.{{{name}}}:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['{{{baseName}}}'] = _items
         {{/items.isEnumOrRef}}
         {{/items.isPrimitiveType}}
@@ -179,9 +187,13 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         if self.{{{name}}}:
             for _key in self.{{{name}}}:
                 if self.{{{name}}}[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.{{{name}}}[_key]
-                    ]
+                    _items = []
+                    for _item in self.{{{name}}}[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['{{{baseName}}}'] = _field_dict_of_array
         {{/items.isArray}}
         {{^items.isArray}}

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
@@ -78,7 +78,10 @@ class Pet(BaseModel):
         if self.tags:
             for _item in self.tags:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_model.py
@@ -58,9 +58,14 @@ class ArrayOfArrayOfModel(BaseModel):
         if self.another_property:
             for _item in self.another_property:
                 if _item:
-                    _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
-                    )
+                    _inner_items = []
+                    for _inner_item in _item:
+                        if _inner_item is not None:
+                            if hasattr(_inner_item, "to_dict") and callable(_inner_item.to_dict):
+                                _inner_items.append(_inner_item.to_dict())
+                            else:
+                                _inner_items.append(_inner_item)
+                    _items.append(_inner_items)
             _dict['another_property'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_test.py
@@ -61,9 +61,14 @@ class ArrayTest(BaseModel):
         if self.array_array_of_model:
             for _item in self.array_array_of_model:
                 if _item:
-                    _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
-                    )
+                    _inner_items = []
+                    for _inner_item in _item:
+                        if _inner_item is not None:
+                            if hasattr(_inner_item, "to_dict") and callable(_inner_item.to_dict):
+                                _inner_items.append(_inner_item.to_dict())
+                            else:
+                                _inner_items.append(_inner_item)
+                    _items.append(_inner_items)
             _dict['array_array_of_model'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file_schema_test_class.py
@@ -62,7 +62,10 @@ class FileSchemaTestClass(BaseModel):
         if self.files:
             for _item in self.files:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['files'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -58,9 +58,13 @@ class MapOfArrayOfModel(BaseModel):
         if self.shop_id_to_org_online_lip_map:
             for _key in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key]
-                    ]
+                    _items = []
+                    for _item in self.shop_id_to_org_online_lip_map[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
@@ -77,7 +77,10 @@ class Pet(BaseModel):
         if self.tags:
             for _item in self.tags:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['tags'] = _items
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -58,9 +58,13 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         if self.dict_property:
             for _key in self.dict_property:
                 if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
+                    _items = []
+                    for _item in self.dict_property[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -57,9 +57,13 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
         if self.dict_property:
             for _key in self.dict_property:
                 if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
+                    _items = []
+                    for _item in self.dict_property[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['dictProperty'] = _field_dict_of_array
         return _dict
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_model.py
@@ -60,9 +60,14 @@ class ArrayOfArrayOfModel(BaseModel):
         if self.another_property:
             for _item in self.another_property:
                 if _item:
-                    _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
-                    )
+                    _inner_items = []
+                    for _inner_item in _item:
+                        if _inner_item is not None:
+                            if hasattr(_inner_item, "to_dict") and callable(_inner_item.to_dict):
+                                _inner_items.append(_inner_item.to_dict())
+                            else:
+                                _inner_items.append(_inner_item)
+                    _items.append(_inner_items)
             _dict['another_property'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_test.py
@@ -63,9 +63,14 @@ class ArrayTest(BaseModel):
         if self.array_array_of_model:
             for _item in self.array_array_of_model:
                 if _item:
-                    _items.append(
-                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
-                    )
+                    _inner_items = []
+                    for _inner_item in _item:
+                        if _inner_item is not None:
+                            if hasattr(_inner_item, "to_dict") and callable(_inner_item.to_dict):
+                                _inner_items.append(_inner_item.to_dict())
+                            else:
+                                _inner_items.append(_inner_item)
+                    _items.append(_inner_items)
             _dict['array_array_of_model'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file_schema_test_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file_schema_test_class.py
@@ -64,7 +64,10 @@ class FileSchemaTestClass(BaseModel):
         if self.files:
             for _item in self.files:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['files'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
@@ -60,9 +60,13 @@ class MapOfArrayOfModel(BaseModel):
         if self.shop_id_to_org_online_lip_map:
             for _key in self.shop_id_to_org_online_lip_map:
                 if self.shop_id_to_org_online_lip_map[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key]
-                    ]
+                    _items = []
+                    for _item in self.shop_id_to_org_online_lip_map[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['shopIdToOrgOnlineLipMap'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
@@ -79,7 +79,10 @@ class Pet(BaseModel):
         if self.tags:
             for _item in self.tags:
                 if _item:
-                    _items.append(_item.to_dict())
+                     if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
             _dict['tags'] = _items
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -60,9 +60,13 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         if self.dict_property:
             for _key in self.dict_property:
                 if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
+                    _items = []
+                    for _item in self.dict_property[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -59,9 +59,13 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
         if self.dict_property:
             for _key in self.dict_property:
                 if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
+                    _items = []
+                    for _item in self.dict_property[_key]:
+                        if hasattr(_item, "to_dict") and callable(_item.to_dict):
+                            _items.append(_item.to_dict())
+                        else:
+                            _items.append(_item)
+                    _field_dict_of_array[_key] = _items
             _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:


### PR DESCRIPTION
When converting an object to dict only call the to_dict function when it's available.

It should resolve [this issue](https://github.com/OpenAPITools/openapi-generator/issues/18096).

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Technical Committee 
@cbornet @tomplus @krjakbrjak @fa0311 @multani 