### PR TITLE
"==" enum value generates "_" in Java which is invalid since Java 9

### DIFF
--- a/docs/generators/groovy.md
+++ b/docs/generators/groovy.md
@@ -135,6 +135,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-camel.md
+++ b/docs/generators/java-camel.md
@@ -174,6 +174,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-helidon-client.md
+++ b/docs/generators/java-helidon-client.md
@@ -128,6 +128,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-helidon-server.md
+++ b/docs/generators/java-helidon-server.md
@@ -130,6 +130,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-inflector.md
+++ b/docs/generators/java-inflector.md
@@ -132,6 +132,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-micronaut-client.md
+++ b/docs/generators/java-micronaut-client.md
@@ -153,6 +153,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-micronaut-server.md
+++ b/docs/generators/java-micronaut-server.md
@@ -153,6 +153,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-msf4j.md
+++ b/docs/generators/java-msf4j.md
@@ -138,6 +138,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-pkmst.md
+++ b/docs/generators/java-pkmst.md
@@ -139,6 +139,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-play-framework.md
+++ b/docs/generators/java-play-framework.md
@@ -142,6 +142,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-undertow-server.md
+++ b/docs/generators/java-undertow-server.md
@@ -132,6 +132,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-vertx-web.md
+++ b/docs/generators/java-vertx-web.md
@@ -132,6 +132,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-vertx.md
+++ b/docs/generators/java-vertx.md
@@ -135,6 +135,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java-wiremock.md
+++ b/docs/generators/java-wiremock.md
@@ -132,6 +132,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/java.md
+++ b/docs/generators/java.md
@@ -164,6 +164,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-cxf-cdi.md
+++ b/docs/generators/jaxrs-cxf-cdi.md
@@ -146,6 +146,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-cxf-client.md
+++ b/docs/generators/jaxrs-cxf-client.md
@@ -137,6 +137,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-cxf-extended.md
+++ b/docs/generators/jaxrs-cxf-extended.md
@@ -160,6 +160,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-cxf.md
+++ b/docs/generators/jaxrs-cxf.md
@@ -155,6 +155,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-jersey.md
+++ b/docs/generators/jaxrs-jersey.md
@@ -138,6 +138,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-resteasy-eap.md
+++ b/docs/generators/jaxrs-resteasy-eap.md
@@ -139,6 +139,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-resteasy.md
+++ b/docs/generators/jaxrs-resteasy.md
@@ -138,6 +138,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/jaxrs-spec.md
+++ b/docs/generators/jaxrs-spec.md
@@ -146,6 +146,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/docs/generators/spring.md
+++ b/docs/generators/spring.md
@@ -167,6 +167,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>_</li>
 <li>abstract</li>
 <li>apiclient</li>
 <li>apiexception</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -192,7 +192,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
                         "ApiClient", "ApiException", "ApiResponse", "Configuration", "StringUtil",
 
                         // language reserved words
-                        "abstract", "continue", "for", "new", "switch", "assert",
+                        "_", "abstract", "continue", "for", "new", "switch", "assert",
                         "default", "if", "package", "synchronized", "boolean", "do", "goto", "private",
                         "this", "break", "double", "implements", "protected", "throw", "byte", "else",
                         "import", "public", "throws", "case", "enum", "instanceof", "return", "transient",
@@ -1908,10 +1908,9 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         // string
         String var = value.replaceAll("\\W+", "_").toUpperCase(Locale.ROOT);
         if (var.matches("\\d.*")) {
-            return "_" + var;
-        } else {
-            return var;
+            var = "_" + var;
         }
+        return this.toVarName(var);
     }
 
     @Override

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -56,6 +56,7 @@ public class AbstractJavaCodegenTest {
     @Test
     public void toEnumVarNameShouldNotResultInSingleUnderscore() throws Exception {
         Assert.assertEquals(fakeJavaCodegen.toEnumVarName(" ", "String"), "SPACE");
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("==", "String"), "u");
     }
 
     @Test


### PR DESCRIPTION
"==" enum value generates "_" in Java which is invalid since Java 9 

to fixes https://github.com/OpenAPITools/openapi-generator/issues/17276

based on https://github.com/OpenAPITools/openapi-generator/pull/17278


<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
