### PR TITLE
[html2] Fix blank responses in html document

### DIFF
--- a/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
@@ -445,48 +445,46 @@
 
 
                             <div class="tab-content" id="responses-{{baseName}}-{{nickname}}-{{code}}-wrapper" style='margin-bottom: 10px;'>
-                              {{#schema}}
-                                <div class="tab-pane active" id="responses-{{baseName}}-{{nickname}}-{{code}}-schema">
-                                  <div id="responses-{{baseName}}-{{nickname}}-schema-{{code}}" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {{{jsonSchema}}};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                          Object.keys(schema.properties).forEach( (item) => {
-                                            if (schema.properties[item].$ref != null) {
-                                              schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
-                                            }
-                                          });
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
+                              <div class="tab-pane active" id="responses-{{baseName}}-{{nickname}}-{{code}}-schema">
+                                <div id="responses-{{baseName}}-{{nickname}}-schema-{{code}}" class="exampleStyle">
+                                  <script>
+                                    $(document).ready(function() {
+                                      var schemaWrapper = {{{jsonSchema}}};
+                                      var schema = findNode('schema',schemaWrapper).schema;
+                                      if (!schema) {
+                                        schema = schemaWrapper.schema;
+                                      }
+                                      if (schema.$ref != null) {
+                                        schema = defsParser.$refs.get(schema.$ref);
+                                        Object.keys(schema.properties).forEach( (item) => {
+                                          if (schema.properties[item].$ref != null) {
+                                            schema.properties[item] = defsParser.$refs.get(schema.properties[item].$ref);
+                                          }
+                                        });
+                                      } else if (schema.items != null && schema.items.$ref != null) {
+                                        schema.items = defsParser.$refs.get(schema.items.$ref);
+                                      } else {
+                                        schemaWrapper.definitions = Object.assign({}, defs);
+                                        $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                          console.log(err);
+                                        });
+                                      }
 
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-{{baseName}}-{{nickname}}-{{code}}-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-{{baseName}}-{{nickname}}-schema-{{code}}');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-{{baseName}}-{{nickname}}-{{code}}-schema-data' type='hidden' value=''></input>
+                                      var view = new JSONSchemaView(schema, 3);
+                                      $('#responses-{{baseName}}-{{nickname}}-{{code}}-schema-data').val(JSON.stringify(schema));
+                                      var result = $('#responses-{{baseName}}-{{nickname}}-schema-{{code}}');
+                                      result.empty();
+                                      result.append(view.render());
+                                    });
+                                  </script>
                                 </div>
-                                {{#examples}}
-                                  <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-{{code}}-example">
-                                    <pre class="prettyprint"><code class="json">{{example}}</code></pre>
-                                  </div>
-                                {{/examples}}
-                              {{/schema}}
+                                <input id='responses-{{baseName}}-{{nickname}}-{{code}}-schema-data' type='hidden' value=''></input>
+                              </div>
+                              {{#examples}}
+                                <div class="tab-pane" id="examples-{{baseName}}-{{nickname}}-{{code}}-example">
+                                  <pre class="prettyprint"><code class="json">{{example}}</code></pre>
+                                </div>
+                              {{/examples}}
                               {{#hasHeaders}}
                                   <div class="tab-pane" id="responses-{{nickname}}-{{code}}-headers">
                                       <table>

--- a/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
+++ b/modules/openapi-generator/src/main/resources/htmlDocs2/index.mustache
@@ -454,6 +454,9 @@
                                       if (!schema) {
                                         schema = schemaWrapper.schema;
                                       }
+                                      if (schema == null) {
+                                        return;
+                                      }
                                       if (schema.$ref != null) {
                                         schema = defsParser.$refs.get(schema.$ref);
                                         Object.keys(schema.properties).forEach( (item) => {


### PR DESCRIPTION
fix #14642
fix #3788
fix #11204
fix #1373
Removed {{#schema}} section tag, so that {{{jsonSchema}}} and the other mustache variables can be retrieved via `apiInfo.apis.operation.responses`

I tested by using the html generated by `modules/openapi-generator/src/test/resources/3_1/petstore.yaml`.
Before my fixing, responses were empty if $ref was used in yaml. It happened because {{{jsonSchema}}} was null in `apiInfo.apis.operation.responses.schema`, but exitsts in `apiInfo.apis.operation.responses`. So the generated script was incomplete as `var schemaWrapper = ;`

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
