### PR TITLE
upgrade swagger-parser to latest version

### DIFF
--- a/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator-gradle-plugin/pom.xml
+++ b/modules/openapi-generator-gradle-plugin/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-        <gradleVersion>7.6</gradleVersion>
-        <gradle-tooling.version>7.3-20210825160000+0000</gradle-tooling.version>
+        <gradleVersion>7.6.4</gradleVersion>
+        <gradle-tooling.version>7.4.2</gradle-tooling.version>
     </properties>
 
     <pluginRepositories>

--- a/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/openapi-generator-gradle-plugin/samples/local-spec/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskConfigurationCacheTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskConfigurationCacheTest.kt
@@ -20,7 +20,7 @@ class GenerateTaskConfigurationCacheTest : TestBase() {
     }
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProviderWithConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("8.1.1"), arrayOf("7.6"))
+    private fun gradleVersionProviderWithConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("8.7"), arrayOf("7.6.4"))
 
     @DataProvider(name = "gradle_version_provider_without_cc")
     private fun gradleVersionProviderWithoutConfigurationCache(): Array<Array<String>> = arrayOf(arrayOf("5.6.1"))

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskFromCacheTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskFromCacheTest.kt
@@ -22,7 +22,7 @@ class GenerateTaskFromCacheTest : TestBase() {
     }
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.1.1"), arrayOf("7.6"))
+    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.7"), arrayOf("7.6.4"))
 
     // inputSpec tests
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskUpToDateTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/GenerateTaskUpToDateTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 class GenerateTaskUpToDateTest : TestBase() {
 
     @DataProvider(name = "gradle_version_provider")
-    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.1.1"), arrayOf("7.6"))
+    private fun gradleVersionProvider(): Array<Array<String>> = arrayOf(arrayOf("8.7"), arrayOf("7.6.4"))
 
     // inputSpec tests
 

--- a/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
+++ b/modules/openapi-generator-gradle-plugin/src/test/kotlin/ValidateTaskDslTest.kt
@@ -17,8 +17,8 @@ class ValidateTaskDslTest : TestBase() {
     @DataProvider(name = "gradle_version_provider")
     fun gradleVersionProvider(): Array<Array<String?>> = arrayOf(
         arrayOf(null), // uses the version of Gradle used to build the plugin itself
-        arrayOf("8.1.1"),
-        arrayOf("7.6")
+        arrayOf("8.7"),
+        arrayOf("7.6.4")
     )
 
     private fun getGradleRunner(gradleVersion: String?): GradleRunner {

--- a/pom.xml
+++ b/pom.xml
@@ -1227,8 +1227,8 @@
         <guava.version>32.1.3-jre</guava.version>
         <handlebars-java.version>4.3.1</handlebars-java.version>
         <jackson-threetenbp.version>2.15.2</jackson-threetenbp.version>
-        <jackson-databind.version>2.15.3</jackson-databind.version>
-        <jackson.version>2.15.3</jackson.version>
+        <jackson-databind.version>2.16.2</jackson-databind.version>
+        <jackson.version>2.16.2</jackson.version>
         <jacoco.version>0.8.10</jacoco.version>
         <jmustache.version>1.15</jmustache.version>
         <junit.version>4.13.2</junit.version>
@@ -1252,7 +1252,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <spotbugs-plugin.version>3.1.12.2</spotbugs-plugin.version>
         <swagger-parser-groupid.version>io.swagger.parser.v3</swagger-parser-groupid.version>
-        <swagger-parser.version>2.1.19</swagger-parser.version>
+        <swagger-parser.version>2.1.22</swagger-parser.version>
         <testng.version>7.5</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
         <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>


### PR DESCRIPTION
This upgrades swagger-parser to the latest release.  In manual testing, this upgrade restored the generator's ability to resolve external references in OpenAPI specs.

Fixes #18429 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
