### PR TITLE
Use Display instead of ToString in Rust generators

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/model.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/model.mustache
@@ -21,12 +21,12 @@ pub enum {{{classname}}} {
 {{/enumVars}}{{/allowableValues}}
 }
 
-impl ToString for {{{classname}}} {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for {{{classname}}} {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             {{#allowableValues}}
             {{#enumVars}}
-            Self::{{{name}}} => String::from("{{{value}}}"),
+            Self::{{{name}}} => write!(f, "{{{value}}}"),
             {{/enumVars}}
             {{/allowableValues}}
         }

--- a/samples/client/others/rust/hyper/api-with-ref-param/src/models/color.rs
+++ b/samples/client/others/rust/hyper/api-with-ref-param/src/models/color.rs
@@ -23,12 +23,12 @@ pub enum Color {
 
 }
 
-impl ToString for Color {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Red => String::from("RED"),
-            Self::Green => String::from("GREEN"),
-            Self::Blue => String::from("BLUE"),
+            Self::Red => write!(f, "RED"),
+            Self::Green => write!(f, "GREEN"),
+            Self::Blue => write!(f, "BLUE"),
         }
     }
 }

--- a/samples/client/others/rust/hyper/oneOf/src/models/fruit_type.rs
+++ b/samples/client/others/rust/hyper/oneOf/src/models/fruit_type.rs
@@ -21,11 +21,11 @@ pub enum FruitType {
 
 }
 
-impl ToString for FruitType {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for FruitType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Apple => String::from("APPLE"),
-            Self::Banana => String::from("BANANA"),
+            Self::Apple => write!(f, "APPLE"),
+            Self::Banana => write!(f, "BANANA"),
         }
     }
 }

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/models/color.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/models/color.rs
@@ -23,12 +23,12 @@ pub enum Color {
 
 }
 
-impl ToString for Color {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Color {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Red => String::from("RED"),
-            Self::Green => String::from("GREEN"),
-            Self::Blue => String::from("BLUE"),
+            Self::Red => write!(f, "RED"),
+            Self::Green => write!(f, "GREEN"),
+            Self::Blue => write!(f, "BLUE"),
         }
     }
 }

--- a/samples/client/others/rust/reqwest/oneOf/src/models/fruit_type.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/models/fruit_type.rs
@@ -21,11 +21,11 @@ pub enum FruitType {
 
 }
 
-impl ToString for FruitType {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for FruitType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Apple => String::from("APPLE"),
-            Self::Banana => String::from("BANANA"),
+            Self::Apple => write!(f, "APPLE"),
+            Self::Banana => write!(f, "BANANA"),
         }
     }
 }

--- a/samples/client/petstore/rust/hyper/petstore/src/models/baz.rs
+++ b/samples/client/petstore/rust/hyper/petstore/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }

--- a/samples/client/petstore/rust/reqwest/petstore/src/models/baz.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/models/baz.rs
@@ -24,12 +24,12 @@ pub enum Baz {
 
 }
 
-impl ToString for Baz {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for Baz {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::A => String::from("A"),
-            Self::B => String::from("B"),
-            Self::Empty => String::from(""),
+            Self::A => write!(f, "A"),
+            Self::B => write!(f, "B"),
+            Self::Empty => write!(f, ""),
         }
     }
 }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

With the latest 1.78 release of Rust, Clippy has introduced a lint warning against the direct implementation of `ToString`, recommending instead to implement `Display`: https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_trait_impl

This PR changes the uses of `impl ToString` in the Rust generator template for `impl Display`. It also updates the Rust samples. Note that because `Display` has a blanket implementation of `ToString`, the resulting enums will still implement `ToString`, so this doesn't break anything.

Tagging `openapi-generator` Rust committee, like the checklist mentions: @frol @farcaller @richardwhiuk @paladinzh @jacob-pro

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.