### PR TITLE
fix: Upgrade testng to avoid CVE-2022-4065

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractIntegrationTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/AbstractIntegrationTest.java
@@ -17,10 +17,11 @@
 
 package org.openapitools.codegen;
 
+import java.nio.file.Files;
+import java.util.stream.Collectors;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.openapitools.codegen.testutils.IntegrationTestPathsConfig;
 import org.testng.annotations.Test;
-import org.testng.reporters.Files;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -51,7 +52,7 @@ public abstract class AbstractIntegrationTest {
 
         IntegrationTestPathsConfig integrationTestPathsConfig = getIntegrationTestPathsConfig();
 
-        String specContent = Files.readFile(integrationTestPathsConfig.getSpecPath().toFile());
+        String specContent = Files.lines(integrationTestPathsConfig.getSpecPath()).collect(Collectors.joining("\n"));
         OpenAPI openAPI = TestUtils.parseContent(specContent);
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>5</version>
-        <relativePath/>
-    <!-- lookup parent from repository -->
+        <relativePath />
+        <!-- lookup parent from repository -->
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openapitools</groupId>
@@ -505,7 +507,8 @@
                             <failOnError>false</failOnError>
                             <!-- https://spotbugs.readthedocs.io/en/stable/effort.html -->
                             <effort>min</effort>
-                            <excludeFilterFile>${project.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
+                            <excludeFilterFile>
+                                ${project.basedir}${file.separator}spotbugs-exclude.xml</excludeFilterFile>
                         </configuration>
                         <executions>
                             <execution>
@@ -1253,7 +1256,7 @@
         <spotbugs-plugin.version>3.1.12.2</spotbugs-plugin.version>
         <swagger-parser-groupid.version>io.swagger.parser.v3</swagger-parser-groupid.version>
         <swagger-parser.version>2.1.22</swagger-parser.version>
-        <testng.version>7.5</testng.version>
+        <testng.version>7.10.2</testng.version>
         <violations-maven-plugin.version>1.34</violations-maven-plugin.version>
         <wagon-ssh-external.version>3.4.3</wagon-ssh-external.version>
         <wagon-svn.version>1.12</wagon-svn.version>


### PR DESCRIPTION
A testNG upgrade to fix a critical CVE.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
