### PR TITLE
Add `ResumableTask` to `URLSessionImplementations.mustache`

### DIFF
--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -130,9 +130,9 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 {{/useAlamofire}}
 {{^useAlamofire}}
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/modules/openapi-generator/src/main/resources/swift5/Models.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/Models.mustache
@@ -130,9 +130,9 @@ extension NullEncodable: Codable where Wrapped: Codable {
     }
 {{/useAlamofire}}
 {{^useAlamofire}}
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol ResumableTask {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol CancellableResumableTask {
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ import UniformTypeIdentifiers
 {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ private var credentialStore = SynchronizedDictionary<Int, URLCredential>()
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
+++ b/modules/openapi-generator/src/main/resources/swift5/libraries/urlsession/URLSessionImplementations.mustache
@@ -12,11 +12,27 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol URLSessionProtocol {
-    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// you may not want to create or return a real URLSessionDataTask.
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol ResumableTask {
+    func resume()
 }
 
-extension URLSession: URLSessionProtocol {}
+// Protocol allowing implementations to alter what is returned or to test their implementations.
+{{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} protocol URLSessionProtocol {
+    // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
+    // is sent off when `.resume()` is called.
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+}
+
+extension URLSession: URLSessionProtocol {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
+  {{#nonPublicApi}}internal{{/nonPublicApi}}{{^nonPublicApi}}public{{/nonPublicApi}} func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+    return dataTask(with: request, completionHandler: completionHandler)
+  }
+}
+
+extension URLSessionDataTask: ResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,25 +14,31 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/anycodableLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask: @unchecked Sendable {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask: @unchecked Sendable {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/asyncAwaitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/combineLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/default/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/deprecated/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/frozenEnums/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ internal class Response<T> {
 
 internal final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ internal class Response<T> {
 
 internal final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-internal protocol ResumableTask {
+internal protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 internal protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  internal func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  internal func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ internal class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/nonPublicApi/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,11 +12,27 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-internal protocol URLSessionProtocol {
-    func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// you may not want to create or return a real URLSessionDataTask.
+internal protocol ResumableTask {
+    func resume()
 }
 
-extension URLSession: URLSessionProtocol {}
+// Protocol allowing implementations to alter what is returned or to test their implementations.
+internal protocol URLSessionProtocol {
+    // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
+    // is sent off when `.resume()` is called.
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+}
+
+extension URLSession: URLSessionProtocol {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
+  internal func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+    return dataTask(with: request, completionHandler: completionHandler)
+  }
+}
+
+extension URLSessionDataTask: ResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/objcCompatible/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/oneOf/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/promisekitLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/readonlyProperties/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/resultLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/rxswiftLibrary/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/urlsessionLibrary/Sources/PetstoreClient/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/validation/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: CancellableResumableTask?
+    private var task: URLSessionDataTaskProtocol?
 
-    internal func set(task: CancellableResumableTask) {
+    internal func set(task: URLSessionDataTaskProtocol) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/Models.swift
@@ -112,9 +112,9 @@ open class Response<T> {
 
 public final class RequestTask {
     private var lock = NSRecursiveLock()
-    private var task: URLSessionTask?
+    private var task: CancellableResumableTask?
 
-    internal func set(task: URLSessionTask) {
+    internal func set(task: CancellableResumableTask) {
         lock.lock()
         defer { lock.unlock() }
         self.task = task

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -38,7 +38,7 @@ extension URLSession: URLSessionProtocol {
   }
 }
 
-extension URLSessionDataTask: ResumableTask {}
+extension URLSessionDataTask: CancellableResumableTask {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -12,9 +12,9 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 #endif
 
-// Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
+// Protocol defined for a session data task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol CancellableResumableTask {
+public protocol URLSessionDataTaskProtocol {
     func resume()
 
     var taskIdentifier: Int { get }
@@ -28,17 +28,17 @@ public protocol CancellableResumableTask {
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
+    func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
 }
 
 extension URLSession: URLSessionProtocol {
-  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
+  // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to URLSessionDataTaskProtocol and fetches the network data.
+  public func dataTaskFromProtocol(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any URLSessionDataTaskProtocol {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
 
-extension URLSessionDataTask: CancellableResumableTask {}
+extension URLSessionDataTask: URLSessionDataTaskProtocol {}
 
 class URLSessionRequestBuilderFactory: RequestBuilderFactory {
     func getNonDecodableBuilder<T>() -> RequestBuilder<T>.Type {
@@ -158,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
+            let dataTask = urlSession.dataTaskFromProtocol(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()

--- a/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
+++ b/samples/client/petstore/swift5/x-swift-hashable/PetstoreClient/Classes/OpenAPIs/URLSessionImplementations.swift
@@ -14,20 +14,26 @@ import UniformTypeIdentifiers
 
 // Protocol defined for a resumable task. This allows mocking out the URLSessionProtocol below since
 // you may not want to create or return a real URLSessionDataTask.
-public protocol ResumableTask {
+public protocol CancellableResumableTask {
     func resume()
+
+    var taskIdentifier: Int { get }
+
+    var progress: Progress { get }
+
+    func cancel()
 }
 
 // Protocol allowing implementations to alter what is returned or to test their implementations.
 public protocol URLSessionProtocol {
     // Task which performs the network fetch. Expected to be from URLSession.dataTask(with:completionHandler:) such that a network request
     // is sent off when `.resume()` is called.
-    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> ResumableTask
+    func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> CancellableResumableTask
 }
 
 extension URLSession: URLSessionProtocol {
   // Passthrough to URLSession.dataTask(with:completionHandler) since URLSessionDataTask conforms to ResumableTask and fetches the network data.
-  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any ResumableTask {
+  public func resumableTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> any CancellableResumableTask {
     return dataTask(with: request, completionHandler: completionHandler)
   }
 }
@@ -152,7 +158,7 @@ open class URLSessionRequestBuilder<T>: RequestBuilder<T> {
                  }
              }
 
-            let dataTask = urlSession.dataTask(with: request) { data, response, error in
+            let dataTask = urlSession.resumableTask(with: request) { data, response, error in
                 apiResponseQueue.async {
                     self.processRequestResponse(urlRequest: request, data: data, response: response, error: error, completion: completion)
                     cleanupRequest()


### PR DESCRIPTION
Add `ResumableTask` to `URLSessionImplementations.mustache`
- Makes it testable
- Implementations can return something _other_ than a URLSessionDataTask if they want to implement another request format (sockets maybe?)
- Default implementation for `URLSession` provided
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.


@jgavris (2017/07) @ehyche (2017/08) @Edubits (2017/09) @jaz-ah (2017/09) @4brunu (2019/11) @dydus0x14 (2023/06)