### PR TITLE
[rust-reqwest]: allow rust configuration struct to be deserialized

### DIFF
--- a/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
@@ -9,10 +9,20 @@ use secrecy::{SecretString, ExposeSecret};
 {{/withAWSV4Signature}}
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client{{/supportMiddleware}},
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -87,6 +97,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+{{#withAWSV4Signature}}            aws_v4_key: None,{{/withAWSV4Signature}}
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: {{#supportMiddleware}}reqwest_middleware::ClientBuilder::new(reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new()).build(){{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client::new(){{/supportMiddleware}},
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 {{#withAWSV4Signature}}            aws_v4_key: None,{{/withAWSV4Signature}}
         }
     }

--- a/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
+++ b/modules/openapi-generator/src/main/resources/rust/reqwest/configuration.mustache
@@ -1,5 +1,6 @@
 {{>partial_header}}
 
+use serde::Deserialize;
 {{#withAWSV4Signature}}
 use std::time::SystemTime;
 use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
@@ -7,10 +8,11 @@ use http;
 use secrecy::{SecretString, ExposeSecret};
 {{/withAWSV4Signature}}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: {{#supportMiddleware}}reqwest_middleware::ClientWithMiddleware{{/supportMiddleware}}{{^supportMiddleware}}reqwest{{^supportAsync}}::blocking{{/supportAsync}}::Client{{/supportMiddleware}},
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest-regression-16119/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/api-with-ref-param/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/composed-oneof/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/emptyObject/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-array-map/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf-reuseRef/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
+++ b/samples/client/others/rust/reqwest/oneOf/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/name-mapping/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest_middleware::ClientWithMiddleware,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async-middleware/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest_middleware::ClientWithMiddleware,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-async/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-avoid-box/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
@@ -16,10 +16,20 @@ use http;
 use secrecy::{SecretString, ExposeSecret};
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -31,7 +41,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -90,6 +100,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+            aws_v4_key: None,
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
             aws_v4_key: None,
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore-awsv4signature/src/apis/configuration.rs
@@ -9,15 +9,17 @@
  */
 
 
+use serde::Deserialize;
 use std::time::SystemTime;
 use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest};
 use http;
 use secrecy::{SecretString, ExposeSecret};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
@@ -12,10 +12,20 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct DeserializedConfiguration {
+    pub base_path: String,
+    pub user_agent: Option<String>,
+    pub basic_auth: Option<BasicAuth>,
+    pub oauth_access_token: Option<String>,
+    pub bearer_access_token: Option<String>,
+    pub api_key: Option<ApiKey>,
+    // TODO: take an oauth2 token source, similar to the go one
+}
+
+#[derive(Debug, Clone)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,
@@ -26,7 +36,7 @@ pub struct Configuration {
 
 pub type BasicAuth = (String, Option<String>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ApiKey {
     pub prefix: Option<String>,
     pub key: String,
@@ -49,6 +59,21 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+
+        }
+    }
+}
+
+impl From<DeserializedConfiguration> for Configuration {
+    fn from(value: DeserializedConfiguration) -> Self {
+        Configuration {
+            base_path: value.base_path,
+            user_agent: value.user_agent,
+            client: reqwest::blocking::Client::new(),
+            basic_auth: value.basic_auth,
+            oauth_access_token: value.oauth_access_token,
+            bearer_access_token: value.bearer_access_token,
+            api_key: value.api_key,
 
         }
     }

--- a/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
+++ b/samples/client/petstore/rust/reqwest/petstore/src/apis/configuration.rs
@@ -9,11 +9,13 @@
  */
 
 
+use serde::Deserialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
+    #[serde(skip)]
     pub client: reqwest::blocking::Client,
     pub basic_auth: Option<BasicAuth>,
     pub oauth_access_token: Option<String>,


### PR DESCRIPTION
Allow rust configuration struct to be deserialized, so it may be easily constructed from a file or other source.
Fixes: https://github.com/OpenAPITools/openapi-generator/issues/18687

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
