### PR TITLE
Upgrade github actions

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/maven.yml.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/maven.yml.mustache
@@ -19,9 +19,9 @@ jobs:
       matrix:
         java: [ '8' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
       {{=< >=}}
         java-version: ${{ matrix.java }}

--- a/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/maven.yml.mustache
+++ b/modules/openapi-generator/src/main/resources/java-helidon/client/libraries/se/maven.yml.mustache
@@ -19,9 +19,9 @@ jobs:
       matrix:
         java: [ '8' ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
       {{=< >=}}
         java-version: ${{ matrix.java }}

--- a/modules/openapi-generator/src/main/resources/r/r-client.mustache
+++ b/modules/openapi-generator/src/main/resources/r/r-client.mustache
@@ -15,7 +15,7 @@ jobs:
     env:
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Hi

I have updated the github mustache template for maven.yml and r-client for use the last action version. Now in version 4, previous inside the template in version 2

ciao
matteo