### PR TITLE
[php-symfony] Allow Symfony 7 / Remove EOL PHP / Bearer Fix

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/Controller.mustache
@@ -92,7 +92,7 @@ class Controller extends AbstractController
         $json = $this->exceptionToArray($exception);
         $json['statusCode'] = $statusCode;
 
-        return new Response(json_encode($json, 15, 512), $statusCode, $headers);
+        return new Response(json_encode($json, 15), $statusCode, $headers);
     }
 
     /**
@@ -219,7 +219,7 @@ class Controller extends AbstractController
     public static function isContentTypeAllowed(Request $request, array $consumes = []): bool
     {
         if (!empty($consumes) && $consumes[0] !== '*/*') {
-            $currentFormat = $request->getContentType();
+            $currentFormat = $request->getContentTypeFormat();
             foreach ($consumes as $mimeType) {
                 // canonize mime type
                 if (is_string($mimeType) && false !== $pos = strpos($mimeType, ';')) {
@@ -230,7 +230,7 @@ class Controller extends AbstractController
                     // add custom format to request
                     $format = $mimeType;
                     $request->setFormat($format, $format);
-                    $currentFormat = $request->getContentType();
+                    $currentFormat = $request->getContentTypeFormat();
                 }
 
                 if ($format === $currentFormat) {

--- a/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/api_controller.mustache
@@ -101,6 +101,10 @@ class {{controllerName}} extends Controller
         // HTTP basic authentication required
         $security{{name}} = $request->headers->get('authorization');
         {{/isBasicBasic}}
+        {{#isBasicBearer}}
+        // HTTP bearer authentication required
+        $security{{name}} = $request->headers->get('authorization');
+        {{/isBasicBearer}}
         {{#isOAuth}}
         // Oauth required
         $security{{name}} = $request->headers->get('authorization');
@@ -148,7 +152,7 @@ class {{controllerName}} extends Controller
             {{#allParams}}
             {{^isFile}}
             {{#isBodyParam}}
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             ${{paramName}} = $this->deserialize(${{paramName}}, '{{#isContainer}}{{#items}}array<{{dataType}}>{{/items}}{{/isContainer}}{{^isContainer}}{{#isEnumRef}}\{{modelPackage}}\{{dataType}}{{/isEnumRef}}{{^isEnumRef}}{{dataType}}{{/isEnumRef}}{{/isContainer}}', $inputFormat);
             {{/isBodyParam}}
             {{^isBodyParam}}
@@ -178,17 +182,12 @@ class {{controllerName}} extends Controller
 
             {{#returnType}}$result = {{/returnType}}$handler->{{operationId}}({{#allParams}}${{paramName}}, {{/allParams}}$responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '{{#responses}}{{#isDefault}}{{message}}{{/isDefault}}{{/responses}}';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
+            $message = match($responseCode) {
             {{#responses}}
-                case {{code}}:
-                    $message = '{{message}}';
-                    break;
+                {{code}} => '{{message}}',
             {{/responses}}
-            }
+                default => '{{#responses}}{{#isDefault}}{{message}}{{/isDefault}}{{/responses}}',
+            };
 
             return new Response(
                 {{#returnType}}$result !== null ?$this->serialize($result, $responseFormat):''{{/returnType}}{{^returnType}}''{{/returnType}},

--- a/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/composer.mustache
@@ -24,19 +24,19 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0|>=8.0.2",
+        "php": ">=8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "symfony/validator": "^5.0|^6.0",
-        "jms/serializer-bundle": "^4.0",
-        "symfony/framework-bundle": "^5.0|^6.0"
+        "symfony/validator": "^6.4|^7.0",
+        "jms/serializer-bundle": "^5.4",
+        "symfony/framework-bundle": "^6.4|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
-        "symfony/browser-kit": "^5.0|^6.0",
-        "symfony/yaml": "^5.0|^6.0",
+        "phpunit/phpunit": "^10.5|^11.0",
+        "friendsofphp/php-cs-fixer": "*",
+        "symfony/browser-kit": "^6.4|7.0",
+        "symfony/yaml": "^6.4|^7.0",
         "hoa/regex": "~1.0"
     },
     "autoload": {

--- a/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/serialization/JmsSerializer.mustache
@@ -47,14 +47,11 @@ class JmsSerializer implements SerializerInterface
 
     private function convertFormat(string $format): ?string
     {
-        switch ($format) {
-            case 'application/json':
-                return 'json';
-            case 'application/xml':
-                return 'xml';
-        }
-
-        return null;
+        return match($format) {
+            'application/json' => 'json',
+            'application/xml' => 'xml',
+            default => null,
+        };
     }
 
     private function deserializeString($data, string $type)
@@ -132,22 +129,13 @@ class JmsSerializer implements SerializerInterface
         }
 
         // Parse the string using the correct separator
-        switch ($format) {
-            case 'csv':
-                $data = explode(',', $data);
-                break;
-            case 'ssv':
-                $data = explode(' ', $data);
-                break;
-            case 'tsv':
-                $data = explode("\t", $data);
-                break;
-            case 'pipes':
-                $data = explode('|', $data);
-                break;
-            default;
-                $data = [];
-        }
+        $data = match($format) {
+            'csv' => explode(',', $data),
+            'ssv' => explode(' ', $data),
+            'tsv' => explode("\t", $data),
+            'pipes' => explode('|', $data),
+            default => [],
+        };
 
         // Deserialize each of the array elements
         foreach ($data as $key => $item) {

--- a/modules/openapi-generator/src/main/resources/php-symfony/testing/ControllerTest.mustache
+++ b/modules/openapi-generator/src/main/resources/php-symfony/testing/ControllerTest.mustache
@@ -55,7 +55,7 @@ class ControllerTest extends TestCase
         );
     }
 
-    public function dataProviderIsContentTypeAllowed(): array
+    public static function dataProviderIsContentTypeAllowed(): array
     {
         return [
             'usual JSON content type' => [

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/Controller.php
@@ -102,7 +102,7 @@ class Controller extends AbstractController
         $json = $this->exceptionToArray($exception);
         $json['statusCode'] = $statusCode;
 
-        return new Response(json_encode($json, 15, 512), $statusCode, $headers);
+        return new Response(json_encode($json, 15), $statusCode, $headers);
     }
 
     /**
@@ -229,7 +229,7 @@ class Controller extends AbstractController
     public static function isContentTypeAllowed(Request $request, array $consumes = []): bool
     {
         if (!empty($consumes) && $consumes[0] !== '*/*') {
-            $currentFormat = $request->getContentType();
+            $currentFormat = $request->getContentTypeFormat();
             foreach ($consumes as $mimeType) {
                 // canonize mime type
                 if (is_string($mimeType) && false !== $pos = strpos($mimeType, ';')) {
@@ -240,7 +240,7 @@ class Controller extends AbstractController
                     // add custom format to request
                     $format = $mimeType;
                     $request->setFormat($format, $format);
-                    $currentFormat = $request->getContentType();
+                    $currentFormat = $request->getContentTypeFormat();
                 }
 
                 if ($format === $currentFormat) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/PetController.php
@@ -88,7 +88,7 @@ class PetController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $pet = $this->deserialize($pet, 'OpenAPI\Server\Model\Pet', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -117,18 +117,11 @@ class PetController extends Controller
 
             $result = $handler->addPet($pet, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 405:
-                    $message = 'Invalid input';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                405 => 'Invalid input',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -202,15 +195,10 @@ class PetController extends Controller
 
             $handler->deletePet($petId, $apiKey, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 400:
-                    $message = 'Invalid pet value';
-                    break;
-            }
+            $message = match($responseCode) {
+                400 => 'Invalid pet value',
+                default => '',
+            };
 
             return new Response(
                 '',
@@ -291,18 +279,11 @@ class PetController extends Controller
 
             $result = $handler->findPetsByStatus($status, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid status value';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid status value',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -382,18 +363,11 @@ class PetController extends Controller
 
             $result = $handler->findPetsByTags($tags, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid tag value';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid tag value',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -468,21 +442,12 @@ class PetController extends Controller
 
             $result = $handler->getPetById($petId, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid ID supplied';
-                    break;
-                case 404:
-                    $message = 'Pet not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid ID supplied',
+                404 => 'Pet not found',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -538,7 +503,7 @@ class PetController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $pet = $this->deserialize($pet, 'OpenAPI\Server\Model\Pet', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -567,24 +532,13 @@ class PetController extends Controller
 
             $result = $handler->updatePet($pet, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid ID supplied';
-                    break;
-                case 404:
-                    $message = 'Pet not found';
-                    break;
-                case 405:
-                    $message = 'Validation exception';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid ID supplied',
+                404 => 'Pet not found',
+                405 => 'Validation exception',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -666,15 +620,10 @@ class PetController extends Controller
 
             $handler->updatePetWithForm($petId, $name, $status, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 405:
-                    $message = 'Invalid input';
-                    break;
-            }
+            $message = match($responseCode) {
+                405 => 'Invalid input',
+                default => '',
+            };
 
             return new Response(
                 '',
@@ -763,15 +712,10 @@ class PetController extends Controller
 
             $result = $handler->uploadFile($petId, $additionalMetadata, $file, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/StoreController.php
@@ -92,18 +92,11 @@ class StoreController extends Controller
 
             $handler->deleteOrder($orderId, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 400:
-                    $message = 'Invalid ID supplied';
-                    break;
-                case 404:
-                    $message = 'Order not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                400 => 'Invalid ID supplied',
+                404 => 'Order not found',
+                default => '',
+            };
 
             return new Response(
                 '',
@@ -163,15 +156,10 @@ class StoreController extends Controller
 
             $result = $handler->getInventory($responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -243,21 +231,12 @@ class StoreController extends Controller
 
             $result = $handler->getOrderById($orderId, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid ID supplied';
-                    break;
-                case 404:
-                    $message = 'Order not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid ID supplied',
+                404 => 'Order not found',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -310,7 +289,7 @@ class StoreController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $order = $this->deserialize($order, 'OpenAPI\Server\Model\Order', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -337,18 +316,11 @@ class StoreController extends Controller
 
             $result = $handler->placeOrder($order, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid Order';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid Order',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Controller/UserController.php
@@ -78,7 +78,7 @@ class UserController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $user = $this->deserialize($user, 'OpenAPI\Server\Model\User', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -107,15 +107,10 @@ class UserController extends Controller
 
             $handler->createUser($user, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = 'successful operation';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 0:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                0 => 'successful operation',
+                default => 'successful operation',
+            };
 
             return new Response(
                 '',
@@ -161,7 +156,7 @@ class UserController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $user = $this->deserialize($user, 'array<OpenAPI\Server\Model\User>', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -192,15 +187,10 @@ class UserController extends Controller
 
             $handler->createUsersWithArrayInput($user, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = 'successful operation';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 0:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                0 => 'successful operation',
+                default => 'successful operation',
+            };
 
             return new Response(
                 '',
@@ -246,7 +236,7 @@ class UserController extends Controller
 
         // Deserialize the input values that needs it
         try {
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $user = $this->deserialize($user, 'array<OpenAPI\Server\Model\User>', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -277,15 +267,10 @@ class UserController extends Controller
 
             $handler->createUsersWithListInput($user, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = 'successful operation';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 0:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                0 => 'successful operation',
+                default => 'successful operation',
+            };
 
             return new Response(
                 '',
@@ -350,18 +335,11 @@ class UserController extends Controller
 
             $handler->deleteUser($username, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 400:
-                    $message = 'Invalid username supplied';
-                    break;
-                case 404:
-                    $message = 'User not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                400 => 'Invalid username supplied',
+                404 => 'User not found',
+                default => '',
+            };
 
             return new Response(
                 '',
@@ -430,21 +408,12 @@ class UserController extends Controller
 
             $result = $handler->getUserByName($username, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid username supplied';
-                    break;
-                case 404:
-                    $message = 'User not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid username supplied',
+                404 => 'User not found',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -525,18 +494,11 @@ class UserController extends Controller
 
             $result = $handler->loginUser($username, $password, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 200:
-                    $message = 'successful operation';
-                    break;
-                case 400:
-                    $message = 'Invalid username/password supplied';
-                    break;
-            }
+            $message = match($responseCode) {
+                200 => 'successful operation',
+                400 => 'Invalid username/password supplied',
+                default => '',
+            };
 
             return new Response(
                 $result !== null ?$this->serialize($result, $responseFormat):'',
@@ -588,15 +550,10 @@ class UserController extends Controller
 
             $handler->logoutUser($responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = 'successful operation';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 0:
-                    $message = 'successful operation';
-                    break;
-            }
+            $message = match($responseCode) {
+                0 => 'successful operation',
+                default => 'successful operation',
+            };
 
             return new Response(
                 '',
@@ -643,7 +600,7 @@ class UserController extends Controller
         // Deserialize the input values that needs it
         try {
             $username = $this->deserialize($username, 'string', 'string');
-            $inputFormat = $request->getMimeType($request->getContentType());
+            $inputFormat = $request->getMimeType($request->getContentTypeFormat());
             $user = $this->deserialize($user, 'OpenAPI\Server\Model\User', $inputFormat);
         } catch (SerializerRuntimeException $exception) {
             return $this->createBadRequestResponse($exception->getMessage());
@@ -679,18 +636,11 @@ class UserController extends Controller
 
             $handler->updateUser($username, $user, $responseCode, $responseHeaders);
 
-            // Find default response message
-            $message = '';
-
-            // Find a more specific message, if available
-            switch ($responseCode) {
-                case 400:
-                    $message = 'Invalid user supplied';
-                    break;
-                case 404:
-                    $message = 'User not found';
-                    break;
-            }
+            $message = match($responseCode) {
+                400 => 'Invalid user supplied',
+                404 => 'User not found',
+                default => '',
+            };
 
             return new Response(
                 '',

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Service/JmsSerializer.php
@@ -47,14 +47,11 @@ class JmsSerializer implements SerializerInterface
 
     private function convertFormat(string $format): ?string
     {
-        switch ($format) {
-            case 'application/json':
-                return 'json';
-            case 'application/xml':
-                return 'xml';
-        }
-
-        return null;
+        return match($format) {
+            'application/json' => 'json',
+            'application/xml' => 'xml',
+            default => null,
+        };
     }
 
     private function deserializeString($data, string $type)
@@ -132,22 +129,13 @@ class JmsSerializer implements SerializerInterface
         }
 
         // Parse the string using the correct separator
-        switch ($format) {
-            case 'csv':
-                $data = explode(',', $data);
-                break;
-            case 'ssv':
-                $data = explode(' ', $data);
-                break;
-            case 'tsv':
-                $data = explode("\t", $data);
-                break;
-            case 'pipes':
-                $data = explode('|', $data);
-                break;
-            default;
-                $data = [];
-        }
+        $data = match($format) {
+            'csv' => explode(',', $data),
+            'ssv' => explode(' ', $data),
+            'tsv' => explode("\t", $data),
+            'pipes' => explode('|', $data),
+            default => [],
+        };
 
         // Deserialize each of the array elements
         foreach ($data as $key => $item) {

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/Tests/Controller/ControllerTest.php
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/Tests/Controller/ControllerTest.php
@@ -65,7 +65,7 @@ class ControllerTest extends TestCase
         );
     }
 
-    public function dataProviderIsContentTypeAllowed(): array
+    public static function dataProviderIsContentTypeAllowed(): array
     {
         return [
             'usual JSON content type' => [

--- a/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
+++ b/samples/server/petstore/php-symfony/SymfonyBundle-php/composer.json
@@ -16,19 +16,19 @@
         }
     ],
     "require": {
-        "php": ">=7.4.0|>=8.0.2",
+        "php": ">=8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "symfony/validator": "^5.0|^6.0",
-        "jms/serializer-bundle": "^4.0",
-        "symfony/framework-bundle": "^5.0|^6.0"
+        "symfony/validator": "^6.4|^7.0",
+        "jms/serializer-bundle": "^5.4",
+        "symfony/framework-bundle": "^6.4|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "friendsofphp/php-cs-fixer": "^2.16.3",
-        "symfony/browser-kit": "^5.0|^6.0",
-        "symfony/yaml": "^5.0|^6.0",
+        "phpunit/phpunit": "^10.5|^11.0",
+        "friendsofphp/php-cs-fixer": "*",
+        "symfony/browser-kit": "^6.4|7.0",
+        "symfony/yaml": "^6.4|^7.0",
         "hoa/regex": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
  - add Symfony 7 support
  - remove support php < 8.2 (EOL)
  - remove symfony < 6.4 support

Bug Fix
  - add missing $security{{name}} variable when using Bearer Auth (https://github.com/Catrobat/Catroweb-API/pull/143/files#r1561127625)

Misc
 - The getContentType method is deprecated; use getContentTypeFormat instead. (Since: symfony/http-foundation', '6.2' deprecated // https://github.com/symfony/symfony/blob/7.1/UPGRADE-7.0.md)
 - use match instead of a switch for simple assignments
 - remove default depth param from json_encode call (`function json_encode(mixed $value, int $flags = 0, int $depth = 512): string|false {}`)
 - make data provider static  - PHPUnit (https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09)

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
