### PR TITLE
Cask version fix

### DIFF
--- a/docs/generators/scala-cask.md
+++ b/docs/generators/scala-cask.md
@@ -21,6 +21,7 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 |allowUnicodeIdentifiers|boolean, toggles whether unicode identifiers are allowed in names or not, default is false| |false|
 |apiPackage|package for generated api classes| |null|
 |artifactId|artifactId in generated pom.xml. This also becomes part of the generated library's filename| |null|
+|artifactVersion|artifact version in generated pom.xml. This also becomes part of the generated library's filename. If not provided, uses the version from the OpenAPI specification file. If that's also not present, uses the default value of the artifactVersion option.| |null|
 |dateLibrary|Option. Date library to use|<dl><dt>**joda**</dt><dd>Joda (for legacy app)</dd><dt>**java8**</dt><dd>Java 8 native JSR310 (preferred for JDK 1.8+)</dd></dl>|java8|
 |disallowAdditionalPropertiesIfNotPresent|If false, the 'additionalProperties' implementation (set to true by default) is compliant with the OAS and JSON schema specifications. If true (default), keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.|<dl><dt>**false**</dt><dd>The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.</dd><dt>**true**</dt><dd>Keep the old (incorrect) behaviour that 'additionalProperties' is set to false by default.</dd></dl>|true|
 |ensureUniqueParams|Whether to ensure parameter names are unique in an operation (rename parameters that are not).| |true|

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaCaskServerCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ScalaCaskServerCodegen.java
@@ -118,6 +118,7 @@ public class ScalaCaskServerCodegen extends AbstractScalaCodegen implements Code
 
         cliOptions.add(new CliOption(CodegenConstants.GROUP_ID, CodegenConstants.GROUP_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_ID, CodegenConstants.ARTIFACT_ID_DESC));
+        cliOptions.add(new CliOption(CodegenConstants.ARTIFACT_VERSION, CodegenConstants.ARTIFACT_VERSION_DESC));
         cliOptions.add(new CliOption(CodegenConstants.GIT_REPO_ID, CodegenConstants.GIT_REPO_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.GIT_USER_ID, CodegenConstants.GIT_USER_ID_DESC));
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, CodegenConstants.PACKAGE_DESCRIPTION));
@@ -158,6 +159,7 @@ public class ScalaCaskServerCodegen extends AbstractScalaCodegen implements Code
         final String groupId = ensureProp(CodegenConstants.GROUP_ID, "org.openapitools");
         ensureProp(CodegenConstants.ARTIFACT_ID, "caskgen");
         artifactVersion = ensureProp(CodegenConstants.ARTIFACT_VERSION, "0.0.1");
+
         gitRepoId = ensureProp(CodegenConstants.GIT_REPO_ID, "<your git repo -- set 'gitRepoId'>");
         gitUserId = ensureProp(CodegenConstants.GIT_USER_ID, "<your git user -- set 'gitUserId'>");
 

--- a/modules/openapi-generator/src/main/resources/scala-cask/build.sbt.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-cask/build.sbt.mustache
@@ -1,6 +1,6 @@
 ThisBuild / name := "{{artifactId}}"
 ThisBuild / organization := "{{groupId}}"
-ThisBuild / version := "0.0.1-SNAPSHOT"
+ThisBuild / version := "{{artifactVersion}}"
 ThisBuild / scalaVersion := "3.4.1"
 ThisBuild / scalafmtOnCompile := true
 ThisBuild / versionScheme := Some("early-semver")

--- a/modules/openapi-generator/src/main/resources/scala-cask/build.sc.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-cask/build.sc.mustache
@@ -8,7 +8,7 @@ import mill._, scalalib._, scalafmt._, publish._
 // mill _.publishLocal
 // mill _.test.test
 object {{artifactId}} extends SbtModule with ScalafmtModule with PublishModule {
-  def scalaVersion = "3.3.1"
+  def scalaVersion = "3.4.1"
 
   def pomSettings = PomSettings(
     description = "{{artifactId}}",
@@ -21,7 +21,7 @@ object {{artifactId}} extends SbtModule with ScalafmtModule with PublishModule {
     )
   )
 
-  def publishVersion: mill.T[String] = T("0.0.1-SNAPSHOT")
+  def publishVersion: mill.T[String] = T("{{artifactVersion}}")
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::cask:0.9.2" ,

--- a/modules/openapi-generator/src/main/resources/scala-cask/example.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-cask/example.mustache
@@ -1,5 +1,5 @@
-//> using scala "3.3.1"
-//> using lib "{{groupId}}::{{artifactId}}:0.0.1-SNAPSHOT"
+//> using scala "3.4.1"
+//> using lib "{{groupId}}::{{artifactId}}:{{artifactVersion}}"
 //> using repositories https://maven.pkg.github.com/{{{gitUserId}}}/{{{gitRepoId}}}
 
 

--- a/samples/server/petstore/scala-cask/build.sbt
+++ b/samples/server/petstore/scala-cask/build.sbt
@@ -1,6 +1,6 @@
 ThisBuild / name := "scala-cask-petstore"
 ThisBuild / organization := "cask.groupId"
-ThisBuild / version := "0.0.1-SNAPSHOT"
+ThisBuild / version := "0.0.1"
 ThisBuild / scalaVersion := "3.4.1"
 ThisBuild / scalafmtOnCompile := true
 ThisBuild / versionScheme := Some("early-semver")

--- a/samples/server/petstore/scala-cask/build.sc
+++ b/samples/server/petstore/scala-cask/build.sc
@@ -8,7 +8,7 @@ import mill._, scalalib._, scalafmt._, publish._
 // mill _.publishLocal
 // mill _.test.test
 object scala-cask-petstore extends SbtModule with ScalafmtModule with PublishModule {
-  def scalaVersion = "3.3.1"
+  def scalaVersion = "3.4.1"
 
   def pomSettings = PomSettings(
     description = "scala-cask-petstore",
@@ -21,7 +21,7 @@ object scala-cask-petstore extends SbtModule with ScalafmtModule with PublishMod
     )
   )
 
-  def publishVersion: mill.T[String] = T("0.0.1-SNAPSHOT")
+  def publishVersion: mill.T[String] = T("0.0.1")
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::cask:0.9.2" ,

--- a/samples/server/petstore/scala-cask/example/Server.scala
+++ b/samples/server/petstore/scala-cask/example/Server.scala
@@ -1,5 +1,5 @@
-//> using scala "3.3.1"
-//> using lib "cask.groupId::scala-cask-petstore:0.0.1-SNAPSHOT"
+//> using scala "3.4.1"
+//> using lib "cask.groupId::scala-cask-petstore:0.0.1"
 //> using repositories https://maven.pkg.github.com/GIT_USER_ID/GIT_REPO_ID
 
 


### PR DESCRIPTION
This PR teaches the scala cask generator about artifact versions. Previously they were hard-coded as 0.0.1-SNAPSHOT, where now configurations are able to specify e.g. "artifactVersion: 1.2.3"

<!-- Please check the completed items below -->
### PR checklist
 
- [ x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
