### PR TITLE
Make Gradle task `GenerateTask` less verbose

### DIFF
--- a/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
+++ b/modules/openapi-generator-gradle-plugin/src/main/kotlin/org/openapitools/generator/gradle/plugin/tasks/GenerateTask.kt
@@ -618,9 +618,11 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
         cleanupOutput.ifNotEmpty { cleanup ->
             if (cleanup) {
                 createFileSystemManager().delete(outputDir)
-                val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
-                out.withStyle(StyledTextOutput.Style.Success)
-                out.println("Cleaned up output directory ${outputDir.get()} before code generation (cleanupOutput set to true).")
+                if (verbose.getOrElse(true)) {
+                    val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
+                    out.withStyle(StyledTextOutput.Style.Success)
+                    out.println("Cleaned up output directory ${outputDir.get()} before code generation (cleanupOutput set to true).")
+                }
             }
         }
 
@@ -933,12 +935,13 @@ open class GenerateTask @Inject constructor(private val objectFactory: ObjectFac
             }
 
             try {
-                val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
-                out.withStyle(StyledTextOutput.Style.Success)
-
                 DefaultGenerator(dryRunSetting).opts(clientOptInput).generate()
 
-                out.println("Successfully generated code to ${outputDir.get()}")
+                if (verbose.getOrElse(true)) {
+                    val out = services.get(StyledTextOutputFactory::class.java).create("openapi")
+                    out.withStyle(StyledTextOutput.Style.Success)
+                    out.println("Successfully generated code to ${outputDir.get()}")
+                }
             } catch (e: RuntimeException) {
                 throw GradleException("Code generation failed.", e)
             }


### PR DESCRIPTION
This PR is related with #8982 but it doesn't fix it. Each time that I execute the `GenerateTask` from gradle I get this output:

```
Cleaned up output directory /path/build/generated/swagger before code generation (cleanupOutput set to true).
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
#                                                                              #
# This generator's contributed by Jim Schubert (https://github.com/jimschubert)#
# Please support his work directly via https://patreon.com/jimschubert 🙏      #
################################################################################
Successfully generated code to /path/build/generated/swagger
```

I get that the donation message is a sensible topic but I think that it's ok to hide the messages "Cleaned up output directory..." and "Successfully generated code to..." behind the current `verbose` flag. Tha's what this PR does.

### PR checklist
 
- [X] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [X] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [X] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [X] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
