### PR TITLE
[crystal-lang] Update dependencies to remedy build failure

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/shard.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/shard.mustache
@@ -8,12 +8,12 @@ crystal: ">= 0.35.1"
 dependencies:
   crest:
     github: mamantoha/crest
-    version: ~> 0.26.0
+    version: ~> 1.3.13
 
 development_dependencies:
   kemal:
     github: kemalcr/kemal
-    version: ~>0.27.0
+    version: ~>1.5.0
   ameba:
     github: crystal-ameba/ameba
 

--- a/samples/client/petstore/crystal/shard.yml
+++ b/samples/client/petstore/crystal/shard.yml
@@ -8,12 +8,12 @@ crystal: ">= 0.35.1"
 dependencies:
   crest:
     github: mamantoha/crest
-    version: ~> 0.26.0
+    version: ~> 1.3.13
 
 development_dependencies:
   kemal:
     github: kemalcr/kemal
-    version: ~>0.27.0
+    version: ~>1.5.0
   ameba:
     github: crystal-ameba/ameba
 


### PR DESCRIPTION
This is an extremely straightforward change that bumps the version of [Kemal](https://github.com/kemalcr/kemal) and [Crest](https://github.com/mamantoha/crest) in order to fix a build error after a `shards update`. The issue experienced is a failure for the generated client library to run due to an error in the dependent library [http_proxy](https://github.com/mamantoha/http_proxy). This library is in a unusable state in version 0.8.1 due to a function prototype mismatch with its provided argument types. For review @wing328.

An OpenAPI-Generator user using the Crystal Language generator will experience a backtrace like this when using the current generator:
```
$ crystal build src/cli.cr --error-trace 
In src/cli.cr:50:6
 50 | main.execute ARGV
           ^------
Error: instantiating 'CLI#execute(Array(String))'

In lib/cling/src/cling/command.cr:182:16
 182 | Executor.handle self, results
                ^-----
Error: instantiating 'Cling::Executor.handle(Build::CLI, Array(Cling::Parser::Result))'

In lib/cling/src/cling/executor.cr:59:24
 59 | resolved_command.run executed.parsed_arguments, executed.parsed_options
                       ^--
Error: instantiating 'Cling::Command+#run(Cling::Arguments, Cling::Options)'

In src/commands/whoami.cr:13:20
 13 | puts api.api_v1_me_get.email
               ^------------
Error: instantiating 'OpenAPIClient::DefaultApi#api_v1_me_get()'

In lib/openapi_client/src/openapi_client/api/default_api.cr:349:38
 349 | data, _status_code, _headers = api_v1_me_get_with_http_info()
                                      ^---------------------------
Error: instantiating 'api_v1_me_get_with_http_info()'

In lib/openapi_client/src/openapi_client/api/default_api.cr:382:48
 382 | data, status_code, headers = @api_client.call_api(:GET,
                                                ^-------
Error: instantiating 'OpenAPIClient::ApiClient#call_api(Symbol, String, Symbol, String, Nil, Array(String), Hash(String, String), Hash(String, String), Hash(Symbol, File | String))'

In lib/openapi_client/src/openapi_client/api_client.cr:160:26
 160 | response = request.execute
                          ^------
Error: instantiating 'Crest::Request#execute()'

In lib/crest/src/crest/request.cr:174:20
 174 | @http_client.set_proxy(@proxy)
                    ^--------
Error: instantiating 'HTTP::Client#set_proxy((HTTP::Proxy::Client | Nil))'

In lib/http_proxy/src/ext/http/client.cr:11:21
 11 | @io = proxy.open(
                  ^---
Error: no overload matches 'HTTP::Proxy::Client#open', host: String, port: Int32, tls: (OpenSSL::SSL::Context::Client | Nil), dns_timeout: (Time::Span | Nil), connect_timeout: (Time::Span | Nil), read_timeout: (Time::Span | Nil)

Overloads are:
 - HTTP::Proxy::Client#open(host, port, tls = nil, *, dns_timeout : ::Float64 | ::Nil, connect_timeout : ::Float64 | ::Nil, read_timeout : ::Float64 | ::Nil)
Couldn't find overloads for these types:
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Time::Span, connect_timeout : Time::Span, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Time::Span, connect_timeout : Time::Span, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Time::Span, connect_timeout : Nil, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Time::Span, connect_timeout : Nil, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Nil, connect_timeout : Time::Span, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Nil, connect_timeout : Time::Span, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : Nil, dns_timeout : Nil, connect_timeout : Nil, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Time::Span, connect_timeout : Time::Span, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Time::Span, connect_timeout : Time::Span, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Time::Span, connect_timeout : Nil, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Time::Span, connect_timeout : Nil, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Nil, connect_timeout : Time::Span, read_timeout : Time::Span)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Nil, connect_timeout : Time::Span, read_timeout : Nil)
 - HTTP::Proxy::Client#open(host : String, port : Int32, tls : OpenSSL::SSL::Context::Client, dns_timeout : Nil, connect_timeout : Nil, read_timeout : Time::Span)
```

The root cause is the definition of time variables as Float64 in http_proxy's [client.cr](https://github.com/mamantoha/http_proxy/blob/4bf6e700f0f1d8ff0384e07f1a6348ebdae770e6/src/http/proxy/client.cr#L24) version 0.8.1.
```
module HTTP
  # :nodoc:
  module Proxy
    # Represents a proxy client with all its attributes.
    # Provides convenient access and modification of them.
    class Client
      getter host : String
      getter port : Int32
      property username : String?
      property password : String?
      property headers : HTTP::Headers

      getter tls : OpenSSL::SSL::Context::Client?

      @dns_timeout : Float64?
      @connect_timeout : Float64?
      @read_timeout : Float64?
```

This conflicts with the same library's prototype which has implied type of Time::Span instead of Float64 [client.cr](https://github.com/mamantoha/http_proxy/blob/4bf6e700f0f1d8ff0384e07f1a6348ebdae770e6/src/ext/http/client.cr).

```
module HTTP
  class Client
    getter proxy : Bool = false

    def set_proxy(proxy : HTTP::Proxy::Client?)
      return unless proxy
  
      begin
        @io = proxy.open(
          host: @host,
          port: @port,
          tls: @tls,
          dns_timeout: @dns_timeout,
          connect_timeout: @connect_timeout,
          read_timeout: @read_timeout
        )
```

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
