### PR TITLE
[Java] Fix missing underscores for PascalCase enum values #4837

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractJavaCodegen.java
@@ -2055,7 +2055,7 @@ public abstract class AbstractJavaCodegen extends DefaultCodegen implements Code
         }
 
         // string
-        String var = value.replaceAll("\\W+", "_").toUpperCase(Locale.ROOT);
+        String var = underscore(value.replaceAll("\\W+", "_")).toUpperCase(Locale.ROOT);
         if (var.matches("\\d.*")) {
             var = "_" + var;
         }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/AbstractJavaCodegenTest.java
@@ -62,6 +62,13 @@ public class AbstractJavaCodegenTest {
     }
 
     @Test
+    public void toEnumVarNameAddUnderscoresIfValueIsPascalCase() {
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("OnlyCamelCase", "String"), "ONLY_CAMEL_CASE");
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("WithNumber1", "String"), "WITH_NUMBER1");
+        Assert.assertEquals(fakeJavaCodegen.toEnumVarName("_LeadingUnderscore", "String"), "_LEADING_UNDERSCORE");
+    }
+
+    @Test
     public void toVarNameShouldAvoidOverloadingGetClassMethod() throws Exception {
         Assert.assertEquals(fakeJavaCodegen.toVarName("class"), "propertyClass");
         Assert.assertEquals(fakeJavaCodegen.toVarName("_class"), "propertyClass");

--- a/samples/client/others/java/okhttp-gson-streaming/docs/SomeObj.md
+++ b/samples/client/others/java/okhttp-gson-streaming/docs/SomeObj.md
@@ -19,7 +19,7 @@
 
 | Name | Value |
 |---- | -----|
-| SOMEOBJIDENTIFIER | &quot;SomeObjIdentifier&quot; |
+| SOME_OBJ_IDENTIFIER | &quot;SomeObjIdentifier&quot; |
 
 
 ## Implemented Interfaces

--- a/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
+++ b/samples/client/others/java/okhttp-gson-streaming/src/main/java/org/openapitools/client/model/SomeObj.java
@@ -59,7 +59,7 @@ public class SomeObj implements Serializable {
    */
   @JsonAdapter(TypeEnum.Adapter.class)
   public enum TypeEnum {
-    SOMEOBJIDENTIFIER("SomeObjIdentifier");
+    SOME_OBJ_IDENTIFIER("SomeObjIdentifier");
 
     private String value;
 
@@ -106,7 +106,7 @@ public class SomeObj implements Serializable {
 
   public static final String SERIALIZED_NAME_$_TYPE = "$_type";
   @SerializedName(SERIALIZED_NAME_$_TYPE)
-  private TypeEnum $type = TypeEnum.SOMEOBJIDENTIFIER;
+  private TypeEnum $type = TypeEnum.SOME_OBJ_IDENTIFIER;
 
   public static final String SERIALIZED_NAME_ID = "id";
   @SerializedName(SERIALIZED_NAME_ID)

--- a/samples/client/petstore/java-helidon-client/v3/mp/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java-helidon-client/v3/mp/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java-helidon-client/v3/mp/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java-helidon-client/v3/mp/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -31,7 +31,7 @@ public class ParentWithNullable  {
   
 public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
     String value;
 

--- a/samples/client/petstore/java-helidon-client/v3/se/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java-helidon-client/v3/se/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java-helidon-client/v3/se/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -31,7 +31,7 @@ public class ParentWithNullable  {
   
 public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
     String value;
 

--- a/samples/client/petstore/java-helidon-client/v4/mp/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java-helidon-client/v4/mp/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java-helidon-client/v4/mp/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java-helidon-client/v4/mp/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -31,7 +31,7 @@ public class ParentWithNullable  {
   
 public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
     String value;
 

--- a/samples/client/petstore/java/apache-httpclient/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/apache-httpclient/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/apache-httpclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -55,7 +55,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/feign/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/jersey3/docs/ChildCat.md
+++ b/samples/client/petstore/java/jersey3/docs/ChildCat.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDCAT | &quot;ChildCat&quot; |
+| CHILD_CAT | &quot;ChildCat&quot; |
 
 
 

--- a/samples/client/petstore/java/native-async/docs/ChildCat.md
+++ b/samples/client/petstore/java/native-async/docs/ChildCat.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDCAT | &quot;ChildCat&quot; |
+| CHILD_CAT | &quot;ChildCat&quot; |
 
 
 

--- a/samples/client/petstore/java/native/docs/ChildCat.md
+++ b/samples/client/petstore/java/native/docs/ChildCat.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDCAT | &quot;ChildCat&quot; |
+| CHILD_CAT | &quot;ChildCat&quot; |
 
 
 

--- a/samples/client/petstore/java/restclient-swagger2/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/restclient-swagger2/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/restclient-swagger2/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -53,7 +53,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/restclient/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/restclient/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/restclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/resteasy/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/resteasy/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/resteasy/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/resttemplate-withXml/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/resttemplate-withXml/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -62,7 +62,7 @@ public class ParentWithNullable {
   @XmlEnum(String.class)
   public enum TypeEnum {
     @XmlEnumValue("ChildWithNullable")
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/resttemplate/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/resttemplate/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/vertx/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/vertx/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/webclient-jakarta/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/webclient-jakarta/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/webclient-jakarta/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/webclient-swagger2/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/webclient-swagger2/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/webclient-swagger2/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -53,7 +53,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/java/webclient/docs/ParentWithNullable.md
+++ b/samples/client/petstore/java/webclient/docs/ParentWithNullable.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDWITHNULLABLE | &quot;ChildWithNullable&quot; |
+| CHILD_WITH_NULLABLE | &quot;ChildWithNullable&quot; |
 
 
 

--- a/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
+++ b/samples/client/petstore/java/webclient/src/main/java/org/openapitools/client/model/ParentWithNullable.java
@@ -52,7 +52,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/client/petstore/spring-http-interface-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -39,7 +39,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/client/petstore/spring-http-interface/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -40,7 +40,7 @@ public class ParentWithNullableDto {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
+++ b/samples/openapi3/client/petstore/java/jersey2-java8/docs/ChildCat.md
@@ -16,7 +16,7 @@
 
 | Name | Value |
 |---- | -----|
-| CHILDCAT | &quot;ChildCat&quot; |
+| CHILD_CAT | &quot;ChildCat&quot; |
 
 
 

--- a/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/client/petstore/spring-cloud-oas3-fakeapi/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -41,7 +41,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -41,7 +41,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/openapi3/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -41,7 +41,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/java-helidon-server/v3/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
+++ b/samples/server/petstore/java-helidon-server/v3/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
@@ -31,7 +31,7 @@ public class ParentWithNullable  {
   
 public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
 
     private String value;

--- a/samples/server/petstore/java-helidon-server/v3/se/src/main/java/org/openapitools/server/model/ParentWithNullable.java
+++ b/samples/server/petstore/java-helidon-server/v3/se/src/main/java/org/openapitools/server/model/ParentWithNullable.java
@@ -18,7 +18,7 @@ public class ParentWithNullable   {
     * Gets or Sets type
     */
     public enum TypeEnum {
-        CHILDWITHNULLABLE("ChildWithNullable");
+        CHILD_WITH_NULLABLE("ChildWithNullable");
 
         private String value;
 

--- a/samples/server/petstore/java-helidon-server/v4/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
+++ b/samples/server/petstore/java-helidon-server/v4/mp/src/main/java/org/openapitools/server/model/ParentWithNullable.java
@@ -31,7 +31,7 @@ public class ParentWithNullable  {
   
 public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
 
     private String value;

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -43,7 +43,7 @@ public class ParentWithNullable   {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec-quarkus-mutiny/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class ParentWithNullable  implements Serializable {
   public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
 
     private String value;

--- a/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs-spec/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 public class ParentWithNullable  implements Serializable {
   public enum TypeEnum {
 
-    CHILDWITHNULLABLE(String.valueOf("ChildWithNullable"));
+    CHILD_WITH_NULLABLE(String.valueOf("ChildWithNullable"));
 
 
     private String value;

--- a/samples/server/petstore/jaxrs/jersey3/src/gen/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/jaxrs/jersey3/src/gen/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable   {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/spring-boot-defaultInterface-unhandledException/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -41,7 +41,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation-no-nullable/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -38,7 +38,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-beanvalidation/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate-j8/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-delegate/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-implicitHeaders/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive-noResponseEntity/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-reactive/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-useoptional/src/main/java/org/openapitools/model/ParentWithNullable.java
@@ -42,7 +42,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
+++ b/samples/server/petstore/springboot-virtualan/src/main/java/org/openapitools/virtualan/model/ParentWithNullable.java
@@ -41,7 +41,7 @@ public class ParentWithNullable {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 

--- a/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
+++ b/samples/server/petstore/springboot/src/main/java/org/openapitools/model/ParentWithNullableDto.java
@@ -43,7 +43,7 @@ public class ParentWithNullableDto {
    * Gets or Sets type
    */
   public enum TypeEnum {
-    CHILDWITHNULLABLE("ChildWithNullable");
+    CHILD_WITH_NULLABLE("ChildWithNullable");
 
     private String value;
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Resolves: #4837

Addresses an issue with the conversion of enum values to valid variable names. When the enum value is a string and contains multiple words without separators (e.g., `TestCase`), underscores between the words were previously missing (e.g., "TESTCASE").

To address this issue, the existing `underscore` method is now applied to the value before all characters are converted to uppercase letters. The underscore method converts CamelCase to SCREAMING_SNAKE_CASE while preserving the case of individual words (e.g., `TestCase` becomes `TEST_CASE`)

Corresponding tests have been added.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
