### PR TITLE
fix: Fix schema generation for `oneOf` when using TS-FETCH client

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -1,5 +1,9 @@
 {{>modelEnumInterfaces}}
 
+export function instanceOf{{classname}}(value: any): boolean {
+    return Object.values({{classname}}).includes(value);
+}
+
 export function {{classname}}FromJSON(json: any): {{classname}} {
     return {{classname}}FromJSONTyped(json, false);
 }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -24,14 +24,14 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     switch (json['{{discriminator.propertyBaseName}}']) {
 {{#discriminator.mappedModels}}
         case '{{mappingName}}':
-            return {...{{modelName}}FromJSONTyped(json, true), {{discriminator.propertyName}}: '{{mappingName}}'};
+            return Object.assign({}, {{modelName}}FromJSONTyped(json, true), { {{discriminator.propertyName}}: '{{mappingName}}' });
 {{/discriminator.mappedModels}}
         default:
             throw new Error(`No variant of {{classname}} exists with '{{discriminator.propertyName}}=${json['{{discriminator.propertyName}}']}'`);
     }
 {{/discriminator}}
 {{^discriminator}}
-    return { {{#oneOf}}...{{{.}}}FromJSONTyped(json, true){{^-last}}, {{/-last}}{{/oneOf}} };
+    return Object.assign({}, {{#oneOf}}{{{.}}}FromJSONTyped(json, true){{^-last}}, {{/-last}}{{/oneOf}});
 {{/discriminator}}
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -25,6 +25,10 @@ export const EnumClass = {
 export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
+export function instanceOfEnumClass(value: any): boolean {
+    return Object.values(EnumClass).includes(value);
+}
+
 export function EnumClassFromJSON(json: any): EnumClass {
     return EnumClassFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -25,6 +25,10 @@ export const OuterEnum = {
 export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
+export function instanceOfOuterEnum(value: any): boolean {
+    return Object.values(OuterEnum).includes(value);
+}
+
 export function OuterEnumFromJSON(json: any): OuterEnum {
     return OuterEnumFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -25,6 +25,10 @@ export const OuterEnumDefaultValue = {
 export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof OuterEnumDefaultValue];
 
 
+export function instanceOfOuterEnumDefaultValue(value: any): boolean {
+    return Object.values(OuterEnumDefaultValue).includes(value);
+}
+
 export function OuterEnumDefaultValueFromJSON(json: any): OuterEnumDefaultValue {
     return OuterEnumDefaultValueFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -25,6 +25,10 @@ export const OuterEnumInteger = {
 export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInteger];
 
 
+export function instanceOfOuterEnumInteger(value: any): boolean {
+    return Object.values(OuterEnumInteger).includes(value);
+}
+
 export function OuterEnumIntegerFromJSON(json: any): OuterEnumInteger {
     return OuterEnumIntegerFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -25,6 +25,10 @@ export const OuterEnumIntegerDefaultValue = {
 export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[keyof typeof OuterEnumIntegerDefaultValue];
 
 
+export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
+    return Object.values(OuterEnumIntegerDefaultValue).includes(value);
+}
+
 export function OuterEnumIntegerDefaultValueFromJSON(json: any): OuterEnumIntegerDefaultValue {
     return OuterEnumIntegerDefaultValueFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -24,6 +24,10 @@ export const SingleRefType = {
 export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
+export function instanceOfSingleRefType(value: any): boolean {
+    return Object.values(SingleRefType).includes(value);
+}
+
 export function SingleRefTypeFromJSON(json: any): SingleRefType {
     return SingleRefTypeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -25,6 +25,10 @@ export const NumberEnum = {
 export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 
 
+export function instanceOfNumberEnum(value: any): boolean {
+    return Object.values(NumberEnum).includes(value);
+}
+
 export function NumberEnumFromJSON(json: any): NumberEnum {
     return NumberEnumFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -25,6 +25,10 @@ export const StringEnum = {
 export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 
 
+export function instanceOfStringEnum(value: any): boolean {
+    return Object.values(StringEnum).includes(value);
+}
+
 export function StringEnumFromJSON(json: any): StringEnum {
     return StringEnumFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -25,6 +25,10 @@ export const BehaviorType = {
 export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 
 
+export function instanceOfBehaviorType(value: any): boolean {
+    return Object.values(BehaviorType).includes(value);
+}
+
 export function BehaviorTypeFromJSON(json: any): BehaviorType {
     return BehaviorTypeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -34,6 +34,10 @@ export const DeploymentRequestStatus = {
 export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeof DeploymentRequestStatus];
 
 
+export function instanceOfDeploymentRequestStatus(value: any): boolean {
+    return Object.values(DeploymentRequestStatus).includes(value);
+}
+
 export function DeploymentRequestStatusFromJSON(json: any): DeploymentRequestStatus {
     return DeploymentRequestStatusFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -40,6 +40,10 @@ export const ErrorCode = {
 export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 
 
+export function instanceOfErrorCode(value: any): boolean {
+    return Object.values(ErrorCode).includes(value);
+}
+
 export function ErrorCodeFromJSON(json: any): ErrorCode {
     return ErrorCodeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -25,6 +25,10 @@ export const PetPartType = {
 export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 
 
+export function instanceOfPetPartType(value: any): boolean {
+    return Object.values(PetPartType).includes(value);
+}
+
 export function PetPartTypeFromJSON(json: any): PetPartType {
     return PetPartTypeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -25,6 +25,10 @@ export const WarningCode = {
 export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 
 
+export function instanceOfWarningCode(value: any): boolean {
+    return Object.values(WarningCode).includes(value);
+}
+
 export function WarningCodeFromJSON(json: any): WarningCode {
     return WarningCodeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -25,6 +25,10 @@ export const EnumClass = {
 export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
+export function instanceOfEnumClass(value: any): boolean {
+    return Object.values(EnumClass).includes(value);
+}
+
 export function EnumClassFromJSON(json: any): EnumClass {
     return EnumClassFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -25,6 +25,10 @@ export const OuterEnum = {
 export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
+export function instanceOfOuterEnum(value: any): boolean {
+    return Object.values(OuterEnum).includes(value);
+}
+
 export function OuterEnumFromJSON(json: any): OuterEnum {
     return OuterEnumFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -25,6 +25,10 @@ export const OuterEnumDefaultValue = {
 export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof OuterEnumDefaultValue];
 
 
+export function instanceOfOuterEnumDefaultValue(value: any): boolean {
+    return Object.values(OuterEnumDefaultValue).includes(value);
+}
+
 export function OuterEnumDefaultValueFromJSON(json: any): OuterEnumDefaultValue {
     return OuterEnumDefaultValueFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -25,6 +25,10 @@ export const OuterEnumInteger = {
 export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInteger];
 
 
+export function instanceOfOuterEnumInteger(value: any): boolean {
+    return Object.values(OuterEnumInteger).includes(value);
+}
+
 export function OuterEnumIntegerFromJSON(json: any): OuterEnumInteger {
     return OuterEnumIntegerFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -25,6 +25,10 @@ export const OuterEnumIntegerDefaultValue = {
 export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[keyof typeof OuterEnumIntegerDefaultValue];
 
 
+export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
+    return Object.values(OuterEnumIntegerDefaultValue).includes(value);
+}
+
 export function OuterEnumIntegerDefaultValueFromJSON(json: any): OuterEnumIntegerDefaultValue {
     return OuterEnumIntegerDefaultValueFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -24,6 +24,10 @@ export const SingleRefType = {
 export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
+export function instanceOfSingleRefType(value: any): boolean {
+    return Object.values(SingleRefType).includes(value);
+}
+
 export function SingleRefTypeFromJSON(json: any): SingleRefType {
     return SingleRefTypeFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -24,6 +24,10 @@ export enum NumberEnum {
 }
 
 
+export function instanceOfNumberEnum(value: any): boolean {
+    return Object.values(NumberEnum).includes(value);
+}
+
 export function NumberEnumFromJSON(json: any): NumberEnum {
     return NumberEnumFromJSONTyped(json, false);
 }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -24,6 +24,10 @@ export enum StringEnum {
 }
 
 
+export function instanceOfStringEnum(value: any): boolean {
+    return Object.values(StringEnum).includes(value);
+}
+
 export function StringEnumFromJSON(json: any): StringEnum {
     return StringEnumFromJSONTyped(json, false);
 }


### PR DESCRIPTION
I'm using Django REST Framework + DRF Spectacular to automatically generate OpenAPI 3 schemas for my APIs.
When defining nullable enums, the API generator `typescript-fetch` creates code that doesn't compile properly with two errors: 

* Spread types may only be created from object types (on `FromJSONTyped` functions).
* Module '"./BlankEnum"' has no exported member 'instanceOfBlankEnum' (enum templaces don't export function used by other API client files).

There's a problem generating `typescript-fetch` API clients using schemas containing `oneOf` and Enums.
Some parts of the API client seem to rely on the `instaceOf{{classname}}`, not provided for enum models.
Also, the code tries to create spread types from function types, leading to a TS compilation error.

_I'm not sure this is the best way to fix the issue, my OpenAPI generator internals knowledge is somewhat limited._

### Testing instructions

1. Check out this branch.
2. Build the generator.
3. Generate an API client using the following schema:
```
openapi: 3.0.3
info:
  title: Some API
  version: 1.0.0
  description: Some API documentation (internal).
paths:
  /api/v1/some-api/{id}/:
    patch:
      operationId: some_api_partial_update
      description: A viewset to edit some api information
      parameters:
      - in: path
        name: id
        schema:
          type: integer
        required: true
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/SomeRequest'
      security:
      - TokenAuthentication: []
      - basicAuth: []
      - cookieAuth: []
      responses:
        '200':
          content:
            application/json:
              schema:
                type: array
                items:
                  $ref: '#/components/schemas/SomeRequest'
          description: ''
components:
  schemas:
    SomeRequest:
      type: object
      description: Some item serializer.
      properties:
        item_type:
          nullable: true
          oneOf:
          - $ref: '#/components/schemas/ItemTypeEnum'
          - $ref: '#/components/schemas/BlankEnum'
          - $ref: '#/components/schemas/NullEnum'
    BlankEnum:
      enum:
      - ''
    ItemTypeEnum:
      enum:
      - A
      - B
      - C
      type: string
    NullEnum:
      enum:
      - null
```
3. Create new node env, install typescript and run `tsc` (target: `es2017`).
4. Check that no type errors are reported by Typescript.

### Related issues 

* https://github.com/OpenAPITools/openapi-generator/issues/15473
* https://github.com/OpenAPITools/openapi-generator/issues/14611
* https://github.com/OpenAPITools/openapi-generator/issues/14763

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
