### PR TITLE
[typescript-fetch] Restore pre-es2017 compatibility in modelEnum template

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -1,10 +1,13 @@
 {{>modelEnumInterfaces}}
 
 export function instanceOf{{classname}}(value: any): boolean {
-    for (const key in {{classname}})
-        if (Object.prototype.hasOwnProperty.call({{classname}}, key))
-            if ({{classname}}[key] == value)
+    for (const key in {{classname}}) {
+        if (Object.prototype.hasOwnProperty.call({{classname}}, key)) {
+            if ({{classname}}[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -3,7 +3,7 @@
 export function instanceOf{{classname}}(value: any): boolean {
     for (const key in {{classname}}) {
         if (Object.prototype.hasOwnProperty.call({{classname}}, key)) {
-            if ({{classname}}[key] == value) {
+            if ({{classname}}[key] === value) {
                 return true;
             }
         }

--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -1,7 +1,11 @@
 {{>modelEnumInterfaces}}
 
 export function instanceOf{{classname}}(value: any): boolean {
-    return Object.values({{classname}}).includes(value);
+    for (const key in {{classname}})
+        if (Object.prototype.hasOwnProperty.call({{classname}}, key))
+            if ({{classname}}[key] == value)
+                return true;
+    return false;
 }
 
 export function {{classname}}FromJSON(json: any): {{classname}} {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -28,7 +28,7 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 export function instanceOfEnumClass(value: any): boolean {
     for (const key in EnumClass) {
         if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
-            if (EnumClass[key] == value) {
+            if (EnumClass[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -26,7 +26,11 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
 export function instanceOfEnumClass(value: any): boolean {
-    return Object.values(EnumClass).includes(value);
+    for (const key in EnumClass)
+        if (Object.prototype.hasOwnProperty.call(EnumClass, key))
+            if (EnumClass[key] == value)
+                return true;
+    return false;
 }
 
 export function EnumClassFromJSON(json: any): EnumClass {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -26,10 +26,13 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
 export function instanceOfEnumClass(value: any): boolean {
-    for (const key in EnumClass)
-        if (Object.prototype.hasOwnProperty.call(EnumClass, key))
-            if (EnumClass[key] == value)
+    for (const key in EnumClass) {
+        if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
+            if (EnumClass[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -26,10 +26,13 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
 export function instanceOfOuterEnum(value: any): boolean {
-    for (const key in OuterEnum)
-        if (Object.prototype.hasOwnProperty.call(OuterEnum, key))
-            if (OuterEnum[key] == value)
+    for (const key in OuterEnum) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
+            if (OuterEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -28,7 +28,7 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 export function instanceOfOuterEnum(value: any): boolean {
     for (const key in OuterEnum) {
         if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
-            if (OuterEnum[key] == value) {
+            if (OuterEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -26,7 +26,11 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
 export function instanceOfOuterEnum(value: any): boolean {
-    return Object.values(OuterEnum).includes(value);
+    for (const key in OuterEnum)
+        if (Object.prototype.hasOwnProperty.call(OuterEnum, key))
+            if (OuterEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumFromJSON(json: any): OuterEnum {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -26,7 +26,11 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 
 
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
-    return Object.values(OuterEnumDefaultValue).includes(value);
+    for (const key in OuterEnumDefaultValue)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key))
+            if (OuterEnumDefaultValue[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumDefaultValueFromJSON(json: any): OuterEnumDefaultValue {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
     for (const key in OuterEnumDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
-            if (OuterEnumDefaultValue[key] == value) {
+            if (OuterEnumDefaultValue[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -26,10 +26,13 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 
 
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
-    for (const key in OuterEnumDefaultValue)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key))
-            if (OuterEnumDefaultValue[key] == value)
+    for (const key in OuterEnumDefaultValue) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
+            if (OuterEnumDefaultValue[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -26,10 +26,13 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 
 
 export function instanceOfOuterEnumInteger(value: any): boolean {
-    for (const key in OuterEnumInteger)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key))
-            if (OuterEnumInteger[key] == value)
+    for (const key in OuterEnumInteger) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
+            if (OuterEnumInteger[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -28,7 +28,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 export function instanceOfOuterEnumInteger(value: any): boolean {
     for (const key in OuterEnumInteger) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
-            if (OuterEnumInteger[key] == value) {
+            if (OuterEnumInteger[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -26,7 +26,11 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 
 
 export function instanceOfOuterEnumInteger(value: any): boolean {
-    return Object.values(OuterEnumInteger).includes(value);
+    for (const key in OuterEnumInteger)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key))
+            if (OuterEnumInteger[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumIntegerFromJSON(json: any): OuterEnumInteger {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -26,7 +26,11 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 
 
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
-    return Object.values(OuterEnumIntegerDefaultValue).includes(value);
+    for (const key in OuterEnumIntegerDefaultValue)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key))
+            if (OuterEnumIntegerDefaultValue[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumIntegerDefaultValueFromJSON(json: any): OuterEnumIntegerDefaultValue {

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -26,10 +26,13 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 
 
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
-    for (const key in OuterEnumIntegerDefaultValue)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key))
-            if (OuterEnumIntegerDefaultValue[key] == value)
+    for (const key in OuterEnumIntegerDefaultValue) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
+            if (OuterEnumIntegerDefaultValue[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
     for (const key in OuterEnumIntegerDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
-            if (OuterEnumIntegerDefaultValue[key] == value) {
+            if (OuterEnumIntegerDefaultValue[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -25,10 +25,13 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
 export function instanceOfSingleRefType(value: any): boolean {
-    for (const key in SingleRefType)
-        if (Object.prototype.hasOwnProperty.call(SingleRefType, key))
-            if (SingleRefType[key] == value)
+    for (const key in SingleRefType) {
+        if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
+            if (SingleRefType[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -27,7 +27,7 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 export function instanceOfSingleRefType(value: any): boolean {
     for (const key in SingleRefType) {
         if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
-            if (SingleRefType[key] == value) {
+            if (SingleRefType[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -25,7 +25,11 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
 export function instanceOfSingleRefType(value: any): boolean {
-    return Object.values(SingleRefType).includes(value);
+    for (const key in SingleRefType)
+        if (Object.prototype.hasOwnProperty.call(SingleRefType, key))
+            if (SingleRefType[key] == value)
+                return true;
+    return false;
 }
 
 export function SingleRefTypeFromJSON(json: any): SingleRefType {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -26,10 +26,13 @@ export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 
 
 export function instanceOfNumberEnum(value: any): boolean {
-    for (const key in NumberEnum)
-        if (Object.prototype.hasOwnProperty.call(NumberEnum, key))
-            if (NumberEnum[key] == value)
+    for (const key in NumberEnum) {
+        if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
+            if (NumberEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -26,7 +26,11 @@ export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 
 
 export function instanceOfNumberEnum(value: any): boolean {
-    return Object.values(NumberEnum).includes(value);
+    for (const key in NumberEnum)
+        if (Object.prototype.hasOwnProperty.call(NumberEnum, key))
+            if (NumberEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function NumberEnumFromJSON(json: any): NumberEnum {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -28,7 +28,7 @@ export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 export function instanceOfNumberEnum(value: any): boolean {
     for (const key in NumberEnum) {
         if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
-            if (NumberEnum[key] == value) {
+            if (NumberEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -26,10 +26,13 @@ export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 
 
 export function instanceOfStringEnum(value: any): boolean {
-    for (const key in StringEnum)
-        if (Object.prototype.hasOwnProperty.call(StringEnum, key))
-            if (StringEnum[key] == value)
+    for (const key in StringEnum) {
+        if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
+            if (StringEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -26,7 +26,11 @@ export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 
 
 export function instanceOfStringEnum(value: any): boolean {
-    return Object.values(StringEnum).includes(value);
+    for (const key in StringEnum)
+        if (Object.prototype.hasOwnProperty.call(StringEnum, key))
+            if (StringEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function StringEnumFromJSON(json: any): StringEnum {

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -28,7 +28,7 @@ export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 export function instanceOfStringEnum(value: any): boolean {
     for (const key in StringEnum) {
         if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
-            if (StringEnum[key] == value) {
+            if (StringEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -26,10 +26,13 @@ export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 
 
 export function instanceOfBehaviorType(value: any): boolean {
-    for (const key in BehaviorType)
-        if (Object.prototype.hasOwnProperty.call(BehaviorType, key))
-            if (BehaviorType[key] == value)
+    for (const key in BehaviorType) {
+        if (Object.prototype.hasOwnProperty.call(BehaviorType, key)) {
+            if (BehaviorType[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -28,7 +28,7 @@ export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 export function instanceOfBehaviorType(value: any): boolean {
     for (const key in BehaviorType) {
         if (Object.prototype.hasOwnProperty.call(BehaviorType, key)) {
-            if (BehaviorType[key] == value) {
+            if (BehaviorType[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -26,7 +26,11 @@ export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 
 
 export function instanceOfBehaviorType(value: any): boolean {
-    return Object.values(BehaviorType).includes(value);
+    for (const key in BehaviorType)
+        if (Object.prototype.hasOwnProperty.call(BehaviorType, key))
+            if (BehaviorType[key] == value)
+                return true;
+    return false;
 }
 
 export function BehaviorTypeFromJSON(json: any): BehaviorType {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -35,10 +35,13 @@ export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeo
 
 
 export function instanceOfDeploymentRequestStatus(value: any): boolean {
-    for (const key in DeploymentRequestStatus)
-        if (Object.prototype.hasOwnProperty.call(DeploymentRequestStatus, key))
-            if (DeploymentRequestStatus[key] == value)
+    for (const key in DeploymentRequestStatus) {
+        if (Object.prototype.hasOwnProperty.call(DeploymentRequestStatus, key)) {
+            if (DeploymentRequestStatus[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -37,7 +37,7 @@ export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeo
 export function instanceOfDeploymentRequestStatus(value: any): boolean {
     for (const key in DeploymentRequestStatus) {
         if (Object.prototype.hasOwnProperty.call(DeploymentRequestStatus, key)) {
-            if (DeploymentRequestStatus[key] == value) {
+            if (DeploymentRequestStatus[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -35,7 +35,11 @@ export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeo
 
 
 export function instanceOfDeploymentRequestStatus(value: any): boolean {
-    return Object.values(DeploymentRequestStatus).includes(value);
+    for (const key in DeploymentRequestStatus)
+        if (Object.prototype.hasOwnProperty.call(DeploymentRequestStatus, key))
+            if (DeploymentRequestStatus[key] == value)
+                return true;
+    return false;
 }
 
 export function DeploymentRequestStatusFromJSON(json: any): DeploymentRequestStatus {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -41,7 +41,11 @@ export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 
 
 export function instanceOfErrorCode(value: any): boolean {
-    return Object.values(ErrorCode).includes(value);
+    for (const key in ErrorCode)
+        if (Object.prototype.hasOwnProperty.call(ErrorCode, key))
+            if (ErrorCode[key] == value)
+                return true;
+    return false;
 }
 
 export function ErrorCodeFromJSON(json: any): ErrorCode {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -41,10 +41,13 @@ export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 
 
 export function instanceOfErrorCode(value: any): boolean {
-    for (const key in ErrorCode)
-        if (Object.prototype.hasOwnProperty.call(ErrorCode, key))
-            if (ErrorCode[key] == value)
+    for (const key in ErrorCode) {
+        if (Object.prototype.hasOwnProperty.call(ErrorCode, key)) {
+            if (ErrorCode[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -43,7 +43,7 @@ export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 export function instanceOfErrorCode(value: any): boolean {
     for (const key in ErrorCode) {
         if (Object.prototype.hasOwnProperty.call(ErrorCode, key)) {
-            if (ErrorCode[key] == value) {
+            if (ErrorCode[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -28,7 +28,7 @@ export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 export function instanceOfPetPartType(value: any): boolean {
     for (const key in PetPartType) {
         if (Object.prototype.hasOwnProperty.call(PetPartType, key)) {
-            if (PetPartType[key] == value) {
+            if (PetPartType[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -26,10 +26,13 @@ export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 
 
 export function instanceOfPetPartType(value: any): boolean {
-    for (const key in PetPartType)
-        if (Object.prototype.hasOwnProperty.call(PetPartType, key))
-            if (PetPartType[key] == value)
+    for (const key in PetPartType) {
+        if (Object.prototype.hasOwnProperty.call(PetPartType, key)) {
+            if (PetPartType[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -26,7 +26,11 @@ export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 
 
 export function instanceOfPetPartType(value: any): boolean {
-    return Object.values(PetPartType).includes(value);
+    for (const key in PetPartType)
+        if (Object.prototype.hasOwnProperty.call(PetPartType, key))
+            if (PetPartType[key] == value)
+                return true;
+    return false;
 }
 
 export function PetPartTypeFromJSON(json: any): PetPartType {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -28,7 +28,7 @@ export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 export function instanceOfWarningCode(value: any): boolean {
     for (const key in WarningCode) {
         if (Object.prototype.hasOwnProperty.call(WarningCode, key)) {
-            if (WarningCode[key] == value) {
+            if (WarningCode[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -26,7 +26,11 @@ export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 
 
 export function instanceOfWarningCode(value: any): boolean {
-    return Object.values(WarningCode).includes(value);
+    for (const key in WarningCode)
+        if (Object.prototype.hasOwnProperty.call(WarningCode, key))
+            if (WarningCode[key] == value)
+                return true;
+    return false;
 }
 
 export function WarningCodeFromJSON(json: any): WarningCode {

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -26,10 +26,13 @@ export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 
 
 export function instanceOfWarningCode(value: any): boolean {
-    for (const key in WarningCode)
-        if (Object.prototype.hasOwnProperty.call(WarningCode, key))
-            if (WarningCode[key] == value)
+    for (const key in WarningCode) {
+        if (Object.prototype.hasOwnProperty.call(WarningCode, key)) {
+            if (WarningCode[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -28,7 +28,7 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 export function instanceOfEnumClass(value: any): boolean {
     for (const key in EnumClass) {
         if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
-            if (EnumClass[key] == value) {
+            if (EnumClass[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -26,7 +26,11 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
 export function instanceOfEnumClass(value: any): boolean {
-    return Object.values(EnumClass).includes(value);
+    for (const key in EnumClass)
+        if (Object.prototype.hasOwnProperty.call(EnumClass, key))
+            if (EnumClass[key] == value)
+                return true;
+    return false;
 }
 
 export function EnumClassFromJSON(json: any): EnumClass {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -26,10 +26,13 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 
 
 export function instanceOfEnumClass(value: any): boolean {
-    for (const key in EnumClass)
-        if (Object.prototype.hasOwnProperty.call(EnumClass, key))
-            if (EnumClass[key] == value)
+    for (const key in EnumClass) {
+        if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
+            if (EnumClass[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -26,10 +26,13 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
 export function instanceOfOuterEnum(value: any): boolean {
-    for (const key in OuterEnum)
-        if (Object.prototype.hasOwnProperty.call(OuterEnum, key))
-            if (OuterEnum[key] == value)
+    for (const key in OuterEnum) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
+            if (OuterEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -28,7 +28,7 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 export function instanceOfOuterEnum(value: any): boolean {
     for (const key in OuterEnum) {
         if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
-            if (OuterEnum[key] == value) {
+            if (OuterEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -26,7 +26,11 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 
 
 export function instanceOfOuterEnum(value: any): boolean {
-    return Object.values(OuterEnum).includes(value);
+    for (const key in OuterEnum)
+        if (Object.prototype.hasOwnProperty.call(OuterEnum, key))
+            if (OuterEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumFromJSON(json: any): OuterEnum {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -26,7 +26,11 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 
 
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
-    return Object.values(OuterEnumDefaultValue).includes(value);
+    for (const key in OuterEnumDefaultValue)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key))
+            if (OuterEnumDefaultValue[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumDefaultValueFromJSON(json: any): OuterEnumDefaultValue {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
     for (const key in OuterEnumDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
-            if (OuterEnumDefaultValue[key] == value) {
+            if (OuterEnumDefaultValue[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -26,10 +26,13 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 
 
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
-    for (const key in OuterEnumDefaultValue)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key))
-            if (OuterEnumDefaultValue[key] == value)
+    for (const key in OuterEnumDefaultValue) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
+            if (OuterEnumDefaultValue[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -26,10 +26,13 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 
 
 export function instanceOfOuterEnumInteger(value: any): boolean {
-    for (const key in OuterEnumInteger)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key))
-            if (OuterEnumInteger[key] == value)
+    for (const key in OuterEnumInteger) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
+            if (OuterEnumInteger[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -28,7 +28,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 export function instanceOfOuterEnumInteger(value: any): boolean {
     for (const key in OuterEnumInteger) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
-            if (OuterEnumInteger[key] == value) {
+            if (OuterEnumInteger[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -26,7 +26,11 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 
 
 export function instanceOfOuterEnumInteger(value: any): boolean {
-    return Object.values(OuterEnumInteger).includes(value);
+    for (const key in OuterEnumInteger)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key))
+            if (OuterEnumInteger[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumIntegerFromJSON(json: any): OuterEnumInteger {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -26,7 +26,11 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 
 
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
-    return Object.values(OuterEnumIntegerDefaultValue).includes(value);
+    for (const key in OuterEnumIntegerDefaultValue)
+        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key))
+            if (OuterEnumIntegerDefaultValue[key] == value)
+                return true;
+    return false;
 }
 
 export function OuterEnumIntegerDefaultValueFromJSON(json: any): OuterEnumIntegerDefaultValue {

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -26,10 +26,13 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 
 
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
-    for (const key in OuterEnumIntegerDefaultValue)
-        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key))
-            if (OuterEnumIntegerDefaultValue[key] == value)
+    for (const key in OuterEnumIntegerDefaultValue) {
+        if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
+            if (OuterEnumIntegerDefaultValue[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
     for (const key in OuterEnumIntegerDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
-            if (OuterEnumIntegerDefaultValue[key] == value) {
+            if (OuterEnumIntegerDefaultValue[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -25,10 +25,13 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
 export function instanceOfSingleRefType(value: any): boolean {
-    for (const key in SingleRefType)
-        if (Object.prototype.hasOwnProperty.call(SingleRefType, key))
-            if (SingleRefType[key] == value)
+    for (const key in SingleRefType) {
+        if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
+            if (SingleRefType[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -27,7 +27,7 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 export function instanceOfSingleRefType(value: any): boolean {
     for (const key in SingleRefType) {
         if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
-            if (SingleRefType[key] == value) {
+            if (SingleRefType[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -25,7 +25,11 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 
 
 export function instanceOfSingleRefType(value: any): boolean {
-    return Object.values(SingleRefType).includes(value);
+    for (const key in SingleRefType)
+        if (Object.prototype.hasOwnProperty.call(SingleRefType, key))
+            if (SingleRefType[key] == value)
+                return true;
+    return false;
 }
 
 export function SingleRefTypeFromJSON(json: any): SingleRefType {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -27,7 +27,7 @@ export enum NumberEnum {
 export function instanceOfNumberEnum(value: any): boolean {
     for (const key in NumberEnum) {
         if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
-            if (NumberEnum[key] == value) {
+            if (NumberEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -25,7 +25,11 @@ export enum NumberEnum {
 
 
 export function instanceOfNumberEnum(value: any): boolean {
-    return Object.values(NumberEnum).includes(value);
+    for (const key in NumberEnum)
+        if (Object.prototype.hasOwnProperty.call(NumberEnum, key))
+            if (NumberEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function NumberEnumFromJSON(json: any): NumberEnum {

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -25,10 +25,13 @@ export enum NumberEnum {
 
 
 export function instanceOfNumberEnum(value: any): boolean {
-    for (const key in NumberEnum)
-        if (Object.prototype.hasOwnProperty.call(NumberEnum, key))
-            if (NumberEnum[key] == value)
+    for (const key in NumberEnum) {
+        if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
+            if (NumberEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -25,10 +25,13 @@ export enum StringEnum {
 
 
 export function instanceOfStringEnum(value: any): boolean {
-    for (const key in StringEnum)
-        if (Object.prototype.hasOwnProperty.call(StringEnum, key))
-            if (StringEnum[key] == value)
+    for (const key in StringEnum) {
+        if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
+            if (StringEnum[key] == value) {
                 return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -27,7 +27,7 @@ export enum StringEnum {
 export function instanceOfStringEnum(value: any): boolean {
     for (const key in StringEnum) {
         if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
-            if (StringEnum[key] == value) {
+            if (StringEnum[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -25,7 +25,11 @@ export enum StringEnum {
 
 
 export function instanceOfStringEnum(value: any): boolean {
-    return Object.values(StringEnum).includes(value);
+    for (const key in StringEnum)
+        if (Object.prototype.hasOwnProperty.call(StringEnum, key))
+            if (StringEnum[key] == value)
+                return true;
+    return false;
 }
 
 export function StringEnumFromJSON(json: any): StringEnum {

--- a/samples/documentation/html2/index.html
+++ b/samples/documentation/html2/index.html
@@ -9512,7 +9512,7 @@ The password for login in clear text
                                               <th>Description</th>
                                           </tr>
                                               <tr>
-                                                  <td>SetDashCookie</td>
+                                                  <td>SetMinusCookie</td>
                                                   <td>String</td>
                                                   <td></td>
                                                   <td>Cookie authentication key for use with the &#x60;api_key&#x60; apiKey authentication.</td>

--- a/samples/documentation/html2/index.html
+++ b/samples/documentation/html2/index.html
@@ -9512,7 +9512,7 @@ The password for login in clear text
                                               <th>Description</th>
                                           </tr>
                                               <tr>
-                                                  <td>SetMinusCookie</td>
+                                                  <td>SetDashCookie</td>
                                                   <td>String</td>
                                                   <td></td>
                                                   <td>Cookie authentication key for use with the &#x60;api_key&#x60; apiKey authentication.</td>


### PR DESCRIPTION
The `instanceOf{{classname}}` function introduced in 93b76dde371b1e3e111040541ef568a329b62be6 makes use of the [Object.values](https://262.ecma-international.org/8.0/#sec-object.values) function introduced in [ECMAScript 2017](https://262.ecma-international.org/8.0), thus breaking compatibility with prior versions such as ES2016 and ES2015.

This PR suggests an alternate implementation for the `instanceOf{{classname}}` function in the `modelEnum.mustache` template that restores backward-compatibility.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov @davidgamero @mkusaka