### PR TITLE
[Python] Fix the post processing of enums

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java
@@ -992,7 +992,10 @@ public abstract class AbstractPythonCodegen extends DefaultCodegen implements Co
                         enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "str"));
                     } else {
                         model.vendorExtensions.putIfAbsent("x-py-enum-type", "int");
-                        enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
+                        // Do not overwrite the variable name if already set through x-enum-varnames
+                        if (model.vendorExtensions.get("x-enum-varnames") == null) {
+                            enumVars.put("name", toEnumVariableName((String) enumVars.get("value"), "int"));
+                        }
                     }
                 }
             }

--- a/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/python/petstore-with-fake-endpoints-models-for-testing.yaml
@@ -2060,6 +2060,35 @@ components:
           enum:
             - 1.1
             - -1.2
+        enum_number_vendor_ext:
+          type: integer
+          format: int32
+          enum:
+            - 42
+            - 18
+            - 56
+          x-enum-descriptions:
+            - 'Description for 42'
+            - 'Description for 18'
+            - 'Description for 56'
+          x-enum-varnames:
+            - FortyTwo
+            - Eigtheen
+            - FiftySix
+        enum_string_vendor_ext:
+          type: string
+          enum:
+            - FOO
+            - Bar
+            - baz
+          x-enum-descriptions:
+            - 'Description for FOO'
+            - 'Description for Bar'
+            - 'Description for baz'
+          x-enum-varnames:
+            - FOOVar
+            - BarVar
+            - bazVar
         outerEnum:
           $ref: '#/components/schemas/OuterEnum'
         outerEnumInteger:

--- a/samples/openapi3/client/petstore/python-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-aiohttp/docs/EnumTest.md
@@ -10,6 +10,8 @@ Name | Type | Description | Notes
 **enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
+**enum_number_vendor_ext** | **int** |  | [optional] 
+**enum_string_vendor_ext** | **str** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-aiohttp/petstore_api/models/enum_test.py
@@ -35,11 +35,13 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[float] = None
+    enum_number_vendor_ext: Optional[StrictInt] = None
+    enum_string_vendor_ext: Optional[StrictStr] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
-    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @field_validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -86,6 +88,26 @@ class EnumTest(BaseModel):
 
         if value not in set([1.1, -1.2]):
             raise ValueError("must be one of enum values (1.1, -1.2)")
+        return value
+
+    @field_validator('enum_number_vendor_ext')
+    def enum_number_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set([42, 18, 56]):
+            raise ValueError("must be one of enum values (42, 18, 56)")
+        return value
+
+    @field_validator('enum_string_vendor_ext')
+    def enum_string_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['FOO', 'Bar', 'baz']):
+            raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
         return value
 
     model_config = ConfigDict(
@@ -149,6 +171,8 @@ class EnumTest(BaseModel):
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
+            "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
+            "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
             "outerEnum": obj.get("outerEnum"),
             "outerEnumInteger": obj.get("outerEnumInteger"),
             "outerEnumDefaultValue": obj.get("outerEnumDefaultValue"),

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/docs/EnumTest.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
+**enum_number_vendor_ext** | **int** |  | [optional] 
+**enum_string_vendor_ext** | **str** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1-aiohttp/petstore_api/models/enum_test.py
@@ -34,11 +34,13 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[float] = None
+    enum_number_vendor_ext: Optional[StrictInt] = None
+    enum_string_vendor_ext: Optional[StrictStr] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
-    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -87,6 +89,26 @@ class EnumTest(BaseModel):
             raise ValueError("must be one of enum values (1.1, -1.2)")
         return value
 
+    @validator('enum_number_vendor_ext')
+    def enum_number_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in (42, 18, 56):
+            raise ValueError("must be one of enum values (42, 18, 56)")
+        return value
+
+    @validator('enum_string_vendor_ext')
+    def enum_string_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in ('FOO', 'Bar', 'baz'):
+            raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
+        return value
+
     class Config:
         """Pydantic configuration"""
         allow_population_by_field_name = True
@@ -133,6 +155,8 @@ class EnumTest(BaseModel):
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
+            "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
+            "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
             "outer_enum_default_value": obj.get("outerEnumDefaultValue"),

--- a/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/docs/EnumTest.md
@@ -9,6 +9,8 @@ Name | Type | Description | Notes
 **enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
+**enum_number_vendor_ext** | **int** |  | [optional] 
+**enum_string_vendor_ext** | **str** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python-pydantic-v1/petstore_api/models/enum_test.py
@@ -34,12 +34,14 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[StrictFloat] = None
+    enum_number_vendor_ext: Optional[StrictInt] = None
+    enum_string_vendor_ext: Optional[StrictStr] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
-    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -86,6 +88,26 @@ class EnumTest(BaseModel):
 
         if value not in (1.1, -1.2):
             raise ValueError("must be one of enum values (1.1, -1.2)")
+        return value
+
+    @validator('enum_number_vendor_ext')
+    def enum_number_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in (42, 18, 56):
+            raise ValueError("must be one of enum values (42, 18, 56)")
+        return value
+
+    @validator('enum_string_vendor_ext')
+    def enum_string_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in ('FOO', 'Bar', 'baz'):
+            raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
         return value
 
     class Config:
@@ -140,6 +162,8 @@ class EnumTest(BaseModel):
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
+            "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
+            "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
             "outer_enum": obj.get("outerEnum"),
             "outer_enum_integer": obj.get("outerEnumInteger"),
             "outer_enum_default_value": obj.get("outerEnumDefaultValue"),

--- a/samples/openapi3/client/petstore/python/docs/EnumTest.md
+++ b/samples/openapi3/client/petstore/python/docs/EnumTest.md
@@ -10,6 +10,8 @@ Name | Type | Description | Notes
 **enum_integer_default** | **int** |  | [optional] [default to 5]
 **enum_integer** | **int** |  | [optional] 
 **enum_number** | **float** |  | [optional] 
+**enum_number_vendor_ext** | **int** |  | [optional] 
+**enum_string_vendor_ext** | **str** |  | [optional] 
 **outer_enum** | [**OuterEnum**](OuterEnum.md) |  | [optional] 
 **outer_enum_integer** | [**OuterEnumInteger**](OuterEnumInteger.md) |  | [optional] 
 **outer_enum_default_value** | [**OuterEnumDefaultValue**](OuterEnumDefaultValue.md) |  | [optional] 

--- a/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
+++ b/samples/openapi3/client/petstore/python/petstore_api/models/enum_test.py
@@ -35,12 +35,14 @@ class EnumTest(BaseModel):
     enum_integer_default: Optional[StrictInt] = 5
     enum_integer: Optional[StrictInt] = None
     enum_number: Optional[StrictFloat] = None
+    enum_number_vendor_ext: Optional[StrictInt] = None
+    enum_string_vendor_ext: Optional[StrictStr] = None
     outer_enum: Optional[OuterEnum] = Field(default=None, alias="outerEnum")
     outer_enum_integer: Optional[OuterEnumInteger] = Field(default=None, alias="outerEnumInteger")
     outer_enum_default_value: Optional[OuterEnumDefaultValue] = Field(default=None, alias="outerEnumDefaultValue")
     outer_enum_integer_default_value: Optional[OuterEnumIntegerDefaultValue] = Field(default=None, alias="outerEnumIntegerDefaultValue")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
+    __properties: ClassVar[List[str]] = ["enum_string", "enum_string_required", "enum_integer_default", "enum_integer", "enum_number", "enum_number_vendor_ext", "enum_string_vendor_ext", "outerEnum", "outerEnumInteger", "outerEnumDefaultValue", "outerEnumIntegerDefaultValue"]
 
     @field_validator('enum_string')
     def enum_string_validate_enum(cls, value):
@@ -87,6 +89,26 @@ class EnumTest(BaseModel):
 
         if value not in set([1.1, -1.2]):
             raise ValueError("must be one of enum values (1.1, -1.2)")
+        return value
+
+    @field_validator('enum_number_vendor_ext')
+    def enum_number_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set([42, 18, 56]):
+            raise ValueError("must be one of enum values (42, 18, 56)")
+        return value
+
+    @field_validator('enum_string_vendor_ext')
+    def enum_string_vendor_ext_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(['FOO', 'Bar', 'baz']):
+            raise ValueError("must be one of enum values ('FOO', 'Bar', 'baz')")
         return value
 
     model_config = ConfigDict(
@@ -157,6 +179,8 @@ class EnumTest(BaseModel):
             "enum_integer_default": obj.get("enum_integer_default") if obj.get("enum_integer_default") is not None else 5,
             "enum_integer": obj.get("enum_integer"),
             "enum_number": obj.get("enum_number"),
+            "enum_number_vendor_ext": obj.get("enum_number_vendor_ext"),
+            "enum_string_vendor_ext": obj.get("enum_string_vendor_ext"),
             "outerEnum": obj.get("outerEnum"),
             "outerEnumInteger": obj.get("outerEnumInteger"),
             "outerEnumDefaultValue": obj.get("outerEnumDefaultValue"),


### PR DESCRIPTION
### description
This fixes the issue described in #16560 of a problem with the Python family of converters that when processing enums, none of them substitutes the enum var extensions.

When processing the following schema:
 
```yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: Weather API
paths: {}

components:
  schemas:
    WeatherType:
      type: integer
      format: int32
      enum:
        - 42
        - 18
        - 56
      x-enum-descriptions:
        - 'Blue sky'
        - 'Slightly overcast'
        - 'Take an umbrella with you'
      x-enum-varnames:
        - Sunny
        - Cloudy
        - Rainy
 ```

The generator would yield:

```Python
from datetime import date, datetime  # noqa: F401

from typing import List, Dict  # noqa: F401

from openapi_server.models.base_model import Model
from openapi_server import util


class WeatherType(Model):
    """NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).

    Do not edit the class manually.
    """

    """
    allowed enum values
    """
    NUMBER_42 = 42
    NUMBER_18 = 18
    NUMBER_56 = 56
    def __init__(self):  # noqa: E501
        """WeatherType - a model defined in OpenAPI

        """
        self.openapi_types = {
        }

        self.attribute_map = {
        }

    @classmethod
    def from_dict(cls, dikt) -> 'WeatherType':
        """Returns the dict as a model

        :param dikt: A dict.
        :type: dict
        :return: The WeatherType of this WeatherType.  # noqa: E501
        :rtype: WeatherType
        """
        return util.deserialize_model(dikt, cls)
```

The variables have the default `NUMBER_x` substitutions.

### problem

The problem is caused by the fact that the enum var extension substitutions done by`postProcessModelsEnum` at the beginning of `postProcessModelsMap` are overwritten at a later point in that same method.

https://github.com/OpenAPITools/openapi-generator/blob/296a6ac5163b226015511b4bea42b78f0d2966f3/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java#L868

The overwriting of the variable names occurs here:

https://github.com/OpenAPITools/openapi-generator/blob/296a6ac5163b226015511b4bea42b78f0d2966f3/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractPythonCodegen.java#L986C10-L998C14

Note: the proposed solution mentioned in #16560 of calling `postProcessModelsEnum` as part of `postProcessModels` seems ineffective, as the override `postProcessModels` is never called by the generator.

### proposed solution

Add a condition to test if `x-enum-varnames` exist before performing the default `NUMBER_x` substition.

A previous attempt to fix the issue by moving `postProcessModelsEnum` to the end of the method lead to a complication with string enum types, ending up with variable names ending up enclosed in double quotes.

With the proposed modification the generated is as expected:

```python
class WeatherType(Model):
    """NOTE: This class is auto generated by OpenAPI Generator (https://openapi-generator.tech).

    Do not edit the class manually.
    """

    """
    allowed enum values
    """
    Sunny = 42
    Cloudy = 18
    Rainy = 56
    def __init__(self):  # noqa: E501
        """WeatherType - a model defined in OpenAPI

        """
        self.openapi_types = {
        }

        self.attribute_map = {
        }
```

## checklist
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
