### PR TITLE
[crystal-lang] Resolve type check compile error in ApiError

### DIFF
--- a/modules/openapi-generator/src/main/resources/crystal/api_error.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api_error.mustache
@@ -21,7 +21,7 @@ module {{moduleName}}
       msg = ""
       msg = msg + "\nHTTP status code: #{code}" if @code
       msg = msg + "\nResponse headers: #{response_headers}" if @response_headers
-      if @message.nil? || @message.empty?
+      if @message.nil? || @message.try &.empty?
         msg = msg + "\nError message: the server returns an error but the HTTP response body is empty."
       else
         msg = msg + "\nResponse body: #{@message}"

--- a/modules/openapi-generator/src/main/resources/crystal/api_error.mustache
+++ b/modules/openapi-generator/src/main/resources/crystal/api_error.mustache
@@ -21,7 +21,7 @@ module {{moduleName}}
       msg = ""
       msg = msg + "\nHTTP status code: #{code}" if @code
       msg = msg + "\nResponse headers: #{response_headers}" if @response_headers
-      if @message.nil? || @message.try &.empty?
+      if @message.try &.empty?
         msg = msg + "\nError message: the server returns an error but the HTTP response body is empty."
       else
         msg = msg + "\nResponse body: #{@message}"

--- a/samples/client/petstore/crystal/src/petstore/api_error.cr
+++ b/samples/client/petstore/crystal/src/petstore/api_error.cr
@@ -29,7 +29,7 @@ module Petstore
       msg = ""
       msg = msg + "\nHTTP status code: #{code}" if @code
       msg = msg + "\nResponse headers: #{response_headers}" if @response_headers
-      if @message.nil? || @message.empty?
+      if @message.nil? || @message.try &.empty?
         msg = msg + "\nError message: the server returns an error but the HTTP response body is empty."
       else
         msg = msg + "\nResponse body: #{@message}"

--- a/samples/client/petstore/crystal/src/petstore/api_error.cr
+++ b/samples/client/petstore/crystal/src/petstore/api_error.cr
@@ -29,7 +29,7 @@ module Petstore
       msg = ""
       msg = msg + "\nHTTP status code: #{code}" if @code
       msg = msg + "\nResponse headers: #{response_headers}" if @response_headers
-      if @message.nil? || @message.try &.empty?
+      if @message.try &.empty?
         msg = msg + "\nError message: the server returns an error but the HTTP response body is empty."
       else
         msg = msg + "\nResponse body: #{@message}"


### PR DESCRIPTION
Displaying a rescue'd ApiError causes a compile-time error using crystal-lang v1.12.1. The `@message` instance variable is defined as `String | Nil`; however, even with a `.nil?` check, the variable causes a compile-time error when a further `.empty?` call is made. 

The offending line uses the`||` (logical OR) operator to ensure `@message` is not `Nil`. Although this should logically ensure that further operations on `@message` were only applied to `@message` when it is of type `String`, this is not what is seen during a compilation. It is unintuitive that this is necessary as crystal-lang's logical OR operator [uses left-hand associativity](https://crystal-lang.org/reference/1.12/syntax_and_semantics/operators.html).

This PR uses `.try` to make the `.empty?` call. Since Nil defines `.try` and ignores it, this achieves the same functional goal.

```
In lib/openapi_client/src/openapi_client/api_error.cr:32:31

 32 | if @message.nil? || @message.empty?
                                   ^-----
Error: undefined method 'empty?' for Nil (compile-time type is (String | Nil))
```

@wing328 @cyangle

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [X] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
