### PR TITLE
[csharp] Fixed property naming convention for composed types

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractCSharpCodegen.java
@@ -585,7 +585,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 List<CodegenProperty> allOf = composedSchemas.getAllOf();
                 if (allOf != null) {
                     for (CodegenProperty property : allOf) {
-                        property.name = patchPropertyName(model, property.baseType);
+                        property.name = patchPropertyName(model, camelize(property.baseType));
                         patchPropertyVendorExtensions(property);
                     }
                 }
@@ -594,7 +594,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 if (anyOf != null) {
                     removePropertiesDeclaredInComposedTypes(objs, model, anyOf);
                     for (CodegenProperty property : anyOf) {
-                        property.name = patchPropertyName(model, property.baseType);
+                        property.name = patchPropertyName(model, camelize(property.baseType));
                         property.isNullable = true;
                         patchPropertyVendorExtensions(property);
                     }
@@ -604,7 +604,7 @@ public abstract class AbstractCSharpCodegen extends DefaultCodegen implements Co
                 if (oneOf != null) {
                     removePropertiesDeclaredInComposedTypes(objs, model, oneOf);
                     for (CodegenProperty property : oneOf) {
-                        property.name = patchPropertyName(model, property.baseType);
+                        property.name = patchPropertyName(model, camelize(property.baseType));
                         property.isNullable = true;
                         patchPropertyVendorExtensions(property);
                     }

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -32,19 +32,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal OneOfString(string varString)
+        /// <param name="string"></param>
+        internal OneOfString(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -32,20 +32,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varBool"></param>
-        internal PolymorphicProperty(bool varBool)
+        /// <param name="bool"></param>
+        internal PolymorphicProperty(bool @bool)
         {
-            VarBool = varBool;
+            Bool = @bool;
             OnCreated();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal PolymorphicProperty(string varString)
+        /// <param name="string"></param>
+        internal PolymorphicProperty(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
@@ -72,14 +72,14 @@ namespace Org.OpenAPITools.Model
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarBool
+        /// Gets or Sets Bool
         /// </summary>
-        public bool? VarBool { get; set; }
+        public bool? Bool { get; set; }
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets Object
@@ -159,11 +159,11 @@ namespace Org.OpenAPITools.Model
 
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
-                    Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    Utf8JsonReader utf8JsonReaderBool = utf8JsonReader;
+                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderBool, jsonSerializerOptions, out varBool);
 
-                    Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
-                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);
+                    Utf8JsonReader utf8JsonReaderString = utf8JsonReader;
+                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderString, jsonSerializerOptions, out varString);
 
                     Utf8JsonReader utf8JsonReaderObject = utf8JsonReader;
                     ClientUtils.TryDeserialize<Object>(ref utf8JsonReaderObject, jsonSerializerOptions, out varObject);

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -34,19 +34,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal OneOfString(string varString)
+        /// <param name="string"></param>
+        internal OneOfString(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string? VarString { get; set; }
+        public string? String { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -34,20 +34,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varBool"></param>
-        internal PolymorphicProperty(bool varBool)
+        /// <param name="bool"></param>
+        internal PolymorphicProperty(bool @bool)
         {
-            VarBool = varBool;
+            Bool = @bool;
             OnCreated();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal PolymorphicProperty(string varString)
+        /// <param name="string"></param>
+        internal PolymorphicProperty(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
@@ -74,14 +74,14 @@ namespace Org.OpenAPITools.Model
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarBool
+        /// Gets or Sets Bool
         /// </summary>
-        public bool? VarBool { get; set; }
+        public bool? Bool { get; set; }
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string? VarString { get; set; }
+        public string? String { get; set; }
 
         /// <summary>
         /// Gets or Sets Object
@@ -161,11 +161,11 @@ namespace Org.OpenAPITools.Model
 
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
-                    Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    Utf8JsonReader utf8JsonReaderBool = utf8JsonReader;
+                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderBool, jsonSerializerOptions, out varBool);
 
-                    Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
-                    ClientUtils.TryDeserialize<string?>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);
+                    Utf8JsonReader utf8JsonReaderString = utf8JsonReader;
+                    ClientUtils.TryDeserialize<string?>(ref utf8JsonReaderString, jsonSerializerOptions, out varString);
 
                     Utf8JsonReader utf8JsonReaderObject = utf8JsonReader;
                     ClientUtils.TryDeserialize<Object?>(ref utf8JsonReaderObject, jsonSerializerOptions, out varObject);

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -32,19 +32,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal OneOfString(string varString)
+        /// <param name="string"></param>
+        internal OneOfString(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -32,20 +32,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varBool"></param>
-        internal PolymorphicProperty(bool varBool)
+        /// <param name="bool"></param>
+        internal PolymorphicProperty(bool @bool)
         {
-            VarBool = varBool;
+            Bool = @bool;
             OnCreated();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal PolymorphicProperty(string varString)
+        /// <param name="string"></param>
+        internal PolymorphicProperty(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
@@ -72,14 +72,14 @@ namespace Org.OpenAPITools.Model
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarBool
+        /// Gets or Sets Bool
         /// </summary>
-        public bool? VarBool { get; set; }
+        public bool? Bool { get; set; }
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets Object
@@ -159,11 +159,11 @@ namespace Org.OpenAPITools.Model
 
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
-                    Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    Utf8JsonReader utf8JsonReaderBool = utf8JsonReader;
+                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderBool, jsonSerializerOptions, out varBool);
 
-                    Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
-                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);
+                    Utf8JsonReader utf8JsonReaderString = utf8JsonReader;
+                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderString, jsonSerializerOptions, out varString);
 
                     Utf8JsonReader utf8JsonReaderObject = utf8JsonReader;
                     ClientUtils.TryDeserialize<Object>(ref utf8JsonReaderObject, jsonSerializerOptions, out varObject);

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -35,19 +35,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal OneOfString(string varString)
+        /// <param name="string"></param>
+        internal OneOfString(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string? VarString { get; set; }
+        public string? String { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -35,20 +35,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varBool"></param>
-        internal PolymorphicProperty(bool varBool)
+        /// <param name="bool"></param>
+        internal PolymorphicProperty(bool @bool)
         {
-            VarBool = varBool;
+            Bool = @bool;
             OnCreated();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal PolymorphicProperty(string varString)
+        /// <param name="string"></param>
+        internal PolymorphicProperty(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
@@ -75,14 +75,14 @@ namespace Org.OpenAPITools.Model
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarBool
+        /// Gets or Sets Bool
         /// </summary>
-        public bool? VarBool { get; set; }
+        public bool? Bool { get; set; }
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string? VarString { get; set; }
+        public string? String { get; set; }
 
         /// <summary>
         /// Gets or Sets Object
@@ -162,11 +162,11 @@ namespace Org.OpenAPITools.Model
 
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
-                    Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    Utf8JsonReader utf8JsonReaderBool = utf8JsonReader;
+                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderBool, jsonSerializerOptions, out varBool);
 
-                    Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
-                    ClientUtils.TryDeserialize<string?>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);
+                    Utf8JsonReader utf8JsonReaderString = utf8JsonReader;
+                    ClientUtils.TryDeserialize<string?>(ref utf8JsonReaderString, jsonSerializerOptions, out varString);
 
                     Utf8JsonReader utf8JsonReaderObject = utf8JsonReader;
                     ClientUtils.TryDeserialize<Object?>(ref utf8JsonReaderObject, jsonSerializerOptions, out varObject);

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/OneOfString.cs
@@ -32,19 +32,19 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="OneOfString" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal OneOfString(string varString)
+        /// <param name="string"></param>
+        internal OneOfString(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets additional properties

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/src/Org.OpenAPITools/Model/PolymorphicProperty.cs
@@ -32,20 +32,20 @@ namespace Org.OpenAPITools.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varBool"></param>
-        internal PolymorphicProperty(bool varBool)
+        /// <param name="bool"></param>
+        internal PolymorphicProperty(bool @bool)
         {
-            VarBool = varBool;
+            Bool = @bool;
             OnCreated();
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolymorphicProperty" /> class.
         /// </summary>
-        /// <param name="varString"></param>
-        internal PolymorphicProperty(string varString)
+        /// <param name="string"></param>
+        internal PolymorphicProperty(string @string)
         {
-            VarString = varString;
+            String = @string;
             OnCreated();
         }
 
@@ -72,14 +72,14 @@ namespace Org.OpenAPITools.Model
         partial void OnCreated();
 
         /// <summary>
-        /// Gets or Sets VarBool
+        /// Gets or Sets Bool
         /// </summary>
-        public bool? VarBool { get; set; }
+        public bool? Bool { get; set; }
 
         /// <summary>
-        /// Gets or Sets VarString
+        /// Gets or Sets String
         /// </summary>
-        public string VarString { get; set; }
+        public string String { get; set; }
 
         /// <summary>
         /// Gets or Sets Object
@@ -159,11 +159,11 @@ namespace Org.OpenAPITools.Model
 
                 if (utf8JsonReaderOneOf.TokenType == JsonTokenType.PropertyName && currentDepth == utf8JsonReaderOneOf.CurrentDepth - 1)
                 {
-                    Utf8JsonReader utf8JsonReaderVarBool = utf8JsonReader;
-                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderVarBool, jsonSerializerOptions, out varBool);
+                    Utf8JsonReader utf8JsonReaderBool = utf8JsonReader;
+                    ClientUtils.TryDeserialize<bool?>(ref utf8JsonReaderBool, jsonSerializerOptions, out varBool);
 
-                    Utf8JsonReader utf8JsonReaderVarString = utf8JsonReader;
-                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderVarString, jsonSerializerOptions, out varString);
+                    Utf8JsonReader utf8JsonReaderString = utf8JsonReader;
+                    ClientUtils.TryDeserialize<string>(ref utf8JsonReaderString, jsonSerializerOptions, out varString);
 
                     Utf8JsonReader utf8JsonReaderObject = utf8JsonReader;
                     ClientUtils.TryDeserialize<Object>(ref utf8JsonReaderObject, jsonSerializerOptions, out varObject);


### PR DESCRIPTION
This is the first step towards adding support for primitive types in composed schemas for generichost library. The problem being fixed is that properties that are composed properties have a different naming convention than the other model properties, which created a downstream issue when improving composed schema support.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
