### PR TITLE
[POSTMAN] Process request with array of string

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/PostmanCollectionCodegen.java
@@ -756,6 +756,8 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
             } else if (value instanceof LinkedHashMap) {
                 String in = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": ";
                 ret = traverseMap(((LinkedHashMap<String, Object>) value),  in);
+            } else if (value instanceof ArrayList<?>) {
+                ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + key + JSON_ESCAPE_DOUBLE_QUOTE + ": " + getJsonArray((ArrayList<Object>) value);
             } else {
                 LOGGER.warn("Value type unrecognised: " + value.getClass());
             }
@@ -768,6 +770,38 @@ public class PostmanCollectionCodegen extends DefaultCodegen implements CodegenC
         }
 
         ret = ret + JSON_ESCAPE_NEW_LINE + "}";
+
+        return ret;
+    }
+
+    String getJsonArray(ArrayList<Object> list) {
+        String ret = "";
+
+        for(Object element: list) {
+            if(element instanceof String) {
+                ret = ret + getStringArrayElement((String) element) + ", ";
+            } else if(element instanceof LinkedHashMap) {
+                ret = traverseMap((LinkedHashMap<String, Object>) element, ret) + ", ";
+            }
+        }
+
+        if(ret.endsWith(", ")) {
+            ret = ret.substring(0, ret.length() - 2);
+        }
+
+        return "[" + ret + "]";
+    }
+
+    String getStringArrayElement(String element) {
+        String ret = "";
+
+        if(element.startsWith("{")) {
+            // isJson (escape all double quotes)
+            ret = ret + element.replace("\"", JSON_ESCAPE_DOUBLE_QUOTE);
+        } else {
+            // string element (add escaped double quotes)
+            ret = ret + JSON_ESCAPE_DOUBLE_QUOTE + element + JSON_ESCAPE_DOUBLE_QUOTE;
+        }
 
         return ret;
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/postman/PostmanCollectionCodegenTest.java
@@ -634,6 +634,46 @@ public class PostmanCollectionCodegenTest {
     }
 
     @Test
+    public void convertNestedArrayListToJson() {
+
+        final String EXPECTED =
+                "{\\n " +
+                        "\\\"id\\\": 1,\\n \\\"city\\\": \\\"Amsterdam\\\",\\n " +
+                        "\\\"tags\\\": [\\\"ams\\\", \\\"adam\\\"]" +
+                        "\\n}";
+
+        LinkedHashMap<String, Object> city = new LinkedHashMap<>();
+        city.put("id", 1);
+        city.put("city", "Amsterdam");
+        ArrayList<String> tags = new ArrayList<>();
+        tags.add("ams");
+        tags.add("adam");
+        city.put("tags", tags);
+
+        assertEquals(EXPECTED, new PostmanCollectionCodegen().convertToJson(city));
+
+    }
+
+    @Test
+    public void convertNestedEmptyArrayListToJson() {
+
+        final String EXPECTED =
+                "{\\n " +
+                        "\\\"id\\\": 1,\\n \\\"city\\\": \\\"Amsterdam\\\",\\n " +
+                        "\\\"tags\\\": []" +
+                        "\\n}";
+
+        LinkedHashMap<String, Object> city = new LinkedHashMap<>();
+        city.put("id", 1);
+        city.put("city", "Amsterdam");
+        ArrayList<String> tags = new ArrayList<>();
+        city.put("tags", tags);
+
+        assertEquals(EXPECTED, new PostmanCollectionCodegen().convertToJson(city));
+
+    }
+
+    @Test
     public void testAddToList()  {
 
         PostmanCollectionCodegen postmanCollectionCodegen = new PostmanCollectionCodegen();

--- a/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/postman-collection/SampleProject.yaml
@@ -322,6 +322,11 @@ components:
           format: date
           description: The date that the user was created.
           example: '2019-08-24'
+        tags:
+          type: array
+          items:
+            type: string
+            description: Tags assigned to the user
       required:
         - id
         - firstName
@@ -353,6 +358,10 @@ components:
         dateOfBirth: '1997-10-31'
         emailVerified: true
         createDate: '2019-08-24'
+        tags:
+          - user
+          - admin
+          - guest
 tags:
   - name: basic
     description: Basic tag

--- a/samples/schema/postman-collection/postman.json
+++ b/samples/schema/postman-collection/postman.json
@@ -345,7 +345,7 @@
                                     ],
                                     "body": {
                                         "mode": "raw",
-                                        "raw": "{\n  \"id\" : 777,\n  \"firstName\" : \"Alotta\",\n  \"lastName\" : \"Rotta\",\n  \"email\" : \"alotta.rotta@gmail.com\",\n  \"dateOfBirth\" : \"1997-10-31\",\n  \"emailVerified\" : true,\n  \"createDate\" : \"2019-08-24\"\n}",
+                                        "raw": "{\n  \"id\" : 777,\n  \"firstName\" : \"Alotta\",\n  \"lastName\" : \"Rotta\",\n  \"email\" : \"alotta.rotta@gmail.com\",\n  \"dateOfBirth\" : \"1997-10-31\",\n  \"emailVerified\" : true,\n  \"createDate\" : \"2019-08-24\",\n  \"tags\" : [ \"user\", \"admin\", \"guest\" ]\n}",
                                         "options": {
                                             "raw": {
                                                 "language": "json"

--- a/samples/schema/postman-collection/python/test/test_endpoints.py
+++ b/samples/schema/postman-collection/python/test/test_endpoints.py
@@ -29,6 +29,16 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(item['request']["method"], 'PATCH')
         self.assertEqual(item['request']["body"]["raw"], '{\n  "firstName" : "Rebecca"\n}')
 
+    def test_request_with_array_strings(self):
+        # item
+        item = self.json_data['item'][2]['item'][0]['item'][0]
+        self.assertEqual(item['request']["method"], 'POST')
+        data = json.loads(item['request']["body"]["raw"])
+        # check is list
+        self.assertTrue(isinstance(data.get("tags"), list))
+        # check values
+        self.assertTrue(set(data.get("tags")) == {"user", "admin", "guest"})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Process request examples that include `array`  to create a valid Postman request that sends a list of values.

- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@wing328 