### PR TITLE
[typescript-fetch] Improve code generation for `oneOf` cases without discriminator

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelOneOf.mustache
@@ -31,7 +31,11 @@ export function {{classname}}FromJSONTyped(json: any, ignoreDiscriminator: boole
     }
 {{/discriminator}}
 {{^discriminator}}
-    return {{#oneOf}}{{{.}}}FromJSONTyped(json, true){{^-last}} || {{/-last}}{{/oneOf}};
+    {{#oneOf}}
+    if (instanceOf{{{.}}}(json)) {
+        return {{{.}}}FromJSONTyped(json, true);
+    }
+    {{/oneOf}}
 {{/discriminator}}
 }
 


### PR DESCRIPTION
### Problem

Previously, generated code from the `oneOf` schema without a discriminator might cause runtime errors.

schema:
```yaml
openapi: 3.0.0
info:
  version: 1.0.0
  title: Test
  description: Test
paths:
  /foo:
    get:
      responses:
        200:
          description: foo
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Foo'
components:
  schemas:
    Foo:
      oneOf:
        - $ref: '#/components/schemas/Bar'
        - $ref: '#/components/schemas/Buzz'
    Bar:
      type: object
      required:
        - abc
      properties:
        abc:
          type: array
          items:
            type: object
            properties:
              xyz:
                type: number
    Buzz:
      type: object
      required:
        - def
      properties:
        def:
          type: number
```

generated model code (partial):
```ts
// models/Foo.ts
// ...
export function FooFromJSON(json: any): Foo {
    return FooFromJSONTyped(json, false);
}

export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
    if (json == null) {
        return json;
    }
    return BarFromJSONTyped(json, true) || BuzzFromJSONTyped(json, true);
}
// ...

// on models/Bar.ts
// ...
export function BarFromJSONTyped(json: any, ignoreDiscriminator: boolean): Bar {
    if (json == null) {
        return json;
    }
    return {
        'abc': ((json['abc'] as Array<any>).map(BarAbcInnerFromJSON)),  // ← this causes error
    };
}
// ...
```

In `BarFromJSONTyped`, if the given json doesn't have the `abc` property, `(json['abc'] as Array<any>).map(...)` will fail.
The same problem also occurs if `abc` is a string with a date-time format.

### Solution

I modified the template to generate `FooFromJSONTyped` like the following:
```ts
// models/Foo.ts
// ...
export function FooFromJSONTyped(json: any, ignoreDiscriminator: boolean): Foo {
    if (json == null) {
        return json;
    }
    if (instanceOfBar(json)) {
        return BarFromJSONTyped(json, true);
    }
    if (instanceOfBuzz(json)) {
        return BuzzFromJSONTyped(json, true);
    }
}
// ...
```

Because `instanceOfXXXX` functions check for the existence of required keys, it makes the generated code safer.

### How to check

1. Check out this branch.
2. Build the generator.
3. Generate an API client using the schema above.
4. Check generated model files.

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
