### PR TITLE
Add rule to set primitive types to nullable

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -605,3 +605,10 @@ Example:
 ```
 java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_CONTAINER_TO_NULLABLE="array|map"
 ```
+
+- `SET_PRIMITIVE_TYPES_TO_NULLABLE`: When set to `string|integer|number|boolean` (or just `string`) for example, it will set the type to `nullable` (nullable: true)
+
+Example:
+```
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_PRIMITIVE_TYPES_TO_NULLABLE="integer|number"
+```

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -112,6 +112,14 @@ public class OpenAPINormalizer {
     boolean updateSetToNullable;
     boolean updateMapToNullable;
 
+    // when set (e.g. operationId:getPetById|addPet), filter out (or remove) everything else
+    final String SET_PRIMITIVE_TYPES_TO_NULLABLE = "SET_PRIMITIVE_TYPES_TO_NULLABLE";
+    HashSet<String> setPrimitiveTypesToNullable = new HashSet<>();
+    boolean updateStringToNullable;
+    boolean updateIntegerToNullable;
+    boolean updateNumberToNullable;
+    boolean updateBooleanToNullable;
+
     // ============= end of rules =============
 
     /**
@@ -143,6 +151,9 @@ public class OpenAPINormalizer {
         ruleNames.add(NORMALIZE_31SPEC);
         ruleNames.add(REMOVE_X_INTERNAL);
         ruleNames.add(FILTER);
+        ruleNames.add(SET_CONTAINER_TO_NULLABLE);
+        ruleNames.add(SET_PRIMITIVE_TYPES_TO_NULLABLE);
+
 
         // rules that are default to true
         rules.put(SIMPLIFY_ONEOF_ANYOF, true);
@@ -221,6 +232,26 @@ public class OpenAPINormalizer {
             }
             if (!updateArrayToNullable && !updateSetToNullable && !updateMapToNullable) {
                 LOGGER.error("SET_CONTAINER_TO_NULLABLE rule must be in the form of `array|set|map`, e.g. `set`, `array|map`: {}", inputRules.get(SET_CONTAINER_TO_NULLABLE));
+            }
+        }
+
+        if (inputRules.get(SET_PRIMITIVE_TYPES_TO_NULLABLE) != null) {
+            rules.put(SET_PRIMITIVE_TYPES_TO_NULLABLE, true);
+            setPrimitiveTypesToNullable = new HashSet<>(Arrays.asList(inputRules.get(SET_PRIMITIVE_TYPES_TO_NULLABLE).split("[|]")));
+            if (setPrimitiveTypesToNullable.contains("string")) {
+                updateStringToNullable = true;
+            }
+            if (setPrimitiveTypesToNullable.contains("integer")) {
+                updateIntegerToNullable = true;
+            }
+            if (setPrimitiveTypesToNullable.contains("number")) {
+                updateNumberToNullable = true;
+            }
+            if (setPrimitiveTypesToNullable.contains("boolean")) {
+                updateBooleanToNullable = true;
+            }
+            if (!updateStringToNullable && !updateIntegerToNullable && !updateNumberToNullable && !updateBooleanToNullable) {
+                LOGGER.error("SET_PRIMITIVE_TYPES_TO_NULLABLE rule must be in the form of `string|integer|number|boolean`, e.g. `string`, `integer|number`: {}", inputRules.get(SET_PRIMITIVE_TYPES_TO_NULLABLE));
             }
         }
     }
@@ -533,15 +564,18 @@ public class OpenAPINormalizer {
     }
 
     private Schema normalizeSimpleSchema(Schema schema, Set<Schema> visitedSchemas) {
-        return processNormalize31Spec(schema, visitedSchemas);
+        Schema result = processNormalize31Spec(schema, visitedSchemas);
+        return processSetPrimitiveTypesToNullable(result);
     }
 
     private void normalizeBooleanSchema(Schema schema, Set<Schema> visitedSchemas) {
         processSimplifyBooleanEnum(schema);
+        processSetPrimitiveTypesToNullable(schema);
     }
 
     private void normalizeIntegerSchema(Schema schema, Set<Schema> visitedSchemas) {
         processAddUnsignedToIntegerWithInvalidMaxValue(schema);
+        processSetPrimitiveTypesToNullable(schema);
     }
 
     private void normalizeProperties(Map<String, Schema> properties, Set<Schema> visitedSchemas) {
@@ -917,25 +951,49 @@ public class OpenAPINormalizer {
 
         if (Boolean.TRUE.equals(schema.getUniqueItems())) { // a set
             if (updateSetToNullable) {
-                if (schema.getNullable() != null || (schema.getExtensions() != null && schema.getExtensions().containsKey("x-nullable"))) {
-                    // already set, don't overwrite
-                    return schema;
-                }
-                schema.setNullable(true);
+                return setNullable(schema);
             }
         } else { // array
             if (updateArrayToNullable) {
-                if (schema.getNullable() != null || (schema.getExtensions() != null && schema.getExtensions().containsKey("x-nullable"))) {
-                    // already set, don't overwrite
-                    return schema;
-                }
-                schema.setNullable(true);
+                return setNullable(schema);
             }
         }
 
         return schema;
     }
 
+    /**
+     * Set nullable to true in primitive types (e.g. string) if needed.
+     *
+     * @param schema Schema
+     * @return Schema
+     */
+    private Schema processSetPrimitiveTypesToNullable(Schema schema) {
+        if (!getRule(SET_PRIMITIVE_TYPES_TO_NULLABLE)) {
+            return schema;
+        }
+
+        if (updateStringToNullable && "string".equals(schema.getType())) {
+            return setNullable(schema);
+        } else if (updateIntegerToNullable && "integer".equals(schema.getType())) {
+            return setNullable(schema);
+        } else if (updateNumberToNullable && "number".equals(schema.getType())) {
+            return setNullable(schema);
+        } else if (updateBooleanToNullable && "boolean".equals(schema.getType())) {
+            return setNullable(schema);
+        }
+
+        return schema;
+    }
+
+    private Schema setNullable(Schema schema) {
+        if (schema.getNullable() != null || (schema.getExtensions() != null && schema.getExtensions().containsKey("x-nullable"))) {
+            // already set, don't overwrite
+            return schema;
+        }
+        schema.setNullable(true);
+        return schema;
+    }
     /**
      * Set nullable to true in map if needed.
      *
@@ -948,11 +1006,7 @@ public class OpenAPINormalizer {
         }
 
         if (updateMapToNullable) {
-            if (schema.getNullable() != null || (schema.getExtensions() != null && schema.getExtensions().containsKey("x-nullable"))) {
-                // already set, don't override
-                return schema;
-            }
-            schema.setNullable(true);
+            return setNullable(schema);
         }
 
         return schema;

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -515,6 +515,48 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
+    public void testSetPrimitiveTypesToNullable() {
+        // test `string|integer|number|boolean`
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0//setPrimitiveTypesToNullable_test.yaml");
+
+        Schema schema = openAPI.getComponents().getSchemas().get("Person");
+        assertEquals(((Schema) schema.getProperties().get("lastName")).getNullable(), null);
+        assertEquals(((Schema) schema.getProperties().get("first_integer")).getNullable(), null);
+        assertEquals(((Schema) schema.getProperties().get("first_number")).getNullable(), null);
+        assertEquals(((Schema) schema.getProperties().get("first_boolean")).getNullable(), null);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SET_PRIMITIVE_TYPES_TO_NULLABLE", "string|integer|number|boolean");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema schema2 = openAPI.getComponents().getSchemas().get("Person");
+        assertEquals(((Schema) schema2.getProperties().get("lastName")).getNullable(), true);
+        assertEquals(((Schema) schema2.getProperties().get("first_integer")).getNullable(), true);
+        assertEquals(((Schema) schema2.getProperties().get("first_number")).getNullable(), true);
+        assertEquals(((Schema) schema2.getProperties().get("first_boolean")).getNullable(), true);
+
+        // test `number` only
+        OpenAPI openAPI2 = TestUtils.parseSpec("src/test/resources/3_0//setPrimitiveTypesToNullable_test.yaml");
+
+        Schema schema3 = openAPI2.getComponents().getSchemas().get("Person");
+        assertEquals(((Schema) schema3.getProperties().get("lastName")).getNullable(), null);
+        assertEquals(((Schema) schema3.getProperties().get("first_integer")).getNullable(), null);
+        assertEquals(((Schema) schema3.getProperties().get("first_number")).getNullable(), null);
+        assertEquals(((Schema) schema3.getProperties().get("first_boolean")).getNullable(), null);
+
+        options.put("SET_PRIMITIVE_TYPES_TO_NULLABLE", "number");
+        OpenAPINormalizer openAPINormalizer2 = new OpenAPINormalizer(openAPI2, options);
+        openAPINormalizer2.normalize();
+
+        Schema schema4 = openAPI2.getComponents().getSchemas().get("Person");
+        assertEquals(((Schema) schema4.getProperties().get("lastName")).getNullable(), null);
+        assertEquals(((Schema) schema4.getProperties().get("first_integer")).getNullable(), null);
+        assertEquals(((Schema) schema4.getProperties().get("first_number")).getNullable(), true);
+        assertEquals(((Schema) schema4.getProperties().get("first_boolean")).getNullable(), null);
+    }
+
+    @Test
     public void testOpenAPINormalizerSimplifyOneOfAnyOf31Spec() {
         // to test the rule SIMPLIFY_ONEOF_ANYOF in 3.1 spec
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_18184.yaml");

--- a/modules/openapi-generator/src/test/resources/3_0/setPrimitiveTypesToNullable_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/setPrimitiveTypesToNullable_test.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Example
+  license:
+    name: MIT
+servers:
+  - url: http://api.example.xyz/v1
+paths:
+  /person/display/{personId}:
+    get:
+      tags:
+        - person
+        - basic
+      parameters:
+        - name: personId
+          in: path
+          required: true
+          description: The id of the person to retrieve
+          schema:
+            type: string
+      operationId: list
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+
+components:
+  schemas:
+    Person:
+      description: person
+      type: object
+      properties:
+        lastName:
+          type: string
+        first_integer:
+          type: integer
+        first_number:
+          type: number 
+        first_boolean:
+          type: boolean


### PR DESCRIPTION
Add rule to set primitive types to nullable

e.g.

```
java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar generate -g java -i modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o /tmp/java-okhttp/ --openapi-normalizer SET_PRIMITIVE_TYPES_TO_NULLABLE="integer|number"
```

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

fyi @OpenAPITools/generator-core-team 