### PR TITLE
Fix long running test

### DIFF
--- a/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
+++ b/modules/openapi-generator-online/src/test/java/org/openapitools/codegen/online/api/GenApiControllerTest.java
@@ -124,9 +124,10 @@ public class GenApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, not(0)));
     }
+
     @Test
     public void generateClientWithInvalidOpenAPIUrl() throws Exception {
-        String invalidOpenAPIUrl = "https://test.com:1234/invalid_openapi.json";
+        final String invalidOpenAPIUrl = "https://[::1]/invalid_openapi.json";
         mockMvc.perform(post("http://test.com:1234/api/gen/clients/java")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"openAPIUrl\": \"" + invalidOpenAPIUrl + "\"}"))


### PR DESCRIPTION
Depending on test exec environment, this test could linger around for ~8 minutes, b/c pinging test.com will not resolve and run into several timeouts.

Brings down CI time for Linux Suite from >10m to ~4m. 

### Before

Connections in this test time out with 

```log
java.net.ConnectException: Connection timed out: connect
```

![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/8a38bace-f565-43ef-98c2-6dcbee9a03fc)
![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/fa49fefa-f7c5-48d9-9ffd-1024ede7613d)


### After

Connection fails immediately with

```
java.net.ConnectException: Connection refused: connect
```

![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/b276a8ca-1c84-4c1c-9b70-ca609cd66585)
![grafik](https://github.com/OpenAPITools/openapi-generator/assets/1634615/2c186e33-624c-440c-8ff4-1f24b1edfc2b)



<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
