### PR TITLE
scala cask fix for missing annotations on simple routes

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaCaskServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaCaskServerCodegen.java
@@ -18,7 +18,6 @@ package org.openapitools.codegen.languages;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.io.FileUtils;
 import org.openapitools.codegen.*;
 import org.openapitools.codegen.model.ModelMap;
@@ -32,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -152,6 +150,7 @@ public class ScalaCaskServerCodegen extends AbstractScalaCodegen implements Code
             return defaultValue;
         }
     }
+
     @Override
     public void processOpts() {
         super.processOpts();
@@ -521,13 +520,14 @@ public class ScalaCaskServerCodegen extends AbstractScalaCodegen implements Code
 
         List<ScalaCaskServerCodegen.OperationGroup> groups = group(operationList);
         operationList.forEach((op) -> {
-            for (final ScalaCaskServerCodegen.OperationGroup group : groups) {
-                // for the usage/call site
-                final String scalaPath = pathWithBracketPlaceholdersRemovedAndXPathIndexAdded(op);
-                op.vendorExtensions.put("x-cask-path", scalaPath);
+            // for the usage/call site
+            final String scalaPath = pathWithBracketPlaceholdersRemovedAndXPathIndexAdded(op);
+            op.vendorExtensions.put("x-cask-path", scalaPath);
 
-                final String annotation = "@cask." + op.httpMethod.toLowerCase(Locale.ROOT);
-                op.vendorExtensions.put("x-annotation", annotation);
+            final String annotation = "@cask." + op.httpMethod.toLowerCase(Locale.ROOT);
+            op.vendorExtensions.put("x-annotation", annotation);
+
+            for (final ScalaCaskServerCodegen.OperationGroup group : groups) {
                 if (!group.contains(op)) {
                     if (op.path.startsWith(group.pathPrefix) && op.httpMethod.equalsIgnoreCase(group.httpMethod)) {
                         group.add(op);


### PR DESCRIPTION
This small change fixes an issue with the recently added scala-cask generator for cases where there are a single route.

In this case, the route annotation would be elided, e.g.:
```
        ("")
        def createContract(request: cask.Request) = ...
```

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
