### PR TITLE
[php-flight] fix: always set http status in streaming response

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-flight/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php-flight/api.mustache
@@ -11,7 +11,8 @@ namespace {{apiPackage}};
     {{#operation}}
     /**
      * Operation {{{operationId}}}
-     * Path: {{{path}}}
+     *
+     * Path: `{{{path}}}`
      *
      {{#summary}}
      * {{{summary}}}
@@ -31,9 +32,10 @@ namespace {{apiPackage}};
         throw new \Exception('Not implemented');
     }
 
-    {{#returnContainer}}
     /**
      * Operation {{{operationId}}} (stream)
+     *
+     * Path: `{{{path}}}`
      *
      {{#summary}}
      * {{{summary}}}
@@ -51,7 +53,6 @@ namespace {{apiPackage}};
     {
         throw new \Exception('Not implemented');
     }
-    {{/returnContainer}}
 {{/operation}}
 }
 {{/operations}}

--- a/modules/openapi-generator/src/main/resources/php-flight/register_routes.mustache
+++ b/modules/openapi-generator/src/main/resources/php-flight/register_routes.mustache
@@ -27,17 +27,16 @@ class RegisterRoutes {
                 );
                 {{^vendorExtensions.x-return-type-is-void}}
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt({{{vendorExtensions.x-default-status-code}}});
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, {{{vendorExtensions.x-default-status-code}}});
                 }
                 {{/vendorExtensions.x-return-type-is-void}}
                 {{#vendorExtensions.x-return-type-is-void}}
-                \Flight::halt(204);
+                \Flight::halt({{{vendorExtensions.x-default-status-code}}});
                 {{/vendorExtensions.x-return-type-is-void}}
             });
         }
-        {{#returnContainer}}
         if (declaresMethod($reflectionClass, '{{operationId}}Stream')) {
             \Flight::route('{{httpMethod}} {{vendorExtensions.x-path}}', function ({{#pathParams}}string ${{paramName}}{{^-last}}, {{/-last}}{{/pathParams}}) use ($handler) {
                 $r = \Flight::request();
@@ -47,9 +46,8 @@ class RegisterRoutes {
                 {{/vendorExtensions.x-nonFormParams}}
                 );
                 // ignore return value: streaming expected
-            })->streamWithHeaders(['Content-Type' => 'application/json']);
+            })->streamWithHeaders(['status' => {{{vendorExtensions.x-default-status-code}}}{{#vendorExtensions.x-default-media-type}}, 'Content-Type' => '{{{vendorExtensions.x-default-media-type}}}'{{/vendorExtensions.x-default-media-type}}]);
         }
-        {{/returnContainer}}
 
         {{/operation}}
         {{/operations}}

--- a/samples/server/petstore/php-flight/Api/AbstractPetApi.php
+++ b/samples/server/petstore/php-flight/Api/AbstractPetApi.php
@@ -23,7 +23,8 @@ abstract class AbstractPetApi
 
     /**
      * Operation addPet
-     * Path: /pet
+     *
+     * Path: `/pet`
      *
      * Add a new pet to the store
      *
@@ -37,8 +38,23 @@ abstract class AbstractPetApi
     }
 
     /**
+     * Operation addPet (stream)
+     *
+     * Path: `/pet`
+     *
+     * Add a new pet to the store
+     *
+     * @param \OpenAPIServer\Model\Pet $pet Pet object that needs to be added to the store (required)
+     *
+     */
+    public function addPetStream(\OpenAPIServer\Model\Pet $pet): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation deletePet
-     * Path: /pet/{petId}
+     *
+     * Path: `/pet/{petId}`
      *
      * Deletes a pet
      *
@@ -53,8 +69,24 @@ abstract class AbstractPetApi
     }
 
     /**
+     * Operation deletePet (stream)
+     *
+     * Path: `/pet/{petId}`
+     *
+     * Deletes a pet
+     *
+     * @param int $petId Pet id to delete (required)
+     * @param ?string $apiKey  (optional)
+     *
+     */
+    public function deletePetStream(int $petId, ?string $apiKey): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation findPetsByStatus
-     * Path: /pet/findByStatus
+     *
+     * Path: `/pet/findByStatus`
      *
      * Finds Pets by status
      *
@@ -70,6 +102,8 @@ abstract class AbstractPetApi
     /**
      * Operation findPetsByStatus (stream)
      *
+     * Path: `/pet/findByStatus`
+     *
      * Finds Pets by status
      *
      * @param array $status Status values that need to be considered for filter (required) (deprecated)
@@ -81,7 +115,8 @@ abstract class AbstractPetApi
     }
     /**
      * Operation findPetsByTags
-     * Path: /pet/findByTags
+     *
+     * Path: `/pet/findByTags`
      *
      * Finds Pets by tags
      *
@@ -98,6 +133,8 @@ abstract class AbstractPetApi
     /**
      * Operation findPetsByTags (stream)
      *
+     * Path: `/pet/findByTags`
+     *
      * Finds Pets by tags
      *
      * @param array $tags Tags to filter by (required)
@@ -110,7 +147,8 @@ abstract class AbstractPetApi
     }
     /**
      * Operation getPetById
-     * Path: /pet/{petId}
+     *
+     * Path: `/pet/{petId}`
      *
      * Find pet by ID
      *
@@ -124,8 +162,23 @@ abstract class AbstractPetApi
     }
 
     /**
+     * Operation getPetById (stream)
+     *
+     * Path: `/pet/{petId}`
+     *
+     * Find pet by ID
+     *
+     * @param int $petId ID of pet to return (required)
+     *
+     */
+    public function getPetByIdStream(int $petId): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation updatePet
-     * Path: /pet
+     *
+     * Path: `/pet`
      *
      * Update an existing pet
      *
@@ -139,8 +192,23 @@ abstract class AbstractPetApi
     }
 
     /**
+     * Operation updatePet (stream)
+     *
+     * Path: `/pet`
+     *
+     * Update an existing pet
+     *
+     * @param \OpenAPIServer\Model\Pet $pet Pet object that needs to be added to the store (required)
+     *
+     */
+    public function updatePetStream(\OpenAPIServer\Model\Pet $pet): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation updatePetWithForm
-     * Path: /pet/{petId}
+     *
+     * Path: `/pet/{petId}`
      *
      * Updates a pet in the store with form data
      *
@@ -154,8 +222,23 @@ abstract class AbstractPetApi
     }
 
     /**
+     * Operation updatePetWithForm (stream)
+     *
+     * Path: `/pet/{petId}`
+     *
+     * Updates a pet in the store with form data
+     *
+     * @param int $petId ID of pet that needs to be updated (required)
+     *
+     */
+    public function updatePetWithFormStream(int $petId): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation uploadFile
-     * Path: /pet/{petId}/uploadImage
+     *
+     * Path: `/pet/{petId}/uploadImage`
      *
      * uploads an image
      *
@@ -168,4 +251,18 @@ abstract class AbstractPetApi
         throw new \Exception('Not implemented');
     }
 
+    /**
+     * Operation uploadFile (stream)
+     *
+     * Path: `/pet/{petId}/uploadImage`
+     *
+     * uploads an image
+     *
+     * @param int $petId ID of pet to update (required)
+     *
+     */
+    public function uploadFileStream(int $petId): void
+    {
+        throw new \Exception('Not implemented');
+    }
 }

--- a/samples/server/petstore/php-flight/Api/AbstractStoreApi.php
+++ b/samples/server/petstore/php-flight/Api/AbstractStoreApi.php
@@ -23,7 +23,8 @@ abstract class AbstractStoreApi
 
     /**
      * Operation deleteOrder
-     * Path: /store/order/{orderId}
+     *
+     * Path: `/store/order/{orderId}`
      *
      * Delete purchase order by ID
      *
@@ -37,8 +38,23 @@ abstract class AbstractStoreApi
     }
 
     /**
+     * Operation deleteOrder (stream)
+     *
+     * Path: `/store/order/{orderId}`
+     *
+     * Delete purchase order by ID
+     *
+     * @param string $orderId ID of the order that needs to be deleted (required)
+     *
+     */
+    public function deleteOrderStream(string $orderId): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation getInventory
-     * Path: /store/inventory
+     *
+     * Path: `/store/inventory`
      *
      * Returns pet inventories by status
      *
@@ -53,6 +69,8 @@ abstract class AbstractStoreApi
     /**
      * Operation getInventory (stream)
      *
+     * Path: `/store/inventory`
+     *
      * Returns pet inventories by status
      *
      *
@@ -63,7 +81,8 @@ abstract class AbstractStoreApi
     }
     /**
      * Operation getOrderById
-     * Path: /store/order/{orderId}
+     *
+     * Path: `/store/order/{orderId}`
      *
      * Find purchase order by ID
      *
@@ -77,8 +96,23 @@ abstract class AbstractStoreApi
     }
 
     /**
+     * Operation getOrderById (stream)
+     *
+     * Path: `/store/order/{orderId}`
+     *
+     * Find purchase order by ID
+     *
+     * @param int $orderId ID of pet that needs to be fetched (required)
+     *
+     */
+    public function getOrderByIdStream(int $orderId): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation placeOrder
-     * Path: /store/order
+     *
+     * Path: `/store/order`
      *
      * Place an order for a pet
      *
@@ -91,4 +125,18 @@ abstract class AbstractStoreApi
         throw new \Exception('Not implemented');
     }
 
+    /**
+     * Operation placeOrder (stream)
+     *
+     * Path: `/store/order`
+     *
+     * Place an order for a pet
+     *
+     * @param \OpenAPIServer\Model\Order $order order placed for purchasing the pet (required)
+     *
+     */
+    public function placeOrderStream(\OpenAPIServer\Model\Order $order): void
+    {
+        throw new \Exception('Not implemented');
+    }
 }

--- a/samples/server/petstore/php-flight/Api/AbstractUserApi.php
+++ b/samples/server/petstore/php-flight/Api/AbstractUserApi.php
@@ -23,7 +23,8 @@ abstract class AbstractUserApi
 
     /**
      * Operation createUser
-     * Path: /user
+     *
+     * Path: `/user`
      *
      * Create user
      *
@@ -37,8 +38,23 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation createUser (stream)
+     *
+     * Path: `/user`
+     *
+     * Create user
+     *
+     * @param \OpenAPIServer\Model\User $user Created user object (required)
+     *
+     */
+    public function createUserStream(\OpenAPIServer\Model\User $user): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation createUsersWithArrayInput
-     * Path: /user/createWithArray
+     *
+     * Path: `/user/createWithArray`
      *
      * Creates list of users with given input array
      *
@@ -52,8 +68,23 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation createUsersWithArrayInput (stream)
+     *
+     * Path: `/user/createWithArray`
+     *
+     * Creates list of users with given input array
+     *
+     * @param array $user List of user object (required)
+     *
+     */
+    public function createUsersWithArrayInputStream(array $user): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation createUsersWithListInput
-     * Path: /user/createWithList
+     *
+     * Path: `/user/createWithList`
      *
      * Creates list of users with given input array
      *
@@ -67,8 +98,23 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation createUsersWithListInput (stream)
+     *
+     * Path: `/user/createWithList`
+     *
+     * Creates list of users with given input array
+     *
+     * @param array $user List of user object (required)
+     *
+     */
+    public function createUsersWithListInputStream(array $user): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation deleteUser
-     * Path: /user/{username}
+     *
+     * Path: `/user/{username}`
      *
      * Delete user
      *
@@ -82,8 +128,23 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation deleteUser (stream)
+     *
+     * Path: `/user/{username}`
+     *
+     * Delete user
+     *
+     * @param string $username The name that needs to be deleted (required)
+     *
+     */
+    public function deleteUserStream(string $username): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation getUserByName
-     * Path: /user/{username}
+     *
+     * Path: `/user/{username}`
      *
      * Get user by user name
      *
@@ -97,8 +158,23 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation getUserByName (stream)
+     *
+     * Path: `/user/{username}`
+     *
+     * Get user by user name
+     *
+     * @param string $username The name that needs to be fetched. Use user1 for testing. (required)
+     *
+     */
+    public function getUserByNameStream(string $username): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation loginUser
-     * Path: /user/login
+     *
+     * Path: `/user/login`
      *
      * Logs user into the system
      *
@@ -113,8 +189,24 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation loginUser (stream)
+     *
+     * Path: `/user/login`
+     *
+     * Logs user into the system
+     *
+     * @param string $username The user name for login (required)
+     * @param string $password The password for login in clear text (required)
+     *
+     */
+    public function loginUserStream(string $username, string $password): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation logoutUser
-     * Path: /user/logout
+     *
+     * Path: `/user/logout`
      *
      * Logs out current logged in user session
      *
@@ -127,8 +219,22 @@ abstract class AbstractUserApi
     }
 
     /**
+     * Operation logoutUser (stream)
+     *
+     * Path: `/user/logout`
+     *
+     * Logs out current logged in user session
+     *
+     *
+     */
+    public function logoutUserStream(): void
+    {
+        throw new \Exception('Not implemented');
+    }
+    /**
      * Operation updateUser
-     * Path: /user/{username}
+     *
+     * Path: `/user/{username}`
      *
      * Updated user
      *
@@ -142,4 +248,19 @@ abstract class AbstractUserApi
         throw new \Exception('Not implemented');
     }
 
+    /**
+     * Operation updateUser (stream)
+     *
+     * Path: `/user/{username}`
+     *
+     * Updated user
+     *
+     * @param string $username name that need to be deleted (required)
+     * @param \OpenAPIServer\Model\User $user Updated user object (required)
+     *
+     */
+    public function updateUserStream(string $username, \OpenAPIServer\Model\User $user): void
+    {
+        throw new \Exception('Not implemented');
+    }
 }

--- a/samples/server/petstore/php-flight/RegisterRoutes.php
+++ b/samples/server/petstore/php-flight/RegisterRoutes.php
@@ -33,11 +33,20 @@ class RegisterRoutes {
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Pet')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'addPetStream')) {
+            \Flight::route('POST /pet', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->addPetStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Pet')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'deletePet') && declaresMethod($reflectionClass, 'deletePetStream')) {
@@ -50,8 +59,18 @@ class RegisterRoutes {
                     parseParam($petId, 'int'), 
                     parseParam($r->getHeader('api_key'), '?string')
                 );
-                \Flight::halt(204);
+                \Flight::halt(400);
             });
+        }
+        if (declaresMethod($reflectionClass, 'deletePetStream')) {
+            \Flight::route('DELETE /pet/@petId', function (string $petId) use ($handler) {
+                $r = \Flight::request();
+                $handler->deletePetStream(
+                    parseParam($petId, 'int'), 
+                    parseParam($r->getHeader('api_key'), '?string')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 400]);
         }
 
         if (declaresMethod($reflectionClass, 'findPetsByStatus') && declaresMethod($reflectionClass, 'findPetsByStatusStream')) {
@@ -64,9 +83,9 @@ class RegisterRoutes {
                     parseParam($r->query['status'] ?? null, '\\OpenAPIServer\\Model\\FindPetsByStatusStatusParameterInner[]')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
         }
@@ -77,7 +96,7 @@ class RegisterRoutes {
                     parseParam($r->query['status'] ?? null, '\\OpenAPIServer\\Model\\FindPetsByStatusStatusParameterInner[]')
                 );
                 // ignore return value: streaming expected
-            })->streamWithHeaders(['Content-Type' => 'application/json']);
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'findPetsByTags') && declaresMethod($reflectionClass, 'findPetsByTagsStream')) {
@@ -90,9 +109,9 @@ class RegisterRoutes {
                     parseParam($r->query['tags'] ?? null, 'string[]')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
         }
@@ -103,7 +122,7 @@ class RegisterRoutes {
                     parseParam($r->query['tags'] ?? null, 'string[]')
                 );
                 // ignore return value: streaming expected
-            })->streamWithHeaders(['Content-Type' => 'application/json']);
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'getPetById') && declaresMethod($reflectionClass, 'getPetByIdStream')) {
@@ -116,11 +135,20 @@ class RegisterRoutes {
                     parseParam($petId, 'int')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'getPetByIdStream')) {
+            \Flight::route('GET /pet/@petId', function (string $petId) use ($handler) {
+                $r = \Flight::request();
+                $handler->getPetByIdStream(
+                    parseParam($petId, 'int')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'updatePet') && declaresMethod($reflectionClass, 'updatePetStream')) {
@@ -133,11 +161,20 @@ class RegisterRoutes {
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Pet')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'updatePetStream')) {
+            \Flight::route('PUT /pet', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->updatePetStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Pet')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'updatePetWithForm') && declaresMethod($reflectionClass, 'updatePetWithFormStream')) {
@@ -149,8 +186,17 @@ class RegisterRoutes {
                 $handler->updatePetWithForm(
                     parseParam($petId, 'int')
                 );
-                \Flight::halt(204);
+                \Flight::halt(405);
             });
+        }
+        if (declaresMethod($reflectionClass, 'updatePetWithFormStream')) {
+            \Flight::route('POST /pet/@petId', function (string $petId) use ($handler) {
+                $r = \Flight::request();
+                $handler->updatePetWithFormStream(
+                    parseParam($petId, 'int')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 405]);
         }
 
         if (declaresMethod($reflectionClass, 'uploadFile') && declaresMethod($reflectionClass, 'uploadFileStream')) {
@@ -163,11 +209,20 @@ class RegisterRoutes {
                     parseParam($petId, 'int')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'uploadFileStream')) {
+            \Flight::route('POST /pet/@petId/uploadImage', function (string $petId) use ($handler) {
+                $r = \Flight::request();
+                $handler->uploadFileStream(
+                    parseParam($petId, 'int')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'deleteOrder') && declaresMethod($reflectionClass, 'deleteOrderStream')) {
@@ -179,8 +234,17 @@ class RegisterRoutes {
                 $handler->deleteOrder(
                     parseParam($orderId, 'string')
                 );
-                \Flight::halt(204);
+                \Flight::halt(400);
             });
+        }
+        if (declaresMethod($reflectionClass, 'deleteOrderStream')) {
+            \Flight::route('DELETE /store/order/@orderId', function (string $orderId) use ($handler) {
+                $r = \Flight::request();
+                $handler->deleteOrderStream(
+                    parseParam($orderId, 'string')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 400]);
         }
 
         if (declaresMethod($reflectionClass, 'getInventory') && declaresMethod($reflectionClass, 'getInventoryStream')) {
@@ -191,7 +255,7 @@ class RegisterRoutes {
                 $r = \Flight::request();
                 $handler->getInventory(
                 );
-                \Flight::halt(204);
+                \Flight::halt(200);
             });
         }
         if (declaresMethod($reflectionClass, 'getInventoryStream')) {
@@ -200,7 +264,7 @@ class RegisterRoutes {
                 $handler->getInventoryStream(
                 );
                 // ignore return value: streaming expected
-            })->streamWithHeaders(['Content-Type' => 'application/json']);
+            })->streamWithHeaders(['status' => 200]);
         }
 
         if (declaresMethod($reflectionClass, 'getOrderById') && declaresMethod($reflectionClass, 'getOrderByIdStream')) {
@@ -213,11 +277,20 @@ class RegisterRoutes {
                     parseParam($orderId, 'int')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'getOrderByIdStream')) {
+            \Flight::route('GET /store/order/@orderId', function (string $orderId) use ($handler) {
+                $r = \Flight::request();
+                $handler->getOrderByIdStream(
+                    parseParam($orderId, 'int')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'placeOrder') && declaresMethod($reflectionClass, 'placeOrderStream')) {
@@ -230,11 +303,20 @@ class RegisterRoutes {
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Order')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'placeOrderStream')) {
+            \Flight::route('POST /store/order', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->placeOrderStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\Order')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'createUser') && declaresMethod($reflectionClass, 'createUserStream')) {
@@ -246,8 +328,17 @@ class RegisterRoutes {
                 $handler->createUser(
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User')
                 );
-                \Flight::halt(204);
+                \Flight::halt(200);
             });
+        }
+        if (declaresMethod($reflectionClass, 'createUserStream')) {
+            \Flight::route('POST /user', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->createUserStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200]);
         }
 
         if (declaresMethod($reflectionClass, 'createUsersWithArrayInput') && declaresMethod($reflectionClass, 'createUsersWithArrayInputStream')) {
@@ -259,8 +350,17 @@ class RegisterRoutes {
                 $handler->createUsersWithArrayInput(
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User[]')
                 );
-                \Flight::halt(204);
+                \Flight::halt(200);
             });
+        }
+        if (declaresMethod($reflectionClass, 'createUsersWithArrayInputStream')) {
+            \Flight::route('POST /user/createWithArray', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->createUsersWithArrayInputStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User[]')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200]);
         }
 
         if (declaresMethod($reflectionClass, 'createUsersWithListInput') && declaresMethod($reflectionClass, 'createUsersWithListInputStream')) {
@@ -272,8 +372,17 @@ class RegisterRoutes {
                 $handler->createUsersWithListInput(
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User[]')
                 );
-                \Flight::halt(204);
+                \Flight::halt(200);
             });
+        }
+        if (declaresMethod($reflectionClass, 'createUsersWithListInputStream')) {
+            \Flight::route('POST /user/createWithList', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->createUsersWithListInputStream(
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User[]')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200]);
         }
 
         if (declaresMethod($reflectionClass, 'deleteUser') && declaresMethod($reflectionClass, 'deleteUserStream')) {
@@ -285,8 +394,17 @@ class RegisterRoutes {
                 $handler->deleteUser(
                     parseParam($username, 'string')
                 );
-                \Flight::halt(204);
+                \Flight::halt(400);
             });
+        }
+        if (declaresMethod($reflectionClass, 'deleteUserStream')) {
+            \Flight::route('DELETE /user/@username', function (string $username) use ($handler) {
+                $r = \Flight::request();
+                $handler->deleteUserStream(
+                    parseParam($username, 'string')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 400]);
         }
 
         if (declaresMethod($reflectionClass, 'getUserByName') && declaresMethod($reflectionClass, 'getUserByNameStream')) {
@@ -299,11 +417,20 @@ class RegisterRoutes {
                     parseParam($username, 'string')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'getUserByNameStream')) {
+            \Flight::route('GET /user/@username', function (string $username) use ($handler) {
+                $r = \Flight::request();
+                $handler->getUserByNameStream(
+                    parseParam($username, 'string')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'loginUser') && declaresMethod($reflectionClass, 'loginUserStream')) {
@@ -317,11 +444,21 @@ class RegisterRoutes {
                     parseParam($r->query['password'] ?? null, 'string')
                 );
                 if ($result === null) {
-                    \Flight::halt(204);
+                    \Flight::halt(200);
                 } else {
-                    \Flight::json($result);
+                    \Flight::json($result, 200);
                 }
             });
+        }
+        if (declaresMethod($reflectionClass, 'loginUserStream')) {
+            \Flight::route('GET /user/login', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->loginUserStream(
+                    parseParam($r->query['username'] ?? null, 'string'), 
+                    parseParam($r->query['password'] ?? null, 'string')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200, 'Content-Type' => 'application/json']);
         }
 
         if (declaresMethod($reflectionClass, 'logoutUser') && declaresMethod($reflectionClass, 'logoutUserStream')) {
@@ -332,8 +469,16 @@ class RegisterRoutes {
                 $r = \Flight::request();
                 $handler->logoutUser(
                 );
-                \Flight::halt(204);
+                \Flight::halt(200);
             });
+        }
+        if (declaresMethod($reflectionClass, 'logoutUserStream')) {
+            \Flight::route('GET /user/logout', function () use ($handler) {
+                $r = \Flight::request();
+                $handler->logoutUserStream(
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 200]);
         }
 
         if (declaresMethod($reflectionClass, 'updateUser') && declaresMethod($reflectionClass, 'updateUserStream')) {
@@ -346,8 +491,18 @@ class RegisterRoutes {
                     parseParam($username, 'string'), 
                     parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User')
                 );
-                \Flight::halt(204);
+                \Flight::halt(400);
             });
+        }
+        if (declaresMethod($reflectionClass, 'updateUserStream')) {
+            \Flight::route('PUT /user/@username', function (string $username) use ($handler) {
+                $r = \Flight::request();
+                $handler->updateUserStream(
+                    parseParam($username, 'string'), 
+                    parseParam(json_decode($r->getBody(), true), '\\OpenAPIServer\\Model\\User')
+                );
+                // ignore return value: streaming expected
+            })->streamWithHeaders(['status' => 400]);
         }
 
     }


### PR DESCRIPTION
…and use http status from spec

 This additionally adds streaming stubs for all methods (rather err on the side of too much stubs).

@jebentier, @dkarlovi, @mandrean, @jfastnacht, @ybelenko, @renepardon

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
