### PR TITLE
[JAXRS-SPEC] no @Valid annotation on simple fields

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/beanValidation.mustache
@@ -1,2 +1,1 @@
-{{#required}}{{^isReadOnly}}  @NotNull
-{{/isReadOnly}}{{/required}}{{>beanValidationCore}}
+{{#required}}{{^isReadOnly}}@NotNull {{/isReadOnly}}{{/required}}{{#isContainer}}{{^isPrimitiveType}}{{^isEnum}}@Valid {{/isEnum}}{{/isPrimitiveType}}{{/isContainer}}{{^isContainer}}{{^isPrimitiveType}}@Valid {{/isPrimitiveType}}{{/isContainer}}{{>beanValidationCore}}

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -72,7 +72,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
   @ApiModelProperty({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}"){{/useSwaggerAnnotations}}{{#useMicroProfileOpenAPIAnnotations}}
   @org.eclipse.microprofile.openapi.annotations.media.Schema({{#example}}example = "{{{.}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}description = "{{{description}}}"){{/useMicroProfileOpenAPIAnnotations}}
   @JsonProperty("{{baseName}}")
-{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  public {{>beanValidatedType}} {{getter}}() {
+  {{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}public {{>beanValidatedType}} {{getter}}() {
     return {{name}};
   }
 

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/pojo.mustache
@@ -32,7 +32,7 @@ public class {{classname}} {{#parent}}extends {{{.}}}{{/parent}} {{#vendorExtens
   {{#vendorExtensions.x-field-extra-annotation}}
   {{{vendorExtensions.x-field-extra-annotation}}}
   {{/vendorExtensions.x-field-extra-annotation}}
-  private {{#useBeanValidation}}@Valid {{/useBeanValidation}}{{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  private {{#isContainer}}{{#useBeanValidation}}@Valid {{/useBeanValidation}}{{/isContainer}}{{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
   {{/vars}}
   {{#generateBuilders}}
   {{^additionalProperties}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/jaxrs/JavaJAXRSSpecServerCodegenTest.java
@@ -715,6 +715,31 @@ public class JavaJAXRSSpecServerCodegenTest extends JavaJaxrsBaseTest {
     }
 
     @Test
+    public void testValidAnnotation_issue14432() throws Exception {
+        File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
+        output.deleteOnExit();
+
+        OpenAPI openAPI = new OpenAPIParser()
+                .readLocation("src/test/resources/3_0/issue_14432.yaml", null, new ParseOptions()).getOpenAPI();
+
+        codegen.setOutputDir(output.getAbsolutePath());
+
+        ClientOptInput input = new ClientOptInput()
+                .openAPI(openAPI)
+                .config(codegen);
+
+        DefaultGenerator generator = new DefaultGenerator();
+        Map<String, File> files = generator.opts(input).generate().stream()
+                .collect(Collectors.toMap(File::getName, Function.identity()));
+
+        JavaFileAssert.assertThat(files.get("ComplexObject.java"))
+                .fileContains("private @Valid List<LocalDate> dates")
+                .fileDoesNotContains("private @Valid SymbolTypeEnum symbolType")
+                .fileDoesNotContains("@Valid String")
+                .fileDoesNotContains("@Valid Double");
+    }
+
+    @Test
     public void arrayNullableDefaultValueTests() throws Exception {
         final File output = Files.createTempDirectory("test").toFile().getCanonicalFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/issue_14432.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/issue_14432.yaml
@@ -1,0 +1,30 @@
+openapi: "3.0.3"
+info:
+  title: "Demo models"
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    ComplexObject:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+        probability:
+          type: "number"
+          format: "double"
+        dates:
+          type: "array"
+          items:
+            type: "string"
+            format: "date"
+        symbolType:
+          type: "string"
+          enum:
+            - "SYMBOL1"
+            - "SYMBOL2"
+            - "SYMBOL3"
+    ComplexArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/ComplexObject'

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   /**
    **/
@@ -79,7 +79,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+  @Valid public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -184,7 +184,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+  @Valid public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+  @Valid public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -254,7 +254,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+  @Valid public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -289,7 +289,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+  @Valid public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   /**
    **/
@@ -40,8 +40,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+  @NotNull public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -34,7 +34,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+  @Valid public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -34,7 +34,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+  @Valid public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -71,7 +71,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+  @Valid public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -106,7 +106,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  @Valid public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   /**
    **/
@@ -50,8 +50,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -68,7 +68,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   /**
    **/
@@ -243,8 +243,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+  @NotNull public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -301,7 +300,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+  @Valid public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<@Valid ModelFile> files = new ArrayList<>();
 
   /**
@@ -35,7 +35,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+  @Valid public ModelFile getFile() {
     return _file;
   }
 
@@ -54,7 +54,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+  @Valid public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   /**
    * minimum: 10
@@ -52,7 +52,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
- @Min(10) @Max(100)  public Integer getInteger() {
+   @Min(10) @Max(100)public Integer getInteger() {
     return integer;
   }
 
@@ -73,7 +73,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
- @Min(20) @Max(200)  public Integer getInt32() {
+   @Min(20) @Max(200)public Integer getInt32() {
     return int32;
   }
 
@@ -113,8 +113,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+  @NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")public BigDecimal getNumber() {
     return number;
   }
 
@@ -135,7 +134,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
- @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
+   @DecimalMin("54.3") @DecimalMax("987.6")public Float getFloat() {
     return _float;
   }
 
@@ -156,7 +155,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
- @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
+   @DecimalMin("67.8") @DecimalMax("123.4")public Double getDouble() {
     return _double;
   }
 
@@ -175,7 +174,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
- @Pattern(regexp="/[a-z]/i")  public String getString() {
+   @Pattern(regexp="/[a-z]/i")public String getString() {
     return string;
   }
 
@@ -194,8 +193,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+  @NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")public byte[] getByte() {
     return _byte;
   }
 
@@ -214,7 +212,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+  @Valid public File getBinary() {
     return binary;
   }
 
@@ -233,8 +231,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+  @NotNull @Valid public LocalDate getDate() {
     return date;
   }
 
@@ -253,7 +250,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -272,7 +269,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -291,8 +288,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+  @NotNull  @Size(min=10,max=64)public String getPassword() {
     return password;
   }
 
@@ -311,7 +307,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+  @Valid public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MapTest.java
@@ -82,7 +82,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+  @Valid public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = new HashMap<>();
 
   /**
@@ -37,7 +37,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -56,7 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -75,7 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+  @Valid public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   /**
    * Test capitalization

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   /**
    **/
@@ -35,8 +35,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+  @NotNull public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   /**
    **/
@@ -31,7 +31,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+  @Valid public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   /**
    **/
@@ -140,7 +140,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+  @Valid public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   /**
    **/
@@ -33,7 +33,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+  @Valid public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Pet.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<@Valid Tag> tags = new ArrayList<>();
   public enum StatusEnum {
@@ -78,7 +78,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   /**
    **/
@@ -109,7 +109,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+  @Valid public Category getCategory() {
     return category;
   }
 
@@ -128,8 +128,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 
@@ -148,8 +147,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+  @NotNull public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -185,7 +183,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  @Valid public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -38,8 +38,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -58,8 +57,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -78,8 +76,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -98,8 +95,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -118,8 +114,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -39,8 +39,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -59,8 +58,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -79,8 +77,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+  @NotNull public Float getFloatItem() {
     return floatItem;
   }
 
@@ -99,8 +96,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -119,8 +115,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -139,8 +134,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface-response/src/gen/java/org/openapitools/model/XmlItem.java
@@ -22,33 +22,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = new ArrayList<>();
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = new ArrayList<>();
   private @Valid List<Integer> nameWrappedArray = new ArrayList<>();
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = new ArrayList<>();
   private @Valid List<Integer> prefixWrappedArray = new ArrayList<>();
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = new ArrayList<>();
   private @Valid List<Integer> namespaceWrappedArray = new ArrayList<>();
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = new ArrayList<>();
   private @Valid List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+  @Valid public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -192,7 +192,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+  @Valid public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -338,7 +338,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+  @Valid public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -484,7 +484,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+  @Valid public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -630,7 +630,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+  @Valid public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   /**
    **/
@@ -79,7 +79,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+  @Valid public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -184,7 +184,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+  @Valid public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -219,7 +219,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+  @Valid public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -254,7 +254,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+  @Valid public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -289,7 +289,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+  @Valid public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   /**
    **/
@@ -40,8 +40,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+  @NotNull public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -34,7 +34,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+  @Valid public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -34,7 +34,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+  @Valid public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -71,7 +71,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+  @Valid public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -106,7 +106,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  @Valid public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   /**
    **/
@@ -50,8 +50,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -68,7 +68,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   /**
    **/
@@ -243,8 +243,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+  @NotNull public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -301,7 +300,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+  @Valid public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<@Valid ModelFile> files = new ArrayList<>();
 
   /**
@@ -35,7 +35,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+  @Valid public ModelFile getFile() {
     return _file;
   }
 
@@ -54,7 +54,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+  @Valid public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   /**
    * minimum: 10
@@ -52,7 +52,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
- @Min(10) @Max(100)  public Integer getInteger() {
+   @Min(10) @Max(100)public Integer getInteger() {
     return integer;
   }
 
@@ -73,7 +73,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
- @Min(20) @Max(200)  public Integer getInt32() {
+   @Min(20) @Max(200)public Integer getInt32() {
     return int32;
   }
 
@@ -113,8 +113,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+  @NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")public BigDecimal getNumber() {
     return number;
   }
 
@@ -135,7 +134,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
- @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
+   @DecimalMin("54.3") @DecimalMax("987.6")public Float getFloat() {
     return _float;
   }
 
@@ -156,7 +155,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
- @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
+   @DecimalMin("67.8") @DecimalMax("123.4")public Double getDouble() {
     return _double;
   }
 
@@ -175,7 +174,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
- @Pattern(regexp="/[a-z]/i")  public String getString() {
+   @Pattern(regexp="/[a-z]/i")public String getString() {
     return string;
   }
 
@@ -194,8 +193,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+  @NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")public byte[] getByte() {
     return _byte;
   }
 
@@ -214,7 +212,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+  @Valid public File getBinary() {
     return binary;
   }
 
@@ -233,8 +231,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+  @NotNull @Valid public LocalDate getDate() {
     return date;
   }
 
@@ -253,7 +250,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -272,7 +269,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -291,8 +288,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+  @NotNull  @Size(min=10,max=64)public String getPassword() {
     return password;
   }
 
@@ -311,7 +307,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+  @Valid public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MapTest.java
@@ -82,7 +82,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+  @Valid public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = new HashMap<>();
 
   /**
@@ -37,7 +37,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -56,7 +56,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -75,7 +75,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+  @Valid public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   /**
    * Test capitalization

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   /**
    **/
@@ -35,8 +35,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+  @NotNull public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   /**
    **/
@@ -31,7 +31,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+  @Valid public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   /**
    **/
@@ -140,7 +140,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+  @Valid public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   /**
    **/
@@ -33,7 +33,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+  @Valid public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Pet.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<@Valid Tag> tags = new ArrayList<>();
   public enum StatusEnum {
@@ -78,7 +78,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   /**
    **/
@@ -109,7 +109,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+  @Valid public Category getCategory() {
     return category;
   }
 
@@ -128,8 +128,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 
@@ -148,8 +147,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+  @NotNull public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -185,7 +183,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  @Valid public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -38,8 +38,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -58,8 +57,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -78,8 +76,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -98,8 +95,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -118,8 +114,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   /**
@@ -39,8 +39,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -59,8 +58,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -79,8 +77,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+  @NotNull public Float getFloatItem() {
     return floatItem;
   }
 
@@ -99,8 +96,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -119,8 +115,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -139,8 +134,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-interface/src/gen/java/org/openapitools/model/XmlItem.java
@@ -22,33 +22,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = new ArrayList<>();
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = new ArrayList<>();
   private @Valid List<Integer> nameWrappedArray = new ArrayList<>();
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = new ArrayList<>();
   private @Valid List<Integer> prefixWrappedArray = new ArrayList<>();
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = new ArrayList<>();
   private @Valid List<Integer> namespaceWrappedArray = new ArrayList<>();
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = new ArrayList<>();
   private @Valid List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
@@ -81,7 +81,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+  @Valid public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -192,7 +192,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+  @Valid public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -338,7 +338,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+  @Valid public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -484,7 +484,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+  @Valid public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -630,7 +630,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+  @Valid public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   protected AdditionalPropertiesClass(AdditionalPropertiesClassBuilder<?, ?> b) {
     this.mapString = b.mapString;
@@ -96,7 +96,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+  @Valid public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -201,7 +201,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+  @Valid public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -236,7 +236,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+  @Valid public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -271,7 +271,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+  @Valid public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -306,7 +306,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+  @Valid public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   protected Animal(AnimalBuilder<?, ?> b) {
     this.className = b.className;
@@ -48,8 +48,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+  @NotNull public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -41,7 +41,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+  @Valid public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -41,7 +41,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+  @Valid public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -80,7 +80,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+  @Valid public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -115,7 +115,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  @Valid public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   protected BigCat(BigCatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   protected Capitalization(CapitalizationBuilder<?, ?> b) {
     this.smallCamel = b.smallCamel;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   protected Cat(CatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   protected Category(CategoryBuilder<?, ?> b) {
     this.id = b.id;
@@ -58,8 +58,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   protected ClassModel(ClassModelBuilder<?, ?> b) {
     this.propertyClass = b.propertyClass;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   protected Client(ClientBuilder<?, ?> b) {
     this.client = b.client;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   protected Dog(DogBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -68,7 +68,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   protected EnumTest(EnumTestBuilder<?, ?> b) {
     this.enumString = b.enumString;
@@ -254,8 +254,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+  @NotNull public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -312,7 +311,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+  @Valid public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<@Valid ModelFile> files = new ArrayList<>();
 
   protected FileSchemaTestClass(FileSchemaTestClassBuilder<?, ?> b) {
@@ -43,7 +43,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+  @Valid public ModelFile getFile() {
     return _file;
   }
 
@@ -62,7 +62,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+  @Valid public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   protected FormatTest(FormatTestBuilder<?, ?> b) {
     this.integer = b.integer;
@@ -72,7 +72,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
- @Min(10) @Max(100)  public Integer getInteger() {
+   @Min(10) @Max(100)public Integer getInteger() {
     return integer;
   }
 
@@ -93,7 +93,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
- @Min(20) @Max(200)  public Integer getInt32() {
+   @Min(20) @Max(200)public Integer getInt32() {
     return int32;
   }
 
@@ -133,8 +133,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+  @NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")public BigDecimal getNumber() {
     return number;
   }
 
@@ -155,7 +154,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
- @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
+   @DecimalMin("54.3") @DecimalMax("987.6")public Float getFloat() {
     return _float;
   }
 
@@ -176,7 +175,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
- @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
+   @DecimalMin("67.8") @DecimalMax("123.4")public Double getDouble() {
     return _double;
   }
 
@@ -195,7 +194,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
- @Pattern(regexp="/[a-z]/i")  public String getString() {
+   @Pattern(regexp="/[a-z]/i")public String getString() {
     return string;
   }
 
@@ -214,8 +213,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+  @NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")public byte[] getByte() {
     return _byte;
   }
 
@@ -234,7 +232,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+  @Valid public File getBinary() {
     return binary;
   }
 
@@ -253,8 +251,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+  @NotNull @Valid public LocalDate getDate() {
     return date;
   }
 
@@ -273,7 +270,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -292,7 +289,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -311,8 +308,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+  @NotNull  @Size(min=10,max=64)public String getPassword() {
     return password;
   }
 
@@ -331,7 +327,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+  @Valid public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   protected HasOnlyReadOnly(HasOnlyReadOnlyBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MapTest.java
@@ -92,7 +92,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+  @Valid public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = new HashMap<>();
 
   protected MixedPropertiesAndAdditionalPropertiesClass(MixedPropertiesAndAdditionalPropertiesClassBuilder<?, ?> b) {
@@ -46,7 +46,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -65,7 +65,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -84,7 +84,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+  @Valid public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   protected Model200Response(Model200ResponseBuilder<?, ?> b) {
     this.name = b.name;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   protected ModelApiResponse(ModelApiResponseBuilder<?, ?> b) {
     this.code = b.code;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   protected ModelFile(ModelFileBuilder<?, ?> b) {
     this.sourceURI = b.sourceURI;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   protected ModelList(ModelListBuilder<?, ?> b) {
     this._123list = b._123list;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   protected ModelReturn(ModelReturnBuilder<?, ?> b) {
     this._return = b._return;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   protected Name(NameBuilder<?, ?> b) {
     this.name = b.name;
@@ -45,8 +45,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+  @NotNull public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   protected NumberOnly(NumberOnlyBuilder<?, ?> b) {
     this.justNumber = b.justNumber;
@@ -38,7 +38,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+  @Valid public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   protected Order(OrderBuilder<?, ?> b) {
     this.id = b.id;
@@ -152,7 +152,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+  @Valid public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   protected OuterComposite(OuterCompositeBuilder<?, ?> b) {
     this.myNumber = b.myNumber;
@@ -42,7 +42,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+  @Valid public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Pet.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<@Valid Tag> tags = new ArrayList<>();
   public enum StatusEnum {
@@ -78,7 +78,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   protected Pet(PetBuilder<?, ?> b) {
     this.id = b.id;
@@ -121,7 +121,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+  @Valid public Category getCategory() {
     return category;
   }
 
@@ -140,8 +140,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 
@@ -160,8 +159,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+  @NotNull public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -197,7 +195,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  @Valid public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   protected ReadOnlyFirst(ReadOnlyFirstBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   protected SpecialModelName(SpecialModelNameBuilder<?, ?> b) {
     this.$specialPropertyName = b.$specialPropertyName;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   protected Tag(TagBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderDefault(TypeHolderDefaultBuilder<?, ?> b) {
@@ -49,8 +49,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -69,8 +68,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -89,8 +87,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -109,8 +106,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -129,8 +125,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderExample(TypeHolderExampleBuilder<?, ?> b) {
@@ -51,8 +51,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -71,8 +70,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -91,8 +89,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+  @NotNull public Float getFloatItem() {
     return floatItem;
   }
 
@@ -111,8 +108,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -131,8 +127,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -151,8 +146,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   protected User(UserBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-jakarta/src/gen/java/org/openapitools/model/XmlItem.java
@@ -22,33 +22,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = new ArrayList<>();
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = new ArrayList<>();
   private @Valid List<Integer> nameWrappedArray = new ArrayList<>();
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = new ArrayList<>();
   private @Valid List<Integer> prefixWrappedArray = new ArrayList<>();
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = new ArrayList<>();
   private @Valid List<Integer> namespaceWrappedArray = new ArrayList<>();
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = new ArrayList<>();
   private @Valid List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
@@ -116,7 +116,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+  @Valid public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -227,7 +227,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+  @Valid public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -373,7 +373,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+  @Valid public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -519,7 +519,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+  @Valid public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -665,7 +665,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+  @Valid public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -28,9 +28,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   protected AdditionalPropertiesClass(AdditionalPropertiesClassBuilder<?, ?> b) {
     this.mapString = b.mapString;
@@ -94,7 +94,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+  @Valid public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -199,7 +199,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+  @Valid public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -234,7 +234,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+  @Valid public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -269,7 +269,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+  @Valid public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -304,7 +304,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+  @Valid public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Animal.java
@@ -25,8 +25,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   protected Animal(AnimalBuilder<?, ?> b) {
     this.className = b.className;
@@ -46,8 +46,7 @@ public class Animal  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+  @NotNull public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -39,7 +39,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+  @Valid public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -39,7 +39,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+  @Valid public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -78,7 +78,7 @@ public class ArrayTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+  @Valid public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -113,7 +113,7 @@ public class ArrayTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  @Valid public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/BigCat.java
@@ -64,7 +64,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   protected BigCat(BigCatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Capitalization.java
@@ -16,12 +16,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   protected Capitalization(CapitalizationBuilder<?, ?> b) {
     this.smallCamel = b.smallCamel;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Cat.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   protected Cat(CatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Category.java
@@ -16,8 +16,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   protected Category(CategoryBuilder<?, ?> b) {
     this.id = b.id;
@@ -56,8 +56,7 @@ public class Category  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ClassModel.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   protected ClassModel(ClassModelBuilder<?, ?> b) {
     this.propertyClass = b.propertyClass;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Client.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   protected Client(ClientBuilder<?, ?> b) {
     this.client = b.client;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Dog.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   protected Dog(DogBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -66,7 +66,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/EnumTest.java
@@ -65,7 +65,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -113,7 +113,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -161,7 +161,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -209,8 +209,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   protected EnumTest(EnumTestBuilder<?, ?> b) {
     this.enumString = b.enumString;
@@ -252,8 +252,7 @@ public class EnumTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+  @NotNull public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -310,7 +309,7 @@ public class EnumTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+  @Valid public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<@Valid ModelFile> files = new ArrayList<>();
 
   protected FileSchemaTestClass(FileSchemaTestClassBuilder<?, ?> b) {
@@ -41,7 +41,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+  @Valid public ModelFile getFile() {
     return _file;
   }
 
@@ -60,7 +60,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+  @Valid public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/FormatTest.java
@@ -23,20 +23,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid LocalDateTime dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private LocalDateTime dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   protected FormatTest(FormatTestBuilder<?, ?> b) {
     this.integer = b.integer;
@@ -70,7 +70,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("integer")
- @Min(10) @Max(100)  public Integer getInteger() {
+   @Min(10) @Max(100)public Integer getInteger() {
     return integer;
   }
 
@@ -91,7 +91,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("int32")
- @Min(20) @Max(200)  public Integer getInt32() {
+   @Min(20) @Max(200)public Integer getInt32() {
     return int32;
   }
 
@@ -131,8 +131,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+  @NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")public BigDecimal getNumber() {
     return number;
   }
 
@@ -153,7 +152,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("float")
- @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
+   @DecimalMin("54.3") @DecimalMax("987.6")public Float getFloat() {
     return _float;
   }
 
@@ -174,7 +173,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("double")
- @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
+   @DecimalMin("67.8") @DecimalMax("123.4")public Double getDouble() {
     return _double;
   }
 
@@ -193,7 +192,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("string")
- @Pattern(regexp="/[a-z]/i")  public String getString() {
+   @Pattern(regexp="/[a-z]/i")public String getString() {
     return string;
   }
 
@@ -212,8 +211,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+  @NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")public byte[] getByte() {
     return _byte;
   }
 
@@ -232,7 +230,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("binary")
-  public File getBinary() {
+  @Valid public File getBinary() {
     return binary;
   }
 
@@ -251,8 +249,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+  @NotNull @Valid public LocalDate getDate() {
     return date;
   }
 
@@ -271,7 +268,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("dateTime")
-  public LocalDateTime getDateTime() {
+  @Valid public LocalDateTime getDateTime() {
     return dateTime;
   }
 
@@ -290,7 +287,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", description = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -309,8 +306,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+  @NotNull  @Size(min=10,max=64)public String getPassword() {
     return password;
   }
 
@@ -329,7 +325,7 @@ public class FormatTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+  @Valid public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   protected HasOnlyReadOnly(HasOnlyReadOnlyBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MapTest.java
@@ -90,7 +90,7 @@ public class MapTest  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+  @Valid public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid LocalDateTime dateTime;
+  private UUID uuid;
+  private LocalDateTime dateTime;
   private @Valid Map<String, Animal> map = new HashMap<>();
 
   protected MixedPropertiesAndAdditionalPropertiesClass(MixedPropertiesAndAdditionalPropertiesClassBuilder<?, ?> b) {
@@ -44,7 +44,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -63,7 +63,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("dateTime")
-  public LocalDateTime getDateTime() {
+  @Valid public LocalDateTime getDateTime() {
     return dateTime;
   }
 
@@ -82,7 +82,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+  @Valid public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Model200Response.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   protected Model200Response(Model200ResponseBuilder<?, ?> b) {
     this.name = b.name;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -17,9 +17,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   protected ModelApiResponse(ModelApiResponseBuilder<?, ?> b) {
     this.code = b.code;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelFile.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   protected ModelFile(ModelFileBuilder<?, ?> b) {
     this.sourceURI = b.sourceURI;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelList.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   protected ModelList(ModelListBuilder<?, ?> b) {
     this._123list = b._123list;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   protected ModelReturn(ModelReturnBuilder<?, ?> b) {
     this._return = b._return;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Name.java
@@ -18,10 +18,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   protected Name(NameBuilder<?, ?> b) {
     this.name = b.name;
@@ -43,8 +43,7 @@ public class Name  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+  @NotNull public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   protected NumberOnly(NumberOnlyBuilder<?, ?> b) {
     this.justNumber = b.justNumber;
@@ -36,7 +36,7 @@ public class NumberOnly  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+  @Valid public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Order.java
@@ -17,10 +17,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid LocalDateTime shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private LocalDateTime shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -68,8 +68,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   protected Order(OrderBuilder<?, ?> b) {
     this.id = b.id;
@@ -150,7 +150,7 @@ public class Order  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("shipDate")
-  public LocalDateTime getShipDate() {
+  @Valid public LocalDateTime getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -17,9 +17,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   protected OuterComposite(OuterCompositeBuilder<?, ?> b) {
     this.myNumber = b.myNumber;
@@ -40,7 +40,7 @@ public class OuterComposite  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+  @Valid public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Pet.java
@@ -24,9 +24,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<@Valid Tag> tags = new ArrayList<>();
   public enum StatusEnum {
@@ -76,7 +76,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   protected Pet(PetBuilder<?, ?> b) {
     this.id = b.id;
@@ -119,7 +119,7 @@ public class Pet  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("category")
-  public Category getCategory() {
+  @Valid public Category getCategory() {
     return category;
   }
 
@@ -138,8 +138,7 @@ public class Pet  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "doggie", required = true, description = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 
@@ -158,8 +157,7 @@ public class Pet  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+  @NotNull public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -195,7 +193,7 @@ public class Pet  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(description = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  @Valid public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -16,8 +16,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   protected ReadOnlyFirst(ReadOnlyFirstBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   protected SpecialModelName(SpecialModelNameBuilder<?, ?> b) {
     this.$specialPropertyName = b.$specialPropertyName;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/Tag.java
@@ -16,8 +16,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   protected Tag(TagBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderDefault(TypeHolderDefaultBuilder<?, ?> b) {
@@ -47,8 +47,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -67,8 +66,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -87,8 +85,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -107,8 +104,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -127,8 +123,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(required = true, description = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderExample(TypeHolderExampleBuilder<?, ?> b) {
@@ -49,8 +49,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "what", required = true, description = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -69,8 +68,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", required = true, description = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -89,8 +87,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", required = true, description = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+  @NotNull public Float getFloatItem() {
     return floatItem;
   }
 
@@ -109,8 +106,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "-2", required = true, description = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -129,8 +125,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "true", required = true, description = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -149,8 +144,7 @@ public class TypeHolderExample  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "[0, 1, 2, 3]", required = true, description = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/User.java
@@ -16,14 +16,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   protected User(UserBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec-microprofile-openapi-annotations/src/gen/java/org/openapitools/model/XmlItem.java
@@ -20,33 +20,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = new ArrayList<>();
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = new ArrayList<>();
   private @Valid List<Integer> nameWrappedArray = new ArrayList<>();
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = new ArrayList<>();
   private @Valid List<Integer> prefixWrappedArray = new ArrayList<>();
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = new ArrayList<>();
   private @Valid List<Integer> namespaceWrappedArray = new ArrayList<>();
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = new ArrayList<>();
   private @Valid List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
@@ -114,7 +114,7 @@ public class XmlItem  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", description = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+  @Valid public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -225,7 +225,7 @@ public class XmlItem  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", description = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+  @Valid public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -371,7 +371,7 @@ public class XmlItem  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", description = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+  @Valid public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -517,7 +517,7 @@ public class XmlItem  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", description = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+  @Valid public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -663,7 +663,7 @@ public class XmlItem  implements Serializable {
   
   @org.eclipse.microprofile.openapi.annotations.media.Schema(example = "1.234", description = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+  @Valid public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
+++ b/samples/server/petstore/jaxrs-spec-required-and-readonly-property/src/gen/java/org/openapitools/model/ReadonlyAndRequiredProperties.java
@@ -18,10 +18,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadonlyAndRequiredProperties")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadonlyAndRequiredProperties  implements Serializable {
-  private @Valid String requiredYesReadonlyYes;
-  private @Valid String requiredYesReadonlyNo;
-  private @Valid String requiredNoReadonlyYes;
-  private @Valid String requiredNoReadonlyNo;
+  private String requiredYesReadonlyYes;
+  private String requiredYesReadonlyNo;
+  private String requiredNoReadonlyYes;
+  private String requiredNoReadonlyNo;
 
   protected ReadonlyAndRequiredProperties(ReadonlyAndRequiredPropertiesBuilder<?, ?> b) {
     this.requiredYesReadonlyYes = b.requiredYesReadonlyYes;
@@ -62,8 +62,7 @@ public class ReadonlyAndRequiredProperties  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("requiredYesReadonlyNo")
-  @NotNull
-  public String getRequiredYesReadonlyNo() {
+  @NotNull public String getRequiredYesReadonlyNo() {
     return requiredYesReadonlyNo;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesAnyType.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesAnyType")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesAnyType extends HashMap<String, Object> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesArray.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesArray")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesArray extends HashMap<String, List> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesBoolean.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesBoolean")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesBoolean extends HashMap<String, Boolean> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesClass.java
@@ -30,9 +30,9 @@ public class AdditionalPropertiesClass  implements Serializable {
   private @Valid Map<String, List<Object>> mapArrayAnytype = new HashMap<>();
   private @Valid Map<String, Map<String, String>> mapMapString = new HashMap<>();
   private @Valid Map<String, Map<String, Object>> mapMapAnytype = new HashMap<>();
-  private @Valid Object anytype1;
-  private @Valid Object anytype2;
-  private @Valid Object anytype3;
+  private Object anytype1;
+  private Object anytype2;
+  private Object anytype3;
 
   protected AdditionalPropertiesClass(AdditionalPropertiesClassBuilder<?, ?> b) {
     this.mapString = b.mapString;
@@ -96,7 +96,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_number")
-  public Map<String, BigDecimal> getMapNumber() {
+  @Valid public Map<String, BigDecimal> getMapNumber() {
     return mapNumber;
   }
 
@@ -201,7 +201,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_integer")
-  public Map<String, List<Integer>> getMapArrayInteger() {
+  @Valid public Map<String, List<Integer>> getMapArrayInteger() {
     return mapArrayInteger;
   }
 
@@ -236,7 +236,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_array_anytype")
-  public Map<String, List<Object>> getMapArrayAnytype() {
+  @Valid public Map<String, List<Object>> getMapArrayAnytype() {
     return mapArrayAnytype;
   }
 
@@ -271,7 +271,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_string")
-  public Map<String, Map<String, String>> getMapMapString() {
+  @Valid public Map<String, Map<String, String>> getMapMapString() {
     return mapMapString;
   }
 
@@ -306,7 +306,7 @@ public class AdditionalPropertiesClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_anytype")
-  public Map<String, Map<String, Object>> getMapMapAnytype() {
+  @Valid public Map<String, Map<String, Object>> getMapMapAnytype() {
     return mapMapAnytype;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesInteger.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesInteger")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesInteger extends HashMap<String, Integer> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesNumber.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesNumber")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesNumber extends HashMap<String, BigDecimal> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesObject.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesObject")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesObject extends HashMap<String, Map> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/AdditionalPropertiesString.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("AdditionalPropertiesString")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class AdditionalPropertiesString extends HashMap<String, String> implements Serializable {
-  private @Valid String name;
+  private String name;
 
   /**
    **/

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Animal.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Animal")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Animal  implements Serializable {
-  private @Valid String className;
-  private @Valid String color = "red";
+  private String className;
+  private String color = "red";
 
   protected Animal(AnimalBuilder<?, ?> b) {
     this.className = b.className;
@@ -48,8 +48,7 @@ public class Animal  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("className")
-  @NotNull
-  public String getClassName() {
+  @NotNull public String getClassName() {
     return className;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfArrayOfNumberOnly.java
@@ -41,7 +41,7 @@ public class ArrayOfArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayArrayNumber")
-  public List<List<BigDecimal>> getArrayArrayNumber() {
+  @Valid public List<@Valid List<@Valid BigDecimal>> getArrayArrayNumber() {
     return arrayArrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayOfNumberOnly.java
@@ -41,7 +41,7 @@ public class ArrayOfNumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("ArrayNumber")
-  public List<BigDecimal> getArrayNumber() {
+  @Valid public List<@Valid BigDecimal> getArrayNumber() {
     return arrayNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ArrayTest.java
@@ -80,7 +80,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_integer")
-  public List<List<Long>> getArrayArrayOfInteger() {
+  @Valid public List<List<Long>> getArrayArrayOfInteger() {
     return arrayArrayOfInteger;
   }
 
@@ -115,7 +115,7 @@ public class ArrayTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("array_array_of_model")
-  public List<List<ReadOnlyFirst>> getArrayArrayOfModel() {
+  @Valid public List<@Valid List<@Valid ReadOnlyFirst>> getArrayArrayOfModel() {
     return arrayArrayOfModel;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/BigCat.java
@@ -66,7 +66,7 @@ public class BigCat extends Cat implements Serializable {
     }
 }
 
-  private @Valid KindEnum kind;
+  private KindEnum kind;
 
   protected BigCat(BigCatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Capitalization.java
@@ -18,12 +18,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Capitalization")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Capitalization  implements Serializable {
-  private @Valid String smallCamel;
-  private @Valid String capitalCamel;
-  private @Valid String smallSnake;
-  private @Valid String capitalSnake;
-  private @Valid String scAETHFlowPoints;
-  private @Valid String ATT_NAME;
+  private String smallCamel;
+  private String capitalCamel;
+  private String smallSnake;
+  private String capitalSnake;
+  private String scAETHFlowPoints;
+  private String ATT_NAME;
 
   protected Capitalization(CapitalizationBuilder<?, ?> b) {
     this.smallCamel = b.smallCamel;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Cat.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Cat")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Cat extends Animal implements Serializable {
-  private @Valid Boolean declawed;
+  private Boolean declawed;
 
   protected Cat(CatBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Category.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Category")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Category  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name = "default-name";
+  private Long id;
+  private String name = "default-name";
 
   protected Category(CategoryBuilder<?, ?> b) {
     this.id = b.id;
@@ -58,8 +58,7 @@ public class Category  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ClassModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ClassModel")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ClassModel  implements Serializable {
-  private @Valid String propertyClass;
+  private String propertyClass;
 
   protected ClassModel(ClassModelBuilder<?, ?> b) {
     this.propertyClass = b.propertyClass;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Client.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Client")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Client  implements Serializable {
-  private @Valid String client;
+  private String client;
 
   protected Client(ClientBuilder<?, ?> b) {
     this.client = b.client;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Dog.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Dog")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Dog extends Animal implements Serializable {
-  private @Valid String breed;
+  private String breed;
 
   protected Dog(DogBuilder<?, ?> b) {
     super(b);

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumArrays.java
@@ -68,7 +68,7 @@ public class EnumArrays  implements Serializable {
     }
 }
 
-  private @Valid JustSymbolEnum justSymbol;
+  private JustSymbolEnum justSymbol;
   public enum ArrayEnumEnum {
 
     FISH(String.valueOf("fish")), CRAB(String.valueOf("crab"));

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/EnumTest.java
@@ -67,7 +67,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringEnum enumString;
+  private EnumStringEnum enumString;
   public enum EnumStringRequiredEnum {
 
     UPPER(String.valueOf("UPPER")), LOWER(String.valueOf("lower")), EMPTY(String.valueOf(""));
@@ -115,7 +115,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumStringRequiredEnum enumStringRequired;
+  private EnumStringRequiredEnum enumStringRequired;
   public enum EnumIntegerEnum {
 
     NUMBER_1(Integer.valueOf(1)), NUMBER_MINUS_1(Integer.valueOf(-1));
@@ -163,7 +163,7 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumIntegerEnum enumInteger;
+  private EnumIntegerEnum enumInteger;
   public enum EnumNumberEnum {
 
     NUMBER_1_DOT_1(Double.valueOf(1.1)), NUMBER_MINUS_1_DOT_2(Double.valueOf(-1.2));
@@ -211,8 +211,8 @@ public class EnumTest  implements Serializable {
     }
 }
 
-  private @Valid EnumNumberEnum enumNumber;
-  private @Valid OuterEnum outerEnum;
+  private EnumNumberEnum enumNumber;
+  private OuterEnum outerEnum;
 
   protected EnumTest(EnumTestBuilder<?, ?> b) {
     this.enumString = b.enumString;
@@ -254,8 +254,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("enum_string_required")
-  @NotNull
-  public EnumStringRequiredEnum getEnumStringRequired() {
+  @NotNull public EnumStringRequiredEnum getEnumStringRequired() {
     return enumStringRequired;
   }
 
@@ -312,7 +311,7 @@ public class EnumTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("outerEnum")
-  public OuterEnum getOuterEnum() {
+  @Valid public OuterEnum getOuterEnum() {
     return outerEnum;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FileSchemaTestClass.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("FileSchemaTestClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FileSchemaTestClass  implements Serializable {
-  private @Valid ModelFile _file;
+  private ModelFile _file;
   private @Valid List<@Valid ModelFile> files = new ArrayList<>();
 
   protected FileSchemaTestClass(FileSchemaTestClassBuilder<?, ?> b) {
@@ -43,7 +43,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("file")
-  public ModelFile getFile() {
+  @Valid public ModelFile getFile() {
     return _file;
   }
 
@@ -62,7 +62,7 @@ public class FileSchemaTestClass  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("files")
-  public List<ModelFile> getFiles() {
+  @Valid public List<@Valid ModelFile> getFiles() {
     return files;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/FormatTest.java
@@ -25,20 +25,20 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("format_test")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class FormatTest  implements Serializable {
-  private @Valid Integer integer;
-  private @Valid Integer int32;
-  private @Valid Long int64;
-  private @Valid BigDecimal number;
-  private @Valid Float _float;
-  private @Valid Double _double;
-  private @Valid String string;
-  private @Valid byte[] _byte;
-  private @Valid File binary;
-  private @Valid LocalDate date;
-  private @Valid Date dateTime;
-  private @Valid UUID uuid;
-  private @Valid String password;
-  private @Valid BigDecimal bigDecimal;
+  private Integer integer;
+  private Integer int32;
+  private Long int64;
+  private BigDecimal number;
+  private Float _float;
+  private Double _double;
+  private String string;
+  private byte[] _byte;
+  private File binary;
+  private LocalDate date;
+  private Date dateTime;
+  private UUID uuid;
+  private String password;
+  private BigDecimal bigDecimal;
 
   protected FormatTest(FormatTestBuilder<?, ?> b) {
     this.integer = b.integer;
@@ -72,7 +72,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("integer")
- @Min(10) @Max(100)  public Integer getInteger() {
+   @Min(10) @Max(100)public Integer getInteger() {
     return integer;
   }
 
@@ -93,7 +93,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("int32")
- @Min(20) @Max(200)  public Integer getInt32() {
+   @Min(20) @Max(200)public Integer getInt32() {
     return int32;
   }
 
@@ -133,8 +133,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number")
-  @NotNull
- @DecimalMin("32.1") @DecimalMax("543.2")  public BigDecimal getNumber() {
+  @NotNull @Valid  @DecimalMin("32.1") @DecimalMax("543.2")public BigDecimal getNumber() {
     return number;
   }
 
@@ -155,7 +154,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("float")
- @DecimalMin("54.3") @DecimalMax("987.6")  public Float getFloat() {
+   @DecimalMin("54.3") @DecimalMax("987.6")public Float getFloat() {
     return _float;
   }
 
@@ -176,7 +175,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("double")
- @DecimalMin("67.8") @DecimalMax("123.4")  public Double getDouble() {
+   @DecimalMin("67.8") @DecimalMax("123.4")public Double getDouble() {
     return _double;
   }
 
@@ -195,7 +194,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("string")
- @Pattern(regexp="/[a-z]/i")  public String getString() {
+   @Pattern(regexp="/[a-z]/i")public String getString() {
     return string;
   }
 
@@ -214,8 +213,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("byte")
-  @NotNull
- @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")  public byte[] getByte() {
+  @NotNull  @Pattern(regexp="^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")public byte[] getByte() {
     return _byte;
   }
 
@@ -234,7 +232,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("binary")
-  public File getBinary() {
+  @Valid public File getBinary() {
     return binary;
   }
 
@@ -253,8 +251,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("date")
-  @NotNull
-  public LocalDate getDate() {
+  @NotNull @Valid public LocalDate getDate() {
     return date;
   }
 
@@ -273,7 +270,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -292,7 +289,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(example = "72f98069-206d-4f12-9f12-3d1e525a8e84", value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -311,8 +308,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("password")
-  @NotNull
- @Size(min=10,max=64)  public String getPassword() {
+  @NotNull  @Size(min=10,max=64)public String getPassword() {
     return password;
   }
 
@@ -331,7 +327,7 @@ public class FormatTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("BigDecimal")
-  public BigDecimal getBigDecimal() {
+  @Valid public BigDecimal getBigDecimal() {
     return bigDecimal;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/HasOnlyReadOnly.java
@@ -19,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("hasOnlyReadOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class HasOnlyReadOnly  implements Serializable {
-  private @Valid String bar;
-  private @Valid String foo;
+  private String bar;
+  private String foo;
 
   protected HasOnlyReadOnly(HasOnlyReadOnlyBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MapTest.java
@@ -92,7 +92,7 @@ public class MapTest  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("map_map_of_string")
-  public Map<String, Map<String, String>> getMapMapOfString() {
+  @Valid public Map<String, Map<String, String>> getMapMapOfString() {
     return mapMapOfString;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/MixedPropertiesAndAdditionalPropertiesClass.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("MixedPropertiesAndAdditionalPropertiesClass")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializable {
-  private @Valid UUID uuid;
-  private @Valid Date dateTime;
+  private UUID uuid;
+  private Date dateTime;
   private @Valid Map<String, Animal> map = new HashMap<>();
 
   protected MixedPropertiesAndAdditionalPropertiesClass(MixedPropertiesAndAdditionalPropertiesClassBuilder<?, ?> b) {
@@ -46,7 +46,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("uuid")
-  public UUID getUuid() {
+  @Valid public UUID getUuid() {
     return uuid;
   }
 
@@ -65,7 +65,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("dateTime")
-  public Date getDateTime() {
+  @Valid public Date getDateTime() {
     return dateTime;
   }
 
@@ -84,7 +84,7 @@ public class MixedPropertiesAndAdditionalPropertiesClass  implements Serializabl
   
   @ApiModelProperty(value = "")
   @JsonProperty("map")
-  public Map<String, Animal> getMap() {
+  @Valid public Map<String, Animal> getMap() {
     return map;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Model200Response.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("200_response")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Model200Response  implements Serializable {
-  private @Valid Integer name;
-  private @Valid String propertyClass;
+  private Integer name;
+  private String propertyClass;
 
   protected Model200Response(Model200ResponseBuilder<?, ?> b) {
     this.name = b.name;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelApiResponse.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ApiResponse")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelApiResponse  implements Serializable {
-  private @Valid Integer code;
-  private @Valid String type;
-  private @Valid String message;
+  private Integer code;
+  private String type;
+  private String message;
 
   protected ModelApiResponse(ModelApiResponseBuilder<?, ?> b) {
     this.code = b.code;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelFile.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("File")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelFile  implements Serializable {
-  private @Valid String sourceURI;
+  private String sourceURI;
 
   protected ModelFile(ModelFileBuilder<?, ?> b) {
     this.sourceURI = b.sourceURI;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelList.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("List")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelList  implements Serializable {
-  private @Valid String _123list;
+  private String _123list;
 
   protected ModelList(ModelListBuilder<?, ?> b) {
     this._123list = b._123list;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ModelReturn.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Return")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ModelReturn  implements Serializable {
-  private @Valid Integer _return;
+  private Integer _return;
 
   protected ModelReturn(ModelReturnBuilder<?, ?> b) {
     this._return = b._return;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Name.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Name")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Name  implements Serializable {
-  private @Valid Integer name;
-  private @Valid Integer snakeCase;
-  private @Valid String property;
-  private @Valid Integer _123number;
+  private Integer name;
+  private Integer snakeCase;
+  private String property;
+  private Integer _123number;
 
   protected Name(NameBuilder<?, ?> b) {
     this.name = b.name;
@@ -45,8 +45,7 @@ public class Name  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public Integer getName() {
+  @NotNull public Integer getName() {
     return name;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/NumberOnly.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("NumberOnly")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class NumberOnly  implements Serializable {
-  private @Valid BigDecimal justNumber;
+  private BigDecimal justNumber;
 
   protected NumberOnly(NumberOnlyBuilder<?, ?> b) {
     this.justNumber = b.justNumber;
@@ -38,7 +38,7 @@ public class NumberOnly  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("JustNumber")
-  public BigDecimal getJustNumber() {
+  @Valid public BigDecimal getJustNumber() {
     return justNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Order.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Order")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Order  implements Serializable {
-  private @Valid Long id;
-  private @Valid Long petId;
-  private @Valid Integer quantity;
-  private @Valid Date shipDate;
+  private Long id;
+  private Long petId;
+  private Integer quantity;
+  private Date shipDate;
   public enum StatusEnum {
 
     PLACED(String.valueOf("placed")), APPROVED(String.valueOf("approved")), DELIVERED(String.valueOf("delivered"));
@@ -70,8 +70,8 @@ public class Order  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
-  private @Valid Boolean complete = false;
+  private StatusEnum status;
+  private Boolean complete = false;
 
   protected Order(OrderBuilder<?, ?> b) {
     this.id = b.id;
@@ -152,7 +152,7 @@ public class Order  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("shipDate")
-  public Date getShipDate() {
+  @Valid public Date getShipDate() {
     return shipDate;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/OuterComposite.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("OuterComposite")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class OuterComposite  implements Serializable {
-  private @Valid BigDecimal myNumber;
-  private @Valid String myString;
-  private @Valid Boolean myBoolean;
+  private BigDecimal myNumber;
+  private String myString;
+  private Boolean myBoolean;
 
   protected OuterComposite(OuterCompositeBuilder<?, ?> b) {
     this.myNumber = b.myNumber;
@@ -42,7 +42,7 @@ public class OuterComposite  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("my_number")
-  public BigDecimal getMyNumber() {
+  @Valid public BigDecimal getMyNumber() {
     return myNumber;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Pet.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Pet")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Pet  implements Serializable {
-  private @Valid Long id;
-  private @Valid Category category;
-  private @Valid String name;
+  private Long id;
+  private Category category;
+  private String name;
   private @Valid Set<String> photoUrls = new LinkedHashSet<>();
   private @Valid List<@Valid Tag> tags = new ArrayList<>();
   public enum StatusEnum {
@@ -78,7 +78,7 @@ public class Pet  implements Serializable {
     }
 }
 
-  private @Valid StatusEnum status;
+  private StatusEnum status;
 
   protected Pet(PetBuilder<?, ?> b) {
     this.id = b.id;
@@ -121,7 +121,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("category")
-  public Category getCategory() {
+  @Valid public Category getCategory() {
     return category;
   }
 
@@ -140,8 +140,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(example = "doggie", required = true, value = "")
   @JsonProperty("name")
-  @NotNull
-  public String getName() {
+  @NotNull public String getName() {
     return name;
   }
 
@@ -160,8 +159,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("photoUrls")
-  @NotNull
-  public Set<String> getPhotoUrls() {
+  @NotNull public Set<String> getPhotoUrls() {
     return photoUrls;
   }
 
@@ -197,7 +195,7 @@ public class Pet  implements Serializable {
   
   @ApiModelProperty(value = "")
   @JsonProperty("tags")
-  public List<Tag> getTags() {
+  @Valid public List<@Valid Tag> getTags() {
     return tags;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ReadOnlyFirst.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("ReadOnlyFirst")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class ReadOnlyFirst  implements Serializable {
-  private @Valid String bar;
-  private @Valid String baz;
+  private String bar;
+  private String baz;
 
   protected ReadOnlyFirst(ReadOnlyFirstBuilder<?, ?> b) {
     this.bar = b.bar;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/SpecialModelName.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("$special[model.name]")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class SpecialModelName  implements Serializable {
-  private @Valid Long $specialPropertyName;
+  private Long $specialPropertyName;
 
   protected SpecialModelName(SpecialModelNameBuilder<?, ?> b) {
     this.$specialPropertyName = b.$specialPropertyName;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/Tag.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("Tag")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class Tag  implements Serializable {
-  private @Valid Long id;
-  private @Valid String name;
+  private Long id;
+  private String name;
 
   protected Tag(TagBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderDefault.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderDefault")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderDefault  implements Serializable {
-  private @Valid String stringItem = "what";
-  private @Valid BigDecimal numberItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem = true;
+  private String stringItem = "what";
+  private BigDecimal numberItem;
+  private Integer integerItem;
+  private Boolean boolItem = true;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderDefault(TypeHolderDefaultBuilder<?, ?> b) {
@@ -49,8 +49,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -69,8 +68,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -89,8 +87,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -109,8 +106,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -129,8 +125,7 @@ public class TypeHolderDefault  implements Serializable {
   
   @ApiModelProperty(required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/TypeHolderExample.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("TypeHolderExample")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class TypeHolderExample  implements Serializable {
-  private @Valid String stringItem;
-  private @Valid BigDecimal numberItem;
-  private @Valid Float floatItem;
-  private @Valid Integer integerItem;
-  private @Valid Boolean boolItem;
+  private String stringItem;
+  private BigDecimal numberItem;
+  private Float floatItem;
+  private Integer integerItem;
+  private Boolean boolItem;
   private @Valid List<Integer> arrayItem = new ArrayList<>();
 
   protected TypeHolderExample(TypeHolderExampleBuilder<?, ?> b) {
@@ -51,8 +51,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "what", required = true, value = "")
   @JsonProperty("string_item")
-  @NotNull
-  public String getStringItem() {
+  @NotNull public String getStringItem() {
     return stringItem;
   }
 
@@ -71,8 +70,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("number_item")
-  @NotNull
-  public BigDecimal getNumberItem() {
+  @NotNull @Valid public BigDecimal getNumberItem() {
     return numberItem;
   }
 
@@ -91,8 +89,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "1.234", required = true, value = "")
   @JsonProperty("float_item")
-  @NotNull
-  public Float getFloatItem() {
+  @NotNull public Float getFloatItem() {
     return floatItem;
   }
 
@@ -111,8 +108,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "-2", required = true, value = "")
   @JsonProperty("integer_item")
-  @NotNull
-  public Integer getIntegerItem() {
+  @NotNull public Integer getIntegerItem() {
     return integerItem;
   }
 
@@ -131,8 +127,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "true", required = true, value = "")
   @JsonProperty("bool_item")
-  @NotNull
-  public Boolean getBoolItem() {
+  @NotNull public Boolean getBoolItem() {
     return boolItem;
   }
 
@@ -151,8 +146,7 @@ public class TypeHolderExample  implements Serializable {
   
   @ApiModelProperty(example = "[0, 1, 2, 3]", required = true, value = "")
   @JsonProperty("array_item")
-  @NotNull
-  public List<Integer> getArrayItem() {
+  @NotNull public List<Integer> getArrayItem() {
     return arrayItem;
   }
 

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/User.java
@@ -18,14 +18,14 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("User")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class User  implements Serializable {
-  private @Valid Long id;
-  private @Valid String username;
-  private @Valid String firstName;
-  private @Valid String lastName;
-  private @Valid String email;
-  private @Valid String password;
-  private @Valid String phone;
-  private @Valid Integer userStatus;
+  private Long id;
+  private String username;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private String password;
+  private String phone;
+  private Integer userStatus;
 
   protected User(UserBuilder<?, ?> b) {
     this.id = b.id;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/XmlItem.java
@@ -22,33 +22,33 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("XmlItem")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaJAXRSSpecServerCodegen", comments = "Generator version: 7.5.0-SNAPSHOT")
 public class XmlItem  implements Serializable {
-  private @Valid String attributeString;
-  private @Valid BigDecimal attributeNumber;
-  private @Valid Integer attributeInteger;
-  private @Valid Boolean attributeBoolean;
+  private String attributeString;
+  private BigDecimal attributeNumber;
+  private Integer attributeInteger;
+  private Boolean attributeBoolean;
   private @Valid List<Integer> wrappedArray = new ArrayList<>();
-  private @Valid String nameString;
-  private @Valid BigDecimal nameNumber;
-  private @Valid Integer nameInteger;
-  private @Valid Boolean nameBoolean;
+  private String nameString;
+  private BigDecimal nameNumber;
+  private Integer nameInteger;
+  private Boolean nameBoolean;
   private @Valid List<Integer> nameArray = new ArrayList<>();
   private @Valid List<Integer> nameWrappedArray = new ArrayList<>();
-  private @Valid String prefixString;
-  private @Valid BigDecimal prefixNumber;
-  private @Valid Integer prefixInteger;
-  private @Valid Boolean prefixBoolean;
+  private String prefixString;
+  private BigDecimal prefixNumber;
+  private Integer prefixInteger;
+  private Boolean prefixBoolean;
   private @Valid List<Integer> prefixArray = new ArrayList<>();
   private @Valid List<Integer> prefixWrappedArray = new ArrayList<>();
-  private @Valid String namespaceString;
-  private @Valid BigDecimal namespaceNumber;
-  private @Valid Integer namespaceInteger;
-  private @Valid Boolean namespaceBoolean;
+  private String namespaceString;
+  private BigDecimal namespaceNumber;
+  private Integer namespaceInteger;
+  private Boolean namespaceBoolean;
   private @Valid List<Integer> namespaceArray = new ArrayList<>();
   private @Valid List<Integer> namespaceWrappedArray = new ArrayList<>();
-  private @Valid String prefixNsString;
-  private @Valid BigDecimal prefixNsNumber;
-  private @Valid Integer prefixNsInteger;
-  private @Valid Boolean prefixNsBoolean;
+  private String prefixNsString;
+  private BigDecimal prefixNsNumber;
+  private Integer prefixNsInteger;
+  private Boolean prefixNsBoolean;
   private @Valid List<Integer> prefixNsArray = new ArrayList<>();
   private @Valid List<Integer> prefixNsWrappedArray = new ArrayList<>();
 
@@ -116,7 +116,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("attribute_number")
-  public BigDecimal getAttributeNumber() {
+  @Valid public BigDecimal getAttributeNumber() {
     return attributeNumber;
   }
 
@@ -227,7 +227,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("name_number")
-  public BigDecimal getNameNumber() {
+  @Valid public BigDecimal getNameNumber() {
     return nameNumber;
   }
 
@@ -373,7 +373,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_number")
-  public BigDecimal getPrefixNumber() {
+  @Valid public BigDecimal getPrefixNumber() {
     return prefixNumber;
   }
 
@@ -519,7 +519,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("namespace_number")
-  public BigDecimal getNamespaceNumber() {
+  @Valid public BigDecimal getNamespaceNumber() {
     return namespaceNumber;
   }
 
@@ -665,7 +665,7 @@ public class XmlItem  implements Serializable {
   
   @ApiModelProperty(example = "1.234", value = "")
   @JsonProperty("prefix_ns_number")
-  public BigDecimal getPrefixNsNumber() {
+  @Valid public BigDecimal getPrefixNsNumber() {
     return prefixNsNumber;
   }
 


### PR DESCRIPTION
based on #14435 by @anatoliy-balakirev

fix #14432

- The change in beanValidation.mustache is still the same as in #14435.
- The change in pojo.mustache had to be adapted a bit, because the file has changed on the master branch in the meantime.
    I also added a small whitespace change to improve the generated code's style a bit. It's still not great though.
- I also added a new unit test in JavaJAXRSSpecServerCodegenTest.java

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
   @bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)