### PR TITLE
[kotlin] implement serializable data classes (fix #8317)

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/dataClass.mustache
@@ -14,7 +14,7 @@
 {{/-last}}{{/requiredVars}}{{#hasRequired}}{{#hasOptional}},
 {{/hasOptional}}{{/hasRequired}}{{#optionalVars}}{{>dataClassOptVar}}{{^-last}},
 {{/-last}}{{/optionalVars}}
-) {{/discriminator}}{{#parent}}: {{{.}}}{{/parent}}{
+) {{/discriminator}}{{#parent}}: {{{.}}}{{#serializableModel}}, Serializable{{/serializableModel}}{{/parent}}{{#serializableModel}}: Serializable{{/serializableModel}}{
 {{#discriminator}}
     {{#requiredVars}}
         {{>interfaceReqVar}}
@@ -33,4 +33,9 @@
         @JsonProperty({{{value}}}) {{{name}}}({{{value}}}){{^-last}},{{/-last}}{{/enumVars}}{{/allowableValues}}
     }
 {{/isEnum}}{{/vars}}{{/hasEnums}}
+{{#serializableModel}}
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
+{{/serializableModel}}
 }

--- a/modules/openapi-generator/src/main/resources/kotlin-spring/model.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/model.mustache
@@ -3,6 +3,9 @@ package {{package}}
 import java.util.Objects
 {{#imports}}import {{import}}
 {{/imports}}
+{{#serializableModel}}
+import java.io.Serializable
+{{/serializableModel}}
 {{#useBeanValidation}}
 import {{javaxPackage}}.validation.constraints.DecimalMax
 import {{javaxPackage}}.validation.constraints.DecimalMin

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -23,7 +24,10 @@ data class Category(
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -35,7 +36,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -48,5 +49,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -40,7 +41,7 @@ data class Pet(
 
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -53,5 +54,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -22,7 +23,10 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-spring-cloud/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -40,7 +41,10 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -23,7 +24,10 @@ data class Category(
 
     @get:Pattern(regexp="^[a-zA-Z0-9]+[a-zA-Z0-9\\.\\-_]*[a-zA-Z0-9]+$")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -25,7 +26,10 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -35,7 +36,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -48,5 +49,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -40,7 +41,7 @@ data class Pet(
 
     @Deprecated(message = "")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -53,5 +54,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -22,7 +23,10 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-3/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import jakarta.validation.constraints.DecimalMax
 import jakarta.validation.constraints.DecimalMin
 import jakarta.validation.constraints.Email
@@ -40,7 +41,10 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") var name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -29,7 +30,10 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") var message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -42,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") var complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -55,5 +56,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -46,7 +47,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") var status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -59,5 +60,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") var name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-modelMutable/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -49,7 +50,10 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") var userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -29,7 +30,10 @@ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -42,7 +43,7 @@ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -55,5 +56,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -46,7 +47,7 @@ data class Pet(
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -59,5 +60,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger1/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -49,7 +50,10 @@ data class User(
 
     @ApiModelProperty(example = "null", value = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Category(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -29,7 +30,10 @@ data class ModelApiResponse(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -42,7 +43,7 @@ data class Order(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -55,5 +56,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -46,7 +47,7 @@ data class Pet(
 
     @Schema(example = "null", description = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -59,5 +60,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Tag(
 
     @Schema(example = "null", description = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-source-swagger2/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -49,7 +50,10 @@ data class User(
 
     @Schema(example = "null", description = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Category(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -29,7 +30,10 @@ data class ModelApiResponse(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -42,7 +43,7 @@ data class Order(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -55,5 +56,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -46,7 +47,7 @@ data class Pet(
 
     @ApiModelProperty(example = "null", value = "pet status in the store")
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -59,5 +60,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class Tag(
 
     @ApiModelProperty(example = "null", value = "")
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot-springfox/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -49,7 +50,10 @@ data class User(
 
     @ApiModelProperty(example = "null", value = "User Status")
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Category.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -22,7 +23,10 @@ data class Category(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/ModelApiResponse.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -25,7 +26,10 @@ data class ModelApiResponse(
     @get:JsonProperty("type") val type: kotlin.String? = null,
 
     @get:JsonProperty("message") val message: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Order.kt
@@ -3,6 +3,7 @@ package org.openapitools.model
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -35,7 +36,7 @@ data class Order(
     @get:JsonProperty("status") val status: Order.Status? = null,
 
     @get:JsonProperty("complete") val complete: kotlin.Boolean? = false
-) {
+) : Serializable{
 
     /**
     * Order Status
@@ -48,5 +49,8 @@ data class Order(
         @JsonProperty("delivered") delivered("delivered")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Pet.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonValue
 import org.openapitools.model.Category
 import org.openapitools.model.Tag
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -39,7 +40,7 @@ data class Pet(
     @get:JsonProperty("tags") val tags: kotlin.collections.List<Tag>? = null,
 
     @get:JsonProperty("status") val status: Pet.Status? = null
-) {
+) : Serializable{
 
     /**
     * pet status in the store
@@ -52,5 +53,8 @@ data class Pet(
         @JsonProperty("sold") sold("sold")
     }
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/Tag.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -22,7 +23,10 @@ data class Tag(
     @get:JsonProperty("id") val id: kotlin.Long? = null,
 
     @get:JsonProperty("name") val name: kotlin.String? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 

--- a/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
+++ b/samples/server/petstore/kotlin-springboot/src/main/kotlin/org/openapitools/model/User.kt
@@ -2,6 +2,7 @@ package org.openapitools.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 import javax.validation.constraints.DecimalMax
 import javax.validation.constraints.DecimalMin
 import javax.validation.constraints.Email
@@ -40,7 +41,10 @@ data class User(
     @get:JsonProperty("phone") val phone: kotlin.String? = null,
 
     @get:JsonProperty("userStatus") val userStatus: kotlin.Int? = null
-) {
+) : Serializable{
 
+    companion object {
+        private const val serialVersionUID: kotlin.Long = 1
+    }
 }
 


### PR DESCRIPTION
Implement `java.io.Serializable` in kotlin data classes for `kotlin-spring` generator when `serializableModel` option is enabled.

Fixes #8317.

These existing samples clearly show the effect of this change, as they have `serializableModel` already set to true:
- kotlin-springboot
- kotlin-springboot-3
- kotlin-springboot-modelMutable
- kotlin-springboot-source-swagger1
- kotlin-springboot-source-swagger2
- kotlin-springboot-springfox

See the added `Serializable` interface on all generated models for those samples, as well as the `serialVersionUID` constant in each data class.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
