### PR TITLE
[BUG][Kotlin] Fix wrong type- and importMapping for kotlinx.date (#17597)

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -578,9 +578,14 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
     private void processKotlinxDate() {
         additionalProperties.put(DateLibrary.KOTLINX_DATETIME.value, true);
 
-        typeMapping.put("date-time", "kotlinx.datetime.Instant");
+        typeMapping.put("date-time", "Instant");
+        typeMapping.put("date", "LocalDate");
+
         typeMapping.put("DateTime", "Instant");
+        typeMapping.put("Date", "LocalDate");
+
         importMapping.put("Instant", "kotlinx.datetime.Instant");
+        importMapping.put("LocalDate", "kotlinx.datetime.LocalDate");
     }
 
     private void processJVMRetrofit2Library(String infrastructureFolder) {


### PR DESCRIPTION
Closes: https://github.com/OpenAPITools/openapi-generator/issues/17597

@jimschubert, @dr4ke616, @karismann, @Zomzog, @andrewemery, @4brunu, @yutaka0m, @stefankoppier

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
