### PR TITLE
Fix javaJaxRS template: remove deprecated in JDK9 method usage

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/api.mustache
@@ -47,7 +47,7 @@ public class {{classname}}  {
          String implClass = servletContext.getInitParameter("{{classname}}.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = ({{classname}}Service) Class.forName(implClass).newInstance();
+               delegate = ({{classname}}Service) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -41,7 +41,7 @@ public class AnotherFakeApi  {
          String implClass = servletContext.getInitParameter("AnotherFakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (AnotherFakeApiService) Class.forName(implClass).newInstance();
+               delegate = (AnotherFakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeApi.java
@@ -50,7 +50,7 @@ public class FakeApi  {
          String implClass = servletContext.getInitParameter("FakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -40,7 +40,7 @@ public class FakeClassnameTestApi  {
          String implClass = servletContext.getInitParameter("FakeClassnameTestApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeClassnameTestApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeClassnameTestApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/PetApi.java
@@ -43,7 +43,7 @@ public class PetApi  {
          String implClass = servletContext.getInitParameter("PetApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (PetApiService) Class.forName(implClass).newInstance();
+               delegate = (PetApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/StoreApi.java
@@ -41,7 +41,7 @@ public class StoreApi  {
          String implClass = servletContext.getInitParameter("StoreApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (StoreApiService) Class.forName(implClass).newInstance();
+               delegate = (StoreApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-datelib-j8/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public class UserApi  {
          String implClass = servletContext.getInitParameter("UserApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (UserApiService) Class.forName(implClass).newInstance();
+               delegate = (UserApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -40,7 +40,7 @@ public class AnotherFakeApi  {
          String implClass = servletContext.getInitParameter("AnotherFakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (AnotherFakeApiService) Class.forName(implClass).newInstance();
+               delegate = (AnotherFakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeApi.java
@@ -55,7 +55,7 @@ public class FakeApi  {
          String implClass = servletContext.getInitParameter("FakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -40,7 +40,7 @@ public class FakeClassnameTestApi  {
          String implClass = servletContext.getInitParameter("FakeClassnameTestApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeClassnameTestApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeClassnameTestApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FooApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/FooApi.java
@@ -40,7 +40,7 @@ public class FooApi  {
          String implClass = servletContext.getInitParameter("FooApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FooApiService) Class.forName(implClass).newInstance();
+               delegate = (FooApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/PetApi.java
@@ -43,7 +43,7 @@ public class PetApi  {
          String implClass = servletContext.getInitParameter("PetApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (PetApiService) Class.forName(implClass).newInstance();
+               delegate = (PetApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/StoreApi.java
@@ -41,7 +41,7 @@ public class StoreApi  {
          String implClass = servletContext.getInitParameter("StoreApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (StoreApiService) Class.forName(implClass).newInstance();
+               delegate = (StoreApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs-jersey/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public class UserApi  {
          String implClass = servletContext.getInitParameter("UserApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (UserApiService) Class.forName(implClass).newInstance();
+               delegate = (UserApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -41,7 +41,7 @@ public class AnotherFakeApi  {
          String implClass = servletContext.getInitParameter("AnotherFakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (AnotherFakeApiService) Class.forName(implClass).newInstance();
+               delegate = (AnotherFakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeApi.java
@@ -48,7 +48,7 @@ public class FakeApi  {
          String implClass = servletContext.getInitParameter("FakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/FakeClassnameTags123Api.java
@@ -40,7 +40,7 @@ public class FakeClassnameTags123Api  {
          String implClass = servletContext.getInitParameter("FakeClassnameTags123Api.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeClassnameTags123ApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeClassnameTags123ApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/PetApi.java
@@ -43,7 +43,7 @@ public class PetApi  {
          String implClass = servletContext.getInitParameter("PetApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (PetApiService) Class.forName(implClass).newInstance();
+               delegate = (PetApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/StoreApi.java
@@ -41,7 +41,7 @@ public class StoreApi  {
          String implClass = servletContext.getInitParameter("StoreApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (StoreApiService) Class.forName(implClass).newInstance();
+               delegate = (StoreApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2-useTags/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public class UserApi  {
          String implClass = servletContext.getInitParameter("UserApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (UserApiService) Class.forName(implClass).newInstance();
+               delegate = (UserApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/AnotherFakeApi.java
@@ -41,7 +41,7 @@ public class AnotherFakeApi  {
          String implClass = servletContext.getInitParameter("AnotherFakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (AnotherFakeApiService) Class.forName(implClass).newInstance();
+               delegate = (AnotherFakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeApi.java
@@ -49,7 +49,7 @@ public class FakeApi  {
          String implClass = servletContext.getInitParameter("FakeApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/FakeClassnameTestApi.java
@@ -40,7 +40,7 @@ public class FakeClassnameTestApi  {
          String implClass = servletContext.getInitParameter("FakeClassnameTestApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (FakeClassnameTestApiService) Class.forName(implClass).newInstance();
+               delegate = (FakeClassnameTestApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/PetApi.java
@@ -43,7 +43,7 @@ public class PetApi  {
          String implClass = servletContext.getInitParameter("PetApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (PetApiService) Class.forName(implClass).newInstance();
+               delegate = (PetApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/StoreApi.java
@@ -41,7 +41,7 @@ public class StoreApi  {
          String implClass = servletContext.getInitParameter("StoreApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (StoreApiService) Class.forName(implClass).newInstance();
+               delegate = (StoreApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }

--- a/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
+++ b/samples/server/petstore/jaxrs/jersey2/src/gen/java/org/openapitools/api/UserApi.java
@@ -41,7 +41,7 @@ public class UserApi  {
          String implClass = servletContext.getInitParameter("UserApi.implementation");
          if (implClass != null && !"".equals(implClass.trim())) {
             try {
-               delegate = (UserApiService) Class.forName(implClass).newInstance();
+               delegate = (UserApiService) Class.forName(implClass).getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                throw new RuntimeException(e);
             }


### PR DESCRIPTION
Small fix for java JaxRS template. newInstance() method is deprecated in Class class since JDK9.