### PR TITLE
feat(php): allow to pass raw boolean to api

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/ObjectSerializer.mustache
@@ -529,22 +529,61 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        array|object $data,
-        string       $numeric_prefix = '',
-        ?string      $arg_separator = null,
-        int          $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
+++ b/modules/openapi-generator/src/main/resources/php/ObjectSerializer.mustache
@@ -536,22 +536,64 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * The function is copied from https://github.com/guzzle/psr7/blob/a243f80a1ca7fe8ceed4deee17f12c1930efe662/src/Query.php#L59-L112
+    * with a modification which is described in https://github.com/guzzle/psr7/pull/603
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -19,7 +19,6 @@
 namespace {{apiPackage}};
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -643,7 +642,7 @@ use function sprintf;
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -762,7 +761,7 @@ use function sprintf;
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
+++ b/samples/client/echo_api/php-nextgen/src/ObjectSerializer.php
@@ -539,22 +539,61 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        array|object $data,
-        string       $numeric_prefix = '',
-        ?string      $arg_separator = null,
-        int          $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -30,6 +30,12 @@ namespace OpenAPI\Client;
 
 use GuzzleHttp\Psr7\Utils;
 use OpenAPI\Client\Model\ModelInterface;
+use function GuzzleHttp\Psr7\;
+use function is_array;
+use function is_bool;
+use function substr;
+use const PHP_QUERY_RFC1738;
+use const PHP_QUERY_RFC3986;
 
 /**
  * ObjectSerializer Class Doc Comment
@@ -545,22 +551,66 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
+     * Build a query string from an array of key value pairs.
      *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
+     * This function can use the return value of `parse()` to build a query
+     * string. This function does not modify the provided keys when an array is
+     * encountered (like `http_build_query()` would).
      *
-     * @return string
+     * The function is copied from https://github.com/guzzle/psr7/blob/a243f80a1ca7fe8ceed4deee17f12c1930efe662/src/Query.php#L59-L112
+     * with a modification which is described in https://github.com/guzzle/psr7/pull/603
+     *
+     * @param array     $params              Query string parameters.
+     * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+     *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+     *                                       to encode using RFC1738.
+     * @param bool      $treatBooleansAsInts When `true` values are cast to int (e.g. ['foo' => false] gives `foo=0`).
+     *                                       When `false` values are cast to strings (e.g. ['foo' => false] gives `foo=false`).
      */
-    public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986, bool $treatBooleansAsInts = true): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = $treatBooleansAsInts
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/ObjectSerializer.php
@@ -538,22 +538,61 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        array|object $data,
-        string       $numeric_prefix = '',
-        ?string      $arg_separator = null,
-        int          $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/test/ObjectSerializerTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/test/ObjectSerializerTest.php
@@ -3,6 +3,7 @@
 namespace OpenAPI\Client;
 
 use DateTime;
+use Generator;
 use GuzzleHttp\Psr7\Utils;
 use OpenAPI\Client\Model\Pet;
 use OpenAPI\Client\Model\Tag;
@@ -569,6 +570,37 @@ class ObjectSerializerTest extends TestCase
                 true, 'skipValidation', 'boolean', 'form', true, false, 'skipValidation=true',
             ],
         ];
+    }
+
+    /**
+     * @covers ObjectSerializer::buildQuery
+     * @dataProvider provideBuildQuery
+     */
+    public function testToBuildQuery(
+        string $expected,
+        array $data,
+        string|null $booleanFormatString = null,
+    ): void
+    {
+        $config = new Configuration();
+        if ($booleanFormatString !== null) {
+            $config->setBooleanFormatForQueryString($booleanFormatString);
+        }
+        $config::setDefaultConfiguration($config);
+
+        $query = ObjectSerializer::buildQuery($data);
+        $this->assertEquals($expected, $query);
+    }
+
+    /** @return Generator<string, array{string, array<string, mixed>, 2?: Configuration::BOOLEAN_FORMAT_*}> */
+    public function provideBuildQuery(): Generator
+    {
+        yield 'true as int' => ['foo=1', ['foo' => true]];
+        yield 'true as int as default' => ['foo=1', ['foo' => true], Configuration::BOOLEAN_FORMAT_INT];
+        yield 'false as int' => ['foo=0', ['foo' => false]];
+        yield 'false as int as default' => ['foo=0', ['foo' => false], Configuration::BOOLEAN_FORMAT_INT];
+        yield 'true as string' => ['foo=true', ['foo' => true], Configuration::BOOLEAN_FORMAT_STRING];
+        yield 'false as string' => ['foo=false', ['foo' => false], Configuration::BOOLEAN_FORMAT_STRING];
     }
 
     /**

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/ObjectSerializer.php
@@ -545,22 +545,64 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * The function is copied from https://github.com/guzzle/psr7/blob/a243f80a1ca7fe8ceed4deee17f12c1930efe662/src/Query.php#L59-L112
+    * with a modification which is described in https://github.com/guzzle/psr7/pull/603
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/ObjectSerializerTest.php
@@ -3,6 +3,7 @@
 namespace OpenAPI\Client;
 
 use DateTime;
+use Generator;
 use GuzzleHttp\Psr7\Utils;
 use OpenAPI\Client\Model\Pet;
 use OpenAPI\Client\Model\Tag;
@@ -569,6 +570,37 @@ class ObjectSerializerTest extends TestCase
                 true, 'skipValidation', 'boolean', 'form', true, false, 'skipValidation=true',
             ],
         ];
+    }
+
+    /**
+     * @covers ObjectSerializer::buildQuery
+     * @dataProvider provideBuildQuery
+     */
+    public function testToBuildQuery(
+        string $expected,
+        array $data,
+        string|null $booleanFormatString = null,
+    ): void
+    {
+        $config = new Configuration();
+        if ($booleanFormatString !== null) {
+            $config->setBooleanFormatForQueryString($booleanFormatString);
+        }
+        $config::setDefaultConfiguration($config);
+
+        $query = ObjectSerializer::buildQuery($data);
+        $this->assertEquals($expected, $query);
+    }
+
+    /** @return Generator<string, array{string, array<string, mixed>, 2?: Configuration::BOOLEAN_FORMAT_*}> */
+    public function provideBuildQuery(): Generator
+    {
+        yield 'true as int' => ['foo=1', ['foo' => true]];
+        yield 'true as int as default' => ['foo=1', ['foo' => true], Configuration::BOOLEAN_FORMAT_INT];
+        yield 'false as int' => ['foo=0', ['foo' => false]];
+        yield 'false as int as default' => ['foo=0', ['foo' => false], Configuration::BOOLEAN_FORMAT_INT];
+        yield 'true as string' => ['foo=true', ['foo' => true], Configuration::BOOLEAN_FORMAT_STRING];
+        yield 'false as string' => ['foo=false', ['foo' => false], Configuration::BOOLEAN_FORMAT_STRING];
     }
 
     /**

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -402,7 +401,7 @@ class AnotherFakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -482,7 +481,7 @@ class AnotherFakeApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -377,7 +376,7 @@ class DefaultApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -457,7 +456,7 @@ class DefaultApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -377,7 +376,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -612,7 +611,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -844,7 +843,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1082,7 +1081,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1320,7 +1319,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1558,7 +1557,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1796,7 +1795,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2040,7 +2039,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2319,7 +2318,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2526,7 +2525,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2725,7 +2724,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2924,7 +2923,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -3145,7 +3144,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -3397,7 +3396,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -3792,7 +3791,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -4105,7 +4104,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -4413,7 +4412,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -4624,7 +4623,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -4831,7 +4830,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -5051,7 +5050,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -5365,7 +5364,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -5572,7 +5571,7 @@ class FakeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -5652,7 +5651,7 @@ class FakeApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -402,7 +401,7 @@ class FakeClassnameTags123Api
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -487,7 +486,7 @@ class FakeClassnameTags123Api
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -382,7 +381,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -608,7 +607,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -865,7 +864,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1123,7 +1122,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1381,7 +1380,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1618,7 +1617,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1853,7 +1852,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2137,7 +2136,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2427,7 +2426,7 @@ class PetApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2511,7 +2510,7 @@ class PetApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -359,7 +358,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -594,7 +593,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -860,7 +859,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1112,7 +1111,7 @@ class StoreApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1192,7 +1191,7 @@ class StoreApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -28,7 +28,6 @@
 namespace OpenAPI\Client\Api;
 
 use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Query;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\RedirectPlugin;
 use Http\Client\Common\PluginClient;
@@ -357,7 +356,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -564,7 +563,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -771,7 +770,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -980,7 +979,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1234,7 +1233,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1513,7 +1512,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1703,7 +1702,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -1929,7 +1928,7 @@ class UserApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = Query::build($formParams);
+                $httpBody = ObjectSerializer::buildQuery($formParams);
             }
         }
 
@@ -2009,7 +2008,7 @@ class UserApi
             ->withHost($host)
             ->withScheme($scheme)
             ->withPort($port)
-            ->withQuery(Query::build($queryParams));
+            ->withQuery(ObjectSerializer::buildQuery($queryParams));
 
         if ($user) {
             $uri = $uri->withUserInfo($user, $password);

--- a/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
+++ b/samples/client/petstore/php/psr-18/lib/ObjectSerializer.php
@@ -545,22 +545,64 @@ class ObjectSerializer
     }
 
     /**
-     * Native `http_build_query` wrapper.
-     * @see https://www.php.net/manual/en/function.http-build-query
-     *
-     * @param array|object $data           May be an array or object containing properties.
-     * @param string       $numeric_prefix If numeric indices are used in the base array and this parameter is provided, it will be prepended to the numeric index for elements in the base array only.
-     * @param string|null  $arg_separator  arg_separator.output is used to separate arguments but may be overridden by specifying this parameter.
-     * @param int          $encoding_type  Encoding type. By default, PHP_QUERY_RFC1738.
-     *
-     * @return string
-     */
-    public static function buildQuery(
-        $data,
-        string $numeric_prefix = '',
-        ?string $arg_separator = null,
-        int $encoding_type = \PHP_QUERY_RFC3986
-    ): string {
-        return \GuzzleHttp\Psr7\Query::build($data, $encoding_type);
+    * Build a query string from an array of key value pairs.
+    *
+    * This function can use the return value of `parse()` to build a query
+    * string. This function does not modify the provided keys when an array is
+    * encountered (like `http_build_query()` would).
+    *
+    * The function is copied from https://github.com/guzzle/psr7/blob/a243f80a1ca7fe8ceed4deee17f12c1930efe662/src/Query.php#L59-L112
+    * with a modification which is described in https://github.com/guzzle/psr7/pull/603
+    *
+    * @param array     $params              Query string parameters.
+    * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+    *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+    *                                       to encode using RFC1738.
+    */
+    public static function buildQuery(array $params, $encoding = PHP_QUERY_RFC3986): string
+    {
+        if (!$params) {
+            return '';
+        }
+
+        if ($encoding === false) {
+            $encoder = function (string $str): string {
+                return $str;
+            };
+        } elseif ($encoding === PHP_QUERY_RFC3986) {
+            $encoder = 'rawurlencode';
+        } elseif ($encoding === PHP_QUERY_RFC1738) {
+            $encoder = 'urlencode';
+        } else {
+            throw new \InvalidArgumentException('Invalid type');
+        }
+
+        $castBool = Configuration::BOOLEAN_FORMAT_INT == Configuration::getDefaultConfiguration()->getBooleanFormatForQueryString()
+            ? function ($v) { return (int) $v; }
+            : function ($v) { return $v ? 'true' : 'false'; };
+
+        $qs = '';
+        foreach ($params as $k => $v) {
+            $k = $encoder((string) $k);
+            if (!is_array($v)) {
+                $qs .= $k;
+                $v = is_bool($v) ? $castBool($v) : $v;
+                if ($v !== null) {
+                    $qs .= '='.$encoder((string) $v);
+                }
+                $qs .= '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    if ($vv !== null) {
+                        $qs .= '='.$encoder((string) $vv);
+                    }
+                    $qs .= '&';
+                }
+            }
+        }
+
+        return $qs ? (string) substr($qs, 0, -1) : '';
     }
 }


### PR DESCRIPTION
This allows users to use APIs that require booleans in query params not to be cast to int, e.g. `&foo=true`. Currently, `true` is cast to `1` so it's passed as `&foo=1`. That might not be supported by the target API.

The fix contains copy-pasted function from guzzlehttp/psr7 `Query::build()` with minor tweaks.

https://github.com/guzzle/psr7/blob/540ec79fb2f2e96591febb0de464bc16ac2ea341/src/Query.php#L73

Related to https://github.com/OpenAPITools/openapi-generator/issues/2204

There's a proposal by me to include the functionality in guzzlehttp/psr7 https://github.com/guzzle/psr7/pull/603

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
