### PR TITLE
fix: ExampleGenerator for composed child schemas and array schemas

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -396,6 +396,13 @@ public class ExampleGenerator {
         }
     }
 
+    /**
+     * Transverse and resolves all property examples for `allOf` composed schemas into `values` map object
+     * @param mediaType MIME type
+     * @param schema OAS schema
+     * @param processedModels Set containing all processed models
+     * @param values Example value map
+     */
     private void resolveAllOfSchemaProperties(String mediaType, Schema schema, Set<String> processedModels, Map<String, Object> values) {
         List<Schema> interfaces = schema.getAllOf();
         for (Schema composed : interfaces) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/examples/ExampleGenerator.java
@@ -363,17 +363,7 @@ public class ExampleGenerator {
             return schema.getExample();
         } else if (ModelUtils.isAllOf(schema) || ModelUtils.isAllOfWithProperties(schema)) {
             LOGGER.debug("Resolving allOf model '{}' to example", name);
-            List<Schema> interfaces = schema.getAllOf();
-            for (Schema composed : interfaces) {
-                traverseSchemaProperties(mediaType, composed, processedModels, values);
-                if (composed.get$ref() != null) {
-                    String ref = ModelUtils.getSimpleRef(composed.get$ref());
-                    Schema resolved = ModelUtils.getSchema(openAPI, ref);
-                    if (resolved != null) {
-                        traverseSchemaProperties(mediaType, resolved, processedModels, values);
-                    }
-                }
-            }
+            resolveAllOfSchemaProperties(mediaType, schema, processedModels, values);
             schema.setExample(values);
             return schema.getExample();
         } else if (ModelUtils.isAnyOf(schema) || ModelUtils.isOneOf(schema)) {
@@ -401,17 +391,20 @@ public class ExampleGenerator {
                 Schema property = (Schema) schema.getProperties().get(propertyName.toString());
                 values.put(propertyName.toString(), resolvePropertyToExample(propertyName.toString(), mediaType, property, processedModels));
             }
+        } else if (ModelUtils.isAllOf(schema) || ModelUtils.isAllOfWithProperties(schema)) {
+            resolveAllOfSchemaProperties(mediaType, schema, processedModels, values);
         }
-        else if (ModelUtils.isAllOf(schema) || ModelUtils.isAllOfWithProperties(schema)) {
-            List<Schema> interfaces = schema.getAllOf();
-            for (Schema composed : interfaces) {
-                traverseSchemaProperties(mediaType, composed, processedModels, values);
-                if (composed.get$ref() != null) {
-                    String ref = ModelUtils.getSimpleRef(composed.get$ref());
-                    Schema resolved = ModelUtils.getSchema(openAPI, ref);
-                    if (resolved != null) {
-                        traverseSchemaProperties(mediaType, resolved, processedModels, values);
-                    }
+    }
+
+    private void resolveAllOfSchemaProperties(String mediaType, Schema schema, Set<String> processedModels, Map<String, Object> values) {
+        List<Schema> interfaces = schema.getAllOf();
+        for (Schema composed : interfaces) {
+            traverseSchemaProperties(mediaType, composed, processedModels, values);
+            if (composed.get$ref() != null) {
+                String ref = ModelUtils.getSimpleRef(composed.get$ref());
+                Schema resolved = ModelUtils.getSchema(openAPI, ref);
+                if (resolved != null) {
+                    traverseSchemaProperties(mediaType, resolved, processedModels, values);
                 }
             }
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -177,11 +177,7 @@ public class ExampleGeneratorTest {
 
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
-        assertEquals("[ {\n" +
-                     "  \"example_schema_property\" : \"example schema property value\"\n" +
-                     "}, {\n" +
-                     "  \"example_schema_property\" : \"example schema property value\"\n" +
-                     "} ]", examples.get(0).get("example"));
+        assertEquals(String.format(Locale.ROOT, "[ {%n  \"example_schema_property\" : \"example schema property value\"%n}, {%n  \"example_schema_property\" : \"example schema property value\"%n} ]"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 
@@ -268,11 +264,7 @@ public class ExampleGeneratorTest {
 
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
-        assertEquals(String.format(Locale.ROOT, "{\n" +
-                                                "  \"example_schema_property_composed\" : \"example schema property value composed\",\n" +
-                                                "  \"example_schema_property_composed_parent\" : \"example schema property value composed parent\",\n" +
-                                                "  \"example_schema_property\" : \"example schema property value\"\n" +
-                                                "}"), examples.get(0).get("example"));
+        assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property_composed_parent\" : \"example schema property value composed parent\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/ExampleGeneratorTest.java
@@ -153,6 +153,39 @@ public class ExampleGeneratorTest {
     }
 
     @Test
+    public void generateFromResponseSchemaWithArraySchema() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_array_reference")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals("[ {\n" +
+                     "  \"example_schema_property\" : \"example schema property value\"\n" +
+                     "}, {\n" +
+                     "  \"example_schema_property\" : \"example schema property value\"\n" +
+                     "} ]", examples.get(0).get("example"));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
+
+    @Test
     public void generateFromResponseSchemaWithModel() {
         OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
 
@@ -207,6 +240,39 @@ public class ExampleGeneratorTest {
         assertEquals(1, examples.size());
         assertEquals("application/json", examples.get(0).get("contentType"));
         assertEquals(String.format(Locale.ROOT, "{%n  \"example_schema_property_composed\" : \"example schema property value composed\",%n  \"example_schema_property\" : \"example schema property value\"%n}"), examples.get(0).get("example"));
+        assertEquals("200", examples.get(0).get("statusCode"));
+    }
+
+    @Test
+    public void generateFromResponseSchemaWithAllOfChildComposedModel() {
+        OpenAPI openAPI = TestUtils.parseFlattenSpec("src/test/resources/3_0/example_generator_test.yaml");
+
+        new InlineModelResolver().flatten(openAPI);
+
+        ExampleGenerator exampleGenerator = new ExampleGenerator(openAPI.getComponents().getSchemas(), openAPI);
+        Set<String> mediaTypeKeys = new TreeSet<>();
+        mediaTypeKeys.add("application/json");
+        List<Map<String, String>> examples = exampleGenerator.generateFromResponseSchema(
+                "200",
+                openAPI
+                        .getPaths()
+                        .get("/generate_from_response_schema_with_allOf_child_composed_model")
+                        .getGet()
+                        .getResponses()
+                        .get("200")
+                        .getContent()
+                        .get("application/json")
+                        .getSchema(),
+                mediaTypeKeys
+        );
+
+        assertEquals(1, examples.size());
+        assertEquals("application/json", examples.get(0).get("contentType"));
+        assertEquals(String.format(Locale.ROOT, "{\n" +
+                                                "  \"example_schema_property_composed\" : \"example schema property value composed\",\n" +
+                                                "  \"example_schema_property_composed_parent\" : \"example schema property value composed parent\",\n" +
+                                                "  \"example_schema_property\" : \"example schema property value\"\n" +
+                                                "}"), examples.get(0).get("example"));
         assertEquals("200", examples.get(0).get("statusCode"));
     }
 

--- a/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/example_generator_test.yaml
@@ -61,6 +61,16 @@ paths:
                 items:
                   type: string
                   example: primitive types example value
+  /generate_from_response_schema_array_reference:
+    get:
+      operationId: generateFromResponseSchemaArrayReference
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleArraySchema'
   /generate_from_response_schema_with_model:
     get:
       operationId: generateFromResponseSchemaWithModel
@@ -81,6 +91,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExampleAllOfSchema'
+  /generate_from_response_schema_with_allOf_child_composed_model:
+    get:
+      operationId: generateFromResponseSchemaWithAllOfModel
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExampleAllOfParentSchema'
   /generate_from_response_schema_with_anyOf_composed_model:
     get:
       operationId: generateFromResponseSchemaWithAnyOfModel
@@ -131,6 +151,15 @@ components:
             example_schema_property_composed:
               type: string
               example: example schema property value composed
+    ExampleAllOfParentSchema:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/ExampleAllOfSchema'
+        - type: object
+          properties:
+            example_schema_property_composed_parent:
+              type: string
+              example: example schema property value composed parent
     ExampleAnyOfSchema:
       type: object
       anyOf:
@@ -149,3 +178,7 @@ components:
             example_schema_property_composed:
               type: string
               example: example schema property value composed
+    ExampleArraySchema:
+      type: array
+      items:
+        $ref: '#/components/schemas/ExampleSchema'

--- a/samples/client/petstore/csharp/generichost/net8/FormModels/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/FormModels/api/openapi.yaml
@@ -1247,6 +1247,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2714,6 +2718,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/NullReferenceTypes/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/generichost/net8/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/Petstore/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/generichost/net8/SourceGeneration/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/net8/SourceGeneration/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/generichost/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/generichost/standard2.0/Petstore/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/httpclient/standard2.0/Petstore/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/net4.7/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/net4.7/Petstore/api/openapi.yaml
@@ -1304,6 +1304,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2894,6 +2898,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/net4.8/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/net4.8/Petstore/api/openapi.yaml
@@ -1304,6 +1304,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2894,6 +2898,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/net7/EnumMappings/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/net7/EnumMappings/api/openapi.yaml
@@ -1304,6 +1304,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2894,6 +2898,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/net7/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/net7/Petstore/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/ConditionalSerialization/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/restsharp/standard2.0/Petstore/api/openapi.yaml
@@ -1304,6 +1304,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2894,6 +2898,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string

--- a/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/api/openapi.yaml
+++ b/samples/client/petstore/csharp/unityWebRequest/standard2.0/Petstore/api/openapi.yaml
@@ -1278,6 +1278,10 @@ components:
       type: array
     RolesReportsHash:
       description: Role report Hash
+      example:
+        role:
+          name: name
+        role_uuid: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
       properties:
         role_uuid:
           format: uuid
@@ -2862,6 +2866,8 @@ components:
         - country
         type: object
     RolesReportsHash_role:
+      example:
+        name: name
       properties:
         name:
           type: string


### PR DESCRIPTION
Fixes example generator when using composed child schemas on `allOf` as well as `array` type schemas.
Fixes: https://github.com/OpenAPITools/openapi-generator/issues/18443

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
