### PR TITLE
[typescript-fetch] Make instanceOf infer type and check for undefineds

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelGeneric.mustache
@@ -20,10 +20,10 @@ import { {{modelName}}FromJSONTyped } from './{{modelName}}{{importFileExtension
 /**
  * Check if a given object implements the {{classname}} interface.
  */
-export function instanceOf{{classname}}(value: object): boolean {
+export function instanceOf{{classname}}(value: object): value is {{classname}} {
     {{#vars}}
     {{#required}}
-    if (!('{{name}}' in value)) return false;
+    if (!('{{name}}' in value) || value['{{name}}'] === undefined) return false;
     {{/required}}
     {{/vars}}
     return true;

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Club.ts
@@ -37,7 +37,7 @@ export interface Club {
 /**
  * Check if a given object implements the Club interface.
  */
-export function instanceOfClub(value: object): boolean {
+export function instanceOfClub(value: object): value is Club {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-nullable/models/Owner.ts
@@ -30,7 +30,7 @@ export interface Owner {
 /**
  * Check if a given object implements the Owner interface.
  */
-export function instanceOfOwner(value: object): boolean {
+export function instanceOfOwner(value: object): value is Owner {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Club.ts
@@ -37,7 +37,7 @@ export interface Club {
 /**
  * Check if a given object implements the Club interface.
  */
-export function instanceOfClub(value: object): boolean {
+export function instanceOfClub(value: object): value is Club {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
+++ b/samples/client/petstore/typescript-fetch/builds/allOf-readonly/models/Owner.ts
@@ -30,7 +30,7 @@ export interface Owner {
 /**
  * Check if a given object implements the Owner interface.
  */
-export function instanceOfOwner(value: object): boolean {
+export function instanceOfOwner(value: object): value is Owner {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AdditionalPropertiesClass.ts
@@ -36,7 +36,7 @@ export interface AdditionalPropertiesClass {
 /**
  * Check if a given object implements the AdditionalPropertiesClass interface.
  */
-export function instanceOfAdditionalPropertiesClass(value: object): boolean {
+export function instanceOfAdditionalPropertiesClass(value: object): value is AdditionalPropertiesClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/AllOfWithSingleRef.ts
@@ -43,7 +43,7 @@ export interface AllOfWithSingleRef {
 /**
  * Check if a given object implements the AllOfWithSingleRef interface.
  */
-export function instanceOfAllOfWithSingleRef(value: object): boolean {
+export function instanceOfAllOfWithSingleRef(value: object): value is AllOfWithSingleRef {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Animal.ts
@@ -38,8 +38,8 @@ export interface Animal {
 /**
  * Check if a given object implements the Animal interface.
  */
-export function instanceOfAnimal(value: object): boolean {
-    if (!('className' in value)) return false;
+export function instanceOfAnimal(value: object): value is Animal {
+    if (!('className' in value) || value['className'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfArrayOfNumberOnly.ts
@@ -30,7 +30,7 @@ export interface ArrayOfArrayOfNumberOnly {
 /**
  * Check if a given object implements the ArrayOfArrayOfNumberOnly interface.
  */
-export function instanceOfArrayOfArrayOfNumberOnly(value: object): boolean {
+export function instanceOfArrayOfArrayOfNumberOnly(value: object): value is ArrayOfArrayOfNumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayOfNumberOnly.ts
@@ -30,7 +30,7 @@ export interface ArrayOfNumberOnly {
 /**
  * Check if a given object implements the ArrayOfNumberOnly interface.
  */
-export function instanceOfArrayOfNumberOnly(value: object): boolean {
+export function instanceOfArrayOfNumberOnly(value: object): value is ArrayOfNumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ArrayTest.ts
@@ -49,7 +49,7 @@ export interface ArrayTest {
 /**
  * Check if a given object implements the ArrayTest interface.
  */
-export function instanceOfArrayTest(value: object): boolean {
+export function instanceOfArrayTest(value: object): value is ArrayTest {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Capitalization.ts
@@ -61,7 +61,7 @@ export interface Capitalization {
 /**
  * Check if a given object implements the Capitalization interface.
  */
-export function instanceOfCapitalization(value: object): boolean {
+export function instanceOfCapitalization(value: object): value is Capitalization {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Cat.ts
@@ -37,7 +37,7 @@ export interface Cat extends Animal {
 /**
  * Check if a given object implements the Cat interface.
  */
-export function instanceOfCat(value: object): boolean {
+export function instanceOfCat(value: object): value is Cat {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Category.ts
@@ -36,8 +36,8 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
-    if (!('name' in value)) return false;
+export function instanceOfCategory(value: object): value is Category {
+    if (!('name' in value) || value['name'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ChildWithNullable.ts
@@ -39,7 +39,7 @@ export interface ChildWithNullable extends ParentWithNullable {
 /**
  * Check if a given object implements the ChildWithNullable interface.
  */
-export function instanceOfChildWithNullable(value: object): boolean {
+export function instanceOfChildWithNullable(value: object): value is ChildWithNullable {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ClassModel.ts
@@ -30,7 +30,7 @@ export interface ClassModel {
 /**
  * Check if a given object implements the ClassModel interface.
  */
-export function instanceOfClassModel(value: object): boolean {
+export function instanceOfClassModel(value: object): value is ClassModel {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Client.ts
@@ -30,7 +30,7 @@ export interface Client {
 /**
  * Check if a given object implements the Client interface.
  */
-export function instanceOfClient(value: object): boolean {
+export function instanceOfClient(value: object): value is Client {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/DeprecatedObject.ts
@@ -30,7 +30,7 @@ export interface DeprecatedObject {
 /**
  * Check if a given object implements the DeprecatedObject interface.
  */
-export function instanceOfDeprecatedObject(value: object): boolean {
+export function instanceOfDeprecatedObject(value: object): value is DeprecatedObject {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Dog.ts
@@ -37,7 +37,7 @@ export interface Dog extends Animal {
 /**
  * Check if a given object implements the Dog interface.
  */
-export function instanceOfDog(value: object): boolean {
+export function instanceOfDog(value: object): value is Dog {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumArrays.ts
@@ -56,7 +56,7 @@ export type EnumArraysArrayEnumEnum = typeof EnumArraysArrayEnumEnum[keyof typeo
 /**
  * Check if a given object implements the EnumArrays interface.
  */
-export function instanceOfEnumArrays(value: object): boolean {
+export function instanceOfEnumArrays(value: object): value is EnumArrays {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumTest.ts
@@ -137,8 +137,8 @@ export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof 
 /**
  * Check if a given object implements the EnumTest interface.
  */
-export function instanceOfEnumTest(value: object): boolean {
-    if (!('enumStringRequired' in value)) return false;
+export function instanceOfEnumTest(value: object): value is EnumTest {
+    if (!('enumStringRequired' in value) || value['enumStringRequired'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FakeBigDecimalMap200Response.ts
@@ -36,7 +36,7 @@ export interface FakeBigDecimalMap200Response {
 /**
  * Check if a given object implements the FakeBigDecimalMap200Response interface.
  */
-export function instanceOfFakeBigDecimalMap200Response(value: object): boolean {
+export function instanceOfFakeBigDecimalMap200Response(value: object): value is FakeBigDecimalMap200Response {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FileSchemaTestClass.ts
@@ -36,7 +36,7 @@ export interface FileSchemaTestClass {
 /**
  * Check if a given object implements the FileSchemaTestClass interface.
  */
-export function instanceOfFileSchemaTestClass(value: object): boolean {
+export function instanceOfFileSchemaTestClass(value: object): value is FileSchemaTestClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Foo.ts
@@ -30,7 +30,7 @@ export interface Foo {
 /**
  * Check if a given object implements the Foo interface.
  */
-export function instanceOfFoo(value: object): boolean {
+export function instanceOfFoo(value: object): value is Foo {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FooGetDefaultResponse.ts
@@ -37,7 +37,7 @@ export interface FooGetDefaultResponse {
 /**
  * Check if a given object implements the FooGetDefaultResponse interface.
  */
-export function instanceOfFooGetDefaultResponse(value: object): boolean {
+export function instanceOfFooGetDefaultResponse(value: object): value is FooGetDefaultResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/FormatTest.ts
@@ -127,11 +127,11 @@ export interface FormatTest {
 /**
  * Check if a given object implements the FormatTest interface.
  */
-export function instanceOfFormatTest(value: object): boolean {
-    if (!('number' in value)) return false;
-    if (!('_byte' in value)) return false;
-    if (!('date' in value)) return false;
-    if (!('password' in value)) return false;
+export function instanceOfFormatTest(value: object): value is FormatTest {
+    if (!('number' in value) || value['number'] === undefined) return false;
+    if (!('_byte' in value) || value['_byte'] === undefined) return false;
+    if (!('date' in value) || value['date'] === undefined) return false;
+    if (!('password' in value) || value['password'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HasOnlyReadOnly.ts
@@ -36,7 +36,7 @@ export interface HasOnlyReadOnly {
 /**
  * Check if a given object implements the HasOnlyReadOnly interface.
  */
-export function instanceOfHasOnlyReadOnly(value: object): boolean {
+export function instanceOfHasOnlyReadOnly(value: object): value is HasOnlyReadOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/HealthCheckResult.ts
@@ -30,7 +30,7 @@ export interface HealthCheckResult {
 /**
  * Check if a given object implements the HealthCheckResult interface.
  */
-export function instanceOfHealthCheckResult(value: object): boolean {
+export function instanceOfHealthCheckResult(value: object): value is HealthCheckResult {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/List.ts
@@ -30,7 +30,7 @@ export interface List {
 /**
  * Check if a given object implements the List interface.
  */
-export function instanceOfList(value: object): boolean {
+export function instanceOfList(value: object): value is List {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MapTest.ts
@@ -59,7 +59,7 @@ export type MapTestMapOfEnumStringEnum = typeof MapTestMapOfEnumStringEnum[keyof
 /**
  * Check if a given object implements the MapTest interface.
  */
-export function instanceOfMapTest(value: object): boolean {
+export function instanceOfMapTest(value: object): value is MapTest {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -49,7 +49,7 @@ export interface MixedPropertiesAndAdditionalPropertiesClass {
 /**
  * Check if a given object implements the MixedPropertiesAndAdditionalPropertiesClass interface.
  */
-export function instanceOfMixedPropertiesAndAdditionalPropertiesClass(value: object): boolean {
+export function instanceOfMixedPropertiesAndAdditionalPropertiesClass(value: object): value is MixedPropertiesAndAdditionalPropertiesClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Model200Response.ts
@@ -36,7 +36,7 @@ export interface Model200Response {
 /**
  * Check if a given object implements the Model200Response interface.
  */
-export function instanceOfModel200Response(value: object): boolean {
+export function instanceOfModel200Response(value: object): value is Model200Response {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ModelFile.ts
@@ -30,7 +30,7 @@ export interface ModelFile {
 /**
  * Check if a given object implements the ModelFile interface.
  */
-export function instanceOfModelFile(value: object): boolean {
+export function instanceOfModelFile(value: object): value is ModelFile {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Name.ts
@@ -48,8 +48,8 @@ export interface Name {
 /**
  * Check if a given object implements the Name interface.
  */
-export function instanceOfName(value: object): boolean {
-    if (!('name' in value)) return false;
+export function instanceOfName(value: object): value is Name {
+    if (!('name' in value) || value['name'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NullableClass.ts
@@ -97,7 +97,7 @@ export interface NullableClass {
 /**
  * Check if a given object implements the NullableClass interface.
  */
-export function instanceOfNullableClass(value: object): boolean {
+export function instanceOfNullableClass(value: object): value is NullableClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/NumberOnly.ts
@@ -30,7 +30,7 @@ export interface NumberOnly {
 /**
  * Check if a given object implements the NumberOnly interface.
  */
-export function instanceOfNumberOnly(value: object): boolean {
+export function instanceOfNumberOnly(value: object): value is NumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ObjectWithDeprecatedFields.ts
@@ -58,7 +58,7 @@ export interface ObjectWithDeprecatedFields {
 /**
  * Check if a given object implements the ObjectWithDeprecatedFields interface.
  */
-export function instanceOfObjectWithDeprecatedFields(value: object): boolean {
+export function instanceOfObjectWithDeprecatedFields(value: object): value is ObjectWithDeprecatedFields {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterComposite.ts
@@ -42,7 +42,7 @@ export interface OuterComposite {
 /**
  * Check if a given object implements the OuterComposite interface.
  */
-export function instanceOfOuterComposite(value: object): boolean {
+export function instanceOfOuterComposite(value: object): value is OuterComposite {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterObjectWithEnumProperty.ts
@@ -37,8 +37,8 @@ export interface OuterObjectWithEnumProperty {
 /**
  * Check if a given object implements the OuterObjectWithEnumProperty interface.
  */
-export function instanceOfOuterObjectWithEnumProperty(value: object): boolean {
-    if (!('value' in value)) return false;
+export function instanceOfOuterObjectWithEnumProperty(value: object): value is OuterObjectWithEnumProperty {
+    if (!('value' in value) || value['value'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ParentWithNullable.ts
@@ -47,7 +47,7 @@ export type ParentWithNullableTypeEnum = typeof ParentWithNullableTypeEnum[keyof
 /**
  * Check if a given object implements the ParentWithNullable interface.
  */
-export function instanceOfParentWithNullable(value: object): boolean {
+export function instanceOfParentWithNullable(value: object): value is ParentWithNullable {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/ReadOnlyFirst.ts
@@ -36,7 +36,7 @@ export interface ReadOnlyFirst {
 /**
  * Check if a given object implements the ReadOnlyFirst interface.
  */
-export function instanceOfReadOnlyFirst(value: object): boolean {
+export function instanceOfReadOnlyFirst(value: object): value is ReadOnlyFirst {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Return.ts
@@ -30,7 +30,7 @@ export interface Return {
 /**
  * Check if a given object implements the Return interface.
  */
-export function instanceOfReturn(value: object): boolean {
+export function instanceOfReturn(value: object): value is Return {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SpecialModelName.ts
@@ -30,7 +30,7 @@ export interface SpecialModelName {
 /**
  * Check if a given object implements the SpecialModelName interface.
  */
-export function instanceOfSpecialModelName(value: object): boolean {
+export function instanceOfSpecialModelName(value: object): value is SpecialModelName {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/TestInlineFreeformAdditionalPropertiesRequest.ts
@@ -31,7 +31,7 @@ export interface TestInlineFreeformAdditionalPropertiesRequest {
 /**
  * Check if a given object implements the TestInlineFreeformAdditionalPropertiesRequest interface.
  */
-export function instanceOfTestInlineFreeformAdditionalPropertiesRequest(value: object): boolean {
+export function instanceOfTestInlineFreeformAdditionalPropertiesRequest(value: object): value is TestInlineFreeformAdditionalPropertiesRequest {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/EnumPatternObject.ts
@@ -61,7 +61,7 @@ export interface EnumPatternObject {
 /**
  * Check if a given object implements the EnumPatternObject interface.
  */
-export function instanceOfEnumPatternObject(value: object): boolean {
+export function instanceOfEnumPatternObject(value: object): value is EnumPatternObject {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/FakeEnumRequestGetInline200Response.ts
@@ -90,7 +90,7 @@ export type FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum = typeof F
 /**
  * Check if a given object implements the FakeEnumRequestGetInline200Response interface.
  */
-export function instanceOfFakeEnumRequestGetInline200Response(value: object): boolean {
+export function instanceOfFakeEnumRequestGetInline200Response(value: object): value is FakeEnumRequestGetInline200Response {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/es6-target/src/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/multiple-parameters/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/prefix-parameter-interfaces/src/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DefaultMetaOnlyResponse.ts
@@ -37,8 +37,8 @@ export interface DefaultMetaOnlyResponse {
 /**
  * Check if a given object implements the DefaultMetaOnlyResponse interface.
  */
-export function instanceOfDefaultMetaOnlyResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfDefaultMetaOnlyResponse(value: object): value is DefaultMetaOnlyResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByStatusResponse.ts
@@ -49,8 +49,8 @@ export interface FindPetsByStatusResponse {
 /**
  * Check if a given object implements the FindPetsByStatusResponse interface.
  */
-export function instanceOfFindPetsByStatusResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfFindPetsByStatusResponse(value: object): value is FindPetsByStatusResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/FindPetsByUserResponse.ts
@@ -49,8 +49,8 @@ export interface FindPetsByUserResponse {
 /**
  * Check if a given object implements the FindPetsByUserResponse interface.
  */
-export function instanceOfFindPetsByUserResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfFindPetsByUserResponse(value: object): value is FindPetsByUserResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorPermissionsResponse.ts
@@ -43,8 +43,8 @@ export interface GetBehaviorPermissionsResponse {
 /**
  * Check if a given object implements the GetBehaviorPermissionsResponse interface.
  */
-export function instanceOfGetBehaviorPermissionsResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfGetBehaviorPermissionsResponse(value: object): value is GetBehaviorPermissionsResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetBehaviorTypeResponse.ts
@@ -49,8 +49,8 @@ export interface GetBehaviorTypeResponse {
 /**
  * Check if a given object implements the GetBehaviorTypeResponse interface.
  */
-export function instanceOfGetBehaviorTypeResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfGetBehaviorTypeResponse(value: object): value is GetBehaviorTypeResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetMatchingPartsResponse.ts
@@ -49,8 +49,8 @@ export interface GetMatchingPartsResponse {
 /**
  * Check if a given object implements the GetMatchingPartsResponse interface.
  */
-export function instanceOfGetMatchingPartsResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfGetMatchingPartsResponse(value: object): value is GetMatchingPartsResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/GetPetPartTypeResponse.ts
@@ -49,8 +49,8 @@ export interface GetPetPartTypeResponse {
 /**
  * Check if a given object implements the GetPetPartTypeResponse interface.
  */
-export function instanceOfGetPetPartTypeResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfGetPetPartTypeResponse(value: object): value is GetPetPartTypeResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ItemId.ts
@@ -36,9 +36,9 @@ export interface ItemId {
 /**
  * Check if a given object implements the ItemId interface.
  */
-export function instanceOfItemId(value: object): boolean {
-    if (!('id' in value)) return false;
-    if (!('type' in value)) return false;
+export function instanceOfItemId(value: object): value is ItemId {
+    if (!('id' in value) || value['id'] === undefined) return false;
+    if (!('type' in value) || value['type'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/MatchingParts.ts
@@ -43,9 +43,9 @@ export interface MatchingParts {
 /**
  * Check if a given object implements the MatchingParts interface.
  */
-export function instanceOfMatchingParts(value: object): boolean {
-    if (!('connected' in value)) return false;
-    if (!('related' in value)) return false;
+export function instanceOfMatchingParts(value: object): value is MatchingParts {
+    if (!('connected' in value) || value['connected'] === undefined) return false;
+    if (!('related' in value) || value['related'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ModelError.ts
@@ -55,8 +55,8 @@ export interface ModelError {
 /**
  * Check if a given object implements the ModelError interface.
  */
-export function instanceOfModelError(value: object): boolean {
-    if (!('type' in value)) return false;
+export function instanceOfModelError(value: object): value is ModelError {
+    if (!('type' in value) || value['type'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Part.ts
@@ -36,9 +36,9 @@ export interface Part {
 /**
  * Check if a given object implements the Part interface.
  */
-export function instanceOfPart(value: object): boolean {
-    if (!('id' in value)) return false;
-    if (!('name' in value)) return false;
+export function instanceOfPart(value: object): value is Part {
+    if (!('id' in value) || value['id'] === undefined) return false;
+    if (!('name' in value) || value['name'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Pet.ts
@@ -187,21 +187,21 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('id' in value)) return false;
-    if (!('otherFriendIds' in value)) return false;
-    if (!('friendAge' in value)) return false;
-    if (!('age' in value)) return false;
-    if (!('isHappy' in value)) return false;
-    if (!('isTall' in value)) return false;
-    if (!('category' in value)) return false;
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
-    if (!('warningStatus' in value)) return false;
-    if (!('alternateStatus' in value)) return false;
-    if (!('otherDepStatuses' in value)) return false;
-    if (!('tags' in value)) return false;
-    if (!('status' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('id' in value) || value['id'] === undefined) return false;
+    if (!('otherFriendIds' in value) || value['otherFriendIds'] === undefined) return false;
+    if (!('friendAge' in value) || value['friendAge'] === undefined) return false;
+    if (!('age' in value) || value['age'] === undefined) return false;
+    if (!('isHappy' in value) || value['isHappy'] === undefined) return false;
+    if (!('isTall' in value) || value['isTall'] === undefined) return false;
+    if (!('category' in value) || value['category'] === undefined) return false;
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
+    if (!('warningStatus' in value) || value['warningStatus'] === undefined) return false;
+    if (!('alternateStatus' in value) || value['alternateStatus'] === undefined) return false;
+    if (!('otherDepStatuses' in value) || value['otherDepStatuses'] === undefined) return false;
+    if (!('tags' in value) || value['tags'] === undefined) return false;
+    if (!('status' in value) || value['status'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetRegionsResponse.ts
@@ -43,8 +43,8 @@ export interface PetRegionsResponse {
 /**
  * Check if a given object implements the PetRegionsResponse interface.
  */
-export function instanceOfPetRegionsResponse(value: object): boolean {
-    if (!('meta' in value)) return false;
+export function instanceOfPetRegionsResponse(value: object): value is PetRegionsResponse {
+    if (!('meta' in value) || value['meta'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ResponseMeta.ts
@@ -99,8 +99,8 @@ export type ResponseMetaCodeEnum = typeof ResponseMetaCodeEnum[keyof typeof Resp
 /**
  * Check if a given object implements the ResponseMeta interface.
  */
-export function instanceOfResponseMeta(value: object): boolean {
-    if (!('code' in value)) return false;
+export function instanceOfResponseMeta(value: object): value is ResponseMeta {
+    if (!('code' in value) || value['code'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/User.ts
@@ -84,9 +84,9 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
-    if (!('id' in value)) return false;
-    if (!('subUser2' in value)) return false;
+export function instanceOfUser(value: object): value is User {
+    if (!('id' in value) || value['id'] === undefined) return false;
+    if (!('subUser2' in value) || value['subUser2'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AdditionalPropertiesClass.ts
@@ -36,7 +36,7 @@ export interface AdditionalPropertiesClass {
 /**
  * Check if a given object implements the AdditionalPropertiesClass interface.
  */
-export function instanceOfAdditionalPropertiesClass(value: object): boolean {
+export function instanceOfAdditionalPropertiesClass(value: object): value is AdditionalPropertiesClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/AllOfWithSingleRef.ts
@@ -43,7 +43,7 @@ export interface AllOfWithSingleRef {
 /**
  * Check if a given object implements the AllOfWithSingleRef interface.
  */
-export function instanceOfAllOfWithSingleRef(value: object): boolean {
+export function instanceOfAllOfWithSingleRef(value: object): value is AllOfWithSingleRef {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Animal.ts
@@ -38,8 +38,8 @@ export interface Animal {
 /**
  * Check if a given object implements the Animal interface.
  */
-export function instanceOfAnimal(value: object): boolean {
-    if (!('className' in value)) return false;
+export function instanceOfAnimal(value: object): value is Animal {
+    if (!('className' in value) || value['className'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfArrayOfNumberOnly.ts
@@ -30,7 +30,7 @@ export interface ArrayOfArrayOfNumberOnly {
 /**
  * Check if a given object implements the ArrayOfArrayOfNumberOnly interface.
  */
-export function instanceOfArrayOfArrayOfNumberOnly(value: object): boolean {
+export function instanceOfArrayOfArrayOfNumberOnly(value: object): value is ArrayOfArrayOfNumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayOfNumberOnly.ts
@@ -30,7 +30,7 @@ export interface ArrayOfNumberOnly {
 /**
  * Check if a given object implements the ArrayOfNumberOnly interface.
  */
-export function instanceOfArrayOfNumberOnly(value: object): boolean {
+export function instanceOfArrayOfNumberOnly(value: object): value is ArrayOfNumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ArrayTest.ts
@@ -49,7 +49,7 @@ export interface ArrayTest {
 /**
  * Check if a given object implements the ArrayTest interface.
  */
-export function instanceOfArrayTest(value: object): boolean {
+export function instanceOfArrayTest(value: object): value is ArrayTest {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Capitalization.ts
@@ -61,7 +61,7 @@ export interface Capitalization {
 /**
  * Check if a given object implements the Capitalization interface.
  */
-export function instanceOfCapitalization(value: object): boolean {
+export function instanceOfCapitalization(value: object): value is Capitalization {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Cat.ts
@@ -37,7 +37,7 @@ export interface Cat extends Animal {
 /**
  * Check if a given object implements the Cat interface.
  */
-export function instanceOfCat(value: object): boolean {
+export function instanceOfCat(value: object): value is Cat {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Category.ts
@@ -36,8 +36,8 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
-    if (!('name' in value)) return false;
+export function instanceOfCategory(value: object): value is Category {
+    if (!('name' in value) || value['name'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ClassModel.ts
@@ -30,7 +30,7 @@ export interface ClassModel {
 /**
  * Check if a given object implements the ClassModel interface.
  */
-export function instanceOfClassModel(value: object): boolean {
+export function instanceOfClassModel(value: object): value is ClassModel {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Client.ts
@@ -30,7 +30,7 @@ export interface Client {
 /**
  * Check if a given object implements the Client interface.
  */
-export function instanceOfClient(value: object): boolean {
+export function instanceOfClient(value: object): value is Client {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/DeprecatedObject.ts
@@ -30,7 +30,7 @@ export interface DeprecatedObject {
 /**
  * Check if a given object implements the DeprecatedObject interface.
  */
-export function instanceOfDeprecatedObject(value: object): boolean {
+export function instanceOfDeprecatedObject(value: object): value is DeprecatedObject {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Dog.ts
@@ -37,7 +37,7 @@ export interface Dog extends Animal {
 /**
  * Check if a given object implements the Dog interface.
  */
-export function instanceOfDog(value: object): boolean {
+export function instanceOfDog(value: object): value is Dog {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumArrays.ts
@@ -56,7 +56,7 @@ export type EnumArraysArrayEnumEnum = typeof EnumArraysArrayEnumEnum[keyof typeo
 /**
  * Check if a given object implements the EnumArrays interface.
  */
-export function instanceOfEnumArrays(value: object): boolean {
+export function instanceOfEnumArrays(value: object): value is EnumArrays {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumTest.ts
@@ -137,8 +137,8 @@ export type EnumTestEnumNumberEnum = typeof EnumTestEnumNumberEnum[keyof typeof 
 /**
  * Check if a given object implements the EnumTest interface.
  */
-export function instanceOfEnumTest(value: object): boolean {
-    if (!('enumStringRequired' in value)) return false;
+export function instanceOfEnumTest(value: object): value is EnumTest {
+    if (!('enumStringRequired' in value) || value['enumStringRequired'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FakeBigDecimalMap200Response.ts
@@ -36,7 +36,7 @@ export interface FakeBigDecimalMap200Response {
 /**
  * Check if a given object implements the FakeBigDecimalMap200Response interface.
  */
-export function instanceOfFakeBigDecimalMap200Response(value: object): boolean {
+export function instanceOfFakeBigDecimalMap200Response(value: object): value is FakeBigDecimalMap200Response {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FileSchemaTestClass.ts
@@ -36,7 +36,7 @@ export interface FileSchemaTestClass {
 /**
  * Check if a given object implements the FileSchemaTestClass interface.
  */
-export function instanceOfFileSchemaTestClass(value: object): boolean {
+export function instanceOfFileSchemaTestClass(value: object): value is FileSchemaTestClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Foo.ts
@@ -30,7 +30,7 @@ export interface Foo {
 /**
  * Check if a given object implements the Foo interface.
  */
-export function instanceOfFoo(value: object): boolean {
+export function instanceOfFoo(value: object): value is Foo {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FooGetDefaultResponse.ts
@@ -37,7 +37,7 @@ export interface FooGetDefaultResponse {
 /**
  * Check if a given object implements the FooGetDefaultResponse interface.
  */
-export function instanceOfFooGetDefaultResponse(value: object): boolean {
+export function instanceOfFooGetDefaultResponse(value: object): value is FooGetDefaultResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/FormatTest.ts
@@ -127,11 +127,11 @@ export interface FormatTest {
 /**
  * Check if a given object implements the FormatTest interface.
  */
-export function instanceOfFormatTest(value: object): boolean {
-    if (!('number' in value)) return false;
-    if (!('_byte' in value)) return false;
-    if (!('date' in value)) return false;
-    if (!('password' in value)) return false;
+export function instanceOfFormatTest(value: object): value is FormatTest {
+    if (!('number' in value) || value['number'] === undefined) return false;
+    if (!('_byte' in value) || value['_byte'] === undefined) return false;
+    if (!('date' in value) || value['date'] === undefined) return false;
+    if (!('password' in value) || value['password'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HasOnlyReadOnly.ts
@@ -36,7 +36,7 @@ export interface HasOnlyReadOnly {
 /**
  * Check if a given object implements the HasOnlyReadOnly interface.
  */
-export function instanceOfHasOnlyReadOnly(value: object): boolean {
+export function instanceOfHasOnlyReadOnly(value: object): value is HasOnlyReadOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/HealthCheckResult.ts
@@ -30,7 +30,7 @@ export interface HealthCheckResult {
 /**
  * Check if a given object implements the HealthCheckResult interface.
  */
-export function instanceOfHealthCheckResult(value: object): boolean {
+export function instanceOfHealthCheckResult(value: object): value is HealthCheckResult {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/List.ts
@@ -30,7 +30,7 @@ export interface List {
 /**
  * Check if a given object implements the List interface.
  */
-export function instanceOfList(value: object): boolean {
+export function instanceOfList(value: object): value is List {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MapTest.ts
@@ -59,7 +59,7 @@ export type MapTestMapOfEnumStringEnum = typeof MapTestMapOfEnumStringEnum[keyof
 /**
  * Check if a given object implements the MapTest interface.
  */
-export function instanceOfMapTest(value: object): boolean {
+export function instanceOfMapTest(value: object): value is MapTest {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/MixedPropertiesAndAdditionalPropertiesClass.ts
@@ -49,7 +49,7 @@ export interface MixedPropertiesAndAdditionalPropertiesClass {
 /**
  * Check if a given object implements the MixedPropertiesAndAdditionalPropertiesClass interface.
  */
-export function instanceOfMixedPropertiesAndAdditionalPropertiesClass(value: object): boolean {
+export function instanceOfMixedPropertiesAndAdditionalPropertiesClass(value: object): value is MixedPropertiesAndAdditionalPropertiesClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Model200Response.ts
@@ -36,7 +36,7 @@ export interface Model200Response {
 /**
  * Check if a given object implements the Model200Response interface.
  */
-export function instanceOfModel200Response(value: object): boolean {
+export function instanceOfModel200Response(value: object): value is Model200Response {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ModelFile.ts
@@ -30,7 +30,7 @@ export interface ModelFile {
 /**
  * Check if a given object implements the ModelFile interface.
  */
-export function instanceOfModelFile(value: object): boolean {
+export function instanceOfModelFile(value: object): value is ModelFile {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Name.ts
@@ -48,8 +48,8 @@ export interface Name {
 /**
  * Check if a given object implements the Name interface.
  */
-export function instanceOfName(value: object): boolean {
-    if (!('name' in value)) return false;
+export function instanceOfName(value: object): value is Name {
+    if (!('name' in value) || value['name'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NullableClass.ts
@@ -97,7 +97,7 @@ export interface NullableClass {
 /**
  * Check if a given object implements the NullableClass interface.
  */
-export function instanceOfNullableClass(value: object): boolean {
+export function instanceOfNullableClass(value: object): value is NullableClass {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/NumberOnly.ts
@@ -30,7 +30,7 @@ export interface NumberOnly {
 /**
  * Check if a given object implements the NumberOnly interface.
  */
-export function instanceOfNumberOnly(value: object): boolean {
+export function instanceOfNumberOnly(value: object): value is NumberOnly {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ObjectWithDeprecatedFields.ts
@@ -58,7 +58,7 @@ export interface ObjectWithDeprecatedFields {
 /**
  * Check if a given object implements the ObjectWithDeprecatedFields interface.
  */
-export function instanceOfObjectWithDeprecatedFields(value: object): boolean {
+export function instanceOfObjectWithDeprecatedFields(value: object): value is ObjectWithDeprecatedFields {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterComposite.ts
@@ -42,7 +42,7 @@ export interface OuterComposite {
 /**
  * Check if a given object implements the OuterComposite interface.
  */
-export function instanceOfOuterComposite(value: object): boolean {
+export function instanceOfOuterComposite(value: object): value is OuterComposite {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterObjectWithEnumProperty.ts
@@ -37,8 +37,8 @@ export interface OuterObjectWithEnumProperty {
 /**
  * Check if a given object implements the OuterObjectWithEnumProperty interface.
  */
-export function instanceOfOuterObjectWithEnumProperty(value: object): boolean {
-    if (!('value' in value)) return false;
+export function instanceOfOuterObjectWithEnumProperty(value: object): value is OuterObjectWithEnumProperty {
+    if (!('value' in value) || value['value'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/ReadOnlyFirst.ts
@@ -36,7 +36,7 @@ export interface ReadOnlyFirst {
 /**
  * Check if a given object implements the ReadOnlyFirst interface.
  */
-export function instanceOfReadOnlyFirst(value: object): boolean {
+export function instanceOfReadOnlyFirst(value: object): value is ReadOnlyFirst {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Return.ts
@@ -30,7 +30,7 @@ export interface Return {
 /**
  * Check if a given object implements the Return interface.
  */
-export function instanceOfReturn(value: object): boolean {
+export function instanceOfReturn(value: object): value is Return {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SpecialModelName.ts
@@ -30,7 +30,7 @@ export interface SpecialModelName {
 /**
  * Check if a given object implements the SpecialModelName interface.
  */
-export function instanceOfSpecialModelName(value: object): boolean {
+export function instanceOfSpecialModelName(value: object): value is SpecialModelName {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-interfaces/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Category.ts
@@ -36,7 +36,7 @@ export interface Category {
 /**
  * Check if a given object implements the Category interface.
  */
-export function instanceOfCategory(value: object): boolean {
+export function instanceOfCategory(value: object): value is Category {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/ModelApiResponse.ts
@@ -42,7 +42,7 @@ export interface ModelApiResponse {
 /**
  * Check if a given object implements the ModelApiResponse interface.
  */
-export function instanceOfModelApiResponse(value: object): boolean {
+export function instanceOfModelApiResponse(value: object): value is ModelApiResponse {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Order.ts
@@ -72,7 +72,7 @@ export type OrderStatusEnum = typeof OrderStatusEnum[keyof typeof OrderStatusEnu
 /**
  * Check if a given object implements the Order interface.
  */
-export function instanceOfOrder(value: object): boolean {
+export function instanceOfOrder(value: object): value is Order {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Pet.ts
@@ -85,9 +85,9 @@ export type PetStatusEnum = typeof PetStatusEnum[keyof typeof PetStatusEnum];
 /**
  * Check if a given object implements the Pet interface.
  */
-export function instanceOfPet(value: object): boolean {
-    if (!('name' in value)) return false;
-    if (!('photoUrls' in value)) return false;
+export function instanceOfPet(value: object): value is Pet {
+    if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('photoUrls' in value) || value['photoUrls'] === undefined) return false;
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/Tag.ts
@@ -36,7 +36,7 @@ export interface Tag {
 /**
  * Check if a given object implements the Tag interface.
  */
-export function instanceOfTag(value: object): boolean {
+export function instanceOfTag(value: object): value is Tag {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-npm-version/src/models/User.ts
@@ -72,7 +72,7 @@ export interface User {
 /**
  * Check if a given object implements the User interface.
  */
-export function instanceOfUser(value: object): boolean {
+export function instanceOfUser(value: object): value is User {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/EnumPatternObject.ts
@@ -61,7 +61,7 @@ export interface EnumPatternObject {
 /**
  * Check if a given object implements the EnumPatternObject interface.
  */
-export function instanceOfEnumPatternObject(value: object): boolean {
+export function instanceOfEnumPatternObject(value: object): value is EnumPatternObject {
     return true;
 }
 

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/FakeEnumRequestGetInline200Response.ts
@@ -86,7 +86,7 @@ export enum FakeEnumRequestGetInline200ResponseNullableNumberEnumEnum {
 /**
  * Check if a given object implements the FakeEnumRequestGetInline200Response interface.
  */
-export function instanceOfFakeEnumRequestGetInline200Response(value: object): boolean {
+export function instanceOfFakeEnumRequestGetInline200Response(value: object): value is FakeEnumRequestGetInline200Response {
     return true;
 }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

Fixes #18059

- Makes the `instanceOf` check infer the type of the parameter
- Adds `undefined` check for required fields in `instanceOf`

Prior to this fix, doing a fetch and then a `toJSON` on that fetched model would return unexpected results in `oneOf` models without a discriminator, as the `oneOf` model spreads all possible values resulting in keys for each of the `oneOf` types existing, but being undefined. Thus the `toJSON` would return `true` for `instanceOf` the first `oneOf` type despite the required fields being undefined.

Per instructions, tagging Typescript technical committee members:
@TiFu @taxpon @sebastianhaas @kenisteward @Vrolijkx @macjohnny @topce @akehir @petejohansonxo @amakhrov  @davidgamero @mkusaka

First time contributor, please let me know if I made any blunders or if any additional info needed.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
