### PR TITLE
Update broken JSON schema links

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/CodegenParameter.java
@@ -76,48 +76,48 @@ public class CodegenParameter implements IJsonSchemaValidationProperties {
      */
     public boolean required;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-maximum">JSON Schema Validation Spec, Section 6.2.2</a>
      */
     public String maximum;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-exclusivemaximum">JSON Schema Validation Spec, Section 6.2.3</a>
      */
     public boolean exclusiveMaximum;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-minimum">JSON Schema Validation Spec, Section 6.2.4</a>
      */
     public String minimum;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-exclusiveminimum">JSON Schema Validation Spec, Section 6.2.5</a>
      */
     public boolean exclusiveMinimum;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor26
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-maxlength">JSON Schema Validation Spec, Section 6.3.1</a>
      */
     public Integer maxLength;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor29
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-minlength">JSON Schema Validation Spec, Section 6.3.2</a>
      */
     public Integer minLength;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor33
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-pattern">JSON Schema Validation Spec, Section 6.3.3</a>
      */
     public String pattern;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor42
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-maxitems">JSON Schema Validation Spec, Section 6.4.1</a>
      */
     public Integer maxItems;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor45
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-minitems">JSON Schema Validation Spec, Section 6.4.2</a>
      */
     public Integer minItems;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor49
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-uniqueitems">JSON Schema Validation Spec, Section 6.4.3</a>
      */
     public boolean uniqueItems;
     private Boolean uniqueItemsBoolean;
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor14
+     * See <a href="https://web.archive.org/web/20240502205731/https://json-schema.org/draft/2020-12/json-schema-validation#name-multipleof">JSON Schema Validation Spec, Section 6.2.1</a>
      */
     public Number multipleOf;
     private Integer maxProperties;


### PR DESCRIPTION
Using archive.org snapshots in case the URLs change again, like they apparently have in the past.

Also fixing formal JavaDoc error, which does not allow bare URLs. This will become a bit less convoluted in Java 23 – however until then proper anchor tags are required.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
