### PR TITLE
[R][Client] Allow API response to be NULL

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
+++ b/modules/openapi-generator/src/main/resources/r/ApiResponse.mustache
@@ -50,6 +50,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/echo_api/r/R/api_response.R
+++ b/samples/client/echo_api/r/R/api_response.R
@@ -57,6 +57,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R-httr2-wrapper/R/api_response.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R-httr2/R/api_response.R
+++ b/samples/client/petstore/R-httr2/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")

--- a/samples/client/petstore/R/R/api_response.R
+++ b/samples/client/petstore/R/R/api_response.R
@@ -56,6 +56,9 @@ ApiResponse <- R6::R6Class(
     #' @param to_encoding The target encoding of the return value.
     #' @export
     response_as_text = function(from_encoding = "", to_encoding = "UTF-8") {
+      if (is.null(self$response)) {
+        self$response <- charToRaw(jsonlite::toJSON("NULL"))
+      }
       text_response <- iconv(readBin(self$response, character()), from = from_encoding, to = to_encoding)
       if (is.na(text_response)) {
         warning("The response is binary and will not be converted to text.")


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Breaking up PR https://github.com/OpenAPITools/openapi-generator/pull/18108 into smaller PRs.
Introduces changes:
**ApiResponse** now deserializes NULL values instead of producing errors by turning them into strings "NULL"
```
if (is.null(self$response)) {
  self$response <- charToRaw(jsonlite::toJSON("NULL"))
}
```

Technical committee @Ramanth @saigiridhar21 