### PR TITLE
Fix 18089: Fail to do model_validate in the deserialization if the object inherited via AllOf

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -2769,7 +2769,6 @@ public class DefaultCodegen implements CodegenConfig {
 
         // TODO revise the logic below to set discriminator, xml attributes
         if (supportsInheritance || supportsMixins) {
-            m.allVars = new ArrayList<>();
             if (composed.getAllOf() != null) {
                 int modelImplCnt = 0; // only one inline object allowed in a ComposedModel
                 int modelDiscriminators = 0; // only one discriminator allowed in a ComposedModel
@@ -5973,7 +5972,7 @@ public class DefaultCodegen implements CodegenConfig {
             addVars(m, m.allVars, allProperties, allMandatory);
             m.allMandatory = allMandatory;
         } else { // without parent, allVars and vars are the same
-            m.allVars = m.vars;
+            m.allVars = new ArrayList<>(m.vars);
             m.allMandatory = m.mandatory;
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -5973,7 +5973,7 @@ public class DefaultCodegen implements CodegenConfig {
             m.allMandatory = allMandatory;
         } else { // without parent, allVars and vars are the same
             m.allVars = new ArrayList<>(m.vars);
-            m.allMandatory = m.mandatory;
+            m.allMandatory = new TreeSet<>(m.mandatory);
         }
 
         // loop through list to update property name with toVarName

--- a/samples/client/petstore/csharp/generichost/net8/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
+++ b/samples/client/petstore/csharp/generichost/net8/OpenAPIClient-generichost-netcore-latest-allOf/src/Org.OpenAPITools/Model/Child.cs
@@ -35,12 +35,12 @@ namespace Org.OpenAPITools.Model
         /// Initializes a new instance of the <see cref="Child" /> class.
         /// </summary>
         /// <param name="age">age</param>
+        /// <param name="boosterSeat">boosterSeat</param>
         /// <param name="firstName">firstName</param>
         /// <param name="lastName">lastName</param>
         /// <param name="type">type</param>
-        /// <param name="boosterSeat">boosterSeat</param>
         [JsonConstructor]
-        public Child(Option<int?> age = default, Option<string?> firstName = default, Option<string?> lastName = default, Option<string?> type = default, Option<bool?> boosterSeat = default) : base(firstName, lastName, type)
+        public Child(Option<int?> age = default, Option<bool?> boosterSeat = default, Option<string?> firstName = default, Option<string?> lastName = default, Option<string?> type = default) : base(firstName, lastName, type)
         {
             AgeOption = age;
             BoosterSeatOption = boosterSeat;
@@ -114,10 +114,10 @@ namespace Org.OpenAPITools.Model
             JsonTokenType startingTokenType = utf8JsonReader.TokenType;
 
             Option<int?> age = default;
+            Option<bool?> boosterSeat = default;
             Option<string?> firstName = default;
             Option<string?> lastName = default;
             Option<string?> type = default;
-            Option<bool?> boosterSeat = default;
 
             while (utf8JsonReader.Read())
             {
@@ -138,6 +138,10 @@ namespace Org.OpenAPITools.Model
                             if (utf8JsonReader.TokenType != JsonTokenType.Null)
                                 age = new Option<int?>(utf8JsonReader.GetInt32());
                             break;
+                        case "boosterSeat":
+                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
+                                boosterSeat = new Option<bool?>(utf8JsonReader.GetBoolean());
+                            break;
                         case "firstName":
                             firstName = new Option<string?>(utf8JsonReader.GetString()!);
                             break;
@@ -146,10 +150,6 @@ namespace Org.OpenAPITools.Model
                             break;
                         case "$_type":
                             type = new Option<string?>(utf8JsonReader.GetString()!);
-                            break;
-                        case "boosterSeat":
-                            if (utf8JsonReader.TokenType != JsonTokenType.Null)
-                                boosterSeat = new Option<bool?>(utf8JsonReader.GetBoolean());
                             break;
                         default:
                             break;
@@ -160,6 +160,9 @@ namespace Org.OpenAPITools.Model
             if (age.IsSet && age.Value == null)
                 throw new ArgumentNullException(nameof(age), "Property is not nullable for class Child.");
 
+            if (boosterSeat.IsSet && boosterSeat.Value == null)
+                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
+
             if (firstName.IsSet && firstName.Value == null)
                 throw new ArgumentNullException(nameof(firstName), "Property is not nullable for class Child.");
 
@@ -169,10 +172,7 @@ namespace Org.OpenAPITools.Model
             if (type.IsSet && type.Value == null)
                 throw new ArgumentNullException(nameof(type), "Property is not nullable for class Child.");
 
-            if (boosterSeat.IsSet && boosterSeat.Value == null)
-                throw new ArgumentNullException(nameof(boosterSeat), "Property is not nullable for class Child.");
-
-            return new Child(age, firstName, lastName, type, boosterSeat);
+            return new Child(age, boosterSeat, firstName, lastName, type);
         }
 
         /// <summary>
@@ -211,6 +211,9 @@ namespace Org.OpenAPITools.Model
             if (child.AgeOption.IsSet)
                 writer.WriteNumber("age", child.AgeOption.Value!.Value);
 
+            if (child.BoosterSeatOption.IsSet)
+                writer.WriteBoolean("boosterSeat", child.BoosterSeatOption.Value!.Value);
+
             if (child.FirstNameOption.IsSet)
                 writer.WriteString("firstName", child.FirstName);
 
@@ -219,9 +222,6 @@ namespace Org.OpenAPITools.Model
 
             if (child.TypeOption.IsSet)
                 writer.WriteString("$_type", child.Type);
-
-            if (child.BoosterSeatOption.IsSet)
-                writer.WriteBoolean("boosterSeat", child.BoosterSeatOption.Value!.Value);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fix issue https://github.com/OpenAPITools/openapi-generator/issues/18089

We are referring the mustache template to generate the model files https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/python/model_generic.mustache#L285 and reading the data stored in `allVars` to generated the codes in model files.

The cause of this issue is now the `allVars` of the generating model only stores the vars/properties in the parent model (_typeName in my example shown in https://github.com/OpenAPITools/openapi-generator/issues/18089), but missing the vars/properties of the generating model itself (nameA, nameB in my example shown in https://github.com/OpenAPITools/openapi-generator/issues/18089). It will cause failing to do the deserialization due to the lack of the vars/properties in `model_validate`.

By my triaging, now we are doing `m.allVars = new ArrayList<>();` if using AllOf and supporting Inheritance, will remove the the vars/properties of the generating model itself stored before. IMO we should have all vars/properties data including those of the parent model and itself both in `allVars`, then it can be generated by the template and pass the `model_validate` in deserialization.

In this change, I remove this line and keep the vars/properties data in `m.allVars` added before in `m.allVars`. Meanwhile, `m.allVars = m.vars` is a shallow copy, causing changing the value of  `m.allVars` will change the value of `m.vars` meanwhile as not expected, so did a packaging here to avoid this.



<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
