### PR TITLE
Update kotlin client dependencies to newer versions

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -33,7 +33,8 @@ buildscript {
     ext.reactor_version = "3.6.4"
     {{/jvm-spring-webclient}}
     {{/jvm-spring}}
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/build.gradle.mustache
@@ -11,35 +11,29 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     {{#jvm-ktor}}
-    ext.ktor_version = '2.2.3'
+    ext.ktor_version = '2.3.9'
     {{/jvm-ktor}}
     {{#jvm-retrofit2}}
-    ext.retrofitVersion = '2.9.0'
+    ext.retrofitVersion = '2.10.0'
     {{/jvm-retrofit2}}
-    {{#useRxJava}}
-    ext.rxJavaVersion = '1.3.8'
-    {{/useRxJava}}
-    {{#useRxJava2}}
-    ext.rxJava2Version = '2.2.21'
-    {{/useRxJava2}}
     {{#useRxJava3}}
-    ext.rxJava3Version = '3.0.12'
+    ext.rxJava3Version = '3.1.8'
     {{/useRxJava3}}
     {{#jvm-vertx}}
-    ext.vertx_version = "4.3.3"
+    ext.vertx_version = "4.5.6"
     {{/jvm-vertx}}
     {{#jvm-spring}}
     {{#useSpringBoot3}}
-    ext.spring_boot_version = "3.2.0"
+    ext.spring_boot_version = "3.2.4"
     {{/useSpringBoot3}}
     {{^useSpringBoot3}}
-    ext.spring_boot_version = "2.7.12"
+    ext.spring_boot_version = "2.7.18"
     {{/useSpringBoot3}}
     {{#jvm-spring-webclient}}
-    ext.reactor_version = "3.5.6"
+    ext.reactor_version = "3.6.4"
     {{/jvm-spring-webclient}}
     {{/jvm-spring}}
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -126,31 +120,31 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     {{^doNotUseRxAndCoroutines}}
     {{#useCoroutines}}
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
     {{/useCoroutines}}
     {{/doNotUseRxAndCoroutines}}
     {{#moshi}}
     {{^moshiCodeGen}}
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
     {{/moshiCodeGen}}
     {{#moshiCodeGen}}
-    implementation "com.squareup.moshi:moshi:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.14.0"
+    implementation "com.squareup.moshi:moshi:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.15.1"
     {{/moshiCodeGen}}
     {{/moshi}}
     {{#gson}}
-    implementation "com.google.code.gson:gson:2.9.0"
+    implementation "com.google.code.gson:gson:2.10.1"
     {{/gson}}
     {{#jackson}}
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     {{/jackson}}
     {{#kotlinx_serialization}}
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
     {{/kotlinx_serialization}}
     {{#jvm-ktor}}
     implementation "io.ktor:ktor-client-core:$ktor_version"
@@ -165,10 +159,10 @@ dependencies {
     {{/jackson}}
     {{/jvm-ktor}}
     {{#jvm-okhttp3}}
-    implementation "com.squareup.okhttp3:okhttp:3.12.13"
+    implementation "com.squareup.okhttp3:okhttp:3.14.9"
     {{/jvm-okhttp3}}
     {{#jvm-okhttp4}}
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     {{/jvm-okhttp4}}
     {{#jvm-spring-webclient}}
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
@@ -181,24 +175,16 @@ dependencies {
     implementation "org.threeten:threetenbp:1.6.8"
     {{/threetenbp}}
     {{#kotlinx-datetime}}
-    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
     {{/kotlinx-datetime}}
     {{#jvm-retrofit2}}
     {{#hasOAuthMethods}}
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
     {{/hasOAuthMethods}}
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
-    {{#useRxJava}}
-    implementation "io.reactivex:rxjava:$rxJavaVersion"
-    implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
-    {{/useRxJava}}
-    {{#useRxJava2}}
-    implementation "io.reactivex.rxjava2:rxjava:$rxJava2Version"
-    implementation "com.squareup.retrofit2:adapter-rxjava2:$retrofitVersion"
-    {{/useRxJava2}}
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     {{#useRxJava3}}
     implementation "io.reactivex.rxjava3:rxjava:$rxJava3Version"
-    implementation "com.squareup.retrofit2:adapter-rxjava3:2.9.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava3:2.10.0"
     {{/useRxJava3}}
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     {{#gson}}
@@ -208,7 +194,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     {{/moshi}}
     {{#kotlinx_serialization}}
-    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
+    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0"
     {{/kotlinx_serialization}}
     {{#jackson}}
     implementation "com.squareup.retrofit2:converter-jackson:$retrofitVersion"

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spring_boot_version = "3.2.0"
-    ext.spotless_version = "6.13.0"
+    ext.spring_boot_version = "3.2.4"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -61,8 +61,8 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-restclient/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.2.4"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spring_boot_version = "3.2.0"
-    ext.spotless_version = "6.13.0"
+    ext.spring_boot_version = "3.2.4"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -61,8 +61,8 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.2.4"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,9 +55,9 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation "com.google.code.gson:gson:2.9.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
+    implementation "com.google.code.gson:gson:2.10.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/echo_api/kotlin-model-prefix-type-mappings/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
+++ b/samples/client/others/kotlin-jvm-okhttp-parameter-tests/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
+++ b/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
+++ b/samples/client/petstore/kotlin-allOff-discriminator/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-array-simple-string-jvm-okhttp4/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-bigdecimal-default-okhttp4/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-okhttp4/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,9 +56,9 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-default-values-jvm-retrofit2/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-enum-default-value/build.gradle
+++ b/samples/client/petstore/kotlin-enum-default-value/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-enum-default-value/build.gradle
+++ b/samples/client/petstore/kotlin-enum-default-value/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -54,7 +54,7 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.google.code.gson:gson:2.9.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.google.code.gson:gson:2.10.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-gson/build.gradle
+++ b/samples/client/petstore/kotlin-gson/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jackson/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -57,8 +57,8 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
 

--- a/samples/client/petstore/kotlin-json-request-string/build.gradle
+++ b/samples/client/petstore/kotlin-json-request-string/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-jackson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,10 +56,10 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-jackson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-jvm-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-jackson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.3.9'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-gson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.ktor_version = '2.2.3'
-    ext.spotless_version = "6.13.0"
+    ext.ktor_version = '2.3.9'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,7 +55,7 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.google.code.gson:gson:2.9.0"
+    implementation "com.google.code.gson:gson:2.10.1"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     implementation "io.ktor:ktor-serialization-gson:$ktor_version"

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.ktor_version = '2.2.3'
-    ext.spotless_version = "6.13.0"
+    ext.ktor_version = '2.3.9'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,8 +56,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     implementation "io.ktor:ktor-client-jackson:$ktor_version"

--- a/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-jackson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.3.9'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.ktor_version = '2.3.9'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-ktor-kotlinx_serialization/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.ktor_version = '2.2.3'
-    ext.spotless_version = "6.13.0"
+    ext.ktor_version = '2.3.9'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -57,7 +57,7 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
     implementation "io.ktor:ktor-client-core:$ktor_version"
     implementation "io.ktor:ktor-client-content-negotiation:$ktor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -54,8 +54,8 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation "com.google.code.gson:gson:2.9.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
+    implementation "com.google.code.gson:gson:2.10.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-okhttp4-coroutines/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
@@ -10,7 +10,8 @@ buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "2.7.18"
     ext.reactor_version = "3.6.4"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-2-webclient/build.gradle
@@ -8,9 +8,9 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spring_boot_version = "2.7.12"
-    ext.reactor_version = "3.5.6"
-    ext.spotless_version = "6.13.0"
+    ext.spring_boot_version = "2.7.18"
+    ext.reactor_version = "3.6.4"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -57,8 +57,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spring_boot_version = "3.2.0"
-    ext.spotless_version = "6.13.0"
+    ext.spring_boot_version = "3.2.4"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -61,8 +61,8 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.2.4"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
@@ -8,9 +8,9 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spring_boot_version = "3.2.0"
-    ext.reactor_version = "3.5.6"
-    ext.spotless_version = "6.13.0"
+    ext.spring_boot_version = "3.2.4"
+    ext.reactor_version = "3.6.4"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -63,8 +63,8 @@ kotlin {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
     implementation "io.projectreactor:reactor-core:$reactor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"

--- a/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-spring-3-webclient/build.gradle
@@ -10,7 +10,8 @@ buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.2.4"
     ext.reactor_version = "3.6.4"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.vertx_version = "4.3.3"
-    ext.spotless_version = "6.13.0"
+    ext.vertx_version = "4.5.6"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,7 +55,7 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.google.code.gson:gson:2.9.0"
+    implementation "com.google.code.gson:gson:2.10.1"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-gson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.5.6"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.vertx_version = "4.3.3"
-    ext.spotless_version = "6.13.0"
+    ext.vertx_version = "4.5.6"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,10 +55,10 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson-coroutines/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.5.6"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.vertx_version = "4.3.3"
-    ext.spotless_version = "6.13.0"
+    ext.vertx_version = "4.5.6"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,8 +56,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-jackson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.5.6"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.vertx_version = "4.3.3"
-    ext.spotless_version = "6.13.0"
+    ext.vertx_version = "4.5.6"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,8 +56,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
     implementation "io.vertx:vertx-web-client:$vertx_version"
     implementation "io.vertx:vertx-core:$vertx_version"

--- a/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
+++ b/samples/client/petstore/kotlin-jvm-vertx-moshi/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.vertx_version = "4.5.6"
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
+++ b/samples/client/petstore/kotlin-kotlinx-datetime/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,9 +55,9 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-datetime:0.5.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,10 +55,10 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4"
-    implementation "com.google.code.gson:gson:2.9.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0"
+    implementation "com.google.code.gson:gson:2.10.1"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-model-prefix-type-mappings/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-modelMutable/build.gradle
+++ b/samples/client/petstore/kotlin-modelMutable/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-modelMutable/build.gradle
+++ b/samples/client/petstore/kotlin-modelMutable/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,9 +55,9 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "com.squareup.moshi:moshi:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    kapt "com.squareup.moshi:moshi-kotlin-codegen:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-moshi-codegen/build.gradle
+++ b/samples/client/petstore/kotlin-moshi-codegen/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
+++ b/samples/client/petstore/kotlin-name-parameter-mappings/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nonpublic/build.gradle
+++ b/samples/client/petstore/kotlin-nonpublic/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-nullable/build.gradle
+++ b/samples/client/petstore/kotlin-nullable/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,10 +56,10 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.14.3"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.3"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-jackson:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-jackson/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -57,11 +57,11 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
+    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-kotlinx_serialization/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -8,9 +8,9 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.rxJava3Version = '3.0.12'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.rxJava3Version = '3.1.8'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -57,12 +57,12 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "io.reactivex.rxjava3:rxjava:$rxJava3Version"
-    implementation "com.squareup.retrofit2:adapter-rxjava3:2.9.0"
+    implementation "com.squareup.retrofit2:adapter-rxjava3:2.10.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2-rx3/build.gradle
@@ -10,7 +10,8 @@ buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
     ext.rxJava3Version = '3.1.8'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -8,8 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.retrofitVersion = '2.9.0'
-    ext.spotless_version = "6.13.0"
+    ext.retrofitVersion = '2.10.0'
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,10 +56,10 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
     implementation "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-moshi:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofitVersion"

--- a/samples/client/petstore/kotlin-retrofit2/build.gradle
+++ b/samples/client/petstore/kotlin-retrofit2/build.gradle
@@ -9,7 +9,8 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.retrofitVersion = '2.10.0'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-string/build.gradle
+++ b/samples/client/petstore/kotlin-string/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-threetenbp/build.gradle
+++ b/samples/client/petstore/kotlin-threetenbp/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,9 +55,9 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation "org.threeten:threetenbp:1.6.8"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }

--- a/samples/client/petstore/kotlin-uppercase-enum/build.gradle
+++ b/samples/client/petstore/kotlin-uppercase-enum/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -56,8 +56,8 @@ test {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }
 

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -8,7 +8,7 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.13.0"
+    ext.spotless_version = "6.25.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }
@@ -55,8 +55,8 @@ test {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    implementation "com.squareup.moshi:moshi-kotlin:1.14.0"
-    implementation "com.squareup.moshi:moshi-adapters:1.14.0"
-    implementation "com.squareup.okhttp3:okhttp:4.11.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.1"
+    implementation "com.squareup.moshi:moshi-adapters:1.15.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/petstore/kotlin/build.gradle
+++ b/samples/client/petstore/kotlin/build.gradle
@@ -8,7 +8,8 @@ wrapper {
 
 buildscript {
     ext.kotlin_version = '1.8.10'
-    ext.spotless_version = "6.25.0"
+    // 6.13.0 is the latest stable release that supports JDK8
+    ext.spotless_version = "6.13.0"
 
     repositories {
         maven { url "https://repo1.maven.org/maven2" }


### PR DESCRIPTION
Update kotlin client dependencies to newer versions 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@jimschubert (2017/09) ❤️, @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)
