### PR TITLE
fix for the artefact names in scala cask

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-cask/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-cask/build.sbt.mustache
@@ -3,13 +3,15 @@ ThisBuild / organization := "{{groupId}}"
 ThisBuild / version := "0.0.1-SNAPSHOT"
 ThisBuild / scalaVersion := "3.4.1"
 ThisBuild / scalafmtOnCompile := true
+ThisBuild / versionScheme := Some("early-semver")
 
 // Common settings
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "com.lihaoyi" %%% "upickle" % "3.2.0",
     "org.scalatest" %%% "scalatest" % "3.2.18" % Test
-  )
+  ),
+  name := "{{artifactId}}"
 )
 
 
@@ -19,7 +21,7 @@ lazy val app = crossProject(JSPlatform, JVMPlatform).in(file(".")).
     libraryDependencies += "com.lihaoyi" %% "cask" % "0.9.2"
   ).
   jsSettings(
-    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer := true
   )
   
 

--- a/samples/server/petstore/scala-cask/build.sbt
+++ b/samples/server/petstore/scala-cask/build.sbt
@@ -3,13 +3,15 @@ ThisBuild / organization := "cask.groupId"
 ThisBuild / version := "0.0.1-SNAPSHOT"
 ThisBuild / scalaVersion := "3.4.1"
 ThisBuild / scalafmtOnCompile := true
+ThisBuild / versionScheme := Some("early-semver")
 
 // Common settings
 lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "com.lihaoyi" %%% "upickle" % "3.2.0",
     "org.scalatest" %%% "scalatest" % "3.2.18" % Test
-  )
+  ),
+  name := "scala-cask-petstore"
 )
 
 
@@ -19,7 +21,7 @@ lazy val app = crossProject(JSPlatform, JVMPlatform).in(file(".")).
     libraryDependencies += "com.lihaoyi" %% "cask" % "0.9.2"
   ).
   jsSettings(
-    scalaJSUseMainModuleInitializer := true,
+    scalaJSUseMainModuleInitializer := true
   )
   
 


### PR DESCRIPTION
This change fixes the published artefact names for both JS and JVM artefacts, where previously the 'ThisBuild / name' apparently didn't get read, leaving the published artefacts to be 'app'.


<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
