### PR TITLE
scala-sttp4: fix for issue 15785 api returns unit.

### DIFF
--- a/modules/openapi-generator/src/main/resources/scala-sttp4/api.mustache
+++ b/modules/openapi-generator/src/main/resources/scala-sttp4/api.mustache
@@ -19,7 +19,7 @@ class {{classname}}(baseUrl: String) {
 {{#javadocRenderer}}
 {{>javadoc}}
 {{/javadocRenderer}}
-  def {{operationId}}({{>methodParameters}}): Request[{{#defaultReturnType}}Either[Either[String, String], Unit]{{/defaultReturnType}}{{^defaultReturnType}}{{#separateErrorChannel}}Either[ResponseException[String, Exception], {{>operationReturnType}}]{{/separateErrorChannel}}{{^separateErrorChannel}}{{>operationReturnType}}{{/separateErrorChannel}}{{/defaultReturnType}}] =
+  def {{operationId}}({{>methodParameters}}): Request[{{#separateErrorChannel}}Either[ResponseException[String, Exception], {{>operationReturnType}}]{{/separateErrorChannel}}{{^separateErrorChannel}}{{>operationReturnType}}{{/separateErrorChannel}}] =
     basicRequest
       .method(Method.{{httpMethod.toUpperCase}}, uri"$baseUrl{{{path}}}{{#queryParams.0}}?{{#queryParams}}{{baseName}}=${ {{{paramName}}} }{{^-last}}&{{/-last}}{{/queryParams}}{{/queryParams.0}}{{#isApiKey}}{{#isKeyInQuery}}{{^queryParams.0}}?{{/queryParams.0}}{{#queryParams.0}}&{{/queryParams.0}}{{keyParamName}}=${apiKey.value}&{{/isKeyInQuery}}{{/isApiKey}}")
       .contentType({{#consumes.0}}"{{{mediaType}}}"{{/consumes.0}}{{^consumes}}"application/json"{{/consumes}}){{#headerParams}}
@@ -35,7 +35,7 @@ class {{classname}}(baseUrl: String) {
         {{>paramMultipartCreation}}{{^-last}}, {{/-last}}{{/formParams}}
       ).flatten){{/isMultipart}}{{/formParams.0}}{{#bodyParam}}
       .body({{paramName}}){{/bodyParam}}
-      .response({{#defaultReturnType}}asEither(asString, ignore){{/defaultReturnType}}{{^defaultReturnType}}{{#separateErrorChannel}}asJson{{/separateErrorChannel}}{{^separateErrorChannel}}asJsonAlwaysUnsafe{{/separateErrorChannel}}[{{>operationReturnType}}]{{/defaultReturnType}})
+      .response({{#separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))){{/returnType}}{{#returnType}}asJson[{{>operationReturnType}}]{{/returnType}}{{/separateErrorChannel}}{{^separateErrorChannel}}{{^returnType}}asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))).getRight{{/returnType}}{{#returnType}}asJson[{{>operationReturnType}}].getRight{{/returnType}}{{/separateErrorChannel}})
 
 {{/operation}}
 }

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/PetApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/PetApi.scala
@@ -54,7 +54,7 @@ class PetApi(baseUrl: String) {
       .method(Method.DELETE, uri"$baseUrl/pet/${petId}")
       .contentType("application/json")
       .header("api_key", apiKey.toString)
-      .response(asJson[Unit])
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * Multiple status values can be provided with comma separated strings
@@ -142,7 +142,7 @@ class PetApi(baseUrl: String) {
         "name" -> name,
         "status" -> status
       ))
-      .response(asJson[Unit])
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * 

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/StoreApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/StoreApi.scala
@@ -35,7 +35,7 @@ class StoreApi(baseUrl: String) {
     basicRequest
       .method(Method.DELETE, uri"$baseUrl/store/order/${orderId}")
       .contentType("application/json")
-      .response(asJson[Unit])
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * Returns a map of status codes to quantities

--- a/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/UserApi.scala
+++ b/samples/client/petstore/scala-sttp4/src/main/scala/org/openapitools/client/api/UserApi.scala
@@ -34,13 +34,13 @@ class UserApi(baseUrl: String) {
    * 
    * @param user Created user object
    */
-  def createUser(apiKey: String)(user: User): Request[Either[Either[String, String], Unit]] =
+  def createUser(apiKey: String)(user: User): Request[Either[ResponseException[String, Exception], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user")
       .contentType("application/json")
       .header("api_key", apiKey)
       .body(user)
-      .response(asEither(asString, ignore))
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * 
@@ -53,13 +53,13 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithArrayInput(apiKey: String)(user: Seq[User]): Request[Either[Either[String, String], Unit]] =
+  def createUsersWithArrayInput(apiKey: String)(user: Seq[User]): Request[Either[ResponseException[String, Exception], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithArray")
       .contentType("application/json")
       .header("api_key", apiKey)
       .body(user)
-      .response(asEither(asString, ignore))
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * 
@@ -72,13 +72,13 @@ class UserApi(baseUrl: String) {
    * 
    * @param user List of user object
    */
-  def createUsersWithListInput(apiKey: String)(user: Seq[User]): Request[Either[Either[String, String], Unit]] =
+  def createUsersWithListInput(apiKey: String)(user: Seq[User]): Request[Either[ResponseException[String, Exception], Unit]] =
     basicRequest
       .method(Method.POST, uri"$baseUrl/user/createWithList")
       .contentType("application/json")
       .header("api_key", apiKey)
       .body(user)
-      .response(asEither(asString, ignore))
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * This can only be done by the logged in user.
@@ -97,7 +97,7 @@ class UserApi(baseUrl: String) {
       .method(Method.DELETE, uri"$baseUrl/user/${username}")
       .contentType("application/json")
       .header("api_key", apiKey)
-      .response(asJson[Unit])
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * 
@@ -144,12 +144,12 @@ class UserApi(baseUrl: String) {
    * Available security schemes:
    *   api_key (apiKey)
    */
-  def logoutUser(apiKey: String)(): Request[Either[Either[String, String], Unit]] =
+  def logoutUser(apiKey: String)(): Request[Either[ResponseException[String, Exception], Unit]] =
     basicRequest
       .method(Method.GET, uri"$baseUrl/user/logout")
       .contentType("application/json")
       .header("api_key", apiKey)
-      .response(asEither(asString, ignore))
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
   /**
    * This can only be done by the logged in user.
@@ -170,6 +170,6 @@ class UserApi(baseUrl: String) {
       .contentType("application/json")
       .header("api_key", apiKey)
       .body(user)
-      .response(asJson[Unit])
+      .response(asString.mapWithMetadata(ResponseAs.deserializeRightWithError(_ => Right(()))))
 
 }


### PR DESCRIPTION
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  
This PR solves #15785 for the scala-sttp4 generator.
Rationale for the changes:
- the problem that was tackled in #11949 was not really about default values.
- asUnit[Unit] leads to an error, anyways, so not only with default responses, this is the wrong encoding.
- using asEither(asString, ignore) works, but turns the structured error in Left into a String, shedding information in the process. The "asString.mapWithMetadata(..."-construct allows for empty or garbage response bodies while keeping the Left() information intact.
- asJsonAlwaysUnsafe is gone from sttp for a LONG time. This needed replacement, anyways.


