### PR TITLE
Fix #18572 rust server: Silence clippy lints by refactoring

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-server/server-make-service.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-make-service.mustache
@@ -31,7 +31,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }

--- a/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/server-operation.mustache
@@ -224,10 +224,11 @@
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
 {{/x-consumes-json}}
 {{^x-consumes-plain-text}}
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_{{{paramName}}}) => param_{{{paramName}}},
 {{#required}}
                                         Err(e) => return Ok(Response::builder()
@@ -421,10 +422,11 @@
                                             Some("{{{contentType}}}") if param_{{{paramName}}}.is_none() => {
                                                 // Extract JSON part.
                                                 let deserializer = &mut serde_json::Deserializer::from_slice(part.body.as_slice());
-                                                let json_data: {{dataType}} = match serde_ignored::deserialize(deserializer, |path| {
+                                                let handle_unknown_field = |path: serde_ignored::Path<'_>| {
                                                     warn!("Ignoring unknown field in JSON part: {}", path);
                                                     unused_elements.push(path.to_string());
-                                                }) {
+                                                };
+                                                let json_data: {{dataType}} = match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                                     Ok(json_data) => json_data,
                                                     Err(e) => return Ok(Response::builder()
                                                                     .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/server/mod.rs
@@ -70,7 +70,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }
@@ -150,10 +150,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_op_get_request: Option<models::OpGetRequest> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_op_get_request) => param_op_get_request,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/client/callbacks.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/client/callbacks.rs
@@ -85,7 +85,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/server/mod.rs
@@ -155,7 +155,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }
@@ -1269,10 +1269,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_object_untyped_props: Option<models::ObjectUntypedProps> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_object_untyped_props) => param_object_untyped_props,
                                         Err(_) => None,
                                     }
@@ -1368,10 +1369,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_duplicate_xml_object: Option<models::DuplicateXmlObject> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_duplicate_xml_object) => param_duplicate_xml_object,
                                         Err(_) => None,
                                     }
@@ -1435,10 +1437,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_another_xml_object: Option<models::AnotherXmlObject> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_another_xml_object) => param_another_xml_object,
                                         Err(_) => None,
                                     }
@@ -1513,10 +1516,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_another_xml_array: Option<models::AnotherXmlArray> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_another_xml_array) => param_another_xml_array,
                                         Err(_) => None,
                                     }
@@ -1580,10 +1584,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_xml_array: Option<models::XmlArray> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_xml_array) => param_xml_array,
                                         Err(_) => None,
                                     }
@@ -1647,10 +1652,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_xml_object: Option<models::XmlObject> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_xml_object) => param_xml_object,
                                         Err(_) => None,
                                     }
@@ -1714,10 +1720,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_object_param: Option<models::ObjectParam> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_object_param) => param_object_param,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/server/mod.rs
@@ -178,7 +178,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/server/mod.rs
@@ -188,7 +188,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }
@@ -268,10 +268,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Client> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -377,10 +378,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::OuterBoolean> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(_) => None,
                                     }
@@ -447,10 +449,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::OuterComposite> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(_) => None,
                                     }
@@ -517,10 +520,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::OuterNumber> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(_) => None,
                                     }
@@ -587,10 +591,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::OuterString> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(_) => None,
                                     }
@@ -766,10 +771,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::User> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -840,10 +846,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Client> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -1136,10 +1143,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_param: Option<std::collections::HashMap<String, String>> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_param) => param_param,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -1254,10 +1262,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Client> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -1364,10 +1373,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Pet> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -1803,10 +1813,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Pet> = if !body.is_empty() {
                                     let deserializer = &mut serde_xml_rs::de::Deserializer::new_from_reader(&*body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -2318,10 +2329,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::Order> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -2402,10 +2414,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::User> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -2475,10 +2488,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<Vec<models::User>> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -2548,10 +2562,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<Vec<models::User>> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -2927,10 +2942,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_body: Option<models::User> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_body) => param_body,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/server/mod.rs
@@ -70,7 +70,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/server/mod.rs
@@ -92,7 +92,7 @@ impl<T, C, Target> hyper::service::Service<Target> for MakeService<T, C> where
     }
 
     fn call(&mut self, target: Target) -> Self::Future {
-        futures::future::ok(Service::new(
+        future::ok(Service::new(
             self.api_impl.clone(),
         ))
     }
@@ -237,10 +237,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_nested_response: Option<models::DummyPutRequest> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_nested_response) => param_nested_response,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
@@ -547,10 +548,11 @@ impl<T, C> hyper::service::Service<(Request<Body>, C)> for Service<T, C> where
                                 let mut unused_elements = Vec::new();
                                 let param_value: Option<serde_json::Value> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
-                                    match serde_ignored::deserialize(deserializer, |path| {
-                                            warn!("Ignoring unknown field in body: {}", path);
-                                            unused_elements.push(path.to_string());
-                                    }) {
+                                    let handle_unknown_field = |path: serde_ignored::Path<'_>| {
+                                        warn!("Ignoring unknown field in body: {}", path);
+                                        unused_elements.push(path.to_string());
+                                    };
+                                    match serde_ignored::deserialize(deserializer, handle_unknown_field) {
                                         Ok(param_value) => param_value,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)


### PR DESCRIPTION
See #18572.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)