### PR TITLE
Rust enum variants from enumNameMappings config should be in PascalCase

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -16,7 +16,7 @@ pub enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}
     #[serde(rename = "{{{value}}}")]
-    {{{name}}},
+    {{#lambda.pascalcase}}{{{name}}}{{/lambda.pascalcase}},
 {{/enumVars}}{{/allowableValues}}
 }
 
@@ -25,7 +25,7 @@ impl ToString for {{{classname}}} {
         match self {
             {{#allowableValues}}
             {{#enumVars}}
-            Self::{{{name}}} => String::from("{{{value}}}"),
+            Self::{{#lambda.pascalcase}}{{{name}}}{{/lambda.pascalcase}} => String::from("{{{value}}}"),
             {{/enumVars}}
             {{/allowableValues}}
         }
@@ -35,7 +35,7 @@ impl ToString for {{{classname}}} {
 impl Default for {{{classname}}} {
     fn default() -> {{{classname}}} {
         {{#allowableValues}}
-        Self::{{ enumVars.0.name }}
+        Self::{{#lambda.pascalcase}}{{enumVars.0.name}}{{/lambda.pascalcase}}
         {{/allowableValues}}
     }
 }
@@ -148,7 +148,7 @@ pub enum {{{enumName}}} {
 {{#allowableValues}}
 {{#enumVars}}
     #[serde(rename = "{{{value}}}")]
-    {{{name}}},
+    {{#lambda.pascalcase}}{{{name}}}{{/lambda.pascalcase}},
 {{/enumVars}}
 {{/allowableValues}}
 }

--- a/modules/openapi-generator/src/main/resources/rust/model_doc.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model_doc.mustache
@@ -5,7 +5,7 @@
 
 | Name | Value |
 |---- | -----|{{#allowableValues}}{{#enumVars}}
-| {{name}} | {{value}} |{{/enumVars}}{{/allowableValues}}
+| {{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}} | {{value}} |{{/enumVars}}{{/allowableValues}}
 
 {{/isEnum}}
 {{#discriminator}}

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/order.rs
@@ -49,7 +49,7 @@ pub enum Status {
     #[serde(rename = "approved")]
     Approved,
     #[serde(rename = "delivered")]
-    shipped,
+    Shipped,
 }
 
 impl Default for Status {


### PR DESCRIPTION
Fixes issue: https://github.com/OpenAPITools/openapi-generator/issues/18602 - Rust enum variants from enumNameMappings config should be in PascalCase

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request. @frol (2017/07) @farcaller (2017/08) @richardwhiuk (2019/07) @paladinzh (2020/05) @jacob-pro (2022/10)
