### PR TITLE
fix: jersey3 library

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/jersey3/api.mustache
@@ -11,6 +11,11 @@ import {{javaxPackage}}.ws.rs.core.GenericType;
 {{#imports}}import {{import}};
 {{/imports}}
 
+{{#useBeanValidation}}
+import {{javaxPackage}}.validation.constraints.*;
+import {{javaxPackage}}.validation.Valid;
+{{/useBeanValidation}}
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;


### PR DESCRIPTION
fix issue that jersey 3 library failed in case pattern matching was used in the api.

In case pattern matching is used:
```yaml
requestBody:
  content:
    "application/json":
      schema:
        type: array
        items:
          type: string
          pattern: "[A-Z0-9]+"
```

The generation fails because of missing imports:
![image](https://github.com/OpenAPITools/openapi-generator/assets/30546982/dc000598-b290-4e33-ac3c-87959957ce9f)
