### PR TITLE
Fixes incorrect Jackson imports in Java templates used in ApiClient.java when useJakartaEe=true

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/ApiClient.mustache
@@ -8,7 +8,12 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 {{/joda}}
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.OffsetDateTime;
+{{#useJakartaEe}}
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+{{/useJakartaEe}}
+{{^useJakartaEe}}
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+{{/useJakartaEe}}
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;

--- a/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/apache-httpclient/ApiClient.mustache
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 {{/joda}}
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.OffsetDateTime;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;

--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/cxf-ext/api_test.mustache
@@ -23,8 +23,14 @@ import org.apache.cxf.transport.common.gzip.GZIPOutInterceptor;
 import org.apache.cxf.interceptor.LoggingOutInterceptor;
 {{/useLoggingFeature}}
 
+{{#useJakartaEe}}
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jakarta.rs.xml.JacksonXMLProvider;
+{{/useJakartaEe}}
+{{^useJakartaEe}}
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
+{{/useJakartaEe}}
 import org.apache.cxf.jaxrs.provider.MultipartProvider;
 
 import java.util.Arrays;

--- a/modules/openapi-generator/src/test/resources/2_0/templates/Java/ApiClient.mustache
+++ b/modules/openapi-generator/src/test/resources/2_0/templates/Java/ApiClient.mustache
@@ -19,7 +19,12 @@ import java.time.OffsetDateTime;
 {{#threetenbp}}
 import com.fasterxml.jackson.datatype.threetenbp.ThreeTenModule;
 {{/threetenbp}}
+{{#useJakartaEe}}
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+{{/useJakartaEe}}
+{{^useJakartaEe}}
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+{{/useJakartaEe}}
 
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;

--- a/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.OffsetDateTime;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/ApiClient.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.OffsetDateTime;
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;


### PR DESCRIPTION
This PR aims to fix a compiler issue I ran into when generating `java` code from an API spec.

The generated code imports `com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider` in `ApiClient.java`, which is the javax package, while my project uses jakarta and requires `com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider`. Upon searching, this seems to be a long-standing issue in this specific configuration, I was able to find at least one issue directly referencing it: #15875.

Upon digging deeper, it seems the generated `ApiClient.java` file in my particular configuration (using the `apache-httpclient` library) doesn't even use the imported class, so in this specialized template it can even be omitted, as is the case in a secondary issue reported as #18289.

The PR does not add any new template parameters, but instead switches over the `useJakartaEe` parameter already exposed to select the appropriate Jackson package to import. This should fix this problem for all Java templates. In addition, I have removed the unused import for the `apache-httpclient` specifically, since it is not needed.

Tagging committee members as requested in the checklist:
@bbdouglas @sreeshas @jfiala @lukoyanov @cbornet @jeff9finger @karismann @Zomzog @lwlee2608 @martin-mfg

I can currently work around the compile issue in my project through an overwritten template file in my template folder where I've fixed this locally, but this PR should fix it for everyone else running into the same issue.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. 
