### PR TITLE
Go generate all of with multiple ref and discriminator

### DIFF
--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -3,17 +3,15 @@ var _ MappedNullable = &{{classname}}{}
 
 // {{classname}} {{{description}}}{{^description}}struct for {{{classname}}}{{/description}}
 type {{classname}} struct {
-{{#parent}}
-{{^isMap}}
+{{#parentModel.name}}
 {{^isArray}}
-	{{{parent}}}
+	{{{parentModel.name}}}
 {{/isArray}}
-{{/isMap}}
 {{#isArray}}
-	Items {{{parent}}}
+	Items {{{parentModel.name}}}
 {{/isArray}}
-{{/parent}}
-{{#allVars}}
+{{/parentModel.name}}
+{{#vars}}
 {{^-first}}
 {{/-first}}
 {{#description}}
@@ -23,7 +21,7 @@ type {{classname}} struct {
 	// Deprecated
 {{/deprecated}}
 	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{{baseName}}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{{baseName}}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
-{{/allVars}}
+{{/vars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]interface{}
 {{/isAdditionalPropertiesTrue}}

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -13,7 +13,7 @@ type {{classname}} struct {
 	Items {{{parent}}}
 {{/isArray}}
 {{/parent}}
-{{#vars}}
+{{#allVars}}
 {{^-first}}
 {{/-first}}
 {{#description}}
@@ -23,7 +23,7 @@ type {{classname}} struct {
 	// Deprecated
 {{/deprecated}}
 	{{name}} {{^required}}{{^isNullable}}{{^isArray}}{{^isFreeFormObject}}*{{/isFreeFormObject}}{{/isArray}}{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{{baseName}}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{{baseName}}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
-{{/vars}}
+{{/allVars}}
 {{#isAdditionalPropertiesTrue}}
 	AdditionalProperties map[string]interface{}
 {{/isAdditionalPropertiesTrue}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -292,6 +292,27 @@ public class GoClientCodegenTest {
     }
 
     @Test
+    public void verifyApiWithAllOfMultipleRefAndDiscriminator() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setGitUserId("OpenAPITools")
+                .setGitRepoId("openapi-generator")
+                .setInputSpec("src/test/resources/3_0/go/allof_multiple_ref_and_discriminator.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/model_final_item.go"));
+        TestUtils.assertFileContains(Paths.get(output + "/model_final_item.go"),
+                "Title string `json:\"title\"");
+    }
+
+    @Test
     public void testAdditionalPropertiesWithGoMod() throws Exception {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -309,7 +309,7 @@ public class GoClientCodegenTest {
 
         TestUtils.assertFileExists(Paths.get(output + "/model_final_item.go"));
         TestUtils.assertFileContains(Paths.get(output + "/model_final_item.go"),
-                "Title string `json:\"title\"");
+                "BaseItem");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/resources/3_0/go/allof_multiple_ref_and_discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/allof_multiple_ref_and_discriminator.yaml
@@ -48,7 +48,7 @@ components:
           example: 9.99
           minimum: 0.0
       required:
-        - sku
+        - prop1
         - quantity
         - unitPrice
         - totalPrice

--- a/modules/openapi-generator/src/test/resources/3_0/go/allof_multiple_ref_and_discriminator.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/allof_multiple_ref_and_discriminator.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FinalItem:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - $ref: '#/components/schemas/AdditionalData'
+    BaseItem:
+      type: object
+      properties:
+        title:
+          type: string
+        type:
+          type: string
+          enum:
+            - FINAL
+          example: FINAL
+      discriminator:
+        propertyName: type
+        mapping:
+          FINAL: '#/components/schemas/FinalItem'
+      required:
+        - title
+        - type
+    AdditionalData:
+      type: object
+      properties:
+        prop1:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+          example: 1
+          minimum: 1
+        unitPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+        totalPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+      required:
+        - sku
+        - quantity
+        - unitPrice
+        - totalPrice


### PR DESCRIPTION
Currently, when the "FinalItem" is a composite schema the parent is not added. 
It seems this is done to handle the "additionalProperties".

My proposal is for this to work for "isMap" schemas and use the parentModel.name which for the items with additionalProperties would be null anyway. 

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5 

To close https://github.com/OpenAPITools/openapi-generator/issues/18385
