### PR TITLE
[Java] [VertX] Handle hyphen-separated security schemes in input spec

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -680,54 +680,54 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         private final Map<String, Authentication> authentications = new LinkedHashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
 
-        public void add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String username, String password) {
+        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String username, String password) {
             HttpBasicAuth auth = new HttpBasicAuth();
             auth.setUsername(username);
             auth.setPassword(password);
             authentications.put("{{name}}", auth);
         }{{/isBasicBasic}}{{#isBasicBearer}}
 
-        public void add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String bearerToken) {
+        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String bearerToken) {
            HttpBearerAuth auth = new
            HttpBearerAuth("{{scheme}}");
            auth.setBearerToken(bearerToken);
            authentications.put("{{name}}", auth);
         }{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
 
-        public void add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
+        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}},"{{keyParamName}}");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("{{name}}", auth);
         }{{/isApiKey}}{{#isOAuth}}
 
-        public void add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String accessToken) {
+        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String accessToken) {
            OAuth auth = new OAuth();
            auth.setAccessToken(accessToken);
            authentications.put("{{name}}", auth);
         }{{/isOAuth}}{{/authMethods}}{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}(String username, String password) {
+        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}(String username, String password) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(username, password);
+            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(username, password);
             return authInfo;
         }{{/isBasicBasic}}{{#isBasicBearer}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String bearerToken) {
+        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String bearerToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(bearerToken);
+            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(bearerToken);
             return authInfo;
         }{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(apikey, apiKeyPrefix);
+            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(apikey, apiKeyPrefix);
             return authInfo;
         }{{/isApiKey}}{{#isOAuth}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(String accessToken) {
+        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String accessToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{name}}{{/lambda.titlecase}}Authentication(accessToken);
+            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(accessToken);
             return authInfo;
         }{{/isOAuth}}{{/authMethods}}
     }

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java
@@ -999,6 +999,39 @@ public class JavaClientCodegenTest {
         Assertions.assertEquals(security.get(0).isBasicBearer, Boolean.TRUE);
     }
 
+    @Test
+    public void testVertXAuthInfoWithHyphenSeparatedSecurityScheme() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(CodegenConstants.API_PACKAGE, "xyz.abcdef.api");
+
+        File output = Files.createTempDirectory("test").toFile();
+        output.deleteOnExit();
+
+        final CodegenConfigurator configurator = new CodegenConfigurator()
+            .setGeneratorName("java")
+            .setLibrary(JavaClientCodegen.VERTX)
+            .setAdditionalProperties(properties)
+            .setInputSpec("src/test/resources/3_0/ping-with-hyphen-separated-security-scheme.yaml")
+            .setOutputDir(output.getAbsolutePath().replace("\\", "/"));
+
+        final ClientOptInput clientOptInput = configurator.toClientOptInput();
+        DefaultGenerator generator = new DefaultGenerator();
+        List<File> files = generator.opts(clientOptInput).generate();
+
+        // Test that hyphen-separated security scheme names does not
+        // break the Java VertX client code generation
+        validateJavaSourceFiles(files);
+
+        // Test that the name was correctly transformed to camelCase
+        // starting with an uppercase letter
+        TestUtils.assertFileContains(
+            Paths.get(output + "/src/main/java/xyz/abcdef/ApiClient.java"),
+                "public static class AuthInfo {",
+                "public void addHyphenatedNameTestAuthentication(String bearerToken) {",
+                "public static AuthInfo forHyphenatedNameTestAuthentication(String bearerToken) {"
+            );
+    }
+
     private CodegenProperty codegenPropertyWithArrayOfIntegerValues() {
         CodegenProperty array = new CodegenProperty();
         final CodegenProperty items = new CodegenProperty();

--- a/modules/openapi-generator/src/test/resources/3_0/ping-with-hyphen-separated-security-scheme.yaml
+++ b/modules/openapi-generator/src/test/resources/3_0/ping-with-hyphen-separated-security-scheme.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.1
+info:
+  title: ping test
+  version: '1.0'
+servers:
+  - url: 'http://localhost:8080/'
+paths:
+  /ping:
+    get:
+      operationId: pingGet
+      responses:
+        '201':
+          description: OK
+components:
+  securitySchemes:
+    hyphenated-name-test:
+      scheme: bearer
+      bearerFormat: token
+      type: http
+security:
+  - hyphenated-name-test: []

--- a/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx-no-nullable/src/main/java/org/openapitools/client/ApiClient.java
@@ -667,54 +667,54 @@ public class ApiClient extends JavaTimeFormatter {
 
         private final Map<String, Authentication> authentications = new LinkedHashMap<>();
 
-        public void addPetstore_authAuthentication(String accessToken) {
+        public void addPetstoreAuthAuthentication(String accessToken) {
            OAuth auth = new OAuth();
            auth.setAccessToken(accessToken);
            authentications.put("petstore_auth", auth);
         }
 
-        public void addApi_keyAuthentication(String apikey, String apiKeyPrefix) {
+        public void addApiKeyAuthentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth("header","api_key");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("api_key", auth);
         }
 
-        public void addApi_key_queryAuthentication(String apikey, String apiKeyPrefix) {
+        public void addApiKeyQueryAuthentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth("query","api_key_query");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("api_key_query", auth);
         }
 
-        public void addHttp_basic_testAuthentication(String username, String password) {
+        public void addHttpBasicTestAuthentication(String username, String password) {
             HttpBasicAuth auth = new HttpBasicAuth();
             auth.setUsername(username);
             auth.setPassword(password);
             authentications.put("http_basic_test", auth);
         }
 
-        public static AuthInfo forPetstore_authAuthentication(String accessToken) {
+        public static AuthInfo forPetstoreAuthAuthentication(String accessToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addPetstore_authAuthentication(accessToken);
+            authInfo.addPetstoreAuthAuthentication(accessToken);
             return authInfo;
         }
 
-        public static AuthInfo forApi_keyAuthentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo forApiKeyAuthentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addApi_keyAuthentication(apikey, apiKeyPrefix);
+            authInfo.addApiKeyAuthentication(apikey, apiKeyPrefix);
             return authInfo;
         }
 
-        public static AuthInfo forApi_key_queryAuthentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo forApiKeyQueryAuthentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addApi_key_queryAuthentication(apikey, apiKeyPrefix);
+            authInfo.addApiKeyQueryAuthentication(apikey, apiKeyPrefix);
             return authInfo;
         }
 
-        public static AuthInfo forHttp_basic_test(String username, String password) {
+        public static AuthInfo forHttpBasicTest(String username, String password) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addHttp_basic_testAuthentication(username, password);
+            authInfo.addHttpBasicTestAuthentication(username, password);
             return authInfo;
         }
     }

--- a/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/vertx/src/main/java/org/openapitools/client/ApiClient.java
@@ -671,67 +671,67 @@ public class ApiClient extends JavaTimeFormatter {
 
         private final Map<String, Authentication> authentications = new LinkedHashMap<>();
 
-        public void addPetstore_authAuthentication(String accessToken) {
+        public void addPetstoreAuthAuthentication(String accessToken) {
            OAuth auth = new OAuth();
            auth.setAccessToken(accessToken);
            authentications.put("petstore_auth", auth);
         }
 
-        public void addApi_keyAuthentication(String apikey, String apiKeyPrefix) {
+        public void addApiKeyAuthentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth("header","api_key");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("api_key", auth);
         }
 
-        public void addApi_key_queryAuthentication(String apikey, String apiKeyPrefix) {
+        public void addApiKeyQueryAuthentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth("query","api_key_query");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("api_key_query", auth);
         }
 
-        public void addHttp_basic_testAuthentication(String username, String password) {
+        public void addHttpBasicTestAuthentication(String username, String password) {
             HttpBasicAuth auth = new HttpBasicAuth();
             auth.setUsername(username);
             auth.setPassword(password);
             authentications.put("http_basic_test", auth);
         }
 
-        public void addBearer_testAuthentication(String bearerToken) {
+        public void addBearerTestAuthentication(String bearerToken) {
            HttpBearerAuth auth = new
            HttpBearerAuth("bearer");
            auth.setBearerToken(bearerToken);
            authentications.put("bearer_test", auth);
         }
 
-        public static AuthInfo forPetstore_authAuthentication(String accessToken) {
+        public static AuthInfo forPetstoreAuthAuthentication(String accessToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addPetstore_authAuthentication(accessToken);
+            authInfo.addPetstoreAuthAuthentication(accessToken);
             return authInfo;
         }
 
-        public static AuthInfo forApi_keyAuthentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo forApiKeyAuthentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addApi_keyAuthentication(apikey, apiKeyPrefix);
+            authInfo.addApiKeyAuthentication(apikey, apiKeyPrefix);
             return authInfo;
         }
 
-        public static AuthInfo forApi_key_queryAuthentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo forApiKeyQueryAuthentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addApi_key_queryAuthentication(apikey, apiKeyPrefix);
+            authInfo.addApiKeyQueryAuthentication(apikey, apiKeyPrefix);
             return authInfo;
         }
 
-        public static AuthInfo forHttp_basic_test(String username, String password) {
+        public static AuthInfo forHttpBasicTest(String username, String password) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addHttp_basic_testAuthentication(username, password);
+            authInfo.addHttpBasicTestAuthentication(username, password);
             return authInfo;
         }
 
-        public static AuthInfo forBearer_testAuthentication(String bearerToken) {
+        public static AuthInfo forBearerTestAuthentication(String bearerToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.addBearer_testAuthentication(bearerToken);
+            authInfo.addBearerTestAuthentication(bearerToken);
             return authInfo;
         }
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
resolves #18629 

Add lambda call to `camelcase` to correctly handle hyphen separated security schemes when generating the `AuthInfo` class in Java vertx client.

Steps to validate this branch:

1. Checkout to this branch locally and build the JAR: `./mvnw clean package`
2. Run the following command:
    ```bash
    java -jar modules/openapi-generator-cli/target/openapi-generator-cli.jar \
    generate \
    -g java \
    --library vertx \
    -o /var/tmp/java-vertx-client-test \
    -i https://gist.githubusercontent.com/rohitsanj/bd1f1f6747c41299bf4ce714ec2cda80/raw/6d46a2cfe8cf2dc173099e2b041af4dccb29c54a/openapi.yaml
    ```
3. After generating the project with the steps above, navigate to `src/main/java/org/openapitools/client/ApiClient.java` and verify that there are no syntax errors in the `AuthInfo` class.

I've also added a unit test to prove the fix.

Tagging openapi-generator Java committee explicitly (as mentioned in the PR checklist): @martin-mfg 

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
