### PR TITLE
Specify named param for field defaults in Python Pydantic V1 generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonPydanticV1Codegen.java
@@ -956,7 +956,7 @@ public abstract class AbstractPythonPydanticV1Codegen extends DefaultCodegen imp
                 }
 
                 if (!fields.isEmpty()) {
-                    fields.add(0, fieldCustomization);
+                    fields.add(0, "default=" + fieldCustomization);
                     pydanticImports.add("Field");
                     fieldCustomization = String.format(Locale.ROOT, "Field(%s)", StringUtils.join(fields, ", "));
                 }

--- a/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python-disallowAdditionalPropertiesIfNotPresent/openapi_client/api/auth_api.py
@@ -17,6 +17,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
+from pydantic import StrictStr
 
 from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/data_query.py
@@ -27,9 +27,9 @@ class DataQuery(Query):
     """
     DataQuery
     """
-    suffix: Optional[StrictStr] = Field(None, description="test suffix")
-    text: Optional[StrictStr] = Field(None, description="Some text containing white spaces")
-    var_date: Optional[datetime] = Field(None, alias="date", description="A date")
+    suffix: Optional[StrictStr] = Field(default=None, description="test suffix")
+    text: Optional[StrictStr] = Field(default=None, description="Some text containing white spaces")
+    var_date: Optional[datetime] = Field(default=None, alias="date", description="A date")
     __properties = ["id", "outcomes", "suffix", "text", "date"]
 
     class Config:

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/pet.py
@@ -31,9 +31,9 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     name: StrictStr = Field(...)
     category: Optional[Category] = None
-    photo_urls: conlist(StrictStr) = Field(..., alias="photoUrls")
+    photo_urls: conlist(StrictStr) = Field(default=..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
-    status: Optional[StrictStr] = Field(None, description="pet status in the store")
+    status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     __properties = ["id", "name", "category", "photoUrls", "tags", "status"]
 
     @validator('status')

--- a/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
+++ b/samples/client/echo_api/python-pydantic-v1/openapi_client/models/query.py
@@ -26,7 +26,7 @@ class Query(BaseModel):
     """
     Query
     """
-    id: Optional[StrictInt] = Field(None, description="Query")
+    id: Optional[StrictInt] = Field(default=None, description="Query")
     outcomes: Optional[conlist(StrictStr)] = None
     __properties = ["id", "outcomes"]
 

--- a/samples/client/echo_api/python/openapi_client/api/auth_api.py
+++ b/samples/client/echo_api/python/openapi_client/api/auth_api.py
@@ -17,6 +17,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
+from pydantic import StrictStr
 
 from openapi_client.api_client import ApiClient, RequestSerialized
 from openapi_client.api_response import ApiResponse

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/api/store_api.py
@@ -16,7 +16,8 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr
+from pydantic import Field, StrictInt, StrictStr
+from typing import Dict
 from typing_extensions import Annotated
 from petstore_api.models.order import Order
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/all_of_with_single_ref.py
@@ -27,7 +27,7 @@ class AllOfWithSingleRef(BaseModel):
     AllOfWithSingleRef
     """
     username: Optional[StrictStr] = None
-    single_ref_type: Optional[SingleRefType] = Field(None, alias="SingleRefType")
+    single_ref_type: Optional[SingleRefType] = Field(default=None, alias="SingleRefType")
     __properties = ["username", "SingleRefType"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/animal.py
@@ -31,7 +31,7 @@ class Animal(BaseModel):
     """
     Animal
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     color: Optional[StrictStr] = 'red'
     __properties = ["className", "color"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/any_of_color.py
@@ -31,11 +31,11 @@ class AnyOfColor(BaseModel):
     """
 
     # data type: List[int]
-    anyof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(None, description="RGB three element array with values 0-255.")
+    anyof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(default=None, description="RGB three element array with values 0-255.")
     # data type: List[int]
-    anyof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(None, description="RGBA four element array with values 0-255.")
+    anyof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
-    anyof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(None, description="Hex color string, such as #00FF00.")
+    anyof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
         actual_instance: Union[List[int], str]
     else:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     """
     ArrayOfArrayOfNumberOnly
     """
-    array_array_number: Optional[conlist(conlist(float))] = Field(None, alias="ArrayArrayNumber")
+    array_array_number: Optional[conlist(conlist(float))] = Field(default=None, alias="ArrayArrayNumber")
     __properties = ["ArrayArrayNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfNumberOnly(BaseModel):
     """
     ArrayOfNumberOnly
     """
-    array_number: Optional[conlist(float)] = Field(None, alias="ArrayNumber")
+    array_number: Optional[conlist(float)] = Field(default=None, alias="ArrayNumber")
     __properties = ["ArrayNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/basque_pig.py
@@ -25,7 +25,7 @@ class BasquePig(BaseModel):
     """
     BasquePig
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     color: StrictStr = Field(...)
     __properties = ["className", "color"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/capitalization.py
@@ -25,12 +25,12 @@ class Capitalization(BaseModel):
     """
     Capitalization
     """
-    small_camel: Optional[StrictStr] = Field(None, alias="smallCamel")
-    capital_camel: Optional[StrictStr] = Field(None, alias="CapitalCamel")
-    small_snake: Optional[StrictStr] = Field(None, alias="small_Snake")
-    capital_snake: Optional[StrictStr] = Field(None, alias="Capital_Snake")
-    sca_eth_flow_points: Optional[StrictStr] = Field(None, alias="SCA_ETH_Flow_Points")
-    att_name: Optional[StrictStr] = Field(None, alias="ATT_NAME", description="Name of the pet ")
+    small_camel: Optional[StrictStr] = Field(default=None, alias="smallCamel")
+    capital_camel: Optional[StrictStr] = Field(default=None, alias="CapitalCamel")
+    small_snake: Optional[StrictStr] = Field(default=None, alias="small_Snake")
+    capital_snake: Optional[StrictStr] = Field(default=None, alias="Capital_Snake")
+    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, alias="SCA_ETH_Flow_Points")
+    att_name: Optional[StrictStr] = Field(default=None, alias="ATT_NAME", description="Name of the pet ")
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/class_model.py
@@ -25,7 +25,7 @@ class ClassModel(BaseModel):
     """
     Model for testing model with \"_class\" property  # noqa: E501
     """
-    var_class: Optional[StrictStr] = Field(None, alias="_class")
+    var_class: Optional[StrictStr] = Field(default=None, alias="_class")
     __properties = ["_class"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/color.py
@@ -30,11 +30,11 @@ class Color(BaseModel):
     RGB array, RGBA array, or hex string.
     """
     # data type: List[int]
-    oneof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(None, description="RGB three element array with values 0-255.")
+    oneof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(default=None, description="RGB three element array with values 0-255.")
     # data type: List[int]
-    oneof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(None, description="RGBA four element array with values 0-255.")
+    oneof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
-    oneof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(None, description="Hex color string, such as #00FF00.")
+    oneof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
         actual_instance: Union[List[int], str]
     else:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/danish_pig.py
@@ -25,7 +25,7 @@ class DanishPig(BaseModel):
     """
     DanishPig
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     size: StrictInt = Field(...)
     __properties = ["className", "size"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/discriminator_all_of_super.py
@@ -30,7 +30,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     """
     DiscriminatorAllOfSuper
     """
-    element_type: StrictStr = Field(..., alias="elementType")
+    element_type: StrictStr = Field(default=..., alias="elementType")
     __properties = ["elementType"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -34,10 +34,10 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[float] = None
-    outer_enum: Optional[OuterEnum] = Field(None, alias="outerEnum")
-    outer_enum_integer: Optional[OuterEnumInteger] = Field(None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(None, alias="outerEnumIntegerDefaultValue")
+    outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
+    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
     __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/file.py
@@ -25,7 +25,7 @@ class File(BaseModel):
     """
     Must be named `File` for test.  # noqa: E501
     """
-    source_uri: Optional[StrictStr] = Field(None, alias="sourceURI", description="Test capitalization")
+    source_uri: Optional[StrictStr] = Field(default=None, alias="sourceURI", description="Test capitalization")
     __properties = ["sourceURI"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/format_test.py
@@ -36,12 +36,12 @@ class FormatTest(BaseModel):
     string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[Union[StrictBytes, StrictStr]] = None
     binary: Optional[Union[StrictBytes, StrictStr]] = None
-    var_date: date = Field(..., alias="date")
-    date_time: Optional[datetime] = Field(None, alias="dateTime")
+    var_date: date = Field(default=..., alias="date")
+    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     uuid: Optional[StrictStr] = None
     password: constr(strict=True, max_length=64, min_length=10) = Field(...)
-    pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
-    pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
+    pattern_with_digits: Optional[constr(strict=True)] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")
+    pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 
     @validator('string')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/health_check_result.py
@@ -25,7 +25,7 @@ class HealthCheckResult(BaseModel):
     """
     Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
-    nullable_message: Optional[StrictStr] = Field(None, alias="NullableMessage")
+    nullable_message: Optional[StrictStr] = Field(default=None, alias="NullableMessage")
     __properties = ["NullableMessage"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/inner_dict_with_property.py
@@ -25,7 +25,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """
-    a_property: Optional[Dict[str, Any]] = Field(None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
     __properties = ["aProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/list_class.py
@@ -25,7 +25,7 @@ class ListClass(BaseModel):
     """
     ListClass
     """
-    var_123_list: Optional[StrictStr] = Field(None, alias="123-list")
+    var_123_list: Optional[StrictStr] = Field(default=None, alias="123-list")
     __properties = ["123-list"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/map_of_array_of_model.py
@@ -26,7 +26,7 @@ class MapOfArrayOfModel(BaseModel):
     """
     MapOfArrayOfModel
     """
-    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(None, alias="shopIdToOrgOnlineLipMap")
+    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, alias="shopIdToOrgOnlineLipMap")
     __properties = ["shopIdToOrgOnlineLipMap"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -27,7 +27,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     MixedPropertiesAndAdditionalPropertiesClass
     """
     uuid: Optional[StrictStr] = None
-    date_time: Optional[datetime] = Field(None, alias="dateTime")
+    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     __properties = ["uuid", "dateTime", "map"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model200_response.py
@@ -26,7 +26,7 @@ class Model200Response(BaseModel):
     Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
-    var_class: Optional[StrictStr] = Field(None, alias="class")
+    var_class: Optional[StrictStr] = Field(default=None, alias="class")
     __properties = ["name", "class"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/model_return.py
@@ -25,7 +25,7 @@ class ModelReturn(BaseModel):
     """
     Model for testing reserved words  # noqa: E501
     """
-    var_return: Optional[StrictInt] = Field(None, alias="return")
+    var_return: Optional[StrictInt] = Field(default=None, alias="return")
     __properties = ["return"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/name.py
@@ -27,8 +27,8 @@ class Name(BaseModel):
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
-    var_property: Optional[StrictStr] = Field(None, alias="property")
-    var_123_number: Optional[StrictInt] = Field(None, alias="123Number")
+    var_property: Optional[StrictStr] = Field(default=None, alias="property")
+    var_123_number: Optional[StrictInt] = Field(default=None, alias="123Number")
     __properties = ["name", "snake_case", "property", "123Number"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/number_only.py
@@ -25,7 +25,7 @@ class NumberOnly(BaseModel):
     """
     NumberOnly
     """
-    just_number: Optional[float] = Field(None, alias="JustNumber")
+    just_number: Optional[float] = Field(default=None, alias="JustNumber")
     __properties = ["JustNumber"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_to_test_additional_properties.py
@@ -25,7 +25,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
     """
     Minimal object  # noqa: E501
     """
-    var_property: Optional[StrictBool] = Field(False, alias="property", description="Property")
+    var_property: Optional[StrictBool] = Field(default=False, alias="property", description="Property")
     __properties = ["property"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/object_with_deprecated_fields.py
@@ -28,7 +28,7 @@ class ObjectWithDeprecatedFields(BaseModel):
     """
     uuid: Optional[StrictStr] = None
     id: Optional[float] = None
-    deprecated_ref: Optional[DeprecatedObject] = Field(None, alias="deprecatedRef")
+    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, alias="deprecatedRef")
     bars: Optional[conlist(StrictStr)] = None
     __properties = ["uuid", "id", "deprecatedRef", "bars"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/order.py
@@ -26,10 +26,10 @@ class Order(BaseModel):
     Order
     """
     id: Optional[StrictInt] = None
-    pet_id: Optional[StrictInt] = Field(None, alias="petId")
+    pet_id: Optional[StrictInt] = Field(default=None, alias="petId")
     quantity: Optional[StrictInt] = None
-    ship_date: Optional[datetime] = Field(None, alias="shipDate")
-    status: Optional[StrictStr] = Field(None, description="Order Status")
+    ship_date: Optional[datetime] = Field(default=None, alias="shipDate")
+    status: Optional[StrictStr] = Field(default=None, description="Order Status")
     complete: Optional[StrictBool] = False
     __properties = ["id", "petId", "quantity", "shipDate", "status", "complete"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent.py
@@ -26,7 +26,7 @@ class Parent(BaseModel):
     """
     Parent
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
     __properties = ["optionalDict"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/parent_with_optional_dict.py
@@ -26,7 +26,7 @@ class ParentWithOptionalDict(BaseModel):
     """
     ParentWithOptionalDict
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
     __properties = ["optionalDict"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/pet.py
@@ -30,9 +30,9 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
     name: StrictStr = Field(...)
-    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(..., alias="photoUrls")
+    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
-    status: Optional[StrictStr] = Field(None, description="pet status in the store")
+    status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     __properties = ["id", "category", "name", "photoUrls", "tags", "status"]
 
     @validator('status')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/property_name_collision.py
@@ -25,7 +25,7 @@ class PropertyNameCollision(BaseModel):
     """
     PropertyNameCollision
     """
-    type: Optional[StrictStr] = Field(None, alias="_type")
+    type: Optional[StrictStr] = Field(default=None, alias="_type")
     type: Optional[StrictStr] = None
     type_: Optional[StrictStr] = None
     __properties = ["_type", "type", "type_"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_model_name.py
@@ -25,7 +25,7 @@ class SpecialModelName(BaseModel):
     """
     SpecialModelName
     """
-    special_property_name: Optional[StrictInt] = Field(None, alias="$special[property.name]")
+    special_property_name: Optional[StrictInt] = Field(default=None, alias="$special[property.name]")
     __properties = ["$special[property.name]"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/special_name.py
@@ -26,9 +26,9 @@ class SpecialName(BaseModel):
     """
     SpecialName
     """
-    var_property: Optional[StrictInt] = Field(None, alias="property")
-    var_async: Optional[Category] = Field(None, alias="async")
-    var_schema: Optional[StrictStr] = Field(None, alias="schema", description="pet status in the store")
+    var_property: Optional[StrictInt] = Field(default=None, alias="property")
+    var_async: Optional[Category] = Field(default=None, alias="async")
+    var_schema: Optional[StrictStr] = Field(default=None, alias="schema", description="pet status in the store")
     __properties = ["property", "async", "schema"]
 
     @validator('var_schema')

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -25,7 +25,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
     TestInlineFreeformAdditionalPropertiesRequest
     """
-    some_property: Optional[StrictStr] = Field(None, alias="someProperty")
+    some_property: Optional[StrictStr] = Field(default=None, alias="someProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["someProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -26,7 +26,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalModelListProperties
     """
-    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, alias="dictProperty")
     __properties = ["dictProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -25,7 +25,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalStringListProperties
     """
-    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, alias="dictProperty")
     __properties = ["dictProperty"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/user.py
@@ -27,12 +27,12 @@ class User(BaseModel):
     """
     id: Optional[StrictInt] = None
     username: Optional[StrictStr] = None
-    first_name: Optional[StrictStr] = Field(None, alias="firstName")
-    last_name: Optional[StrictStr] = Field(None, alias="lastName")
+    first_name: Optional[StrictStr] = Field(default=None, alias="firstName")
+    last_name: Optional[StrictStr] = Field(default=None, alias="lastName")
     email: Optional[StrictStr] = None
     password: Optional[StrictStr] = None
     phone: Optional[StrictStr] = None
-    user_status: Optional[StrictInt] = Field(None, alias="userStatus", description="User Status")
+    user_status: Optional[StrictInt] = Field(default=None, alias="userStatus", description="User Status")
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 
     class Config:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/all_of_with_single_ref.py
@@ -27,7 +27,7 @@ class AllOfWithSingleRef(BaseModel):
     AllOfWithSingleRef
     """
     username: Optional[StrictStr] = None
-    single_ref_type: Optional[SingleRefType] = Field(None, alias="SingleRefType")
+    single_ref_type: Optional[SingleRefType] = Field(default=None, alias="SingleRefType")
     additional_properties: Dict[str, Any] = {}
     __properties = ["username", "SingleRefType"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/animal.py
@@ -31,7 +31,7 @@ class Animal(BaseModel):
     """
     Animal
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     color: Optional[StrictStr] = 'red'
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/any_of_color.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/any_of_color.py
@@ -31,11 +31,11 @@ class AnyOfColor(BaseModel):
     """
 
     # data type: List[int]
-    anyof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(None, description="RGB three element array with values 0-255.")
+    anyof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(default=None, description="RGB three element array with values 0-255.")
     # data type: List[int]
-    anyof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(None, description="RGBA four element array with values 0-255.")
+    anyof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
-    anyof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(None, description="Hex color string, such as #00FF00.")
+    anyof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
         actual_instance: Union[List[int], str]
     else:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfArrayOfNumberOnly(BaseModel):
     """
     ArrayOfArrayOfNumberOnly
     """
-    array_array_number: Optional[conlist(conlist(StrictFloat))] = Field(None, alias="ArrayArrayNumber")
+    array_array_number: Optional[conlist(conlist(StrictFloat))] = Field(default=None, alias="ArrayArrayNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayArrayNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/array_of_number_only.py
@@ -25,7 +25,7 @@ class ArrayOfNumberOnly(BaseModel):
     """
     ArrayOfNumberOnly
     """
-    array_number: Optional[conlist(StrictFloat)] = Field(None, alias="ArrayNumber")
+    array_number: Optional[conlist(StrictFloat)] = Field(default=None, alias="ArrayNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["ArrayNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/basque_pig.py
@@ -25,7 +25,7 @@ class BasquePig(BaseModel):
     """
     BasquePig
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     color: StrictStr = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "color"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/capitalization.py
@@ -25,12 +25,12 @@ class Capitalization(BaseModel):
     """
     Capitalization
     """
-    small_camel: Optional[StrictStr] = Field(None, alias="smallCamel")
-    capital_camel: Optional[StrictStr] = Field(None, alias="CapitalCamel")
-    small_snake: Optional[StrictStr] = Field(None, alias="small_Snake")
-    capital_snake: Optional[StrictStr] = Field(None, alias="Capital_Snake")
-    sca_eth_flow_points: Optional[StrictStr] = Field(None, alias="SCA_ETH_Flow_Points")
-    att_name: Optional[StrictStr] = Field(None, alias="ATT_NAME", description="Name of the pet ")
+    small_camel: Optional[StrictStr] = Field(default=None, alias="smallCamel")
+    capital_camel: Optional[StrictStr] = Field(default=None, alias="CapitalCamel")
+    small_snake: Optional[StrictStr] = Field(default=None, alias="small_Snake")
+    capital_snake: Optional[StrictStr] = Field(default=None, alias="Capital_Snake")
+    sca_eth_flow_points: Optional[StrictStr] = Field(default=None, alias="SCA_ETH_Flow_Points")
+    att_name: Optional[StrictStr] = Field(default=None, alias="ATT_NAME", description="Name of the pet ")
     additional_properties: Dict[str, Any] = {}
     __properties = ["smallCamel", "CapitalCamel", "small_Snake", "Capital_Snake", "SCA_ETH_Flow_Points", "ATT_NAME"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/class_model.py
@@ -25,7 +25,7 @@ class ClassModel(BaseModel):
     """
     Model for testing model with \"_class\" property  # noqa: E501
     """
-    var_class: Optional[StrictStr] = Field(None, alias="_class")
+    var_class: Optional[StrictStr] = Field(default=None, alias="_class")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_class"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/color.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/color.py
@@ -30,11 +30,11 @@ class Color(BaseModel):
     RGB array, RGBA array, or hex string.
     """
     # data type: List[int]
-    oneof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(None, description="RGB three element array with values 0-255.")
+    oneof_schema_1_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=3, min_items=3)] = Field(default=None, description="RGB three element array with values 0-255.")
     # data type: List[int]
-    oneof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(None, description="RGBA four element array with values 0-255.")
+    oneof_schema_2_validator: Optional[conlist(conint(strict=True, le=255, ge=0), max_items=4, min_items=4)] = Field(default=None, description="RGBA four element array with values 0-255.")
     # data type: str
-    oneof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(None, description="Hex color string, such as #00FF00.")
+    oneof_schema_3_validator: Optional[constr(strict=True, max_length=7, min_length=7)] = Field(default=None, description="Hex color string, such as #00FF00.")
     if TYPE_CHECKING:
         actual_instance: Union[List[int], str]
     else:

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/danish_pig.py
@@ -25,7 +25,7 @@ class DanishPig(BaseModel):
     """
     DanishPig
     """
-    class_name: StrictStr = Field(..., alias="className")
+    class_name: StrictStr = Field(default=..., alias="className")
     size: StrictInt = Field(...)
     additional_properties: Dict[str, Any] = {}
     __properties = ["className", "size"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/discriminator_all_of_super.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/discriminator_all_of_super.py
@@ -30,7 +30,7 @@ class DiscriminatorAllOfSuper(BaseModel):
     """
     DiscriminatorAllOfSuper
     """
-    element_type: StrictStr = Field(..., alias="elementType")
+    element_type: StrictStr = Field(default=..., alias="elementType")
     additional_properties: Dict[str, Any] = {}
     __properties = ["elementType"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -34,10 +34,10 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[StrictFloat] = None
-    outer_enum: Optional[OuterEnum] = Field(None, alias="outerEnum")
-    outer_enum_integer: Optional[OuterEnumInteger] = Field(None, alias="outerEnumInteger")
-    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(None, alias="outerEnumDefaultValue")
-    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(None, alias="outerEnumIntegerDefaultValue")
+    outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
+    outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
+    outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
+    outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
     __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/file.py
@@ -25,7 +25,7 @@ class File(BaseModel):
     """
     Must be named `File` for test.  # noqa: E501
     """
-    source_uri: Optional[StrictStr] = Field(None, alias="sourceURI", description="Test capitalization")
+    source_uri: Optional[StrictStr] = Field(default=None, alias="sourceURI", description="Test capitalization")
     additional_properties: Dict[str, Any] = {}
     __properties = ["sourceURI"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/format_test.py
@@ -36,12 +36,12 @@ class FormatTest(BaseModel):
     string_with_double_quote_pattern: Optional[constr(strict=True)] = None
     byte: Optional[Union[StrictBytes, StrictStr]] = None
     binary: Optional[Union[StrictBytes, StrictStr]] = None
-    var_date: date = Field(..., alias="date")
-    date_time: Optional[datetime] = Field(None, alias="dateTime")
+    var_date: date = Field(default=..., alias="date")
+    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     uuid: Optional[StrictStr] = None
     password: constr(strict=True, max_length=64, min_length=10) = Field(...)
-    pattern_with_digits: Optional[constr(strict=True)] = Field(None, description="A string that is a 10 digit number. Can have leading zeros.")
-    pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
+    pattern_with_digits: Optional[constr(strict=True)] = Field(default=None, description="A string that is a 10 digit number. Can have leading zeros.")
+    pattern_with_digits_and_delimiter: Optional[constr(strict=True)] = Field(default=None, description="A string starting with 'image_' (case insensitive) and one to three digits following i.e. Image_01.")
     additional_properties: Dict[str, Any] = {}
     __properties = ["integer", "int32", "int64", "number", "float", "double", "decimal", "string", "string_with_double_quote_pattern", "byte", "binary", "date", "dateTime", "uuid", "password", "pattern_with_digits", "pattern_with_digits_and_delimiter"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/health_check_result.py
@@ -25,7 +25,7 @@ class HealthCheckResult(BaseModel):
     """
     Just a string to inform instance is up and running. Make it nullable in hope to get it as pointer in generated model.  # noqa: E501
     """
-    nullable_message: Optional[StrictStr] = Field(None, alias="NullableMessage")
+    nullable_message: Optional[StrictStr] = Field(default=None, alias="NullableMessage")
     additional_properties: Dict[str, Any] = {}
     __properties = ["NullableMessage"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/inner_dict_with_property.py
@@ -25,7 +25,7 @@ class InnerDictWithProperty(BaseModel):
     """
     InnerDictWithProperty
     """
-    a_property: Optional[Dict[str, Any]] = Field(None, alias="aProperty")
+    a_property: Optional[Dict[str, Any]] = Field(default=None, alias="aProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["aProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/list_class.py
@@ -25,7 +25,7 @@ class ListClass(BaseModel):
     """
     ListClass
     """
-    var_123_list: Optional[StrictStr] = Field(None, alias="123-list")
+    var_123_list: Optional[StrictStr] = Field(default=None, alias="123-list")
     additional_properties: Dict[str, Any] = {}
     __properties = ["123-list"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/map_of_array_of_model.py
@@ -26,7 +26,7 @@ class MapOfArrayOfModel(BaseModel):
     """
     MapOfArrayOfModel
     """
-    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(None, alias="shopIdToOrgOnlineLipMap")
+    shop_id_to_org_online_lip_map: Optional[Dict[str, conlist(Tag)]] = Field(default=None, alias="shopIdToOrgOnlineLipMap")
     additional_properties: Dict[str, Any] = {}
     __properties = ["shopIdToOrgOnlineLipMap"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/mixed_properties_and_additional_properties_class.py
@@ -27,7 +27,7 @@ class MixedPropertiesAndAdditionalPropertiesClass(BaseModel):
     MixedPropertiesAndAdditionalPropertiesClass
     """
     uuid: Optional[StrictStr] = None
-    date_time: Optional[datetime] = Field(None, alias="dateTime")
+    date_time: Optional[datetime] = Field(default=None, alias="dateTime")
     map: Optional[Dict[str, Animal]] = None
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "dateTime", "map"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model200_response.py
@@ -26,7 +26,7 @@ class Model200Response(BaseModel):
     Model for testing model name starting with number  # noqa: E501
     """
     name: Optional[StrictInt] = None
-    var_class: Optional[StrictStr] = Field(None, alias="class")
+    var_class: Optional[StrictStr] = Field(default=None, alias="class")
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "class"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/model_return.py
@@ -25,7 +25,7 @@ class ModelReturn(BaseModel):
     """
     Model for testing reserved words  # noqa: E501
     """
-    var_return: Optional[StrictInt] = Field(None, alias="return")
+    var_return: Optional[StrictInt] = Field(default=None, alias="return")
     additional_properties: Dict[str, Any] = {}
     __properties = ["return"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/name.py
@@ -27,8 +27,8 @@ class Name(BaseModel):
     """
     name: StrictInt = Field(...)
     snake_case: Optional[StrictInt] = None
-    var_property: Optional[StrictStr] = Field(None, alias="property")
-    var_123_number: Optional[StrictInt] = Field(None, alias="123Number")
+    var_property: Optional[StrictStr] = Field(default=None, alias="property")
+    var_123_number: Optional[StrictInt] = Field(default=None, alias="123Number")
     additional_properties: Dict[str, Any] = {}
     __properties = ["name", "snake_case", "property", "123Number"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/number_only.py
@@ -25,7 +25,7 @@ class NumberOnly(BaseModel):
     """
     NumberOnly
     """
-    just_number: Optional[StrictFloat] = Field(None, alias="JustNumber")
+    just_number: Optional[StrictFloat] = Field(default=None, alias="JustNumber")
     additional_properties: Dict[str, Any] = {}
     __properties = ["JustNumber"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_to_test_additional_properties.py
@@ -25,7 +25,7 @@ class ObjectToTestAdditionalProperties(BaseModel):
     """
     Minimal object  # noqa: E501
     """
-    var_property: Optional[StrictBool] = Field(False, alias="property", description="Property")
+    var_property: Optional[StrictBool] = Field(default=False, alias="property", description="Property")
     additional_properties: Dict[str, Any] = {}
     __properties = ["property"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/object_with_deprecated_fields.py
@@ -28,7 +28,7 @@ class ObjectWithDeprecatedFields(BaseModel):
     """
     uuid: Optional[StrictStr] = None
     id: Optional[StrictFloat] = None
-    deprecated_ref: Optional[DeprecatedObject] = Field(None, alias="deprecatedRef")
+    deprecated_ref: Optional[DeprecatedObject] = Field(default=None, alias="deprecatedRef")
     bars: Optional[conlist(StrictStr)] = None
     additional_properties: Dict[str, Any] = {}
     __properties = ["uuid", "id", "deprecatedRef", "bars"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/order.py
@@ -26,10 +26,10 @@ class Order(BaseModel):
     Order
     """
     id: Optional[StrictInt] = None
-    pet_id: Optional[StrictInt] = Field(None, alias="petId")
+    pet_id: Optional[StrictInt] = Field(default=None, alias="petId")
     quantity: Optional[StrictInt] = None
-    ship_date: Optional[datetime] = Field(None, alias="shipDate")
-    status: Optional[StrictStr] = Field(None, description="Order Status")
+    ship_date: Optional[datetime] = Field(default=None, alias="shipDate")
+    status: Optional[StrictStr] = Field(default=None, description="Order Status")
     complete: Optional[StrictBool] = False
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "petId", "quantity", "shipDate", "status", "complete"]

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent.py
@@ -26,7 +26,7 @@ class Parent(BaseModel):
     """
     Parent
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/parent_with_optional_dict.py
@@ -26,7 +26,7 @@ class ParentWithOptionalDict(BaseModel):
     """
     ParentWithOptionalDict
     """
-    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(None, alias="optionalDict")
+    optional_dict: Optional[Dict[str, InnerDictWithProperty]] = Field(default=None, alias="optionalDict")
     additional_properties: Dict[str, Any] = {}
     __properties = ["optionalDict"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/pet.py
@@ -30,9 +30,9 @@ class Pet(BaseModel):
     id: Optional[StrictInt] = None
     category: Optional[Category] = None
     name: StrictStr = Field(...)
-    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(..., alias="photoUrls")
+    photo_urls: conlist(StrictStr, min_items=0, unique_items=True) = Field(default=..., alias="photoUrls")
     tags: Optional[conlist(Tag)] = None
-    status: Optional[StrictStr] = Field(None, description="pet status in the store")
+    status: Optional[StrictStr] = Field(default=None, description="pet status in the store")
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "category", "name", "photoUrls", "tags", "status"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/property_name_collision.py
@@ -25,9 +25,9 @@ class PropertyNameCollision(BaseModel):
     """
     PropertyNameCollision
     """
-    underscore_type: Optional[StrictStr] = Field(None, alias="_type")
+    underscore_type: Optional[StrictStr] = Field(default=None, alias="_type")
     type: Optional[StrictStr] = None
-    type_with_underscore: Optional[StrictStr] = Field(None, alias="type_")
+    type_with_underscore: Optional[StrictStr] = Field(default=None, alias="type_")
     additional_properties: Dict[str, Any] = {}
     __properties = ["_type", "type", "type_"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_model_name.py
@@ -25,7 +25,7 @@ class SpecialModelName(BaseModel):
     """
     SpecialModelName
     """
-    special_property_name: Optional[StrictInt] = Field(None, alias="$special[property.name]")
+    special_property_name: Optional[StrictInt] = Field(default=None, alias="$special[property.name]")
     additional_properties: Dict[str, Any] = {}
     __properties = ["$special[property.name]"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/special_name.py
@@ -26,9 +26,9 @@ class SpecialName(BaseModel):
     """
     SpecialName
     """
-    var_property: Optional[StrictInt] = Field(None, alias="property")
-    var_async: Optional[Category] = Field(None, alias="async")
-    var_schema: Optional[StrictStr] = Field(None, alias="schema", description="pet status in the store")
+    var_property: Optional[StrictInt] = Field(default=None, alias="property")
+    var_async: Optional[Category] = Field(default=None, alias="async")
+    var_schema: Optional[StrictStr] = Field(default=None, alias="schema", description="pet status in the store")
     additional_properties: Dict[str, Any] = {}
     __properties = ["property", "async", "schema"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/test_inline_freeform_additional_properties_request.py
@@ -25,7 +25,7 @@ class TestInlineFreeformAdditionalPropertiesRequest(BaseModel):
     """
     TestInlineFreeformAdditionalPropertiesRequest
     """
-    some_property: Optional[StrictStr] = Field(None, alias="someProperty")
+    some_property: Optional[StrictStr] = Field(default=None, alias="someProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["someProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_model_list_properties.py
@@ -26,7 +26,7 @@ class UnnamedDictWithAdditionalModelListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalModelListProperties
     """
-    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(CreatureInfo)]] = Field(default=None, alias="dictProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["dictProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/unnamed_dict_with_additional_string_list_properties.py
@@ -25,7 +25,7 @@ class UnnamedDictWithAdditionalStringListProperties(BaseModel):
     """
     UnnamedDictWithAdditionalStringListProperties
     """
-    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(None, alias="dictProperty")
+    dict_property: Optional[Dict[str, conlist(StrictStr)]] = Field(default=None, alias="dictProperty")
     additional_properties: Dict[str, Any] = {}
     __properties = ["dictProperty"]
 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/user.py
@@ -27,12 +27,12 @@ class User(BaseModel):
     """
     id: Optional[StrictInt] = None
     username: Optional[StrictStr] = None
-    first_name: Optional[StrictStr] = Field(None, alias="firstName")
-    last_name: Optional[StrictStr] = Field(None, alias="lastName")
+    first_name: Optional[StrictStr] = Field(default=None, alias="firstName")
+    last_name: Optional[StrictStr] = Field(default=None, alias="lastName")
     email: Optional[StrictStr] = None
     password: Optional[StrictStr] = None
     phone: Optional[StrictStr] = None
-    user_status: Optional[StrictInt] = Field(None, alias="userStatus", description="User Status")
+    user_status: Optional[StrictInt] = Field(default=None, alias="userStatus", description="User Status")
     additional_properties: Dict[str, Any] = {}
     __properties = ["id", "username", "firstName", "lastName", "email", "password", "phone", "userStatus"]
 

--- a/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/api/store_api.py
@@ -16,7 +16,8 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictStr
+from pydantic import Field, StrictInt, StrictStr
+from typing import Dict
 from typing_extensions import Annotated
 from petstore_api.models.order import Order
 


### PR DESCRIPTION
Type-checkers like pyright require the Field-default by the dataclass decorator to be a named parameter. Using the positional variant will result in it being considered a required parameter.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@cbornet @tomplus @krjakbrjak @fa0311 @multani