### PR TITLE
[R][Client] fix brackets for httr2 file_params

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -515,7 +515,7 @@
       file_params["{{baseName}}"] <- httr::upload_file(`{{paramName}}`)
       {{/isHttr2}}
       {{#isHttr2}}
-      file_params["{{baseName}}"] <- curl::form_file(`{{paramName}}`)
+      file_params[["{{baseName}}"]] <- curl::form_file(`{{paramName}}`)
       {{/isHttr2}}
       {{/isFile}}
       {{/formParams}}

--- a/modules/openapi-generator/src/main/resources/r/api.mustache
+++ b/modules/openapi-generator/src/main/resources/r/api.mustache
@@ -515,7 +515,7 @@
       file_params["{{baseName}}"] <- httr::upload_file(`{{paramName}}`)
       {{/isHttr2}}
       {{#isHttr2}}
-      file_params[["{{baseName}}"]] <- curl::form_file(`{{paramName}}`)
+      file_params[["{{{baseName}}}"]] <- curl::form_file(`{{paramName}}`)
       {{/isHttr2}}
       {{/isFile}}
       {{/formParams}}

--- a/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet_api.R
@@ -1807,7 +1807,7 @@ PetApi <- R6::R6Class(
 
 
       form_params["additionalMetadata"] <- `additional_metadata`
-      file_params["file"] <- curl::form_file(`file`)
+      file_params[["file"]] <- curl::form_file(`file`)
       local_var_url_path <- "/pet/{petId}/uploadImage"
       if (!missing(`pet_id`)) {
         local_var_url_path <- gsub("\\{petId\\}", URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)

--- a/samples/client/petstore/R-httr2/R/pet_api.R
+++ b/samples/client/petstore/R-httr2/R/pet_api.R
@@ -1807,7 +1807,7 @@ PetApi <- R6::R6Class(
 
 
       form_params["additionalMetadata"] <- `additional_metadata`
-      file_params["file"] <- curl::form_file(`file`)
+      file_params[["file"]] <- curl::form_file(`file`)
       local_var_url_path <- "/pet/{petId}/uploadImage"
       if (!missing(`pet_id`)) {
         local_var_url_path <- gsub("\\{petId\\}", URLencode(as.character(`pet_id`), reserved = TRUE), local_var_url_path)


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Breaking up PR https://github.com/OpenAPITools/openapi-generator/pull/18108 into smaller PRs.
Introduces changes:
**api.mustache** `file_params["{{baseName}}"]` has been changed to `file_params[["{{baseName}}"]]` in order to function as intended when a file path is given as `paramName` in ```file_params[["{{baseName}}"]] <- curl::form_file(`{{paramName}}`)```

Technical committee @Ramanth @saigiridhar21 