### PR TITLE
[go-server] Fix: missing sample changes from previous commit (#18546)

### DIFF
--- a/samples/server/petstore/go-api-server/go/api_pet.go
+++ b/samples/server/petstore/go-api-server/go/api_pet.go
@@ -251,7 +251,7 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 			WithParse[int32](parseInt32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "defaultInt", Err: err}, nil)
 			return
 		}
 
@@ -267,7 +267,7 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 			WithParse[float32](parseFloat32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "defaultNum", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-api-server/go/api_user.go
+++ b/samples/server/petstore/go-api-server/go/api_user.go
@@ -191,7 +191,7 @@ func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
 			return
 		}
 
@@ -258,7 +258,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "remember_me", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-chi-server/go/api_pet.go
+++ b/samples/server/petstore/go-chi-server/go/api_pet.go
@@ -248,7 +248,7 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 			WithParse[int32](parseInt32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "defaultInt", Err: err}, nil)
 			return
 		}
 
@@ -264,7 +264,7 @@ func (c *PetAPIController) FindPetsByStatus(w http.ResponseWriter, r *http.Reque
 			WithParse[float32](parseFloat32),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "defaultNum", Err: err}, nil)
 			return
 		}
 

--- a/samples/server/petstore/go-chi-server/go/api_user.go
+++ b/samples/server/petstore/go-chi-server/go/api_user.go
@@ -190,7 +190,7 @@ func (c *UserAPIController) DeleteUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "confirmation", Err: err}, nil)
 			return
 		}
 
@@ -256,7 +256,7 @@ func (c *UserAPIController) LoginUser(w http.ResponseWriter, r *http.Request) {
 			WithParse[bool](parseBool),
 		)
 		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "boolean_test", Err: err}, nil)
+			c.errorHandler(w, r, &ParsingError{Param: "remember_me", Err: err}, nil)
 			return
 		}
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The PR for issue #18546 did not seem to include all the required sample changes to pass the `Verify git status` check.
All open PRs seem to be failing with that commit.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
