### PR TITLE
[Java][native] Fix: empty deepObject can produce invalid query [fix #18736]

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/native/api.mustache
@@ -372,7 +372,10 @@ public class {{classname}} {
       }
             {{/isArray}}
             {{^isArray}}
-      localVarQueryStringJoiner.add({{paramName}}.toUrlQueryString("{{baseName}}"));
+      String queryString = {{paramName}}.toUrlQueryString("{{baseName}}");
+      if (!queryString.isBlank()) {
+        localVarQueryStringJoiner.add(queryString);
+      }
             {{/isArray}}
     }
         {{/isDeepObject}}

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientDeepObjectTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/java/JavaClientDeepObjectTest.java
@@ -59,6 +59,6 @@ public class JavaClientDeepObjectTest {
 
         assertFileContains(Paths.get(outputPath + "/src/main/java/org/openapitools/client/api/DefaultApi.java"),
                 "options.toUrlQueryString(\"options\")",
-                "inputOptions.toUrlQueryString(\"inputOptions\"))");
+                "inputOptions.toUrlQueryString(\"inputOptions\")");
     }
 }

--- a/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
+++ b/samples/client/echo_api/java/native/src/main/java/org/openapitools/client/api/QueryApi.java
@@ -453,7 +453,10 @@ public class QueryApi {
     String localVarQueryParameterBaseName;
     localVarQueryParameterBaseName = "query_object";
     if (queryObject != null) {
-      localVarQueryStringJoiner.add(queryObject.toUrlQueryString("query_object"));
+      String queryString = queryObject.toUrlQueryString("query_object");
+      if (!queryString.isBlank()) {
+        localVarQueryStringJoiner.add(queryString);
+      }
     }
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
@@ -546,7 +549,10 @@ public class QueryApi {
     String localVarQueryParameterBaseName;
     localVarQueryParameterBaseName = "query_object";
     if (queryObject != null) {
-      localVarQueryStringJoiner.add(queryObject.toUrlQueryString("query_object"));
+      String queryString = queryObject.toUrlQueryString("query_object");
+      if (!queryString.isBlank()) {
+        localVarQueryStringJoiner.add(queryString);
+      }
     }
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {


### PR DESCRIPTION
Implements proposed solution from #18736. Empty Strings are no longer added to the string builder in order to avoid creating invalid request querys.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@bbdouglas (2017/07) @sreeshas (2017/08) @jfiala (2017/08) @lukoyanov (2017/09) @cbornet (2017/09) @jeff9finger (2018/01) @karismann (2019/03) @Zomzog (2019/04) @lwlee2608 (2019/10) @martin-mfg (2023/08)
