### PR TITLE
SWIFT5: sort query items alphabetically to allow better server side caching of requests with same URL

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/APIHelper.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/APIHelper.mustache
@@ -92,7 +92,7 @@ import Vapor{{/useVapor}}
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -115,6 +115,6 @@ import Vapor{{/useVapor}}
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/alamofireLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ internal struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ internal struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIHelper.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/APIHelper.swift
@@ -91,7 +91,7 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 
     /// maps all values from source to query parameters
@@ -114,6 +114,6 @@ public struct APIHelper {
         if destination.isEmpty {
             return nil
         }
-        return destination
+        return destination.sorted { $0.name < $1.name }
     }
 }


### PR DESCRIPTION
Currently query items in a request have random ordering that can change with every request.
For example we see

`/geolocations?latitude=52.519&longitude=13.408`
and
`/geolocations?longitude=13.408&latitude=52.519`

To allow caching based on same URLs this PR takes care of ordering the query items alphabetically.
This should not have any impact on backward compatibility, because no installation will require a random ordering.

@dydus0x14

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
