### PR TITLE
[Java] [Vertx] Use pascalcase instead of double lambda

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/vertx/ApiClient.mustache
@@ -680,54 +680,54 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
 
         private final Map<String, Authentication> authentications = new LinkedHashMap<>();{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
 
-        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String username, String password) {
+        public void add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String username, String password) {
             HttpBasicAuth auth = new HttpBasicAuth();
             auth.setUsername(username);
             auth.setPassword(password);
             authentications.put("{{name}}", auth);
         }{{/isBasicBasic}}{{#isBasicBearer}}
 
-        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String bearerToken) {
+        public void add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String bearerToken) {
            HttpBearerAuth auth = new
            HttpBearerAuth("{{scheme}}");
            auth.setBearerToken(bearerToken);
            authentications.put("{{name}}", auth);
         }{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
 
-        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
+        public void add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String apikey, String apiKeyPrefix) {
            ApiKeyAuth auth = new ApiKeyAuth({{#isKeyInHeader}}"header"{{/isKeyInHeader}}{{#isKeyInQuery}}"query"{{/isKeyInQuery}}{{#isKeyInCookie}}"cookie"{{/isKeyInCookie}},"{{keyParamName}}");
            auth.setApiKey(apikey);
            auth.setApiKeyPrefix(apiKeyPrefix);
            authentications.put("{{name}}", auth);
         }{{/isApiKey}}{{#isOAuth}}
 
-        public void add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String accessToken) {
+        public void add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String accessToken) {
            OAuth auth = new OAuth();
            auth.setAccessToken(accessToken);
            authentications.put("{{name}}", auth);
         }{{/isOAuth}}{{/authMethods}}{{#authMethods}}{{#isBasic}}{{#isBasicBasic}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}(String username, String password) {
+        public static AuthInfo for{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}(String username, String password) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(username, password);
+            authInfo.add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(username, password);
             return authInfo;
         }{{/isBasicBasic}}{{#isBasicBearer}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String bearerToken) {
+        public static AuthInfo for{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String bearerToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(bearerToken);
+            authInfo.add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(bearerToken);
             return authInfo;
         }{{/isBasicBearer}}{{/isBasic}}{{#isApiKey}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String apikey, String apiKeyPrefix) {
+        public static AuthInfo for{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String apikey, String apiKeyPrefix) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(apikey, apiKeyPrefix);
+            authInfo.add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(apikey, apiKeyPrefix);
             return authInfo;
         }{{/isApiKey}}{{#isOAuth}}
 
-        public static AuthInfo for{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(String accessToken) {
+        public static AuthInfo for{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(String accessToken) {
             AuthInfo authInfo = new AuthInfo();
-            authInfo.add{{#lambda.titlecase}}{{#lambda.camelcase}}{{name}}{{/lambda.camelcase}}{{/lambda.titlecase}}Authentication(accessToken);
+            authInfo.add{{#lambda.pascalcase}}{{name}}{{/lambda.pascalcase}}Authentication(accessToken);
             return authInfo;
         }{{/isOAuth}}{{/authMethods}}
     }


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Follow up task from #18630, see this [comment](https://github.com/OpenAPITools/openapi-generator/pull/18630#discussion_r1598109709).

Existing unit test in `JavaClientCodeGenTest` covers the change in this PR.
https://github.com/OpenAPITools/openapi-generator/blob/926a07fe4dccf654d6f012b432c4a89cc2cb4bd7/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientCodegenTest.java#L1002-L1033

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
