### PR TITLE
[typescript-nestjs] Fix template for useSingleRequestParameter

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-nestjs/api.service.mustache
@@ -84,8 +84,8 @@ export class {{classname}} {
      {{#useSingleRequestParameter}}
      {{#allParams.0}}
      * @param {{=<% %>=}}{<%& classname %><%& operationIdCamelCase %>Request}<%={{ }}=%> requestParameters Request parameters.
-     */
      {{/allParams.0}}
+     */
      {{/useSingleRequestParameter}}
      {{^useSingleRequestParameter}}
      {{#allParams}}* @param {{paramName}} {{description}}
@@ -101,15 +101,16 @@ export class {{classname}} {
     public {{nickname}}({{#allParams}}{{^isConstEnumParam}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isConstEnumParam}}{{/allParams}}): Observable<AxiosResponse<{{#returnType}}{{{returnType}}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}>>;
     public {{nickname}}({{#allParams}}{{^isConstEnumParam}}{{paramName}}{{^required}}?{{/required}}: {{{dataType}}}, {{/isConstEnumParam}}{{/allParams}}): Observable<any> {
     {{/useSingleRequestParameter}}
+{{#allParams.0}}
 {{#useSingleRequestParameter}}
-const {
-{{#allParams}}
-    {{paramName}},
-{{/allParams}}
-} = requestParameters;
+        const {
+        {{#allParams}}
+            {{paramName}},
+        {{/allParams}}
+        } = requestParameters;
 
 {{/useSingleRequestParameter}}
-
+{{/allParams.0}}
 {{#allParams}}
 {{#required}}
         {{#isConstEnumParam}}

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/pet.service.ts
@@ -50,7 +50,6 @@ export class PetService {
      */
     public addPet(pet: Pet, ): Observable<AxiosResponse<Pet>>;
     public addPet(pet: Pet, ): Observable<any> {
-
         if (pet === null || pet === undefined) {
             throw new Error('Required parameter pet was null or undefined when calling addPet.');
         }
@@ -111,7 +110,6 @@ export class PetService {
      */
     public deletePet(petId: number, apiKey?: string, ): Observable<AxiosResponse<any>>;
     public deletePet(petId: number, apiKey?: string, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
@@ -165,7 +163,6 @@ export class PetService {
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, ): Observable<AxiosResponse<Array<Pet>>>;
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, ): Observable<any> {
-
         if (status === null || status === undefined) {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
@@ -224,7 +221,6 @@ export class PetService {
      */
     public findPetsByTags(tags: Array<string>, ): Observable<AxiosResponse<Array<Pet>>>;
     public findPetsByTags(tags: Array<string>, ): Observable<any> {
-
         if (tags === null || tags === undefined) {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
@@ -283,7 +279,6 @@ export class PetService {
      */
     public getPetById(petId: number, ): Observable<AxiosResponse<Pet>>;
     public getPetById(petId: number, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
@@ -334,7 +329,6 @@ export class PetService {
      */
     public updatePet(pet: Pet, ): Observable<AxiosResponse<Pet>>;
     public updatePet(pet: Pet, ): Observable<any> {
-
         if (pet === null || pet === undefined) {
             throw new Error('Required parameter pet was null or undefined when calling updatePet.');
         }
@@ -396,7 +390,6 @@ export class PetService {
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, ): Observable<AxiosResponse<any>>;
     public updatePetWithForm(petId: number, name?: string, status?: string, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
@@ -471,7 +464,6 @@ export class PetService {
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, ): Observable<AxiosResponse<ApiResponse>>;
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/store.service.ts
@@ -49,7 +49,6 @@ export class StoreService {
      */
     public deleteOrder(orderId: string, ): Observable<AxiosResponse<any>>;
     public deleteOrder(orderId: string, ): Observable<any> {
-
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
@@ -92,7 +91,6 @@ export class StoreService {
      */
     public getInventory(): Observable<AxiosResponse<{ [key: string]: number; }>>;
     public getInventory(): Observable<any> {
-
         let headers = {...this.defaultHeaders};
 
         let accessTokenObservable: Observable<any> = of(null);
@@ -138,7 +136,6 @@ export class StoreService {
      */
     public getOrderById(orderId: number, ): Observable<AxiosResponse<Order>>;
     public getOrderById(orderId: number, ): Observable<any> {
-
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
@@ -184,7 +181,6 @@ export class StoreService {
      */
     public placeOrder(order: Order, ): Observable<AxiosResponse<Order>>;
     public placeOrder(order: Order, ): Observable<any> {
-
         if (order === null || order === undefined) {
             throw new Error('Required parameter order was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v6-provided-in-root/builds/default/api/user.service.ts
@@ -49,7 +49,6 @@ export class UserService {
      */
     public createUser(user: User, ): Observable<AxiosResponse<any>>;
     public createUser(user: User, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUser.');
         }
@@ -104,7 +103,6 @@ export class UserService {
      */
     public createUsersWithArrayInput(user: Array<User>, ): Observable<AxiosResponse<any>>;
     public createUsersWithArrayInput(user: Array<User>, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -159,7 +157,6 @@ export class UserService {
      */
     public createUsersWithListInput(user: Array<User>, ): Observable<AxiosResponse<any>>;
     public createUsersWithListInput(user: Array<User>, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithListInput.');
         }
@@ -214,7 +211,6 @@ export class UserService {
      */
     public deleteUser(username: string, ): Observable<AxiosResponse<any>>;
     public deleteUser(username: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
@@ -263,7 +259,6 @@ export class UserService {
      */
     public getUserByName(username: string, ): Observable<AxiosResponse<User>>;
     public getUserByName(username: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
@@ -310,7 +305,6 @@ export class UserService {
      */
     public loginUser(username: string, password: string, ): Observable<AxiosResponse<string>>;
     public loginUser(username: string, password: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling loginUser.');
         }
@@ -368,7 +362,6 @@ export class UserService {
      */
     public logoutUser(): Observable<AxiosResponse<any>>;
     public logoutUser(): Observable<any> {
-
         let headers = {...this.defaultHeaders};
 
         let accessTokenObservable: Observable<any> = of(null);
@@ -414,7 +407,6 @@ export class UserService {
      */
     public updateUser(username: string, user: User, ): Observable<AxiosResponse<any>>;
     public updateUser(username: string, user: User, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/pet.service.ts
@@ -51,7 +51,6 @@ export class PetService {
      */
     public addPet(pet: Pet, ): Observable<AxiosResponse<Pet>>;
     public addPet(pet: Pet, ): Observable<any> {
-
         if (pet === null || pet === undefined) {
             throw new Error('Required parameter pet was null or undefined when calling addPet.');
         }
@@ -112,7 +111,6 @@ export class PetService {
      */
     public deletePet(petId: number, apiKey?: string, ): Observable<AxiosResponse<any>>;
     public deletePet(petId: number, apiKey?: string, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling deletePet.');
         }
@@ -166,7 +164,6 @@ export class PetService {
      */
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, ): Observable<AxiosResponse<Array<Pet>>>;
     public findPetsByStatus(status: Array<'available' | 'pending' | 'sold'>, ): Observable<any> {
-
         if (status === null || status === undefined) {
             throw new Error('Required parameter status was null or undefined when calling findPetsByStatus.');
         }
@@ -225,7 +222,6 @@ export class PetService {
      */
     public findPetsByTags(tags: Array<string>, ): Observable<AxiosResponse<Array<Pet>>>;
     public findPetsByTags(tags: Array<string>, ): Observable<any> {
-
         if (tags === null || tags === undefined) {
             throw new Error('Required parameter tags was null or undefined when calling findPetsByTags.');
         }
@@ -284,7 +280,6 @@ export class PetService {
      */
     public getPetById(petId: number, ): Observable<AxiosResponse<Pet>>;
     public getPetById(petId: number, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling getPetById.');
         }
@@ -335,7 +330,6 @@ export class PetService {
      */
     public updatePet(pet: Pet, ): Observable<AxiosResponse<Pet>>;
     public updatePet(pet: Pet, ): Observable<any> {
-
         if (pet === null || pet === undefined) {
             throw new Error('Required parameter pet was null or undefined when calling updatePet.');
         }
@@ -397,7 +391,6 @@ export class PetService {
      */
     public updatePetWithForm(petId: number, name?: string, status?: string, ): Observable<AxiosResponse<any>>;
     public updatePetWithForm(petId: number, name?: string, status?: string, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling updatePetWithForm.');
         }
@@ -472,7 +465,6 @@ export class PetService {
      */
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, ): Observable<AxiosResponse<ApiResponse>>;
     public uploadFile(petId: number, additionalMetadata?: string, file?: Blob, ): Observable<any> {
-
         if (petId === null || petId === undefined) {
             throw new Error('Required parameter petId was null or undefined when calling uploadFile.');
         }

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/store.service.ts
@@ -50,7 +50,6 @@ export class StoreService {
      */
     public deleteOrder(orderId: string, ): Observable<AxiosResponse<any>>;
     public deleteOrder(orderId: string, ): Observable<any> {
-
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling deleteOrder.');
         }
@@ -93,7 +92,6 @@ export class StoreService {
      */
     public getInventory(): Observable<AxiosResponse<{ [key: string]: number; }>>;
     public getInventory(): Observable<any> {
-
         let headers = {...this.defaultHeaders};
 
         let accessTokenObservable: Observable<any> = of(null);
@@ -139,7 +137,6 @@ export class StoreService {
      */
     public getOrderById(orderId: number, ): Observable<AxiosResponse<Order>>;
     public getOrderById(orderId: number, ): Observable<any> {
-
         if (orderId === null || orderId === undefined) {
             throw new Error('Required parameter orderId was null or undefined when calling getOrderById.');
         }
@@ -185,7 +182,6 @@ export class StoreService {
      */
     public placeOrder(order: Order, ): Observable<AxiosResponse<Order>>;
     public placeOrder(order: Order, ): Observable<any> {
-
         if (order === null || order === undefined) {
             throw new Error('Required parameter order was null or undefined when calling placeOrder.');
         }

--- a/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
+++ b/samples/client/petstore/typescript-nestjs-v8-provided-in-root/builds/default/api/user.service.ts
@@ -50,7 +50,6 @@ export class UserService {
      */
     public createUser(user: User, ): Observable<AxiosResponse<any>>;
     public createUser(user: User, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUser.');
         }
@@ -105,7 +104,6 @@ export class UserService {
      */
     public createUsersWithArrayInput(user: Array<User>, ): Observable<AxiosResponse<any>>;
     public createUsersWithArrayInput(user: Array<User>, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithArrayInput.');
         }
@@ -160,7 +158,6 @@ export class UserService {
      */
     public createUsersWithListInput(user: Array<User>, ): Observable<AxiosResponse<any>>;
     public createUsersWithListInput(user: Array<User>, ): Observable<any> {
-
         if (user === null || user === undefined) {
             throw new Error('Required parameter user was null or undefined when calling createUsersWithListInput.');
         }
@@ -215,7 +212,6 @@ export class UserService {
      */
     public deleteUser(username: string, ): Observable<AxiosResponse<any>>;
     public deleteUser(username: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling deleteUser.');
         }
@@ -264,7 +260,6 @@ export class UserService {
      */
     public getUserByName(username: string, ): Observable<AxiosResponse<User>>;
     public getUserByName(username: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling getUserByName.');
         }
@@ -311,7 +306,6 @@ export class UserService {
      */
     public loginUser(username: string, password: string, ): Observable<AxiosResponse<string>>;
     public loginUser(username: string, password: string, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling loginUser.');
         }
@@ -369,7 +363,6 @@ export class UserService {
      */
     public logoutUser(): Observable<AxiosResponse<any>>;
     public logoutUser(): Observable<any> {
-
         let headers = {...this.defaultHeaders};
 
         let accessTokenObservable: Observable<any> = of(null);
@@ -415,7 +408,6 @@ export class UserService {
      */
     public updateUser(username: string, user: User, ): Observable<AxiosResponse<any>>;
     public updateUser(username: string, user: User, ): Observable<any> {
-
         if (username === null || username === undefined) {
             throw new Error('Required parameter username was null or undefined when calling updateUser.');
         }


### PR DESCRIPTION
Fixes mustach template from https://github.com/OpenAPITools/openapi-generator/pull/18476
- Comment block was improperly closed
- Also removes empty param destructuring when there are no params

Before (unterminated comment block)
```ts
    /**
     * 
     * 
    public metadataControllerGetMetadata(): Observable<AxiosResponse<GetDto>>;
    public metadataControllerGetMetadata(): Observable<any> {
const {
} = requestParameters;
        let headers = {...this.defaultHeaders};
```

After
```ts
    /**
     * 
     * 
     */
    public metadataControllerGetMetadata(): Observable<AxiosResponse<GetDto>>;
    public metadataControllerGetMetadata(): Observable<any> {
        let headers = {...this.defaultHeaders};
```

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
