### PR TITLE
[go-server] add field name in parsing error messages

### DIFF
--- a/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/controller-api.mustache
@@ -116,7 +116,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isNumber}}
@@ -130,7 +130,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isFloat}}
@@ -144,7 +144,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float64]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isDouble}}
@@ -158,7 +158,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int64]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isLong}}
@@ -172,14 +172,14 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isInteger}}
 	{{#isDateTime}}
 	{{paramName}}Param, err := parseTime({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isDateTime}}
@@ -199,7 +199,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	{{#isEnumRef}}
 	{{paramName}}Param, err := New{{dataType}}FromValue({{#routers}}{{#mux}}params["{{baseName}}"]{{/mux}}{{#chi}}chi.URLParam(r, "{{baseName}}"){{/chi}}{{/routers}})
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isEnumRef}}
@@ -216,7 +216,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 	if query.Has("{{baseName}}"){
 		param, err := parseTime(query.Get("{{baseName}}"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -238,7 +238,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[float32]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -266,7 +266,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[float32]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -294,7 +294,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[float64]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -322,7 +322,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[int64]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -350,7 +350,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[int32]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -378,7 +378,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 			WithMaximum[bool]({{maximum}}),{{/maximum}}
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -405,7 +405,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/items.isNumber}}
@@ -417,7 +417,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 	return
 	}
 	{{/items.isFloat}}
@@ -429,7 +429,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[float64]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/items.isDouble}}
@@ -441,7 +441,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int64]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/items.isLong}}
@@ -453,14 +453,14 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/items.isInteger}}
 	{{#items.isDateTime}}
 	{{paramName}}Param, err := parseTimes(query.Get("{{baseName"}}))
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/items.isDateTime}}
@@ -483,7 +483,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		for _, param := range paramSplits {
 			paramEnum, err := New{{items.dataType}}FromValue(param)
 			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+				c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 				return
 			}
 			{{paramName}}Param = append({{paramName}}Param, paramEnum)
@@ -541,7 +541,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		param, err := ReadFormFileToTempFile(r, "{{baseName}}")
 		{{/isArray}}
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 			return
 		}
 
@@ -556,7 +556,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int64]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isArray}}{{/isLong}}
@@ -568,7 +568,7 @@ func (c *{{classname}}Controller) {{nickname}}(w http.ResponseWriter, r *http.Re
 		WithMaximum[int32]({{maximum}}),{{/maximum}}
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "{{baseName}}", Err: err}, nil)
 		return
 	}
 	{{/isArray}}{{/isInteger}}

--- a/modules/openapi-generator/src/main/resources/go-server/error.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/error.mustache
@@ -14,7 +14,8 @@ var (
 
 // ParsingError indicates that an error has occurred when parsing request parameters
 type ParsingError struct {
-	Err error
+	Param string
+	Err   error
 }
 
 func (e *ParsingError) Unwrap() error {
@@ -22,7 +23,11 @@ func (e *ParsingError) Unwrap() error {
 }
 
 func (e *ParsingError) Error() string {
-	return e.Err.Error()
+	if e.Param == "" {
+		return e.Err.Error()
+	} else {
+		return e.Param + ": " + e.Err.Error()
+	}
 }
 
 // RequiredError indicates that an error has occurred when parsing request parameters

--- a/modules/openapi-generator/src/main/resources/go-server/model.mustache
+++ b/modules/openapi-generator/src/main/resources/go-server/model.mustache
@@ -166,12 +166,12 @@ func Assert{{classname}}Constraints(obj {{classname}}) error {
 {{#Vars}}
 {{#minimum}}
 	if {{#isNullable}}obj.{{name}} != nil && *{{/isNullable}}obj.{{name}} < {{minimum}} {
-		return &ParsingError{Err: errors.New(errMsgMinValueConstraint)}
+		return &ParsingError{Param: "{{name}}", Err: errors.New(errMsgMinValueConstraint)}
 	}
 {{/minimum}}
 {{#maximum}}
 	if {{#isNullable}}obj.{{name}} != nil && *{{/isNullable}}obj.{{name}} > {{maximum}} {
-		return &ParsingError{Err: errors.New(errMsgMaxValueConstraint)}
+		return &ParsingError{Param: "{{name}}", Err: errors.New(errMsgMaxValueConstraint)}
 	}
 {{/maximum}}
 {{/Vars}}

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_pet.go
@@ -129,7 +129,7 @@ func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	apiKeyParam := r.Header.Get("api_key")
@@ -193,7 +193,7 @@ func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetById(r.Context(), petIdParam)
@@ -244,7 +244,7 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -274,7 +274,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -284,7 +284,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	{
 		param, err := ReadFormFileToTempFile(r, "file")
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
 			return
 		}
 

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_store.go
@@ -112,7 +112,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 		WithMaximum[int64](5),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "orderId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetOrderById(r.Context(), orderIdParam)

--- a/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/api_user.go
@@ -190,7 +190,7 @@ func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 
@@ -256,7 +256,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[int32](parseInt32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "int32_test", Err: err}, nil)
 			return
 		}
 
@@ -270,7 +270,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[int64](parseInt64),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "int64_test", Err: err}, nil)
 			return
 		}
 
@@ -284,7 +284,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[float32](parseFloat32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "float32_test", Err: err}, nil)
 			return
 		}
 
@@ -298,7 +298,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[float64](parseFloat64),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "float64_test", Err: err}, nil)
 			return
 		}
 
@@ -312,7 +312,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 

--- a/samples/openapi3/server/petstore/go/go-petstore/go/error.go
+++ b/samples/openapi3/server/petstore/go/go-petstore/go/error.go
@@ -23,7 +23,8 @@ var (
 
 // ParsingError indicates that an error has occurred when parsing request parameters
 type ParsingError struct {
-	Err error
+	Param string
+	Err   error
 }
 
 func (e *ParsingError) Unwrap() error {
@@ -31,7 +32,11 @@ func (e *ParsingError) Unwrap() error {
 }
 
 func (e *ParsingError) Error() string {
-	return e.Err.Error()
+	if e.Param == "" {
+		return e.Err.Error()
+	} else {
+		return e.Param + ": " + e.Err.Error()
+	}
 }
 
 // RequiredError indicates that an error has occurred when parsing request parameters

--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -161,7 +161,7 @@ func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	apiKeyParam := r.Header.Get("api_key")
@@ -185,7 +185,7 @@ func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.R
 	}
 	genderParam, err := NewGenderFromValue(params["gender"])
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
 		return
 	}
 	var speciesParam Species
@@ -204,7 +204,7 @@ func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.R
 		for _, param := range paramSplits {
 			paramEnum, err := NewSpeciesFromValue(param)
 			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
 				return
 			}
 			notSpeciesParam = append(notSpeciesParam, paramEnum)
@@ -270,7 +270,7 @@ func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	if query.Has("bornAfter"){
 		param, err := parseTime(query.Get("bornAfter"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
 			return
 		}
 
@@ -283,7 +283,7 @@ func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	if query.Has("bornBefore"){
 		param, err := parseTime(query.Get("bornBefore"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
 			return
 		}
 
@@ -315,7 +315,7 @@ func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetById(r.Context(), petIdParam)
@@ -336,7 +336,7 @@ func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Reques
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
@@ -354,7 +354,7 @@ func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request)
 	params := mux.Vars(r)
 	createdTimeParam, err := parseTime(params["createdTime"])
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
@@ -381,7 +381,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
 			return
 		}
 
@@ -397,7 +397,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
 			return
 		}
 
@@ -411,7 +411,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
 			return
 		}
 
@@ -444,7 +444,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[int64](parseInt64),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "age", Err: err}, nil)
 			return
 		}
 
@@ -458,7 +458,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[float32](parseFloat32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "price", Err: err}, nil)
 			return
 		}
 
@@ -469,7 +469,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	if query.Has("bornAfter"){
 		param, err := parseTime(query.Get("bornAfter"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
 			return
 		}
 
@@ -483,7 +483,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "old", Err: err}, nil)
 			return
 		}
 
@@ -539,7 +539,7 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -570,7 +570,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -583,7 +583,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	{
 		param, err := ReadFormFileToTempFile(r, "file")
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
 			return
 		}
 
@@ -613,7 +613,7 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -623,7 +623,7 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	{
 		param, err := ReadFormFilesToTempFiles(r, "files")
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "files", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-api-server/go/api_store.go
+++ b/samples/server/petstore/go-api-server/go/api_store.go
@@ -114,7 +114,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 		WithMaximum[int64](5),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "orderId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetOrderById(r.Context(), orderIdParam)

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -191,7 +191,7 @@ func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 
@@ -258,7 +258,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-api-server/go/error.go
+++ b/samples/server/petstore/go-api-server/go/error.go
@@ -23,7 +23,8 @@ var (
 
 // ParsingError indicates that an error has occurred when parsing request parameters
 type ParsingError struct {
-	Err error
+	Param string
+	Err   error
 }
 
 func (e *ParsingError) Unwrap() error {
@@ -31,7 +32,11 @@ func (e *ParsingError) Unwrap() error {
 }
 
 func (e *ParsingError) Error() string {
-	return e.Err.Error()
+	if e.Param == "" {
+		return e.Err.Error()
+	} else {
+		return e.Param + ": " + e.Err.Error()
+	}
 }
 
 // RequiredError indicates that an error has occurred when parsing request parameters

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -160,7 +160,7 @@ func (c *PetAPIController) DeletePet(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	apiKeyParam := r.Header.Get("api_key")
@@ -183,7 +183,7 @@ func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.R
 	}
 	genderParam, err := NewGenderFromValue(chi.URLParam(r, "gender"))
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "gender", Err: err}, nil)
 		return
 	}
 	var speciesParam Species
@@ -202,7 +202,7 @@ func (c *PetAPIController) FilterPetsByCategory(w http.ResponseWriter, r *http.R
 		for _, param := range paramSplits {
 			paramEnum, err := NewSpeciesFromValue(param)
 			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+				c.errorHandler(w, r, &ParsingError{Param: "notSpecies", Err: err}, nil)
 				return
 			}
 			notSpeciesParam = append(notSpeciesParam, paramEnum)
@@ -267,7 +267,7 @@ func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	if query.Has("bornAfter"){
 		param, err := parseTime(query.Get("bornAfter"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
 			return
 		}
 
@@ -280,7 +280,7 @@ func (c *PetAPIController) FindPetsByTags(w http.ResponseWriter, r *http.Request
 	if query.Has("bornBefore"){
 		param, err := parseTime(query.Get("bornBefore"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornBefore", Err: err}, nil)
 			return
 		}
 
@@ -311,7 +311,7 @@ func (c *PetAPIController) GetPetById(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetById(r.Context(), petIdParam)
@@ -331,7 +331,7 @@ func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Reques
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetImageById(r.Context(), petIdParam)
@@ -348,7 +348,7 @@ func (c *PetAPIController) GetPetImageById(w http.ResponseWriter, r *http.Reques
 func (c *PetAPIController) GetPetsByTime(w http.ResponseWriter, r *http.Request) {
 	createdTimeParam, err := parseTime(chi.URLParam(r, "createdTime"))
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "createdTime", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetPetsByTime(r.Context(), createdTimeParam)
@@ -375,7 +375,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "expr", Err: err}, nil)
 			return
 		}
 
@@ -391,7 +391,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "grouping", Err: err}, nil)
 			return
 		}
 
@@ -405,7 +405,7 @@ func (c *PetAPIController) GetPetsUsingBooleanQueryParameters(w http.ResponseWri
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "inactive", Err: err}, nil)
 			return
 		}
 
@@ -438,7 +438,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[int64](parseInt64),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "age", Err: err}, nil)
 			return
 		}
 
@@ -452,7 +452,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[float32](parseFloat32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "price", Err: err}, nil)
 			return
 		}
 
@@ -463,7 +463,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 	if query.Has("bornAfter"){
 		param, err := parseTime(query.Get("bornAfter"))
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "bornAfter", Err: err}, nil)
 			return
 		}
 
@@ -477,7 +477,7 @@ func (c *PetAPIController) SearchPet(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "old", Err: err}, nil)
 			return
 		}
 
@@ -532,7 +532,7 @@ func (c *PetAPIController) UpdatePetWithForm(w http.ResponseWriter, r *http.Requ
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -562,7 +562,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -575,7 +575,7 @@ func (c *PetAPIController) UploadFile(w http.ResponseWriter, r *http.Request) {
 	{
 		param, err := ReadFormFileToTempFile(r, "file")
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "file", Err: err}, nil)
 			return
 		}
 
@@ -604,7 +604,7 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 		WithRequire[int64](parseInt64),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "petId", Err: err}, nil)
 		return
 	}
 	
@@ -614,7 +614,7 @@ func (c *PetAPIController) UploadFileArrayOfFiles(w http.ResponseWriter, r *http
 	{
 		param, err := ReadFormFilesToTempFiles(r, "files")
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "files", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-chi-server/go/api_store.go
+++ b/samples/server/petstore/go-chi-server/go/api_store.go
@@ -112,7 +112,7 @@ func (c *StoreAPIController) GetOrderById(w http.ResponseWriter, r *http.Request
 		WithMaximum[int64](5),
 	)
 	if err != nil {
-		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+		c.errorHandler(w, r, &ParsingError{Param: "orderId", Err: err}, nil)
 		return
 	}
 	result, err := c.service.GetOrderById(r.Context(), orderIdParam)

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -190,7 +190,7 @@ func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 
@@ -256,7 +256,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-chi-server/go/error.go
+++ b/samples/server/petstore/go-chi-server/go/error.go
@@ -23,7 +23,8 @@ var (
 
 // ParsingError indicates that an error has occurred when parsing request parameters
 type ParsingError struct {
-	Err error
+	Param string
+	Err   error
 }
 
 func (e *ParsingError) Unwrap() error {
@@ -31,7 +32,11 @@ func (e *ParsingError) Unwrap() error {
 }
 
 func (e *ParsingError) Error() string {
-	return e.Err.Error()
+	if e.Param == "" {
+		return e.Err.Error()
+	} else {
+		return e.Param + ": " + e.Err.Error()
+	}
 }
 
 // RequiredError indicates that an error has occurred when parsing request parameters


### PR DESCRIPTION
Currently when a min/max value for a number field is not respected, the api only returns a generic error message without providing any useful information to fix the request. This commit add the field name to the error message to help the user of the API.