### PR TITLE
docs: add instruction for building the binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Please file the pull request against the correct branch, e.g. `master` for non-b
 
 All the code generators can be found in [modules/openapi-generator/src/main/java/org/openapitools/codegen/languages](https://github.com/openapitools/openapi-generator/tree/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages)
 
-If you want to add a new generator, follow the [new-generator](https://openapi-generator.tech/docs/new-generator) guide. 
+If you want to add a new generator, follow the [new-generator](https://openapi-generator.tech/docs/new-generator) guide.
 
 ### Templates
 
@@ -84,6 +84,26 @@ For [Vendor Extensions](https://github.com/OAI/OpenAPI-Specification/blob/master
 - For language-specified vendor extension, put it in the form of `x-{lang}-{extension-name}`. e.g. `x-objc-operation-id`, `x-java-feign-retry-limit`
 - For a list of existing vendor extensions in use, please refer to https://github.com/openapitools/openapi-generator/wiki/Vendor-Extensions. If you've added new vendor extensions as part of your PR, please update the wiki page.
 
+### Building
+
+The `openapi-generator-cli` can be built using the following command. This will generate the `openapi-generator-cli.jar` in the `modules/openapi-generator-cli/target` directory without running the tests and generating the Javadocs.
+
+```shell
+./mvnw clean install -DskipTests -Dmaven.javadoc.skip=true
+```
+
+Or on Windows:
+
+```shell
+mvnw.cmd clean install -DskipTests -Dmaven.javadoc.skip=true
+```
+
+The binary can run via `java -jar`. For example:
+
+```shell
+java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar help
+```
+
 ### Testing
 
 To add test cases (optional) covering the change in the code generator, please refer to [modules/openapi-generator/src/test/java/org/openapitools/codegen](https://github.com/openapitools/openapi-generator/tree/master/modules/openapi-generator/src/test/java/org/openapitools/codegen)
@@ -112,5 +132,5 @@ See [OpenAPI Tools wiki](https://github.com/OpenAPITools/openapi-generator/wiki/
 - File a PR with meaningful title, description and commit messages
 - Make sure the option "Allow edits from maintainers" in the PR is selected so that the maintainers can update your PRs with minor fixes, if needed.
 - Recommended git settings
-   - `git config core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around 
+   - `git config core.autocrlf input` to tell Git convert CRLF to LF on commit but not the other way around
 - To close an issue (e.g. issue 1542) automatically after a PR is merged, use keywords "fix", "close", "resolve" in the PR description, e.g. `fix #1542`. (Ref: [closing issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
This adds instructions for building the binary to the Contributing guide without needing to run all the tests. The information is useful for new contributors who are not necessarily familiar with the Java ecosystem.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
