### PR TITLE
[go-server] Set default values in object properties

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -591,7 +591,12 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{paramName}}Param := r.Header.Get("{{baseName}}")
 	{{/isHeaderParam}}
 	{{#isBodyParam}}
+	{{#isArray}}
 	{{paramName}}Param := {{dataType}}{}
+	{{/isArray}}
+	{{^isArray}}
+	{{paramName}}Param := New{{dataType}}WithDefaults()
+	{{/isArray}}
 	d := json.NewDecoder(r.Body)
 	{{^isAdditionalPropertiesTrue}}
 	d.DisallowUnknownFields()

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -74,7 +74,34 @@ type {{classname}} struct {
 	{{/deprecated}}
 	{{name}} {{#isNullable}}*{{/isNullable}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
-}{{/isEnum}}
+}
+
+{{^isArray}}
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() {{classname}} {
+	this := {{classname}}{}
+{{#parent}}
+{{^isMap}}
+{{^isArray}}
+	this.{{{parent}}} = New{{{parent}}}WithDefaults()
+{{/isArray}}
+{{/isMap}}
+{{/parent}}
+{{#vars}}
+{{#defaultValue}}
+{{^isArray}}
+	this.{{name}} = {{#isBoolean}}{{{.}}}{{/isBoolean}}{{#isNumeric}}{{{.}}}{{/isNumeric}}{{^isBoolean}}{{^isNumeric}}"{{{.}}}"{{/isNumeric}}{{/isBoolean}}
+{{/isArray}}
+{{/defaultValue}}
+{{#isModel}}
+	{{#isNullable}}*{{/isNullable}}this.{{name}} = New{{dataType}}WithDefaults()
+{{/isModel}}
+{{/vars}}
+	return this
+}{{/isArray}}
+{{/isEnum}}
 
 // Assert{{classname}}Required checks if the required fields are not zero-ed
 func Assert{{classname}}Required(obj {{classname}}) error {

--- a/modules/openapi-generator/src/test/resources/3_0/go-server/petstore_with_test_endpoint.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/go-server/petstore_with_test_endpoint.yaml
@@ -651,6 +651,7 @@ components:
         quantity:
           type: integer
           format: int32
+          default: 1
         shipDate:
           type: string
           format: date-time
@@ -669,6 +670,7 @@ components:
           type: string
         type:
           type: string
+          default: "dog"
       required:
         - requireTest
       xml:
@@ -687,9 +689,6 @@ components:
         petId:
           type: integer
           format: int64
-        quantity:
-          type: integer
-          format: int32
         shipDate:
           type: string
           format: date-time
@@ -700,6 +699,7 @@ components:
             - placed
             - approved
             - delivered
+          default: "placed"
         complete:
           type: boolean
           default: false

--- a/samples/openapi3/server/petstore/go/api_store_test.go
+++ b/samples/openapi3/server/petstore/go/api_store_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	petstoreserver "go-petstore/go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	petstoreserver "go-petstore/go"
 )
 
 type StoreAPITestService struct {
@@ -61,9 +62,7 @@ func TestPlaceOrderOK(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewStoreAPIController(service)
-	controller, ok := router.(*petstoreserver.StoreAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewStoreAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.PlaceOrder(w, req)
@@ -107,9 +106,7 @@ func TestPlaceOrderFailEmbeddedRequired(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewStoreAPIController(service)
-	controller, ok := router.(*petstoreserver.StoreAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewStoreAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.PlaceOrder(w, req)

--- a/samples/openapi3/server/petstore/go/api_user_test.go
+++ b/samples/openapi3/server/petstore/go/api_user_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	petstoreserver "go-petstore/go"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	petstoreserver "go-petstore/go"
 )
 
 type UserAPITestService struct {
@@ -115,9 +116,7 @@ func TestCreateUserOK(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewUserAPIController(service)
-	controller, ok := router.(*petstoreserver.UserAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewUserAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.CreateUser(w, req)
@@ -214,9 +213,7 @@ func TestCreateUserOKNullablePhone(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewUserAPIController(service)
-	controller, ok := router.(*petstoreserver.UserAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewUserAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.CreateUser(w, req)
@@ -258,9 +255,7 @@ func TestCreateUserFailDeepSliceModelRequired(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewUserAPIController(service)
-	controller, ok := router.(*petstoreserver.UserAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewUserAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.CreateUser(w, req)
@@ -328,7 +323,7 @@ func TestLoginUserOK(t *testing.T) {
 		status = http.StatusOK
 	)
 
-	req := httptest.NewRequest(http.MethodPost, "/user/login?username=test&int32_test=1&int64_test=2&float32_test=1.1&float64_test=1.2&boolean_test=true", nil)
+	req := httptest.NewRequest(http.MethodPost, "/user/login?username=test&password=test&int32_test=1&int64_test=2&float32_test=1.1&float64_test=1.2&boolean_test=true", nil)
 	w := httptest.NewRecorder()
 
 	// Create the service and inject the logic
@@ -345,9 +340,7 @@ func TestLoginUserOK(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewUserAPIController(service)
-	controller, ok := router.(*petstoreserver.UserAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewUserAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.LoginUser(w, req)
@@ -367,7 +360,7 @@ func TestLoginUserOKOptional(t *testing.T) {
 		status = http.StatusOK
 	)
 
-	req := httptest.NewRequest(http.MethodPost, "/user/login?username=test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/user/login?username=test&password=test", nil)
 	w := httptest.NewRecorder()
 
 	// Create the service and inject the logic
@@ -385,9 +378,7 @@ func TestLoginUserOKOptional(t *testing.T) {
 	}
 
 	// Create the controller with the service
-	router := petstoreserver.NewUserAPIController(service)
-	controller, ok := router.(*petstoreserver.UserAPIController)
-	require.True(t, ok)
+	controller := petstoreserver.NewUserAPIController(service)
 
 	// Call the method of controller we are testing
 	controller.LoginUser(w, req)

--- a/samples/openapi3/server/petstore/go/go-petstore/api/openapi.yaml
+++ b/samples/openapi3/server/petstore/go/go-petstore/api/openapi.yaml
@@ -662,6 +662,7 @@ components:
           format: int64
           type: integer
         quantity:
+          default: 1
           format: int32
           type: integer
         shipDate:
@@ -681,6 +682,7 @@ components:
         requireTest:
           type: string
         type:
+          default: dog
           type: string
       required:
       - requireTest
@@ -695,7 +697,6 @@ components:
       description: An order for a pets from the pet store
       example:
         petId: 6
-        quantity: 1
         comment: comment
         id: 0
         shipDate: 2000-01-23T04:56:07.000+00:00
@@ -708,13 +709,11 @@ components:
         petId:
           format: int64
           type: integer
-        quantity:
-          format: int32
-          type: integer
         shipDate:
           format: date-time
           type: string
         status:
+          default: placed
           description: Order Status
           enum:
           - placed

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -97,7 +97,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -208,7 +208,7 @@ func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
@@ -127,7 +127,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	orderParam := NewOrderWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -348,7 +348,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_an_object.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_an_object.go
@@ -22,6 +22,15 @@ type AnObject struct {
 	Pet []Pet `json:"Pet,omitempty"`
 }
 
+// NewAnObjectWithDefaults instantiates a new AnObject object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewAnObjectWithDefaults() AnObject {
+	this := AnObject{}
+	this.Tag = NewTagWithDefaults()
+	return this
+}
+
 // AssertAnObjectRequired checks if the required fields are not zero-ed
 func AssertAnObjectRequired(obj AnObject) error {
 	if err := AssertTagRequired(obj.Tag); err != nil {

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_api_response.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_api_response.go
@@ -23,6 +23,14 @@ type ApiResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+// NewApiResponseWithDefaults instantiates a new ApiResponse object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewApiResponseWithDefaults() ApiResponse {
+	this := ApiResponse{}
+	return this
+}
+
 // AssertApiResponseRequired checks if the required fields are not zero-ed
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_category.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_category.go
@@ -21,6 +21,14 @@ type Category struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewCategoryWithDefaults instantiates a new Category object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewCategoryWithDefaults() Category {
+	this := Category{}
+	return this
+}
+
 // AssertCategoryRequired checks if the required fields are not zero-ed
 func AssertCategoryRequired(obj Category) error {
 	return nil

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_order.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_order.go
@@ -25,8 +25,6 @@ type Order struct {
 
 	PetId int64 `json:"petId,omitempty"`
 
-	Quantity int32 `json:"quantity,omitempty"`
-
 	ShipDate time.Time `json:"shipDate,omitempty"`
 
 	// Order Status
@@ -35,6 +33,20 @@ type Order struct {
 	Complete bool `json:"complete,omitempty"`
 
 	Comment *string `json:"comment"`
+
+	Quantity int32 `json:"quantity,omitempty"`
+}
+
+// NewOrderWithDefaults instantiates a new Order object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderWithDefaults() Order {
+	this := Order{}
+	this.SpecialInfo = NewSpecialInfoWithDefaults()
+	this.Status = "placed"
+	this.Complete = false
+	this.Quantity = 1
+	return this
 }
 
 // AssertOrderRequired checks if the required fields are not zero-ed

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_order_info.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_order_info.go
@@ -27,6 +27,15 @@ type OrderInfo struct {
 	ShipDate time.Time `json:"shipDate,omitempty"`
 }
 
+// NewOrderInfoWithDefaults instantiates a new OrderInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderInfoWithDefaults() OrderInfo {
+	this := OrderInfo{}
+	this.Quantity = 1
+	return this
+}
+
 // AssertOrderInfoRequired checks if the required fields are not zero-ed
 func AssertOrderInfoRequired(obj OrderInfo) error {
 	return nil

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_pet.go
@@ -31,6 +31,15 @@ type Pet struct {
 	Status string `json:"status,omitempty"`
 }
 
+// NewPetWithDefaults instantiates a new Pet object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewPetWithDefaults() Pet {
+	this := Pet{}
+	*this.Category = NewCategoryWithDefaults()
+	return this
+}
+
 // AssertPetRequired checks if the required fields are not zero-ed
 func AssertPetRequired(obj Pet) error {
 	elements := map[string]interface{}{

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_special_info.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_special_info.go
@@ -23,6 +23,15 @@ type SpecialInfo struct {
 	Type string `json:"type,omitempty"`
 }
 
+// NewSpecialInfoWithDefaults instantiates a new SpecialInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewSpecialInfoWithDefaults() SpecialInfo {
+	this := SpecialInfo{}
+	this.Type = "dog"
+	return this
+}
+
 // AssertSpecialInfoRequired checks if the required fields are not zero-ed
 func AssertSpecialInfoRequired(obj SpecialInfo) error {
 	elements := map[string]interface{}{

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_tag.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_tag.go
@@ -21,6 +21,14 @@ type Tag struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewTagWithDefaults instantiates a new Tag object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewTagWithDefaults() Tag {
+	this := Tag{}
+	return this
+}
+
 // AssertTagRequired checks if the required fields are not zero-ed
 func AssertTagRequired(obj Tag) error {
 	return nil

--- a/samples/openapi3/server/petstore/go/go-petstore/go/model_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/model_user.go
@@ -40,6 +40,14 @@ type User struct {
 	DeepSliceMap [][]AnObject `json:"deepSliceMap,omitempty"`
 }
 
+// NewUserWithDefaults instantiates a new User object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewUserWithDefaults() User {
+	this := User{}
+	return this
+}
+
 // AssertUserRequired checks if the required fields are not zero-ed
 func AssertUserRequired(obj User) error {
 	elements := map[string]interface{}{

--- a/samples/openapi3/server/petstore/go/model_store_test.go
+++ b/samples/openapi3/server/petstore/go/model_store_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"testing"
+
+	petstoreserver "go-petstore/go"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPlaceOrderOK tests PlaceOrder operation. This operation contains Order which has an
+// embedding struct that will be tested as well.
+func TestDefaultValues(t *testing.T) {
+	m := petstoreserver.NewOrderWithDefaults()
+
+	assert.Equal(t, "placed", m.Status)
+
+	// Order object contain this definition
+	// allOf:
+	// - $ref: '#/components/schemas/OrderInfo'
+	// - $ref: '#/components/schemas/SpecialInfo'
+
+	// Quantity comes from composition with OrderInfo
+	assert.Equal(t, int32(1), m.Quantity)
+
+	// SpecialInfo is embedded in Order struct
+	assert.Equal(t, "dog", m.SpecialInfo.Type)
+}

--- a/samples/server/others/go-server/no-body-path-params/go/api_body.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_body.go
@@ -59,7 +59,7 @@ func (c *BodyAPIController) Routes() Routes {
 
 // Body - summary
 func (c *BodyAPIController) Body(w http.ResponseWriter, r *http.Request) {
-	bodyRequestParam := BodyRequest{}
+	bodyRequestParam := NewBodyRequestWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&bodyRequestParam); err != nil {

--- a/samples/server/others/go-server/no-body-path-params/go/api_both.go
+++ b/samples/server/others/go-server/no-body-path-params/go/api_both.go
@@ -67,7 +67,7 @@ func (c *BothAPIController) Both(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"pathParam"}, nil)
 		return
 	}
-	bodyRequestParam := BodyRequest{}
+	bodyRequestParam := NewBodyRequestWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&bodyRequestParam); err != nil {

--- a/samples/server/others/go-server/no-body-path-params/go/model_body_request.go
+++ b/samples/server/others/go-server/no-body-path-params/go/model_body_request.go
@@ -18,6 +18,14 @@ type BodyRequest struct {
 	Param string `json:"param,omitempty"`
 }
 
+// NewBodyRequestWithDefaults instantiates a new BodyRequest object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewBodyRequestWithDefaults() BodyRequest {
+	this := BodyRequest{}
+	return this
+}
+
 // AssertBodyRequestRequired checks if the required fields are not zero-ed
 func AssertBodyRequestRequired(obj BodyRequest) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -128,7 +128,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -543,7 +543,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -129,7 +129,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	orderParam := NewOrderWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -295,7 +295,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {

--- a/samples/server/petstore/go-api-server/go/model_an_object.go
+++ b/samples/server/petstore/go-api-server/go/model_an_object.go
@@ -22,6 +22,15 @@ type AnObject struct {
 	Pet []Pet `json:"Pet,omitempty"`
 }
 
+// NewAnObjectWithDefaults instantiates a new AnObject object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewAnObjectWithDefaults() AnObject {
+	this := AnObject{}
+	this.Tag = NewTagWithDefaults()
+	return this
+}
+
 // AssertAnObjectRequired checks if the required fields are not zero-ed
 func AssertAnObjectRequired(obj AnObject) error {
 	if err := AssertTagRequired(obj.Tag); err != nil {

--- a/samples/server/petstore/go-api-server/go/model_api_response.go
+++ b/samples/server/petstore/go-api-server/go/model_api_response.go
@@ -23,6 +23,14 @@ type ApiResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+// NewApiResponseWithDefaults instantiates a new ApiResponse object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewApiResponseWithDefaults() ApiResponse {
+	this := ApiResponse{}
+	return this
+}
+
 // AssertApiResponseRequired checks if the required fields are not zero-ed
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_category.go
+++ b/samples/server/petstore/go-api-server/go/model_category.go
@@ -21,6 +21,14 @@ type Category struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewCategoryWithDefaults instantiates a new Category object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewCategoryWithDefaults() Category {
+	this := Category{}
+	return this
+}
+
 // AssertCategoryRequired checks if the required fields are not zero-ed
 func AssertCategoryRequired(obj Category) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_colour.go
+++ b/samples/server/petstore/go-api-server/go/model_colour.go
@@ -55,7 +55,6 @@ func NewColourFromValue(v string) (Colour, error) {
 }
 
 
-
 // AssertColourRequired checks if the required fields are not zero-ed
 func AssertColourRequired(obj Colour) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_gender.go
+++ b/samples/server/petstore/go-api-server/go/model_gender.go
@@ -55,7 +55,6 @@ func NewGenderFromValue(v string) (Gender, error) {
 }
 
 
-
 // AssertGenderRequired checks if the required fields are not zero-ed
 func AssertGenderRequired(obj Gender) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_order.go
+++ b/samples/server/petstore/go-api-server/go/model_order.go
@@ -37,6 +37,16 @@ type Order struct {
 	Comment *string `json:"comment"`
 }
 
+// NewOrderWithDefaults instantiates a new Order object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderWithDefaults() Order {
+	this := Order{}
+	this.SpecialInfo = NewSpecialInfoWithDefaults()
+	this.Complete = false
+	return this
+}
+
 // AssertOrderRequired checks if the required fields are not zero-ed
 func AssertOrderRequired(obj Order) error {
 	elements := map[string]interface{}{

--- a/samples/server/petstore/go-api-server/go/model_order_info.go
+++ b/samples/server/petstore/go-api-server/go/model_order_info.go
@@ -27,6 +27,14 @@ type OrderInfo struct {
 	ShipDate time.Time `json:"shipDate,omitempty"`
 }
 
+// NewOrderInfoWithDefaults instantiates a new OrderInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderInfoWithDefaults() OrderInfo {
+	this := OrderInfo{}
+	return this
+}
+
 // AssertOrderInfoRequired checks if the required fields are not zero-ed
 func AssertOrderInfoRequired(obj OrderInfo) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_pet.go
+++ b/samples/server/petstore/go-api-server/go/model_pet.go
@@ -31,6 +31,15 @@ type Pet struct {
 	Status string `json:"status,omitempty"`
 }
 
+// NewPetWithDefaults instantiates a new Pet object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewPetWithDefaults() Pet {
+	this := Pet{}
+	*this.Category = NewCategoryWithDefaults()
+	return this
+}
+
 // AssertPetRequired checks if the required fields are not zero-ed
 func AssertPetRequired(obj Pet) error {
 	elements := map[string]interface{}{

--- a/samples/server/petstore/go-api-server/go/model_special_info.go
+++ b/samples/server/petstore/go-api-server/go/model_special_info.go
@@ -21,6 +21,14 @@ type SpecialInfo struct {
 	Type string `json:"type,omitempty"`
 }
 
+// NewSpecialInfoWithDefaults instantiates a new SpecialInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewSpecialInfoWithDefaults() SpecialInfo {
+	this := SpecialInfo{}
+	return this
+}
+
 // AssertSpecialInfoRequired checks if the required fields are not zero-ed
 func AssertSpecialInfoRequired(obj SpecialInfo) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_species.go
+++ b/samples/server/petstore/go-api-server/go/model_species.go
@@ -64,7 +64,6 @@ func NewSpeciesFromValue(v string) (Species, error) {
 }
 
 
-
 // AssertSpeciesRequired checks if the required fields are not zero-ed
 func AssertSpeciesRequired(obj Species) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_tag.go
+++ b/samples/server/petstore/go-api-server/go/model_tag.go
@@ -21,6 +21,14 @@ type Tag struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewTagWithDefaults instantiates a new Tag object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewTagWithDefaults() Tag {
+	this := Tag{}
+	return this
+}
+
 // AssertTagRequired checks if the required fields are not zero-ed
 func AssertTagRequired(obj Tag) error {
 	return nil

--- a/samples/server/petstore/go-api-server/go/model_user.go
+++ b/samples/server/petstore/go-api-server/go/model_user.go
@@ -40,6 +40,14 @@ type User struct {
 	DeepSliceMap [][]AnObject `json:"deepSliceMap,omitempty"`
 }
 
+// NewUserWithDefaults instantiates a new User object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewUserWithDefaults() User {
+	this := User{}
+	return this
+}
+
 // AssertUserRequired checks if the required fields are not zero-ed
 func AssertUserRequired(obj User) error {
 	elements := map[string]interface{}{

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -128,7 +128,7 @@ func (c *PetAPIController) Routes() Routes {
 
 // AddPet - Add a new pet to the store
 func (c *PetAPIController) AddPet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {
@@ -537,7 +537,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 
 // UpdatePet - Update an existing pet
 func (c *PetAPIController) UpdatePet(w http.ResponseWriter, r *http.Request) {
-	petParam := Pet{}
+	petParam := NewPetWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&petParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -127,7 +127,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 
 // PlaceOrder - Place an order for a pet
 func (c *StoreAPIController) PlaceOrder(w http.ResponseWriter, r *http.Request) {
-	orderParam := Order{}
+	orderParam := NewOrderWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&orderParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -96,7 +96,7 @@ func (c *UserAPIController) Routes() Routes {
 
 // CreateUser - Create user
 func (c *UserAPIController) CreateUser(w http.ResponseWriter, r *http.Request) {
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {
@@ -292,7 +292,7 @@ func (c *UserAPIController) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		c.errorHandler(w, r, &RequiredError{"username"}, nil)
 		return
 	}
-	userParam := User{}
+	userParam := NewUserWithDefaults()
 	d := json.NewDecoder(r.Body)
 	d.DisallowUnknownFields()
 	if err := d.Decode(&userParam); err != nil {

--- a/samples/server/petstore/go-chi-server/go/model_an_object.go
+++ b/samples/server/petstore/go-chi-server/go/model_an_object.go
@@ -22,6 +22,15 @@ type AnObject struct {
 	Pet []Pet `json:"Pet,omitempty"`
 }
 
+// NewAnObjectWithDefaults instantiates a new AnObject object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewAnObjectWithDefaults() AnObject {
+	this := AnObject{}
+	this.Tag = NewTagWithDefaults()
+	return this
+}
+
 // AssertAnObjectRequired checks if the required fields are not zero-ed
 func AssertAnObjectRequired(obj AnObject) error {
 	if err := AssertTagRequired(obj.Tag); err != nil {

--- a/samples/server/petstore/go-chi-server/go/model_api_response.go
+++ b/samples/server/petstore/go-chi-server/go/model_api_response.go
@@ -23,6 +23,14 @@ type ApiResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
+// NewApiResponseWithDefaults instantiates a new ApiResponse object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewApiResponseWithDefaults() ApiResponse {
+	this := ApiResponse{}
+	return this
+}
+
 // AssertApiResponseRequired checks if the required fields are not zero-ed
 func AssertApiResponseRequired(obj ApiResponse) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_category.go
+++ b/samples/server/petstore/go-chi-server/go/model_category.go
@@ -21,6 +21,14 @@ type Category struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewCategoryWithDefaults instantiates a new Category object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewCategoryWithDefaults() Category {
+	this := Category{}
+	return this
+}
+
 // AssertCategoryRequired checks if the required fields are not zero-ed
 func AssertCategoryRequired(obj Category) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_colour.go
+++ b/samples/server/petstore/go-chi-server/go/model_colour.go
@@ -55,7 +55,6 @@ func NewColourFromValue(v string) (Colour, error) {
 }
 
 
-
 // AssertColourRequired checks if the required fields are not zero-ed
 func AssertColourRequired(obj Colour) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_gender.go
+++ b/samples/server/petstore/go-chi-server/go/model_gender.go
@@ -55,7 +55,6 @@ func NewGenderFromValue(v string) (Gender, error) {
 }
 
 
-
 // AssertGenderRequired checks if the required fields are not zero-ed
 func AssertGenderRequired(obj Gender) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_order.go
+++ b/samples/server/petstore/go-chi-server/go/model_order.go
@@ -37,6 +37,16 @@ type Order struct {
 	Comment *string `json:"comment"`
 }
 
+// NewOrderWithDefaults instantiates a new Order object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderWithDefaults() Order {
+	this := Order{}
+	this.SpecialInfo = NewSpecialInfoWithDefaults()
+	this.Complete = false
+	return this
+}
+
 // AssertOrderRequired checks if the required fields are not zero-ed
 func AssertOrderRequired(obj Order) error {
 	elements := map[string]interface{}{

--- a/samples/server/petstore/go-chi-server/go/model_order_info.go
+++ b/samples/server/petstore/go-chi-server/go/model_order_info.go
@@ -27,6 +27,14 @@ type OrderInfo struct {
 	ShipDate time.Time `json:"shipDate,omitempty"`
 }
 
+// NewOrderInfoWithDefaults instantiates a new OrderInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewOrderInfoWithDefaults() OrderInfo {
+	this := OrderInfo{}
+	return this
+}
+
 // AssertOrderInfoRequired checks if the required fields are not zero-ed
 func AssertOrderInfoRequired(obj OrderInfo) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_pet.go
+++ b/samples/server/petstore/go-chi-server/go/model_pet.go
@@ -31,6 +31,15 @@ type Pet struct {
 	Status string `json:"status,omitempty"`
 }
 
+// NewPetWithDefaults instantiates a new Pet object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewPetWithDefaults() Pet {
+	this := Pet{}
+	*this.Category = NewCategoryWithDefaults()
+	return this
+}
+
 // AssertPetRequired checks if the required fields are not zero-ed
 func AssertPetRequired(obj Pet) error {
 	elements := map[string]interface{}{

--- a/samples/server/petstore/go-chi-server/go/model_special_info.go
+++ b/samples/server/petstore/go-chi-server/go/model_special_info.go
@@ -21,6 +21,14 @@ type SpecialInfo struct {
 	Type string `json:"type,omitempty"`
 }
 
+// NewSpecialInfoWithDefaults instantiates a new SpecialInfo object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewSpecialInfoWithDefaults() SpecialInfo {
+	this := SpecialInfo{}
+	return this
+}
+
 // AssertSpecialInfoRequired checks if the required fields are not zero-ed
 func AssertSpecialInfoRequired(obj SpecialInfo) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_species.go
+++ b/samples/server/petstore/go-chi-server/go/model_species.go
@@ -64,7 +64,6 @@ func NewSpeciesFromValue(v string) (Species, error) {
 }
 
 
-
 // AssertSpeciesRequired checks if the required fields are not zero-ed
 func AssertSpeciesRequired(obj Species) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_tag.go
+++ b/samples/server/petstore/go-chi-server/go/model_tag.go
@@ -21,6 +21,14 @@ type Tag struct {
 	Name string `json:"name,omitempty"`
 }
 
+// NewTagWithDefaults instantiates a new Tag object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewTagWithDefaults() Tag {
+	this := Tag{}
+	return this
+}
+
 // AssertTagRequired checks if the required fields are not zero-ed
 func AssertTagRequired(obj Tag) error {
 	return nil

--- a/samples/server/petstore/go-chi-server/go/model_user.go
+++ b/samples/server/petstore/go-chi-server/go/model_user.go
@@ -40,6 +40,14 @@ type User struct {
 	DeepSliceMap [][]AnObject `json:"deepSliceMap,omitempty"`
 }
 
+// NewUserWithDefaults instantiates a new User object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func NewUserWithDefaults() User {
+	this := User{}
+	return this
+}
+
 // AssertUserRequired checks if the required fields are not zero-ed
 func AssertUserRequired(obj User) error {
 	elements := map[string]interface{}{


### PR DESCRIPTION
When a default value is set for an object property, ensure it is set into the struct before decoding the JSON body.

Fix OpenAPITools#4579