### PR TITLE
feat(go): Add a vendor extension to option out of generating the Unma…

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractGoCodegen.java
@@ -777,6 +777,10 @@ public abstract class AbstractGoCodegen extends DefaultCodegen implements Codege
             if (generateMarshalJSON) {
                 model.vendorExtensions.put("x-go-generate-marshal-json", true);
             }
+
+            if (!model.vendorExtensions.containsKey("x-go-generate-unmarshal-json")) {
+                model.vendorExtensions.put("x-go-generate-unmarshal-json", true);
+            }
         }
 
         // recursively add import for mapping one type to multiple imports

--- a/modules/openapi-generator/src/main/resources/go/model_simple.mustache
+++ b/modules/openapi-generator/src/main/resources/go/model_simple.mustache
@@ -337,6 +337,7 @@ func (o {{classname}}) ToMap() (map[string]interface{}, error) {
 	return toSerialize, nil
 }
 
+{{#vendorExtensions.x-go-generate-unmarshal-json}}
 {{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 {{/isAdditionalPropertiesTrue}}
@@ -514,4 +515,5 @@ func (o *{{{classname}}}) UnmarshalJSON(data []byte) (err error) {
 }
 
 {{/isArray}}
+{{/vendorExtensions.x-go-generate-unmarshal-json}}
 {{>nullable_model}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/go/GoClientCodegenTest.java
@@ -313,6 +313,48 @@ public class GoClientCodegenTest {
     }
 
     @Test
+    public void testVendorExtensionGenerateUnmarshalJson() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setGitUserId("OpenAPITools")
+                .setGitRepoId("openapi-generator")
+                .setInputSpec("src/test/resources/3_0/go/allof_with_unmarshal_json.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/model_base_item.go"));
+        TestUtils.assertFileContains(Paths.get(output + "/model_base_item.go"),
+                "func (o *BaseItem) UnmarshalJSON(data []byte) (err error) {");
+    }
+
+    @Test
+    public void testVendorExtensionSkipGenerateUnmarshalJson() throws IOException {
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("go")
+                .setGitUserId("OpenAPITools")
+                .setGitRepoId("openapi-generator")
+                .setInputSpec("src/test/resources/3_0/go/allof_skip_unmarshal_json.yaml")
+                .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(configurator.toClientOptInput()).generate();
+        files.forEach(File::deleteOnExit);
+
+        TestUtils.assertFileExists(Paths.get(output + "/model_base_item.go"));
+        TestUtils.assertFileNotContains(Paths.get(output + "/model_base_item.go"),
+                "func (o *BaseItem) UnmarshalJSON(data []byte) (err error) {");
+    }
+
+    @Test
     public void testAdditionalPropertiesWithGoMod() throws Exception {
         File output = Files.createTempDirectory("test").toFile();
         output.deleteOnExit();

--- a/modules/openapi-generator/src/test/resources/3_0/go/allof_skip_unmarshal_json.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/allof_skip_unmarshal_json.yaml
@@ -1,0 +1,55 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FinalItem:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - $ref: '#/components/schemas/AdditionalData'
+    BaseItem:
+      type: object
+      x-go-generate-unmarshal-json: false
+      properties:
+        title:
+          type: string
+        type:
+          type: string
+          enum:
+            - FINAL
+          example: FINAL
+      discriminator:
+        propertyName: type
+        mapping:
+          FINAL: '#/components/schemas/FinalItem'
+      required:
+        - title
+        - type
+    AdditionalData:
+      type: object
+      properties:
+        prop1:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+          example: 1
+          minimum: 1
+        unitPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+        totalPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+      required:
+        - prop1
+        - quantity
+        - unitPrice
+        - totalPrice

--- a/modules/openapi-generator/src/test/resources/3_0/go/allof_with_unmarshal_json.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go/allof_with_unmarshal_json.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    FinalItem:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - $ref: '#/components/schemas/AdditionalData'
+    BaseItem:
+      type: object
+      properties:
+        title:
+          type: string
+        type:
+          type: string
+          enum:
+            - FINAL
+          example: FINAL
+      discriminator:
+        propertyName: type
+        mapping:
+          FINAL: '#/components/schemas/FinalItem'
+      required:
+        - title
+        - type
+    AdditionalData:
+      type: object
+      properties:
+        prop1:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+          example: 1
+          minimum: 1
+        unitPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+        totalPrice:
+          type: number
+          format: double
+          example: 9.99
+          minimum: 0.0
+      required:
+        - prop1
+        - quantity
+        - unitPrice
+        - totalPrice


### PR DESCRIPTION
…rshalJSON method

The purpose of this is to introduce a vendor extension:

```
x-go-generate-unmarshal-json
```

Via this vendor extension a user can option out of having the generator make the UnmarshalJSON method. The purpose behind this is that for embedded structs sometimes the generated method provides bad functionality. 

An example of how proper UnmarshalJSON for embedded structs should work can be found here:
https://github.com/golang/go/issues/39470

Since this may depend on the individual use case I think it would be best if developers implement it themselves rather than have it generated. 
The default value is true, only if the user decides to skip the generation for a model - he can set it to false.

```
    BaseItem:
      type: object
      x-go-generate-unmarshal-json: false
```

@antihax @grokify @kemokemo @jirikuncar @ph4r5h4d @lwj5

