### PR TITLE
Fix string comparison in haskell servant generator

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/HaskellServantCodegen.java
@@ -333,13 +333,14 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
     /**
      * Internal method to set the generateToSchema parameter.
-     *
+     * <p>
      * Basically we're generating ToSchema instances (generically) for all schemas.
      * However, if any of the contained datatypes doesn't have the ToSchema instance,
      * we cannot generate it for its "ancestor" type.
      * This is the case with the "Data.Aeson.Value" type: it doesn't (and cannot) have
      * a Swagger-compatible ToSchema instance. So we have to detect its presence "downstream"
      * the current schema, and if we find it we just don't generate any ToSchema instance.
+     *
      * @param model
      */
     private void setGenerateToSchema(CodegenModel model) {
@@ -356,7 +357,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
 
         List<CodegenModel> children = model.getChildren();
         if (children != null) {
-            for(CodegenModel child : children) {
+            for (CodegenModel child : children) {
                 setGenerateToSchema(child);
             }
         }
@@ -512,7 +513,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
         // Query parameters appended to routes
         for (CodegenParameter param : op.queryParams) {
             String paramType = param.dataType;
-            if (param.contentType == "application/json") {
+            if ("application/json".equals(param.contentType)) {
                 if (param.isArray) {
                     paramType = "[JSONQueryParam " + paramType.substring(1, paramType.length() - 1) + "]";
                 } else {
@@ -554,7 +555,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
             path.add("Header \"" + param.baseName + "\" " + param.dataType);
 
             String paramType = param.dataType;
-            if (param.contentType == "application/json") {
+            if ("application/json".equals(param.contentType)) {
                 if (param.isArray) {
                     paramType = "(JSONQueryParam " + paramType.substring(1, paramType.length() - 1) + ")";
                 } else {
@@ -721,5 +722,7 @@ public class HaskellServantCodegen extends DefaultCodegen implements CodegenConf
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.HASKELL; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.HASKELL;
+    }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
