### PR TITLE
[R][Client] allow to initialize enum classes without parameters

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelEnum.mustache
@@ -21,11 +21,21 @@
       val <- unlist(local.optional.var)
       enumvec <- .parse_{{name}}()
 
-      stopifnot(length(val) == 1L)
+      if (length(val) == 0L) {
+        val = "DUMMY_ENUM"
+      } else {
+        stopifnot(length(val) == 1L)
+      }
 
-      if (!val %in% enumvec)
+      if (!val %in% enumvec) {
+        if (!(val=="DUMMY_ENUM")) {
           stop("Use one of the valid values: ",
-              paste0(enumvec, collapse = ", "))
+            paste0(enumvec, collapse = ", "))
+        }
+        warning("Initializing {{{classname}}} with DUMMY_ENUM. Use one of the valid values: ",
+          paste0(enumvec, collapse = ", "),
+          ". If you did not manually initialize {{{classname}}}, this may already be overwritten by an enum loaded from a JSON config.")
+      }
       private$value <- val
     },
     #' To JSON string

--- a/samples/client/echo_api/r/R/string_enum_ref.R
+++ b/samples/client/echo_api/r/R/string_enum_ref.R
@@ -20,11 +20,21 @@ StringEnumRef <- R6::R6Class(
       val <- unlist(local.optional.var)
       enumvec <- .parse_StringEnumRef()
 
-      stopifnot(length(val) == 1L)
+      if (length(val) == 0L) {
+        val = "DUMMY_ENUM"
+      } else {
+        stopifnot(length(val) == 1L)
+      }
 
-      if (!val %in% enumvec)
+      if (!val %in% enumvec) {
+        if (!(val=="DUMMY_ENUM")) {
           stop("Use one of the valid values: ",
-              paste0(enumvec, collapse = ", "))
+            paste0(enumvec, collapse = ", "))
+        }
+        warning("Initializing StringEnumRef with DUMMY_ENUM. Use one of the valid values: ",
+          paste0(enumvec, collapse = ", "),
+          ". If you did not manually initialize StringEnumRef, this may already be overwritten by an enum loaded from a JSON config.")
+      }
       private$value <- val
     },
     #' To JSON string


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

`modelEnum.mustache` currently produces classes that do not allow initialization as 
```
MyEnumClass$new()
```
The above produces an error due to `stopifnot(length(val) == 1L)`. The problem is that if this enum class is a parameter in another class, within the `fromJSON` function of this class it will say
```
if (!is.null(this_object$`enumExample`)) {
  `enumExample_object` <- MyEnumClass$new()
  `enumExample_object`$fromJSON(jsonlite::toJSON(this_object$`enumExample`, auto_unbox = TRUE, digits = NA))
  self$`enumExample` <- `enumExample_object`
}
```
and in turn try to initialize the enum class as given above. I re-wrote the initialization in `modelEnum.mustache` to behave as before if a wrong enum value is given, but allow initializing as `MyEnumClass$new()` by using a dummy enum `DUMMY_ENUM` and warning the user about it. This way the user is warned when using the class itself incorreclty, but can (in most cases) ignore the warning if the enum is instantly corrected like in the latter code example.

TL;DR having an enum class as a class parameter currently does not work in any case, and this PR allows it to work (while expressing warnings to the user)
Technical committee @Ramanth @saigiridhar21