### PR TITLE
Disable clippy::too_many_arguments in generated Rust client code.

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-axum/lib.mustache
@@ -6,9 +6,13 @@
     unused_extern_crates,
     non_camel_case_types,
     unused_imports,
-    unused_attributes
+    unused_attributes,
 )]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(
+    clippy::derive_partial_eq_without_eq,
+    clippy::disallowed_names,
+    clippy::too_many_arguments
+)]
 
 use async_trait::async_trait;
 use axum::extract::*;

--- a/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust-server/lib.mustache
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/modules/openapi-generator/src/main/resources/rust/lib.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/lib.mustache
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/lib.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/composed-oneof/src/lib.rs
+++ b/samples/client/others/rust/hyper/composed-oneof/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/emptyObject/src/lib.rs
+++ b/samples/client/others/rust/hyper/emptyObject/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/oneOf-array-map/src/lib.rs
+++ b/samples/client/others/rust/hyper/oneOf-array-map/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/oneOf-reuseRef/src/lib.rs
+++ b/samples/client/others/rust/hyper/oneOf-reuseRef/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/hyper/oneOf/src/lib.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest-regression-16119/src/lib.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/lib.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/composed-oneof/src/lib.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/emptyObject/src/lib.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/lib.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/lib.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/others/rust/reqwest/oneOf/src/lib.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/hyper/petstore/src/lib.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/client/petstore/rust/reqwest/petstore/src/lib.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports)]
+#![allow(clippy::too_many_arguments)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/multipart-v3/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/no-example-v3/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/openapi-v3/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ops-v3/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/petstore-with-fake-endpoints-models-for-testing/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/ping-bearer-auth/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;

--- a/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
+++ b/samples/server/petstore/rust-server/output/rust-server-test/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs, trivial_casts, unused_variables, unused_mut, unused_imports, unused_extern_crates, non_camel_case_types)]
 #![allow(unused_imports, unused_attributes)]
-#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names)]
+#![allow(clippy::derive_partial_eq_without_eq, clippy::disallowed_names, clippy::too_many_arguments)]
 
 use async_trait::async_trait;
 use futures::Stream;


### PR DESCRIPTION
Addresses issue: https://github.com/OpenAPITools/openapi-generator/issues/18600

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)
