### PR TITLE
Fix null check in 3.1 spec

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -880,6 +880,7 @@ public class OpenAPINormalizer {
      * @param schema Schema
      */
     public boolean isNullTypeSchema(Schema schema) {
+        LOGGER.info("null? {}", schema);
         if (schema == null) {
             return true;
         }
@@ -890,7 +891,7 @@ public class OpenAPINormalizer {
 
         if (schema.getTypes() != null && !schema.getTypes().isEmpty()) {
             // 3.1 spec
-            if (schema.getTypes().size() ==1) { // 1 type only
+            if (schema.getTypes().size() == 1) { // 1 type only
                 String type = (String) schema.getTypes().iterator().next();
                 return type == null || "null".equals(type);
             } else { // more than 1 type so must not be just null
@@ -900,6 +901,11 @@ public class OpenAPINormalizer {
 
         if (schema instanceof JsonSchema) { // 3.1 spec
             if (Boolean.TRUE.equals(schema.getNullable())) {
+                return true;
+            }
+
+            // for `type: null`
+            if (schema.getTypes() == null && schema.get$ref() == null) {
                 return true;
             }
         } else { // 3.0.x or 2.x spec
@@ -938,7 +944,7 @@ public class OpenAPINormalizer {
             if (oneOfSchemas.size() == 6) {
                 TreeSet<String> ts = new TreeSet<>();
                 for (Schema s: oneOfSchemas) {
-                    ts.add(s.getType());
+                    ts.add(ModelUtils.getType(s));
                 }
 
                 if (ts.equals(anyTypeTreeSet)) {
@@ -1063,7 +1069,7 @@ public class OpenAPINormalizer {
             if (anyOfSchemas.size() == 6) {
                 TreeSet<String> ts = new TreeSet<>();
                 for (Schema s: anyOfSchemas) {
-                    ts.add(s.getType());
+                    ts.add(ModelUtils.getType(s));
                 }
 
                 if (ts.equals(anyTypeTreeSet)) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/OpenAPINormalizer.java
@@ -880,7 +880,6 @@ public class OpenAPINormalizer {
      * @param schema Schema
      */
     public boolean isNullTypeSchema(Schema schema) {
-        LOGGER.info("null? {}", schema);
         if (schema == null) {
             return true;
         }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/utils/ModelUtils.java
@@ -2127,6 +2127,25 @@ public class ModelUtils {
     }
 
     /**
+     * Returns schema type.
+     * For 3.1 spec, return the first one.
+     *
+     * @param schema the schema
+     * @return schema type
+     */
+    public static String getType(Schema schema) {
+        if (schema == null) {
+            return null;
+        }
+
+        if (schema instanceof JsonSchema) {
+            return String.valueOf(schema.getTypes().iterator().next());
+        } else {
+            return schema.getType();
+        }
+    }
+
+    /**
      * Returns true if any of the common attributes of the schema (e.g. readOnly, default, maximum, etc) is defined.
      *
      * @param schema the schema

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/OpenAPINormalizerTest.java
@@ -158,6 +158,10 @@ public class OpenAPINormalizerTest {
         assertEquals(schema2.getOneOf().size(), 4);
         assertNull(schema2.getNullable());
 
+        Schema schema2b = openAPI.getComponents().getSchemas().get("OneOfTest2");
+        assertEquals(schema2b.getOneOf().size(), 2);
+        assertNull(schema2b.getNullable());
+
         Schema schema5 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
         assertEquals(schema5.getOneOf().size(), 3);
         assertNull(schema5.getNullable());
@@ -188,6 +192,11 @@ public class OpenAPINormalizerTest {
         assertNull(schema4.getOneOf());
         assertTrue(schema4 instanceof IntegerSchema);
         assertTrue(schema4.getNullable());
+
+        Schema schema4b = openAPI.getComponents().getSchemas().get("OneOfTest2");
+        assertNull(schema4b.getOneOf());
+        assertTrue(schema4b instanceof StringSchema);
+        assertTrue(schema4b.getNullable());
 
         Schema schema6 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
         assertEquals(schema6.getOneOf().size(), 2);
@@ -532,7 +541,7 @@ public class OpenAPINormalizerTest {
     @Test
     public void testSetPrimitiveTypesToNullable() {
         // test `string|integer|number|boolean`
-        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0//setPrimitiveTypesToNullable_test.yaml");
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_0/setPrimitiveTypesToNullable_test.yaml");
 
         Schema schema = openAPI.getComponents().getSchemas().get("Person");
         assertEquals(((Schema) schema.getProperties().get("lastName")).getNullable(), null);
@@ -552,7 +561,7 @@ public class OpenAPINormalizerTest {
         assertEquals(((Schema) schema2.getProperties().get("first_boolean")).getNullable(), true);
 
         // test `number` only
-        OpenAPI openAPI2 = TestUtils.parseSpec("src/test/resources/3_0//setPrimitiveTypesToNullable_test.yaml");
+        OpenAPI openAPI2 = TestUtils.parseSpec("src/test/resources/3_0/setPrimitiveTypesToNullable_test.yaml");
 
         Schema schema3 = openAPI2.getComponents().getSchemas().get("Person");
         assertEquals(((Schema) schema3.getProperties().get("lastName")).getNullable(), null);
@@ -572,7 +581,7 @@ public class OpenAPINormalizerTest {
     }
 
     @Test
-    public void testOpenAPINormalizerSimplifyOneOfAnyOf31Spec() {
+    public void testOpenAPINormalizerSimplifyOneOfAnyOf31SpecForIssue18184  () {
         // to test the rule SIMPLIFY_ONEOF_ANYOF in 3.1 spec
         OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/issue_18184.yaml");
         // test spec contains anyOf with a ref to enum and another scheme type is null
@@ -636,6 +645,77 @@ public class OpenAPINormalizerTest {
         assertEquals(((Schema) schema6.getProperties().get("arrayOfStrings")).getItems().getTypes().contains("string"), true);
         assertEquals(((Schema) schema6.getProperties().get("arrayOfStrings")).getItems().getType(), "string");
         assertEquals(((Schema) schema6.getProperties().get("arrayOfStrings")).getType(), "array");
+    }
 
+    @Test
+    public void testOpenAPINormalizerSimplifyOneOfAnyOf31Spec() {
+        // to test the rule SIMPLIFY_ONEOF_ANYOF with 3.1 spec
+        OpenAPI openAPI = TestUtils.parseSpec("src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml");
+
+        Schema schema = openAPI.getComponents().getSchemas().get("AnyOfTest");
+        assertEquals(schema.getAnyOf().size(), 4);
+        assertNull(schema.getNullable());
+
+        Schema schema2 = openAPI.getComponents().getSchemas().get("OneOfTest");
+        assertEquals(schema2.getOneOf().size(), 4);
+        assertNull(schema2.getNullable());
+
+        Schema schema2b = openAPI.getComponents().getSchemas().get("OneOfTest2");
+        assertEquals(schema2b.getOneOf().size(), 2);
+        assertNull(schema2b.getNullable());
+
+        Schema schema5 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
+        assertEquals(schema5.getOneOf().size(), 3);
+        assertNull(schema5.getNullable());
+
+        Schema schema7 = openAPI.getComponents().getSchemas().get("Parent");
+        assertEquals(((Schema) schema7.getProperties().get("number")).getAnyOf().size(), 1);
+
+        Schema schema9 = openAPI.getComponents().getSchemas().get("AnyOfStringArrayOfString");
+        assertEquals(schema9.getAnyOf().size(), 2);
+
+        Schema schema11 = openAPI.getComponents().getSchemas().get("AnyOfAnyType");
+        assertEquals(schema11.getAnyOf().size(), 6);
+
+        Schema schema13 = openAPI.getComponents().getSchemas().get("OneOfAnyType");
+        assertEquals(schema13.getOneOf().size(), 6);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("SIMPLIFY_ONEOF_ANYOF", "true");
+        OpenAPINormalizer openAPINormalizer = new OpenAPINormalizer(openAPI, options);
+        openAPINormalizer.normalize();
+
+        Schema schema3 = openAPI.getComponents().getSchemas().get("AnyOfTest");
+        assertNull(schema3.getAnyOf());
+        assertEquals(ModelUtils.getType(schema3), "string");
+        assertTrue(schema3.getNullable());
+
+        Schema schema4 = openAPI.getComponents().getSchemas().get("OneOfTest");
+        assertNull(schema4.getOneOf());
+        assertEquals(ModelUtils.getType(schema4), "integer");
+        assertTrue(schema4.getNullable());
+
+        Schema schema4b = openAPI.getComponents().getSchemas().get("OneOfTest2");
+        assertNull(schema4b.getOneOf());
+        assertEquals(ModelUtils.getType(schema4b), "string");
+        assertTrue(schema4b.getNullable());
+
+        Schema schema6 = openAPI.getComponents().getSchemas().get("OneOfNullableTest");
+        assertEquals(schema6.getOneOf().size(), 2);
+        assertTrue(schema6.getNullable());
+
+        Schema schema8 = openAPI.getComponents().getSchemas().get("Parent");
+        assertEquals(((Schema) schema8.getProperties().get("number")).get$ref(), "#/components/schemas/Number");
+
+        Schema schema10 = openAPI.getComponents().getSchemas().get("AnyOfStringArrayOfString");
+        assertEquals(schema10.getAnyOf().size(), 2);
+
+        Schema schema12 = openAPI.getComponents().getSchemas().get("AnyOfAnyType");
+        assertEquals(schema12.getAnyOf(), null);
+        assertEquals(schema12.getType(), null);
+
+        Schema schema14 = openAPI.getComponents().getSchemas().get("OneOfAnyType");
+        assertEquals(schema14.getOneOf(), null);
+        assertEquals(schema14.getType(), null);
     }
 }

--- a/modules/openapi-generator/src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_1/simplifyOneOfAnyOf_test.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   version: 1.0.0
   title: Example


### PR DESCRIPTION
- Fix null check in 3.1 spec
- add getType method in modeltuils to support both 3.0 and 3.1 spec

fyi @OpenAPITools/generator-core-team 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

