### PR TITLE
Use the current Java version in devcontainer.json.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,8 @@
         "java.configuration.runtimes": [
           {
             "name": "JavaSE-11",
-            "path": "/usr/local/sdkman/candidates/java/11.0.16.1-ms",
-            "sources": "/usr/local/sdkman/candidates/java/11.0.16.1-ms/lib/src.zip",
+            "path": "/usr/local/sdkman/candidates/java/current",
+            "sources": "/usr/local/sdkman/candidates/java/current/lib/src.zip",
             "javadoc": "https://docs.oracle.com/en/java/javase/11/docs/api",
             "default": true
           }


### PR DESCRIPTION
Inside a new devcontainer, I got a `/usr/local/sdkman/candidates/java/11.0.23-ms/` path, but the settings in devcontainer.json referred to ...11.0.16.1-ms, causing errors in VSCode. This updates the path to a more stable one. 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)