### PR TITLE
cask fix for response encoding

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-cask/apiRoutes.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-cask/apiRoutes.mustache
@@ -46,16 +46,12 @@ class {{classname}}Routes(service : {{classname}}Service) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-        {{#vendorExtensions.x-has-response-types}}
-            {{#responses}}
-                {{#dataType}}
-                    case Right(value : {{dataType}}) => cask.Response(data = write(value), {{code}}, headers = Seq("Content-Type" -> "application/json"))
-                {{/dataType}}
-            {{/responses}}
-        {{/vendorExtensions.x-has-response-types}}
-        {{^vendorExtensions.x-has-response-types}}
-            case Right(_) => cask.Response("", 200)
-        {{/vendorExtensions.x-has-response-types}}
+        {{#responses}}
+            {{#dataType}}
+          case Right(value : {{dataType}}) => cask.Response(data = write(value), {{code}}, headers = Seq("Content-Type" -> "application/json"))
+            {{/dataType}}
+        {{/responses}}
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
     {{/operation}}

--- a/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/PetRoutes.scala
+++ b/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/PetRoutes.scala
@@ -67,7 +67,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Pet) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Deletes a pet
@@ -87,7 +88,7 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Finds Pets by status
@@ -105,7 +106,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : List[Pet]) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Finds Pets by tags
@@ -123,7 +125,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : List[Pet]) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Find pet by ID
@@ -142,7 +145,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Pet) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Update an existing pet
@@ -162,7 +166,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Pet) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Updates a pet in the store with form data
@@ -183,7 +188,7 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** uploads an image
@@ -204,7 +209,8 @@ class PetRoutes(service : PetService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : ApiResponse) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
 

--- a/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/StoreRoutes.scala
+++ b/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/StoreRoutes.scala
@@ -43,7 +43,7 @@ class StoreRoutes(service : StoreService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Returns pet inventories by status
@@ -61,7 +61,8 @@ class StoreRoutes(service : StoreService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Map[String, Int]) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Find purchase order by ID
@@ -79,7 +80,8 @@ class StoreRoutes(service : StoreService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Order) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Place an order for a pet
@@ -98,7 +100,8 @@ class StoreRoutes(service : StoreService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : Order) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
 

--- a/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/UserRoutes.scala
+++ b/samples/server/petstore/scala-cask/src/main/scala/sample/cask/api/UserRoutes.scala
@@ -56,7 +56,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Creates list of users with given input array
@@ -75,7 +75,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Creates list of users with given input array
@@ -94,7 +94,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Delete user
@@ -113,7 +113,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Get user by user name
@@ -131,7 +131,8 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : User) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Logs user into the system
@@ -148,7 +149,8 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(value : String) => cask.Response(data = write(value), 200, headers = Seq("Content-Type" -> "application/json"))
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Logs out current logged in user session
@@ -166,7 +168,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
         /** Updated user
@@ -187,7 +189,7 @@ class UserRoutes(service : UserService) extends cask.Routes {
 
         result match {
           case Left(error) => cask.Response(error, 500)
-            case Right(_) => cask.Response("", 200)
+          case Right(other) => cask.Response(s"$other", 200)
         }
       }
 


### PR DESCRIPTION
Fix for scala cask service responses to handle where there are zero or more defined response types

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
