### PR TITLE
[TS-FETCH] Generate `models/index.ts` in `postProcessModels`

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java
@@ -340,6 +340,12 @@ public class TypeScriptFetchClientCodegen extends AbstractTypeScriptClientCodege
             this.processCodeGenModel(cm);
         }
 
+        // Add supporting file only if we plan to generate files in /models
+        if (!objs.isEmpty() && !addedModelIndex) {
+            addedModelIndex = true;
+            supportingFiles.add(new SupportingFile("models.index.mustache", modelPackage().replace('.', File.separatorChar), "index.ts"));
+        }
+
         return objs;
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/typescript/fetch/TypeScriptFetchClientCodegenTest.java
@@ -6,8 +6,12 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import org.openapitools.codegen.config.CodegenConfigurator;
+import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.Generator;
 import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.TestUtils;
 import org.openapitools.codegen.languages.AbstractTypeScriptClientCodegen;
@@ -16,6 +20,14 @@ import org.openapitools.codegen.typescript.TypeScriptGroups;
 import org.openapitools.codegen.utils.ModelUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,6 +65,32 @@ public class TypeScriptFetchClientCodegenTest {
         PathItem path = openApi.getPaths().get("/api/Users/{userId}");
         CodegenOperation operation = codegen.fromOperation("/api/Users/{userId}", "get", path.getGet(), path.getServers());
         Assert.assertEquals(operation.isResponseOptional, true);
+    }
+
+    @Test
+    public void testModelsWithoutPaths() throws IOException {
+        final String specPath = "src/test/resources/3_1/reusable-components-without-paths.yaml";
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("supportsES6", true);
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("typescript-fetch")
+                .setInputSpec(specPath)
+                .setAdditionalProperties(properties)
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        Generator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/index.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/runtime.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/models/Pet.ts"));
+        TestUtils.assertFileExists(Paths.get(output + "/models/index.ts"));
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_1/reusable-components-without-paths.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/reusable-components-without-paths.yaml
@@ -1,0 +1,19 @@
+openapi: 3.1.0
+info:
+  title: Reusable components without paths example
+  version: 1.0.0
+# Since OAS 3.1.0 the paths element isn't necessary. Now a valid OpenAPI Document can describe only paths, webhooks, or even only reusable components
+components:
+  schemas:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

@mkusaka Can I get a review for this bug fix, 🙏  please?

Fixes: https://github.com/OpenAPITools/openapi-generator/issues/18207

# The Issue

If you use an OpenAPI 3.1.0 schema without `paths`, the `typescript-fetch` generator produces a broken package. The root index file `index.ts` is:

```ts
/* tslint:disable */
/* eslint-disable */
export * from './runtime';
export * from './models/index';
```

but there isn't any `./models/index`.
Therefore Typescript gives this error:

> Cannot find module './models/index' or its corresponding type declarations. ts(2307)

# The bug

`./models/index` is generated in the `TypeScriptFetchClientCodegen.postProcessOperationsWithModels` method ([ref](https://github.com/OpenAPITools/openapi-generator/blob/34ebc1c644f2072b4eb9caaabbb8f96c374249d1/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/TypeScriptFetchClientCodegen.java#L593-L597))
- called by `DefaultGenerator.processOperations` method ([ref](https://github.com/OpenAPITools/openapi-generator/blob/34ebc1c644f2072b4eb9caaabbb8f96c374249d1/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java#L1583))
  - called by `DefaultGenerator.generateApis` **while it is generating the operations** ([ref](https://github.com/OpenAPITools/openapi-generator/blob/34ebc1c644f2072b4eb9caaabbb8f96c374249d1/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultGenerator.java#L622))

This is why `./models/index` is generated only when at least a path is specified.

# The fix

Since `./models/index` file is related to models, I think it is better if we generate it in `postProcessModels` method. I didn't remove it from `postProcessOperationsWithModels` to keep backward compatibility.

## Example

You can save the following specs in a file called `openapi-example.yml`:
```yml
openapi: 3.1.0
info:
  title: Example of specs for reusable components
  version: master

components:
  schemas:
    Planet:
      type: object
      properties:
        type:
          $ref: '#/components/schemas/PlanetType'
        name:
          type: string
    PlanetType:
      type: string
      enum:
        - SATURN
        - MARS
        - EARTH
      default: EARTH
```

Then you can test this PR running:
```shell
./run-in-docker.sh generate -i openapi-example.yml -g typescript-fetch --additional-properties "supportsES6=true"
```

You can see that `models/index.ts` is generated correctly.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
