### PR TITLE
[typescript-fetch] Remove a cycle in the discriminator dependency graph.

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -11,12 +11,9 @@ import {
 
 {{/hasImports}}
 {{#discriminator}}
-import {
 {{#discriminator.mappedModels}}
-     {{modelName}}FromJSONTyped{{^-last}},{{/-last}}
+import { {{modelName}}FromJSONTyped } from './{{modelName}}{{importFileExtension}}';
 {{/discriminator.mappedModels}}
-} from './index{{importFileExtension}}';
-
 {{/discriminator}}
 {{>modelGenericInterfaces}}
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -13,11 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import {
-     CatFromJSONTyped,
-     DogFromJSONTyped
-} from './index';
-
+import { CatFromJSONTyped } from './Cat';
+import { DogFromJSONTyped } from './Dog';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -13,10 +13,7 @@
  */
 
 import { mapValues } from '../runtime';
-import {
-     ChildWithNullableFromJSONTyped
-} from './index';
-
+import { ChildWithNullableFromJSONTyped } from './ChildWithNullable';
 /**
  * 
  * @export

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -13,11 +13,8 @@
  */
 
 import { mapValues } from '../runtime';
-import {
-     CatFromJSONTyped,
-     DogFromJSONTyped
-} from './index';
-
+import { CatFromJSONTyped } from './Cat';
+import { DogFromJSONTyped } from './Dog';
 /**
  * 
  * @export


### PR DESCRIPTION
This is very similar to https://github.com/OpenAPITools/openapi-generator/issues/6140 and came up in https://github.com/GoogleChrome/chromium-dashboard/pull/3819. I haven't reduced a test case from that PR, but I can if the maintainers here want. I did check that this change removes the circular dependency from https://github.com/GoogleChrome/chromium-dashboard/pull/3819, although getting rid of the cycle requires writing the schema in a way that removes the inheritance from the common base class.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
@TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)