### PR TITLE
[kotlin][client] fix warning

### DIFF
--- a/bin/configs/kotlin-jvm-spring-3-webclient-echo-api.yaml
+++ b/bin/configs/kotlin-jvm-spring-3-webclient-echo-api.yaml
@@ -1,6 +1,6 @@
 generatorName: kotlin
 outputDir: samples/client/echo_api/kotlin-jvm-spring-3-webclient
-library: jvm-spring-restclient
+library: jvm-spring-webclient
 inputSpec: modules/openapi-generator/src/test/resources/3_0/kotlin/echo_api.yaml
 templateDir: modules/openapi-generator/src/main/resources/kotlin-client
 additionalProperties:

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/jvm-spring-restclient/api.mustache
@@ -67,7 +67,7 @@ import {{packageName}}.infrastructure.*
     @Deprecated(message = "This operation is deprecated.")
     {{/isDeprecated}}
     fun {{operationId}}({{#allParams}}{{{paramName}}}: {{#isEnum}}{{#isContainer}}kotlin.collections.List<{{enumName}}{{operationIdCamelCase}}>{{/isContainer}}{{^isContainer}}{{enumName}}{{operationIdCamelCase}}{{/isContainer}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{/isEnum}}{{^required}}?{{#defaultValue}} = {{>param_default_value}}{{/defaultValue}}{{^defaultValue}} = null{{/defaultValue}}{{/required}}{{^-last}}, {{/-last}}{{/allParams}}): {{#returnType}}{{{returnType}}}{{#nullableReturnType}}?{{/nullableReturnType}}{{/returnType}}{{^returnType}}Unit{{/returnType}} {
-        val result = {{operationId}}WithHttpInfo({{#allParams}}{{{paramName}}} = {{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
+        {{#returnType}}val result = {{/returnType}}{{operationId}}WithHttpInfo({{#allParams}}{{{paramName}}} = {{{paramName}}}{{^-last}}, {{/-last}}{{/allParams}})
         {{#returnType}}
         return result.body!!
         {{/returnType}}

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/build.gradle
@@ -9,6 +9,7 @@ wrapper {
 buildscript {
     ext.kotlin_version = '1.8.10'
     ext.spring_boot_version = "3.2.4"
+    ext.reactor_version = "3.6.4"
     // 6.13.0 is the latest stable release that supports JDK8
     ext.spotless_version = "6.13.0"
 
@@ -59,11 +60,13 @@ kotlin {
         languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.0"
-    implementation "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
+    implementation "org.springframework.boot:spring-boot-starter-webflux:$spring_boot_version"
+    implementation "io.projectreactor:reactor-core:$reactor_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit5:3.4.2"
 }

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/AuthApi.kt
@@ -17,33 +17,37 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.infrastructure.*
 
-class AuthApi(client: RestClient) : ApiClient(client) {
+class AuthApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
 
-    @Throws(RestClientResponseException::class)
-    fun testAuthHttpBasic(): kotlin.String {
-        val result = testAuthHttpBasicWithHttpInfo()
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testAuthHttpBasic(): Mono<kotlin.String> {
+        return testAuthHttpBasicWithHttpInfo()
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testAuthHttpBasicWithHttpInfo(): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testAuthHttpBasicWithHttpInfo(): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testAuthHttpBasicRequestConfig()
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -71,14 +75,14 @@ class AuthApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testAuthHttpBearer(): kotlin.String {
-        val result = testAuthHttpBearerWithHttpInfo()
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testAuthHttpBearer(): Mono<kotlin.String> {
+        return testAuthHttpBearerWithHttpInfo()
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testAuthHttpBearerWithHttpInfo(): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testAuthHttpBearerWithHttpInfo(): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testAuthHttpBearerRequestConfig()
         return request<Unit, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/BodyApi.kt
@@ -17,35 +17,39 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.Pet
 import org.openapitools.client.models.Tag
 import org.openapitools.client.infrastructure.*
 
-class BodyApi(client: RestClient) : ApiClient(client) {
+class BodyApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
 
-    @Throws(RestClientResponseException::class)
-    fun testBinaryGif(): java.io.File {
-        val result = testBinaryGifWithHttpInfo()
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testBinaryGif(): Mono<java.io.File> {
+        return testBinaryGifWithHttpInfo()
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testBinaryGifWithHttpInfo(): ResponseEntity<java.io.File> {
+    @Throws(WebClientResponseException::class)
+    fun testBinaryGifWithHttpInfo(): Mono<ResponseEntity<java.io.File>> {
         val localVariableConfig = testBinaryGifRequestConfig()
         return request<Unit, java.io.File>(
             localVariableConfig
@@ -73,14 +77,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyApplicationOctetstreamBinary(body: java.io.File? = null): kotlin.String {
-        val result = testBodyApplicationOctetstreamBinaryWithHttpInfo(body = body)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testBodyApplicationOctetstreamBinary(body: java.io.File? = null): Mono<kotlin.String> {
+        return testBodyApplicationOctetstreamBinaryWithHttpInfo(body = body)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyApplicationOctetstreamBinaryWithHttpInfo(body: java.io.File? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testBodyApplicationOctetstreamBinaryWithHttpInfo(body: java.io.File? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testBodyApplicationOctetstreamBinaryRequestConfig(body = body)
         return request<java.io.File, kotlin.String>(
             localVariableConfig
@@ -109,14 +113,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyMultipartFormdataArrayOfBinary(files: kotlin.collections.List<java.io.File>): kotlin.String {
-        val result = testBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files = files)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testBodyMultipartFormdataArrayOfBinary(files: kotlin.collections.List<java.io.File>): Mono<kotlin.String> {
+        return testBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files = files)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files: kotlin.collections.List<java.io.File>): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testBodyMultipartFormdataArrayOfBinaryWithHttpInfo(files: kotlin.collections.List<java.io.File>): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testBodyMultipartFormdataArrayOfBinaryRequestConfig(files = files)
         return request<Map<String, PartConfig<*>>, kotlin.String>(
             localVariableConfig
@@ -145,14 +149,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyMultipartFormdataSingleBinary(myFile: java.io.File? = null): kotlin.String {
-        val result = testBodyMultipartFormdataSingleBinaryWithHttpInfo(myFile = myFile)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testBodyMultipartFormdataSingleBinary(myFile: java.io.File? = null): Mono<kotlin.String> {
+        return testBodyMultipartFormdataSingleBinaryWithHttpInfo(myFile = myFile)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testBodyMultipartFormdataSingleBinaryWithHttpInfo(myFile: java.io.File? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testBodyMultipartFormdataSingleBinaryWithHttpInfo(myFile: java.io.File? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testBodyMultipartFormdataSingleBinaryRequestConfig(myFile = myFile)
         return request<Map<String, PartConfig<*>>, kotlin.String>(
             localVariableConfig
@@ -181,14 +185,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyFreeFormObjectResponseString(body: kotlin.Any? = null): kotlin.String {
-        val result = testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body = body)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyFreeFormObjectResponseString(body: kotlin.Any? = null): Mono<kotlin.String> {
+        return testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body = body)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body: kotlin.Any? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyFreeFormObjectResponseStringWithHttpInfo(body: kotlin.Any? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testEchoBodyFreeFormObjectResponseStringRequestConfig(body = body)
         return request<kotlin.Any, kotlin.String>(
             localVariableConfig
@@ -217,14 +221,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyPet(pet: Pet? = null): Pet {
-        val result = testEchoBodyPetWithHttpInfo(pet = pet)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyPet(pet: Pet? = null): Mono<Pet> {
+        return testEchoBodyPetWithHttpInfo(pet = pet)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyPetWithHttpInfo(pet: Pet? = null): ResponseEntity<Pet> {
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyPetWithHttpInfo(pet: Pet? = null): Mono<ResponseEntity<Pet>> {
         val localVariableConfig = testEchoBodyPetRequestConfig(pet = pet)
         return request<Pet, Pet>(
             localVariableConfig
@@ -253,14 +257,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyPetResponseString(pet: Pet? = null): kotlin.String {
-        val result = testEchoBodyPetResponseStringWithHttpInfo(pet = pet)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyPetResponseString(pet: Pet? = null): Mono<kotlin.String> {
+        return testEchoBodyPetResponseStringWithHttpInfo(pet = pet)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyPetResponseStringWithHttpInfo(pet: Pet? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyPetResponseStringWithHttpInfo(pet: Pet? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testEchoBodyPetResponseStringRequestConfig(pet = pet)
         return request<Pet, kotlin.String>(
             localVariableConfig
@@ -289,14 +293,14 @@ class BodyApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyTagResponseString(tag: Tag? = null): kotlin.String {
-        val result = testEchoBodyTagResponseStringWithHttpInfo(tag = tag)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyTagResponseString(tag: Tag? = null): Mono<kotlin.String> {
+        return testEchoBodyTagResponseStringWithHttpInfo(tag = tag)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testEchoBodyTagResponseStringWithHttpInfo(tag: Tag? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testEchoBodyTagResponseStringWithHttpInfo(tag: Tag? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testEchoBodyTagResponseStringRequestConfig(tag = tag)
         return request<Tag, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/FormApi.kt
@@ -17,33 +17,37 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.infrastructure.*
 
-class FormApi(client: RestClient) : ApiClient(client) {
+class FormApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
 
-    @Throws(RestClientResponseException::class)
-    fun testFormIntegerBooleanString(integerForm: kotlin.Int? = null, booleanForm: kotlin.Boolean? = null, stringForm: kotlin.String? = null): kotlin.String {
-        val result = testFormIntegerBooleanStringWithHttpInfo(integerForm = integerForm, booleanForm = booleanForm, stringForm = stringForm)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testFormIntegerBooleanString(integerForm: kotlin.Int? = null, booleanForm: kotlin.Boolean? = null, stringForm: kotlin.String? = null): Mono<kotlin.String> {
+        return testFormIntegerBooleanStringWithHttpInfo(integerForm = integerForm, booleanForm = booleanForm, stringForm = stringForm)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testFormIntegerBooleanStringWithHttpInfo(integerForm: kotlin.Int? = null, booleanForm: kotlin.Boolean? = null, stringForm: kotlin.String? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testFormIntegerBooleanStringWithHttpInfo(integerForm: kotlin.Int? = null, booleanForm: kotlin.Boolean? = null, stringForm: kotlin.String? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testFormIntegerBooleanStringRequestConfig(integerForm = integerForm, booleanForm = booleanForm, stringForm = stringForm)
         return request<Map<String, PartConfig<*>>, kotlin.String>(
             localVariableConfig
@@ -74,14 +78,14 @@ class FormApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testFormOneof(form1: kotlin.String? = null, form2: kotlin.Int? = null, form3: kotlin.String? = null, form4: kotlin.Boolean? = null, id: kotlin.Long? = null, name: kotlin.String? = null): kotlin.String {
-        val result = testFormOneofWithHttpInfo(form1 = form1, form2 = form2, form3 = form3, form4 = form4, id = id, name = name)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testFormOneof(form1: kotlin.String? = null, form2: kotlin.Int? = null, form3: kotlin.String? = null, form4: kotlin.Boolean? = null, id: kotlin.Long? = null, name: kotlin.String? = null): Mono<kotlin.String> {
+        return testFormOneofWithHttpInfo(form1 = form1, form2 = form2, form3 = form3, form4 = form4, id = id, name = name)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testFormOneofWithHttpInfo(form1: kotlin.String? = null, form2: kotlin.Int? = null, form3: kotlin.String? = null, form4: kotlin.Boolean? = null, id: kotlin.Long? = null, name: kotlin.String? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testFormOneofWithHttpInfo(form1: kotlin.String? = null, form2: kotlin.Int? = null, form3: kotlin.String? = null, form4: kotlin.Boolean? = null, id: kotlin.Long? = null, name: kotlin.String? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testFormOneofRequestConfig(form1 = form1, form2 = form2, form3 = form3, form4 = form4, id = id, name = name)
         return request<Map<String, PartConfig<*>>, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/HeaderApi.kt
@@ -17,22 +17,26 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.StringEnumRef
 import org.openapitools.client.infrastructure.*
 
-class HeaderApi(client: RestClient) : ApiClient(client) {
+class HeaderApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
@@ -46,14 +50,14 @@ class HeaderApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testHeaderIntegerBooleanStringEnums(integerHeader: kotlin.Int? = null, booleanHeader: kotlin.Boolean? = null, stringHeader: kotlin.String? = null, enumNonrefStringHeader: EnumNonrefStringHeaderTestHeaderIntegerBooleanStringEnums? = null, enumRefStringHeader: StringEnumRef? = null): kotlin.String {
-        val result = testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader = integerHeader, booleanHeader = booleanHeader, stringHeader = stringHeader, enumNonrefStringHeader = enumNonrefStringHeader, enumRefStringHeader = enumRefStringHeader)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testHeaderIntegerBooleanStringEnums(integerHeader: kotlin.Int? = null, booleanHeader: kotlin.Boolean? = null, stringHeader: kotlin.String? = null, enumNonrefStringHeader: EnumNonrefStringHeaderTestHeaderIntegerBooleanStringEnums? = null, enumRefStringHeader: StringEnumRef? = null): Mono<kotlin.String> {
+        return testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader = integerHeader, booleanHeader = booleanHeader, stringHeader = stringHeader, enumNonrefStringHeader = enumNonrefStringHeader, enumRefStringHeader = enumRefStringHeader)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader: kotlin.Int? = null, booleanHeader: kotlin.Boolean? = null, stringHeader: kotlin.String? = null, enumNonrefStringHeader: EnumNonrefStringHeaderTestHeaderIntegerBooleanStringEnums? = null, enumRefStringHeader: StringEnumRef? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testHeaderIntegerBooleanStringEnumsWithHttpInfo(integerHeader: kotlin.Int? = null, booleanHeader: kotlin.Boolean? = null, stringHeader: kotlin.String? = null, enumNonrefStringHeader: EnumNonrefStringHeaderTestHeaderIntegerBooleanStringEnums? = null, enumRefStringHeader: StringEnumRef? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testHeaderIntegerBooleanStringEnumsRequestConfig(integerHeader = integerHeader, booleanHeader = booleanHeader, stringHeader = stringHeader, enumNonrefStringHeader = enumNonrefStringHeader, enumRefStringHeader = enumRefStringHeader)
         return request<Unit, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/PathApi.kt
@@ -17,22 +17,26 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.StringEnumRef
 import org.openapitools.client.infrastructure.*
 
-class PathApi(client: RestClient) : ApiClient(client) {
+class PathApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
@@ -46,14 +50,14 @@ class PathApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString: kotlin.String, pathInteger: kotlin.Int, enumNonrefStringPath: EnumNonrefStringPathTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath, enumRefStringPath: StringEnumRef): kotlin.String {
-        val result = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString = pathString, pathInteger = pathInteger, enumNonrefStringPath = enumNonrefStringPath, enumRefStringPath = enumRefStringPath)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath(pathString: kotlin.String, pathInteger: kotlin.Int, enumNonrefStringPath: EnumNonrefStringPathTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath, enumRefStringPath: StringEnumRef): Mono<kotlin.String> {
+        return testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString = pathString, pathInteger = pathInteger, enumNonrefStringPath = enumNonrefStringPath, enumRefStringPath = enumRefStringPath)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString: kotlin.String, pathInteger: kotlin.Int, enumNonrefStringPath: EnumNonrefStringPathTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath, enumRefStringPath: StringEnumRef): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathWithHttpInfo(pathString: kotlin.String, pathInteger: kotlin.Int, enumNonrefStringPath: EnumNonrefStringPathTestsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPath, enumRefStringPath: StringEnumRef): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testsPathStringPathStringIntegerPathIntegerEnumNonrefStringPathEnumRefStringPathRequestConfig(pathString = pathString, pathInteger = pathInteger, enumNonrefStringPath = enumNonrefStringPath, enumRefStringPath = enumRefStringPath)
         return request<Unit, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/apis/QueryApi.kt
@@ -17,24 +17,28 @@ package org.openapitools.client.apis
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-import org.springframework.web.client.RestClient
-import org.springframework.web.client.RestClientResponseException
-
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.http.ResponseEntity
 import org.springframework.http.MediaType
-
+import reactor.core.publisher.Mono
+import org.springframework.util.LinkedMultiValueMap
 
 import org.openapitools.client.models.Pet
 import org.openapitools.client.models.StringEnumRef
 import org.openapitools.client.models.TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter
 import org.openapitools.client.infrastructure.*
 
-class QueryApi(client: RestClient) : ApiClient(client) {
+class QueryApi(client: WebClient) : ApiClient(client) {
 
-    constructor(baseUrl: String) : this(RestClient.builder()
+    constructor(baseUrl: String) : this(WebClient.builder()
         .baseUrl(baseUrl)
-        .messageConverters { it.add(MappingJackson2HttpMessageConverter()) }
+        .codecs {
+            it.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+            it.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(Serializer.jacksonObjectMapper, MediaType.APPLICATION_JSON))
+        }
         .build()
     )
 
@@ -48,14 +52,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testEnumRefString(enumNonrefStringQuery: EnumNonrefStringQueryTestEnumRefString? = null, enumRefStringQuery: StringEnumRef? = null): kotlin.String {
-        val result = testEnumRefStringWithHttpInfo(enumNonrefStringQuery = enumNonrefStringQuery, enumRefStringQuery = enumRefStringQuery)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testEnumRefString(enumNonrefStringQuery: EnumNonrefStringQueryTestEnumRefString? = null, enumRefStringQuery: StringEnumRef? = null): Mono<kotlin.String> {
+        return testEnumRefStringWithHttpInfo(enumNonrefStringQuery = enumNonrefStringQuery, enumRefStringQuery = enumRefStringQuery)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testEnumRefStringWithHttpInfo(enumNonrefStringQuery: EnumNonrefStringQueryTestEnumRefString? = null, enumRefStringQuery: StringEnumRef? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testEnumRefStringWithHttpInfo(enumNonrefStringQuery: EnumNonrefStringQueryTestEnumRefString? = null, enumRefStringQuery: StringEnumRef? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testEnumRefStringRequestConfig(enumNonrefStringQuery = enumNonrefStringQuery, enumRefStringQuery = enumRefStringQuery)
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -91,14 +95,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryDatetimeDateString(datetimeQuery: java.time.OffsetDateTime? = null, dateQuery: java.time.LocalDate? = null, stringQuery: kotlin.String? = null): kotlin.String {
-        val result = testQueryDatetimeDateStringWithHttpInfo(datetimeQuery = datetimeQuery, dateQuery = dateQuery, stringQuery = stringQuery)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testQueryDatetimeDateString(datetimeQuery: java.time.OffsetDateTime? = null, dateQuery: java.time.LocalDate? = null, stringQuery: kotlin.String? = null): Mono<kotlin.String> {
+        return testQueryDatetimeDateStringWithHttpInfo(datetimeQuery = datetimeQuery, dateQuery = dateQuery, stringQuery = stringQuery)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryDatetimeDateStringWithHttpInfo(datetimeQuery: java.time.OffsetDateTime? = null, dateQuery: java.time.LocalDate? = null, stringQuery: kotlin.String? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testQueryDatetimeDateStringWithHttpInfo(datetimeQuery: java.time.OffsetDateTime? = null, dateQuery: java.time.LocalDate? = null, stringQuery: kotlin.String? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testQueryDatetimeDateStringRequestConfig(datetimeQuery = datetimeQuery, dateQuery = dateQuery, stringQuery = stringQuery)
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -137,14 +141,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryIntegerBooleanString(integerQuery: kotlin.Int? = null, booleanQuery: kotlin.Boolean? = null, stringQuery: kotlin.String? = null): kotlin.String {
-        val result = testQueryIntegerBooleanStringWithHttpInfo(integerQuery = integerQuery, booleanQuery = booleanQuery, stringQuery = stringQuery)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testQueryIntegerBooleanString(integerQuery: kotlin.Int? = null, booleanQuery: kotlin.Boolean? = null, stringQuery: kotlin.String? = null): Mono<kotlin.String> {
+        return testQueryIntegerBooleanStringWithHttpInfo(integerQuery = integerQuery, booleanQuery = booleanQuery, stringQuery = stringQuery)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryIntegerBooleanStringWithHttpInfo(integerQuery: kotlin.Int? = null, booleanQuery: kotlin.Boolean? = null, stringQuery: kotlin.String? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testQueryIntegerBooleanStringWithHttpInfo(integerQuery: kotlin.Int? = null, booleanQuery: kotlin.Boolean? = null, stringQuery: kotlin.String? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testQueryIntegerBooleanStringRequestConfig(integerQuery = integerQuery, booleanQuery = booleanQuery, stringQuery = stringQuery)
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -183,14 +187,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleDeepObjectExplodeTrueObject(queryObject: Pet? = null): kotlin.String {
-        val result = testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(queryObject = queryObject)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleDeepObjectExplodeTrueObject(queryObject: Pet? = null): Mono<kotlin.String> {
+        return testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(queryObject = queryObject)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(queryObject: Pet? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleDeepObjectExplodeTrueObjectWithHttpInfo(queryObject: Pet? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testQueryStyleDeepObjectExplodeTrueObjectRequestConfig(queryObject = queryObject)
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -223,14 +227,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleFormExplodeTrueArrayString(queryObject: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter? = null): kotlin.String {
-        val result = testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(queryObject = queryObject)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleFormExplodeTrueArrayString(queryObject: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter? = null): Mono<kotlin.String> {
+        return testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(queryObject = queryObject)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(queryObject: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleFormExplodeTrueArrayStringWithHttpInfo(queryObject: TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testQueryStyleFormExplodeTrueArrayStringRequestConfig(queryObject = queryObject)
         return request<Unit, kotlin.String>(
             localVariableConfig
@@ -263,14 +267,14 @@ class QueryApi(client: RestClient) : ApiClient(client) {
     }
 
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleFormExplodeTrueObject(queryObject: Pet? = null): kotlin.String {
-        val result = testQueryStyleFormExplodeTrueObjectWithHttpInfo(queryObject = queryObject)
-        return result.body!!
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleFormExplodeTrueObject(queryObject: Pet? = null): Mono<kotlin.String> {
+        return testQueryStyleFormExplodeTrueObjectWithHttpInfo(queryObject = queryObject)
+            .map { it.body }
     }
 
-    @Throws(RestClientResponseException::class)
-    fun testQueryStyleFormExplodeTrueObjectWithHttpInfo(queryObject: Pet? = null): ResponseEntity<kotlin.String> {
+    @Throws(WebClientResponseException::class)
+    fun testQueryStyleFormExplodeTrueObjectWithHttpInfo(queryObject: Pet? = null): Mono<ResponseEntity<kotlin.String>> {
         val localVariableConfig = testQueryStyleFormExplodeTrueObjectRequestConfig(queryObject = queryObject)
         return request<Unit, kotlin.String>(
             localVariableConfig

--- a/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
+++ b/samples/client/echo_api/kotlin-jvm-spring-3-webclient/src/main/kotlin/org/openapitools/client/infrastructure/ApiClient.kt
@@ -4,13 +4,14 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
-import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.http.ResponseEntity
 import org.springframework.util.LinkedMultiValueMap
+import reactor.core.publisher.Mono
 
-open class ApiClient(protected val client: RestClient) {
+open class ApiClient(protected val client: WebClient) {
 
-    protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): ResponseEntity<T> {
+    protected inline fun <reified I : Any, reified T: Any?> request(requestConfig: RequestConfig<I>): Mono<ResponseEntity<T>> {
         return prepare(defaults(requestConfig))
             .retrieve()
             .toEntity(object : ParameterizedTypeReference<T>() {})
@@ -20,7 +21,7 @@ open class ApiClient(protected val client: RestClient) {
         client.method(requestConfig)
             .uri(requestConfig)
             .headers(requestConfig)
-            .nullableBody(requestConfig)
+            .body(requestConfig)
 
     protected fun <I> defaults(requestConfig: RequestConfig<I>) =
         requestConfig.apply {
@@ -32,10 +33,10 @@ open class ApiClient(protected val client: RestClient) {
             }
         }
 
-    private fun <I> RestClient.method(requestConfig: RequestConfig<I>)=
+    private fun <I> WebClient.method(requestConfig: RequestConfig<I>)=
         method(HttpMethod.valueOf(requestConfig.method.name))
 
-    private fun <I> RestClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
+    private fun <I> WebClient.RequestBodyUriSpec.uri(requestConfig: RequestConfig<I>) =
         uri { builder ->
             builder
                 .path(requestConfig.path)
@@ -43,11 +44,11 @@ open class ApiClient(protected val client: RestClient) {
                 .build(requestConfig.params)
         }
 
-    private fun <I> RestClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
+    private fun <I> WebClient.RequestBodySpec.headers(requestConfig: RequestConfig<I>) =
         apply { requestConfig.headers.forEach { (name, value) -> header(name, value) } }
 
-    private fun <I : Any> RestClient.RequestBodySpec.nullableBody(requestConfig: RequestConfig<I>) =
-        apply { if (requestConfig.body != null) body(requestConfig.body) }
+    private fun <I : Any> WebClient.RequestBodySpec.body(requestConfig: RequestConfig<I>) =
+        apply { if (requestConfig.body != null) bodyValue(requestConfig.body) }
 }
 
 inline fun <reified T: Any> parseDateToQueryString(value : T): String {

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/PetApi.kt
@@ -77,7 +77,7 @@ class PetApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun deletePet(petId: kotlin.Long, apiKey: kotlin.String? = null): Unit {
-        val result = deletePetWithHttpInfo(petId = petId, apiKey = apiKey)
+        deletePetWithHttpInfo(petId = petId, apiKey = apiKey)
     }
 
     @Throws(RestClientResponseException::class)
@@ -273,7 +273,7 @@ class PetApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun updatePetWithForm(petId: kotlin.Long, name: kotlin.String? = null, status: kotlin.String? = null): Unit {
-        val result = updatePetWithFormWithHttpInfo(petId = petId, name = name, status = status)
+        updatePetWithFormWithHttpInfo(petId = petId, name = name, status = status)
     }
 
     @Throws(RestClientResponseException::class)

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/StoreApi.kt
@@ -39,7 +39,7 @@ class StoreApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun deleteOrder(orderId: kotlin.String): Unit {
-        val result = deleteOrderWithHttpInfo(orderId = orderId)
+        deleteOrderWithHttpInfo(orderId = orderId)
     }
 
     @Throws(RestClientResponseException::class)

--- a/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
+++ b/samples/client/petstore/kotlin-jvm-spring-3-restclient/src/main/kotlin/org/openapitools/client/apis/UserApi.kt
@@ -39,7 +39,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun createUser(user: User): Unit {
-        val result = createUserWithHttpInfo(user = user)
+        createUserWithHttpInfo(user = user)
     }
 
     @Throws(RestClientResponseException::class)
@@ -73,7 +73,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun createUsersWithArrayInput(user: kotlin.collections.List<User>): Unit {
-        val result = createUsersWithArrayInputWithHttpInfo(user = user)
+        createUsersWithArrayInputWithHttpInfo(user = user)
     }
 
     @Throws(RestClientResponseException::class)
@@ -107,7 +107,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun createUsersWithListInput(user: kotlin.collections.List<User>): Unit {
-        val result = createUsersWithListInputWithHttpInfo(user = user)
+        createUsersWithListInputWithHttpInfo(user = user)
     }
 
     @Throws(RestClientResponseException::class)
@@ -141,7 +141,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun deleteUser(username: kotlin.String): Unit {
-        val result = deleteUserWithHttpInfo(username = username)
+        deleteUserWithHttpInfo(username = username)
     }
 
     @Throws(RestClientResponseException::class)
@@ -250,7 +250,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun logoutUser(): Unit {
-        val result = logoutUserWithHttpInfo()
+        logoutUserWithHttpInfo()
     }
 
     @Throws(RestClientResponseException::class)
@@ -283,7 +283,7 @@ class UserApi(client: RestClient) : ApiClient(client) {
 
     @Throws(RestClientResponseException::class)
     fun updateUser(username: kotlin.String, user: User): Unit {
-        val result = updateUserWithHttpInfo(username = username, user = user)
+        updateUserWithHttpInfo(username = username, user = user)
     }
 
     @Throws(RestClientResponseException::class)


### PR DESCRIPTION
Fixed a warning in kotlin-jvm-spring-restclient. I also noted that a sample was using the incorrect library.

<!-- Please check the completed items below -->
### PR checklist
 
- [x ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jimschubert (2017/09) [❤️](https://www.patreon.com/jimschubert), @dr4ke616 (2018/08) @karismann (2019/03) @Zomzog (2019/04) @andrewemery (2019/10) @4brunu (2019/11) @yutaka0m (2020/03) @stefankoppier (2022/06)