### PR TITLE
Check nullable to detect null type in 3.1 spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -852,8 +852,14 @@ public class OpenAPINormalizer {
             }
         }
 
-        if (!(schema instanceof JsonSchema) && (schema.getType() == null || schema.getType().equals("null")) && schema.get$ref() == null) {
-            return true;
+        if (schema instanceof JsonSchema) { // 3.1 spec
+            if (Boolean.TRUE.equals(schema.getNullable())) {
+                return true;
+            }
+        } else { // 3.0.x or 2.x spec
+            if ((schema.getType() == null || schema.getType().equals("null")) && schema.get$ref() == null) {
+                return true;
+            }
         }
 
         // convert referenced enum of null only to `nullable:true`

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -513,4 +513,23 @@ public class OpenAPINormalizerTest {
         assertEquals(((Schema) schema4.getProperties().get("set_property")).getNullable(), true);
         assertEquals(((Schema) schema4.getProperties().get("map_property")).getNullable(), null);
     }
+
+    @Test
+    public void testOpenAPINormalizerSimplifyOneOfAnyOf31Spec() {
+        // to test the rule SIMPLIFY_ONEOF_ANYOF in 3.1 spec
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_18184.yaml");
+        // test spec contains anyOf with a ref to enum and another scheme type is null
+
+        Schema schema = openAPI.getComponents().getSchemas().get("Item");
+        assertEquals(((Schema) schema.getProperties().get("my_enum")).getAnyOf().size(), 2);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SIMPLIFY_ANYOF_STRING_AND_ENUM_STRING", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema schema2 = openAPI.getComponents().getSchemas().get("Item");
+        assertEquals(((Schema) schema2.getProperties().get("my_enum")).getAnyOf(), null);
+        assertEquals(((Schema) schema2.getProperties().get("my_enum")).get$ref(), "#/components/schemas/MyEnum");
+    }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/issue_18184.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/issue_18184.yaml
@@ -1,0 +1,77 @@
+---
+openapi: 3.1.0
+info:
+  title: simplify-oneof-anyof bug repro
+  version: 0.1.0
+paths:
+  "/items/{item_id}":
+    put:
+      operationId: update_item
+      summary: Update Item
+      parameters:
+      - in: path
+        name: item_id
+        required: true
+        schema:
+          title: Item Id
+          type: integer
+      - in: query
+        name: q
+        required: false
+        schema:
+          title: Q
+          anyOf:
+          - type: string
+          - type: 'null'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Item"
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateResponse"
+components:
+  schemas:
+    Item:
+      title: Item
+      type: object
+      properties:
+        is_offer:
+          title: Is Offer
+          anyOf:
+          - type: boolean
+          - type: 'null'
+        my_enum:
+          anyOf:
+          - "$ref": "#/components/schemas/MyEnum"
+          - type: 'null'
+        name:
+          title: Name
+          type: string
+      required:
+      - name
+    MyEnum:
+      title: MyEnum
+      type: string
+      enum:
+      - value-1
+      - value-2
+    UpdateResponse:
+      properties:
+        id:
+          title: Item Id
+          type: integer
+        name:
+          title: Item Name
+          type: string
+      required:
+      - name
+      - id
+      title: UpdateResponse
+      type: object


### PR DESCRIPTION
- Fix #18184
- Add a test


fyi @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
