### PR TITLE
[R][Client] catch enum classes in toJSON

### DIFF
--- a/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/r/modelGeneric.mustache
@@ -238,7 +238,11 @@
           self$`{{name}}`
           {{/isPrimitiveType}}
           {{^isPrimitiveType}}
-          self$`{{name}}`$toJSON()
+          if (length(names(self$`{{name}}`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`{{name}}`$toJSON()))) {
+            jsonlite::fromJSON(self$`{{name}}`$toJSON())
+          } else {
+            self$`{{name}}`$toJSON()
+          }
           {{/isPrimitiveType}}
           {{/isContainer}}
       }

--- a/samples/client/echo_api/r/R/pet.R
+++ b/samples/client/echo_api/r/R/pet.R
@@ -94,7 +94,11 @@ Pet <- R6::R6Class(
       }
       if (!is.null(self$`category`)) {
         PetObject[["category"]] <-
-          self$`category`$toJSON()
+          if (length(names(self$`category`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`category`$toJSON()))) {
+            jsonlite::fromJSON(self$`category`$toJSON())
+          } else {
+            self$`category`$toJSON()
+          }
       }
       if (!is.null(self$`photoUrls`)) {
         PetObject[["photoUrls"]] <-

--- a/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/nested_one_of.R
@@ -63,7 +63,11 @@ NestedOneOf <- R6::R6Class(
       }
       if (!is.null(self$`nested_pig`)) {
         NestedOneOfObject[["nested_pig"]] <-
-          self$`nested_pig`$toJSON()
+          if (length(names(self$`nested_pig`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`nested_pig`$toJSON()))) {
+            jsonlite::fromJSON(self$`nested_pig`$toJSON())
+          } else {
+            self$`nested_pig`$toJSON()
+          }
       }
       for (key in names(self$additional_properties)) {
         NestedOneOfObject[[key]] <- self$additional_properties[[key]]

--- a/samples/client/petstore/R-httr2-wrapper/R/pet.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/pet.R
@@ -100,7 +100,11 @@ Pet <- R6::R6Class(
       }
       if (!is.null(self$`category`)) {
         PetObject[["category"]] <-
-          self$`category`$toJSON()
+          if (length(names(self$`category`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`category`$toJSON()))) {
+            jsonlite::fromJSON(self$`category`$toJSON())
+          } else {
+            self$`category`$toJSON()
+          }
       }
       if (!is.null(self$`name`)) {
         PetObject[["name"]] <-

--- a/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2-wrapper/R/update_pet_request.R
@@ -56,7 +56,11 @@ UpdatePetRequest <- R6::R6Class(
       UpdatePetRequestObject <- list()
       if (!is.null(self$`jsonData`)) {
         UpdatePetRequestObject[["jsonData"]] <-
-          self$`jsonData`$toJSON()
+          if (length(names(self$`jsonData`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`jsonData`$toJSON()))) {
+            jsonlite::fromJSON(self$`jsonData`$toJSON())
+          } else {
+            self$`jsonData`$toJSON()
+          }
       }
       if (!is.null(self$`binaryDataN2Information`)) {
         UpdatePetRequestObject[["binaryDataN2Information"]] <-

--- a/samples/client/petstore/R-httr2/R/nested_one_of.R
+++ b/samples/client/petstore/R-httr2/R/nested_one_of.R
@@ -53,7 +53,11 @@ NestedOneOf <- R6::R6Class(
       }
       if (!is.null(self$`nested_pig`)) {
         NestedOneOfObject[["nested_pig"]] <-
-          self$`nested_pig`$toJSON()
+          if (length(names(self$`nested_pig`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`nested_pig`$toJSON()))) {
+            jsonlite::fromJSON(self$`nested_pig`$toJSON())
+          } else {
+            self$`nested_pig`$toJSON()
+          }
       }
       NestedOneOfObject
     },

--- a/samples/client/petstore/R-httr2/R/pet.R
+++ b/samples/client/petstore/R-httr2/R/pet.R
@@ -90,7 +90,11 @@ Pet <- R6::R6Class(
       }
       if (!is.null(self$`category`)) {
         PetObject[["category"]] <-
-          self$`category`$toJSON()
+          if (length(names(self$`category`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`category`$toJSON()))) {
+            jsonlite::fromJSON(self$`category`$toJSON())
+          } else {
+            self$`category`$toJSON()
+          }
       }
       if (!is.null(self$`name`)) {
         PetObject[["name"]] <-

--- a/samples/client/petstore/R-httr2/R/update_pet_request.R
+++ b/samples/client/petstore/R-httr2/R/update_pet_request.R
@@ -46,7 +46,11 @@ UpdatePetRequest <- R6::R6Class(
       UpdatePetRequestObject <- list()
       if (!is.null(self$`jsonData`)) {
         UpdatePetRequestObject[["jsonData"]] <-
-          self$`jsonData`$toJSON()
+          if (length(names(self$`jsonData`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`jsonData`$toJSON()))) {
+            jsonlite::fromJSON(self$`jsonData`$toJSON())
+          } else {
+            self$`jsonData`$toJSON()
+          }
       }
       if (!is.null(self$`binaryDataN2Information`)) {
         UpdatePetRequestObject[["binaryDataN2Information"]] <-

--- a/samples/client/petstore/R/R/nested_one_of.R
+++ b/samples/client/petstore/R/R/nested_one_of.R
@@ -63,7 +63,11 @@ NestedOneOf <- R6::R6Class(
       }
       if (!is.null(self$`nested_pig`)) {
         NestedOneOfObject[["nested_pig"]] <-
-          self$`nested_pig`$toJSON()
+          if (length(names(self$`nested_pig`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`nested_pig`$toJSON()))) {
+            jsonlite::fromJSON(self$`nested_pig`$toJSON())
+          } else {
+            self$`nested_pig`$toJSON()
+          }
       }
       for (key in names(self$additional_properties)) {
         NestedOneOfObject[[key]] <- self$additional_properties[[key]]

--- a/samples/client/petstore/R/R/pet.R
+++ b/samples/client/petstore/R/R/pet.R
@@ -100,7 +100,11 @@ Pet <- R6::R6Class(
       }
       if (!is.null(self$`category`)) {
         PetObject[["category"]] <-
-          self$`category`$toJSON()
+          if (length(names(self$`category`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`category`$toJSON()))) {
+            jsonlite::fromJSON(self$`category`$toJSON())
+          } else {
+            self$`category`$toJSON()
+          }
       }
       if (!is.null(self$`name`)) {
         PetObject[["name"]] <-

--- a/samples/client/petstore/R/R/update_pet_request.R
+++ b/samples/client/petstore/R/R/update_pet_request.R
@@ -56,7 +56,11 @@ UpdatePetRequest <- R6::R6Class(
       UpdatePetRequestObject <- list()
       if (!is.null(self$`jsonData`)) {
         UpdatePetRequestObject[["jsonData"]] <-
-          self$`jsonData`$toJSON()
+          if (length(names(self$`jsonData`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`jsonData`$toJSON()))) {
+            jsonlite::fromJSON(self$`jsonData`$toJSON())
+          } else {
+            self$`jsonData`$toJSON()
+          }
       }
       if (!is.null(self$`binaryDataN2Information`)) {
         UpdatePetRequestObject[["binaryDataN2Information"]] <-


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Related to https://github.com/OpenAPITools/openapi-generator/pull/18183

If an enum-class is parameter of another class, it currently gets serialized by `toJSON` like every other class:
```
EnumObject[["enum"]] <-
  self$`enum`$toJSON()
```
This runs into issues as an enum class is essentially just a class holding a singular string value "ENUM". In the JSON that is being put into the http request, `"ENUM"` is then turned into `"\"ENUM\""`, which will not be recognized by the API as it is not a valid enum, but rather the same enum with quotations marks around it.

To circumvent this, I implemented a check in `toJSON` that looks at the class in JSON form and checks if it has no keys and its only value is a string. 
```
if (length(names(self$`{{name}}`$toJSON())) == 0L && is.character(jsonlite::fromJSON(self$`{{name}}`$toJSON()))) {
  jsonlite::fromJSON(self$`{{name}}`$toJSON())
} else {
  self$`{{name}}`$toJSON()
}
```
This way, the enum will be assigned as a string instead of an JSON object and serialized correctly. If you see any better fixes for this problem, please feel free to pitch some ideas. This was just the easiest and most obvious fix for me right now.
Technical committee @Ramanth @saigiridhar21