### PR TITLE
Fix TS7053 errors in generated instanceOf* methods

### DIFF
--- a/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
+++ b/modules/openapi-generator/src/main/resources/typescript-fetch/modelEnum.mustache
@@ -3,7 +3,7 @@
 export function instanceOf{{classname}}(value: any): boolean {
     for (const key in {{classname}}) {
         if (Object.prototype.hasOwnProperty.call({{classname}}, key)) {
-            if ({{classname}}[key] === value) {
+            if (({{classname}} as Record<string, {{classname}}>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/EnumClass.ts
@@ -28,7 +28,7 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 export function instanceOfEnumClass(value: any): boolean {
     for (const key in EnumClass) {
         if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
-            if (EnumClass[key] === value) {
+            if ((EnumClass as Record<string, EnumClass>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnum.ts
@@ -28,7 +28,7 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 export function instanceOfOuterEnum(value: any): boolean {
     for (const key in OuterEnum) {
         if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
-            if (OuterEnum[key] === value) {
+            if ((OuterEnum as Record<string, OuterEnum>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
     for (const key in OuterEnumDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
-            if (OuterEnumDefaultValue[key] === value) {
+            if ((OuterEnumDefaultValue as Record<string, OuterEnumDefaultValue>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumInteger.ts
@@ -28,7 +28,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 export function instanceOfOuterEnumInteger(value: any): boolean {
     for (const key in OuterEnumInteger) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
-            if (OuterEnumInteger[key] === value) {
+            if ((OuterEnumInteger as Record<string, OuterEnumInteger>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/OuterEnumIntegerDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
     for (const key in OuterEnumIntegerDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
-            if (OuterEnumIntegerDefaultValue[key] === value) {
+            if ((OuterEnumIntegerDefaultValue as Record<string, OuterEnumIntegerDefaultValue>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/default-v3.0/models/SingleRefType.ts
@@ -27,7 +27,7 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 export function instanceOfSingleRefType(value: any): boolean {
     for (const key in SingleRefType) {
         if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
-            if (SingleRefType[key] === value) {
+            if ((SingleRefType as Record<string, SingleRefType>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/NumberEnum.ts
@@ -28,7 +28,7 @@ export type NumberEnum = typeof NumberEnum[keyof typeof NumberEnum];
 export function instanceOfNumberEnum(value: any): boolean {
     for (const key in NumberEnum) {
         if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
-            if (NumberEnum[key] === value) {
+            if ((NumberEnum as Record<string, NumberEnum>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/enum/models/StringEnum.ts
@@ -28,7 +28,7 @@ export type StringEnum = typeof StringEnum[keyof typeof StringEnum];
 export function instanceOfStringEnum(value: any): boolean {
     for (const key in StringEnum) {
         if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
-            if (StringEnum[key] === value) {
+            if ((StringEnum as Record<string, StringEnum>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/BehaviorType.ts
@@ -28,7 +28,7 @@ export type BehaviorType = typeof BehaviorType[keyof typeof BehaviorType];
 export function instanceOfBehaviorType(value: any): boolean {
     for (const key in BehaviorType) {
         if (Object.prototype.hasOwnProperty.call(BehaviorType, key)) {
-            if (BehaviorType[key] === value) {
+            if ((BehaviorType as Record<string, BehaviorType>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/DeploymentRequestStatus.ts
@@ -37,7 +37,7 @@ export type DeploymentRequestStatus = typeof DeploymentRequestStatus[keyof typeo
 export function instanceOfDeploymentRequestStatus(value: any): boolean {
     for (const key in DeploymentRequestStatus) {
         if (Object.prototype.hasOwnProperty.call(DeploymentRequestStatus, key)) {
-            if (DeploymentRequestStatus[key] === value) {
+            if ((DeploymentRequestStatus as Record<string, DeploymentRequestStatus>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/ErrorCode.ts
@@ -43,7 +43,7 @@ export type ErrorCode = typeof ErrorCode[keyof typeof ErrorCode];
 export function instanceOfErrorCode(value: any): boolean {
     for (const key in ErrorCode) {
         if (Object.prototype.hasOwnProperty.call(ErrorCode, key)) {
-            if (ErrorCode[key] === value) {
+            if ((ErrorCode as Record<string, ErrorCode>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/PetPartType.ts
@@ -28,7 +28,7 @@ export type PetPartType = typeof PetPartType[keyof typeof PetPartType];
 export function instanceOfPetPartType(value: any): boolean {
     for (const key in PetPartType) {
         if (Object.prototype.hasOwnProperty.call(PetPartType, key)) {
-            if (PetPartType[key] === value) {
+            if ((PetPartType as Record<string, PetPartType>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
+++ b/samples/client/petstore/typescript-fetch/builds/sagas-and-records/src/models/WarningCode.ts
@@ -28,7 +28,7 @@ export type WarningCode = typeof WarningCode[keyof typeof WarningCode];
 export function instanceOfWarningCode(value: any): boolean {
     for (const key in WarningCode) {
         if (Object.prototype.hasOwnProperty.call(WarningCode, key)) {
-            if (WarningCode[key] === value) {
+            if ((WarningCode as Record<string, WarningCode>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/EnumClass.ts
@@ -28,7 +28,7 @@ export type EnumClass = typeof EnumClass[keyof typeof EnumClass];
 export function instanceOfEnumClass(value: any): boolean {
     for (const key in EnumClass) {
         if (Object.prototype.hasOwnProperty.call(EnumClass, key)) {
-            if (EnumClass[key] === value) {
+            if ((EnumClass as Record<string, EnumClass>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnum.ts
@@ -28,7 +28,7 @@ export type OuterEnum = typeof OuterEnum[keyof typeof OuterEnum];
 export function instanceOfOuterEnum(value: any): boolean {
     for (const key in OuterEnum) {
         if (Object.prototype.hasOwnProperty.call(OuterEnum, key)) {
-            if (OuterEnum[key] === value) {
+            if ((OuterEnum as Record<string, OuterEnum>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumDefaultValue = typeof OuterEnumDefaultValue[keyof typeof Ou
 export function instanceOfOuterEnumDefaultValue(value: any): boolean {
     for (const key in OuterEnumDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumDefaultValue, key)) {
-            if (OuterEnumDefaultValue[key] === value) {
+            if ((OuterEnumDefaultValue as Record<string, OuterEnumDefaultValue>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumInteger.ts
@@ -28,7 +28,7 @@ export type OuterEnumInteger = typeof OuterEnumInteger[keyof typeof OuterEnumInt
 export function instanceOfOuterEnumInteger(value: any): boolean {
     for (const key in OuterEnumInteger) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumInteger, key)) {
-            if (OuterEnumInteger[key] === value) {
+            if ((OuterEnumInteger as Record<string, OuterEnumInteger>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/OuterEnumIntegerDefaultValue.ts
@@ -28,7 +28,7 @@ export type OuterEnumIntegerDefaultValue = typeof OuterEnumIntegerDefaultValue[k
 export function instanceOfOuterEnumIntegerDefaultValue(value: any): boolean {
     for (const key in OuterEnumIntegerDefaultValue) {
         if (Object.prototype.hasOwnProperty.call(OuterEnumIntegerDefaultValue, key)) {
-            if (OuterEnumIntegerDefaultValue[key] === value) {
+            if ((OuterEnumIntegerDefaultValue as Record<string, OuterEnumIntegerDefaultValue>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
+++ b/samples/client/petstore/typescript-fetch/builds/snakecase-discriminator/models/SingleRefType.ts
@@ -27,7 +27,7 @@ export type SingleRefType = typeof SingleRefType[keyof typeof SingleRefType];
 export function instanceOfSingleRefType(value: any): boolean {
     for (const key in SingleRefType) {
         if (Object.prototype.hasOwnProperty.call(SingleRefType, key)) {
-            if (SingleRefType[key] === value) {
+            if ((SingleRefType as Record<string, SingleRefType>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/NumberEnum.ts
@@ -27,7 +27,7 @@ export enum NumberEnum {
 export function instanceOfNumberEnum(value: any): boolean {
     for (const key in NumberEnum) {
         if (Object.prototype.hasOwnProperty.call(NumberEnum, key)) {
-            if (NumberEnum[key] === value) {
+            if ((NumberEnum as Record<string, NumberEnum>)[key] === value) {
                 return true;
             }
         }

--- a/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
+++ b/samples/client/petstore/typescript-fetch/builds/with-string-enums/models/StringEnum.ts
@@ -27,7 +27,7 @@ export enum StringEnum {
 export function instanceOfStringEnum(value: any): boolean {
     for (const key in StringEnum) {
         if (Object.prototype.hasOwnProperty.call(StringEnum, key)) {
-            if (StringEnum[key] === value) {
+            if ((StringEnum as Record<string, StringEnum>)[key] === value) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes a typescipt bug that was introduced in #18418 , details are explained in #18746 

@mkusaka 

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
