### PR TITLE
Update versions for typescript-node and remove vulnerable test package

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-node/package.mustache
@@ -16,9 +16,8 @@
     "author": "OpenAPI-Generator Contributors",
     "license": "Unlicense",
     "dependencies": {
-        "bluebird": "^3.5.0",
-        "request": "^2.81.0",
-        "rewire": "^3.0.2"
+        "bluebird": "^3.7.2",
+        "request": "^2.88.2"
     },
     "devDependencies": {
         "@types/bluebird": "^3.5.33",

--- a/samples/client/petstore/typescript-node/npm/package.json
+++ b/samples/client/petstore/typescript-node/npm/package.json
@@ -16,9 +16,8 @@
     "author": "OpenAPI-Generator Contributors",
     "license": "Unlicense",
     "dependencies": {
-        "bluebird": "^3.5.0",
-        "request": "^2.81.0",
-        "rewire": "^3.0.2"
+        "bluebird": "^3.7.2",
+        "request": "^2.88.2"
     },
     "devDependencies": {
         "@types/bluebird": "^3.5.33",


### PR DESCRIPTION
Use latest versions for `bluebird` and `request` and remove `rewire`. `rewire` has high security alerts in Github security alerts as it depends on `json5` (https://nvd.nist.gov/vuln/detail/CVE-2022-46175) and shouldn't have been added to the generated clients as its used in tests. It was introduced here https://github.com/OpenAPITools/openapi-generator/commit/960412a9b4b60c597ebab5b11871b5848f5c97cb#diff-1df884eca4890fc2cff7eec6f61ac2157b1b9e72fe4cc13c782e300125fb0da3R20 although the same commit shows that it used to work without it https://github.com/OpenAPITools/openapi-generator/commit/960412a9b4b60c597ebab5b11871b5848f5c97cb#diff-d2785da28187b6d6ef1e0bdab42139309e443906fb5d9d365fce5e2a01673ef5R52-R56

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Typescript technical committee: @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
