### PR TITLE
fix[kotlin]: only use data class when it has constructor vars

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-server/data_class.mustache
@@ -15,7 +15,7 @@ import java.io.Serializable
 {{#parcelizeModels}}
 @Parcelize
 {{/parcelizeModels}}
-data class {{classname}}(
+{{#hasVars}}data {{/hasVars}}class {{classname}}(
 {{#requiredVars}}
 {{>data_class_req_var}}{{^-last}},
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},


### PR DESCRIPTION
Ran into the issue https://github.com/OpenAPITools/openapi-generator/issues/14710 as well. The kotlin-spring template is very similar but [includes a conditional](https://github.com/OpenAPITools/openapi-generator/blob/84b3cd9962c033bfb9ce0f4832ac006f26f39b75/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache#L8) using `#hasVars` which controls whether a regular or a data class is generated.

AFAICT that variable comes in somewhere via the `CodegenModel` since the `KotlinSpringServerCodegen` doesn't specify it explicitly.

<!-- Please check the completed items below -->
### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples...
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

Comittee members: @jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier