### PR TITLE
typescript-axios: withSeparateModelsAndApi - fix missing import type

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/apiInner.mustache
@@ -18,10 +18,10 @@ import FormData from 'form-data'
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '{{apiRelativeToRoot}}common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '{{apiRelativeToRoot}}base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError, operationServerMap } from '{{apiRelativeToRoot}}base';
 {{#imports}}
 // @ts-ignore
-import { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
+import type { {{classname}} } from '{{apiRelativeToRoot}}{{tsModelPackage}}';
 {{/imports}}
 {{/withSeparateModelsAndApi}}
 {{^withSeparateModelsAndApi}}

--- a/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-axios/model.mustache
@@ -4,13 +4,13 @@
 {{#withSeparateModelsAndApi}}{{#hasAllOf}}{{#allOf}}
 // May contain unused imports in some cases
 // @ts-ignore
-import { {{class}} } from './{{filename}}';{{/allOf}}{{/hasAllOf}}{{#hasOneOf}}{{#oneOf}}
+import type { {{class}} } from './{{filename}}';{{/allOf}}{{/hasAllOf}}{{#hasOneOf}}{{#oneOf}}
 // May contain unused imports in some cases
 // @ts-ignore
-import { {{class}} } from './{{filename}}';{{/oneOf}}{{/hasOneOf}}{{^hasAllOf}}{{^hasOneOf}}{{#imports}}
+import type { {{class}} } from './{{filename}}';{{/oneOf}}{{/hasOneOf}}{{^hasAllOf}}{{^hasOneOf}}{{#imports}}
 // May contain unused imports in some cases
 // @ts-ignore
-import { {{class}} } from './{{filename}}';{{/imports}}{{/hasOneOf}}{{/hasAllOf}}{{/withSeparateModelsAndApi}}
+import type { {{class}} } from './{{filename}}';{{/imports}}{{/hasOneOf}}{{/hasAllOf}}{{/withSeparateModelsAndApi}}
 {{#models}}{{#model}}
 {{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{#allOf}}{{#-first}}{{>modelAllOf}}{{/-first}}{{/allOf}}{{^isEnum}}{{^oneOf}}{{^allOf}}{{>modelGeneric}}{{/allOf}}{{/oneOf}}{{/isEnum}}
 {{/model}}{{/models}}

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/abstract-user-dto.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/abstract-user-dto.ts
@@ -15,7 +15,7 @@
 
 // May contain unused imports in some cases
 // @ts-ignore
-import { BranchDto } from './branch-dto';
+import type { BranchDto } from './branch-dto';
 
 /**
  * 

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/flat-stock-pick-order-dto.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/flat-stock-pick-order-dto.ts
@@ -15,7 +15,7 @@
 
 // May contain unused imports in some cases
 // @ts-ignore
-import { AbstractFlatStockPickOrderBaseDto } from './abstract-flat-stock-pick-order-base-dto';
+import type { AbstractFlatStockPickOrderBaseDto } from './abstract-flat-stock-pick-order-base-dto';
 
 /**
  * @type FlatStockPickOrderDto

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/internal-authenticated-user-dto.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/internal-authenticated-user-dto.ts
@@ -15,10 +15,10 @@
 
 // May contain unused imports in some cases
 // @ts-ignore
-import { AbstractUserDto } from './abstract-user-dto';
+import type { AbstractUserDto } from './abstract-user-dto';
 // May contain unused imports in some cases
 // @ts-ignore
-import { BranchDto } from './branch-dto';
+import type { BranchDto } from './branch-dto';
 
 /**
  * @type InternalAuthenticatedUserDto

--- a/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/remote-authenticated-user-dto.ts
+++ b/samples/client/others/typescript-axios/with-separate-models-and-api-inheritance/model/remote-authenticated-user-dto.ts
@@ -15,10 +15,10 @@
 
 // May contain unused imports in some cases
 // @ts-ignore
-import { AbstractUserDto } from './abstract-user-dto';
+import type { AbstractUserDto } from './abstract-user-dto';
 // May contain unused imports in some cases
 // @ts-ignore
-import { BranchDto } from './branch-dto';
+import type { BranchDto } from './branch-dto';
 
 /**
  * @type RemoteAuthenticatedUserDto

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/pet-api.ts
@@ -20,11 +20,11 @@ import globalAxios from 'axios';
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
 // @ts-ignore
-import { ApiResponse } from '../../../model/some/levels/deep';
+import type { ApiResponse } from '../../../model/some/levels/deep';
 // @ts-ignore
-import { Pet } from '../../../model/some/levels/deep';
+import type { Pet } from '../../../model/some/levels/deep';
 /**
  * PetApi - axios parameter creator
  * @export

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/store-api.ts
@@ -20,9 +20,9 @@ import globalAxios from 'axios';
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
 // @ts-ignore
-import { Order } from '../../../model/some/levels/deep';
+import type { Order } from '../../../model/some/levels/deep';
 /**
  * StoreApi - axios parameter creator
  * @export

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/api/another/level/user-api.ts
@@ -20,9 +20,9 @@ import globalAxios from 'axios';
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '../../../common';
 // @ts-ignore
-import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
+import { BASE_PATH, COLLECTION_FORMATS, type RequestArgs, BaseAPI, RequiredError, operationServerMap } from '../../../base';
 // @ts-ignore
-import { User } from '../../../model/some/levels/deep';
+import type { User } from '../../../model/some/levels/deep';
 /**
  * UserApi - axios parameter creator
  * @export

--- a/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
+++ b/samples/client/petstore/typescript-axios/builds/with-npm-version-and-separate-models-and-api/model/some/levels/deep/pet.ts
@@ -15,10 +15,10 @@
 
 // May contain unused imports in some cases
 // @ts-ignore
-import { Category } from './category';
+import type { Category } from './category';
 // May contain unused imports in some cases
 // @ts-ignore
-import { Tag } from './tag';
+import type { Tag } from './tag';
 
 /**
  * A pet for sale in the pet store


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
Fixes #17461.

Similar to #12195 but there does not seem to be solved type import issued for `withSeparateModelsAndApi` and as far as i saw, all the changes have already been addressed by #13964, therefore that PR can be closed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

CC @TiFu (2017/07) @taxpon (2017/07) @sebastianhaas (2017/07) @kenisteward (2017/07) @Vrolijkx (2017/09) @macjohnny (2018/01) @topce (2018/10) @akehir (2019/07) @petejohansonxo (2019/11) @amakhrov (2020/02) @davidgamero (2022/03) @mkusaka (2022/04)
