### PR TITLE
[python-pydantic-v1] Fix unnamed dicts with additional properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
+++ b/modules/openapi-generator/src/main/resources/python-pydantic-v1/model_generic.mustache
@@ -174,15 +174,17 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         {{/isArray}}
         {{#isMap}}
         {{#items.isArray}}
+        {{^items.items.isPrimitiveType}}
         # override the default output from pydantic by calling `to_dict()` of each value in {{{name}}} (dict of array)
         _field_dict_of_array = {}
         if self.{{{name}}}:
             for _key in self.{{{name}}}:
-                if self.{{{name}}}[_key]:
+                if self.{{{name}}}[_key] is not None:
                     _field_dict_of_array[_key] = [
                         _item.to_dict() for _item in self.{{{name}}}[_key]
                     ]
             _dict['{{{baseName}}}'] = _field_dict_of_array
+        {{/items.items.isPrimitiveType}}
         {{/items.isArray}}
         {{^items.isArray}}
         {{^items.isPrimitiveType}}

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -57,7 +57,7 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key]:
+                if self.shop_id_to_org_online_lip_map[_key] is not None:
                     _field_dict_of_array[_key] = [
                         _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key]
                     ]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -57,7 +57,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key in self.dict_property:
-                if self.dict_property[_key]:
+                if self.dict_property[_key] is not None:
                     _field_dict_of_array[_key] = [
                         _item.to_dict() for _item in self.dict_property[_key]
                     ]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -52,15 +52,6 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
                           exclude={
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each value in dict_property (dict of array)
-        _field_dict_of_array = {}
-        if self.dict_property:
-            for _key in self.dict_property:
-                if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
-            _dict['dictProperty'] = _field_dict_of_array
         return _dict
 
     @classmethod

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
@@ -59,7 +59,7 @@ class MapOfArrayOfModel(BaseModel):
         _field_dict_of_array = {}
         if self.shop_id_to_org_online_lip_map:
             for _key in self.shop_id_to_org_online_lip_map:
-                if self.shop_id_to_org_online_lip_map[_key]:
+                if self.shop_id_to_org_online_lip_map[_key] is not None:
                     _field_dict_of_array[_key] = [
                         _item.to_dict() for _item in self.shop_id_to_org_online_lip_map[_key]
                     ]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -59,7 +59,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
         _field_dict_of_array = {}
         if self.dict_property:
             for _key in self.dict_property:
-                if self.dict_property[_key]:
+                if self.dict_property[_key] is not None:
                     _field_dict_of_array[_key] = [
                         _item.to_dict() for _item in self.dict_property[_key]
                     ]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -54,15 +54,6 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
                             "additional_properties"
                           },
                           exclude_none=True)
-        # override the default output from pydantic by calling `to_dict()` of each value in dict_property (dict of array)
-        _field_dict_of_array = {}
-        if self.dict_property:
-            for _key in self.dict_property:
-                if self.dict_property[_key]:
-                    _field_dict_of_array[_key] = [
-                        _item.to_dict() for _item in self.dict_property[_key]
-                    ]
-            _dict['dictProperty'] = _field_dict_of_array
         # puts key-value pairs in additional_properties in the top level
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():

--- a/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/tests/test_model.py
@@ -534,3 +534,30 @@ class ModelTests(unittest.TestCase):
         a3.additional_properties = { "xyz": 45.6 }
         self.assertEqual(a3.to_dict(), {"xyz": 45.6})
         self.assertEqual(a3.to_json(), "{\"xyz\": 45.6}")
+
+class TestUnnamedDictWithAdditionalStringListProperties:
+    def test_empty_dict(self):
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={})
+        assert a.to_dict() == {"dictProperty": {}}
+
+    def test_empty_list(self):
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={"b": []})
+        assert a.to_dict() == {"dictProperty": {"b": []}}
+
+    def test_single_string_item(self):
+        a = petstore_api.UnnamedDictWithAdditionalStringListProperties(dict_property={"b": ["c"]})
+        assert a.to_dict() == {"dictProperty": {"b": ["c"]}}
+
+class TestUnnamedDictWithAdditionalModelListProperties:
+    def test_empty_dict(self):
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property={})
+        assert a.to_dict() == {"dictProperty": {}}
+
+    def test_empty_list(self):
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property={"b": []})
+        assert a.to_dict() == {"dictProperty": {"b": []}}
+
+    def test_single_string_item(self):
+        value = {"b": [petstore_api.CreatureInfo(name="creature_name")]}
+        a = petstore_api.UnnamedDictWithAdditionalModelListProperties(dict_property=value)
+        assert a.to_dict() == {"dictProperty": {"b": [{"name": "creature_name"}]}}


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

This PR applies the changes made by #16779 to pydantic-v1.
It fixes #18096, but with a different approach than #18110.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@cbornet (2017/09) @tomplus (2018/10) @krjakbrjak (2023/02) @fa0311 (2023/10) @multani (2023/10)