### PR TITLE
fix(php): prevent duplicate method name

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api.mustache
@@ -110,7 +110,7 @@ use {{invokerPackage}}\ObjectSerializer;
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -110,7 +110,7 @@ use {{invokerPackage}}\ObjectSerializer;
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/libraries/psr-18/api.mustache
@@ -159,7 +159,7 @@ use function sprintf;
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/AuthApi.php
@@ -121,7 +121,7 @@ class AuthApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/BodyApi.php
@@ -145,7 +145,7 @@ class BodyApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/FormApi.php
@@ -124,7 +124,7 @@ class FormApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/HeaderApi.php
@@ -118,7 +118,7 @@ class HeaderApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/PathApi.php
@@ -118,7 +118,7 @@ class PathApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
+++ b/samples/client/echo_api/php-nextgen/src/Api/QueryApi.php
@@ -145,7 +145,7 @@ class QueryApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/AnotherFakeApi.php
@@ -117,7 +117,7 @@ class AnotherFakeApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/DefaultApi.php
@@ -117,7 +117,7 @@ class DefaultApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeApi.php
@@ -181,7 +181,7 @@ class FakeApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/FakeClassnameTags123Api.php
@@ -117,7 +117,7 @@ class FakeClassnameTags123Api
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/PetApi.php
@@ -143,7 +143,7 @@ class PetApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/StoreApi.php
@@ -126,7 +126,7 @@ class StoreApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/src/Api/UserApi.php
@@ -138,7 +138,7 @@ class UserApi
     /**
      * @return Configuration
      */
-    public function getConfig(): Configuration
+    public function config(): Configuration
     {
         return $this->config;
     }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/test/PetApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/test/PetApiTest.php
@@ -81,7 +81,7 @@ class PetApiTest extends TestCase
      * // initialize the API client without host
      * $pet_id = 10005;  // ID of pet that needs to be fetched
      * $pet_api = new Api\PetApi();
-     * $pet_api->getApiClient()->getConfig()->setApiKey('api_key', '111222333444555');
+     * $pet_api->getApiClient()->config()->setApiKey('api_key', '111222333444555');
      * // return Pet (inline model)
      * $response = $pet_api->getPetByIdInObject($pet_id);
      * $this->assertInstanceOf('OpenAPI\Client\Model\InlineResponse200', $response);

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/AnotherFakeApi.php
@@ -117,7 +117,7 @@ class AnotherFakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/DefaultApi.php
@@ -117,7 +117,7 @@ class DefaultApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeApi.php
@@ -181,7 +181,7 @@ class FakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/FakeClassnameTags123Api.php
@@ -117,7 +117,7 @@ class FakeClassnameTags123Api
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/PetApi.php
@@ -143,7 +143,7 @@ class PetApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/StoreApi.php
@@ -126,7 +126,7 @@ class StoreApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/lib/Api/UserApi.php
@@ -138,7 +138,7 @@ class UserApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/OpenAPIClient-php/tests/PetApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/tests/PetApiTest.php
@@ -79,7 +79,7 @@ class PetApiTest extends TestCase
      * // initialize the API client without host
      * $pet_id = 10005;  // ID of pet that needs to be fetched
      * $pet_api = new Api\PetApi();
-     * $pet_api->getApiClient()->getConfig()->setApiKey('api_key', '111222333444555');
+     * $pet_api->getApiClient()->config()->setApiKey('api_key', '111222333444555');
      * // return Pet (inline model)
      * $response = $pet_api->getPetByIdInObject($pet_id);
      * $this->assertInstanceOf('OpenAPI\Client\Model\InlineResponse200', $response);

--- a/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/AnotherFakeApi.php
@@ -168,7 +168,7 @@ class AnotherFakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/DefaultApi.php
@@ -168,7 +168,7 @@ class DefaultApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeApi.php
@@ -168,7 +168,7 @@ class FakeApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/FakeClassnameTags123Api.php
@@ -168,7 +168,7 @@ class FakeClassnameTags123Api
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/PetApi.php
@@ -168,7 +168,7 @@ class PetApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/StoreApi.php
@@ -168,7 +168,7 @@ class StoreApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }

--- a/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
+++ b/samples/client/petstore/php/psr-18/lib/Api/UserApi.php
@@ -168,7 +168,7 @@ class UserApi
     /**
      * @return Configuration
      */
-    public function getConfig()
+    public function config()
     {
         return $this->config;
     }


### PR DESCRIPTION
_This is a BC break_

When target API contains `GET /config` endpoint, the codegen generates two methods with name `getConfig()`. That causes PHP Fatal error: Cannot redeclare My\Ns\...\Api\ConfigApi::getConfig() in /file.php

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
