### PR TITLE
[Elixir] Fix generation issues and compilation warnings in Elixir generator

### DIFF
--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -63,14 +63,21 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
-<li>__CALLER__</li>
-<li>__DIR__</li>
-<li>__ENV__</li>
-<li>__FILE__</li>
-<li>__MODULE__</li>
+<li>after</li>
+<li>and</li>
+<li>catch</li>
+<li>do</li>
+<li>else</li>
+<li>end</li>
 <li>false</li>
+<li>fn</li>
+<li>in</li>
 <li>nil</li>
+<li>not</li>
+<li>or</li>
+<li>rescue</li>
 <li>true</li>
+<li>when</li>
 </ul>
 
 ## FEATURE SET

--- a/docs/generators/elixir.md
+++ b/docs/generators/elixir.md
@@ -63,6 +63,12 @@ These options may be applied as additional-properties (cli) or configOptions (pl
 ## RESERVED WORDS
 
 <ul class="column-ul">
+<li>__CALLER__</li>
+<li>__DIR__</li>
+<li>__ENV__</li>
+<li>__FILE__</li>
+<li>__MODULE__</li>
+<li>__struct__</li>
 <li>after</li>
 <li>and</li>
 <li>catch</li>

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -836,9 +836,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
                     returnEntry.append(normalizeTypeName(exResponse.dataType, exResponse.primitiveType));
                 } else {
                     if (exResponse.containerType.equals("array") || exResponse.containerType.equals("set")) {
-                        returnEntry.append("list(");
-                        returnEntry.append(normalizeTypeName(exResponse.baseType, exResponse.primitiveType));
-                        returnEntry.append(")");
+                        returnEntry.append(normalizeTypeName(exResponse.dataType, true));
                     } else if (exResponse.containerType.equals("map")) {
                         returnEntry.append("map()");
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -833,7 +833,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 if (exResponse.baseType == null) {
                     returnEntry.append("nil");
                 } else if (exResponse.containerType == null) { // not container (array, map, set)
-                    returnEntry.append(normalizeTypeName(exResponse.baseType, exResponse.primitiveType));
+                    returnEntry.append(normalizeTypeName(exResponse.dataType, exResponse.primitiveType));
                 } else {
                     if (exResponse.containerType.equals("array") || exResponse.containerType.equals("set")) {
                         returnEntry.append("list(");
@@ -901,7 +901,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 buildTypespec(property.items, sb);
                 sb.append("}");
             } else {
-                sb.append(normalizeTypeName(property.baseType, property.isPrimitiveType));
+                sb.append(normalizeTypeName(property.dataType, property.isPrimitiveType));
             }
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -120,7 +120,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
 
         /**
          * Reserved words. Override this with reserved words specific to your language
-         * Ref: https://hexdocs.pm/elixir/1.13/syntax-reference.html#reserved-words
+         * Ref: https://hexdocs.pm/elixir/1.16.3/syntax-reference.html#reserved-words
          */
         reservedWords = new HashSet<>(
                 Arrays.asList(
@@ -138,7 +138,13 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "catch",
                         "rescue",
                         "after",
-                        "else"));
+                        "else",
+                        "__struct__",
+                        "__MODULE__",
+                        "__FILE__",
+                        "__DIR__",
+                        "__ENV__",
+                        "__CALLER__"));
 
         /**
          * Additional Properties. These values can be passed to the templates and
@@ -432,7 +438,11 @@ public class ElixirClientCodegen extends DefaultCodegen {
      */
     @Override
     public String escapeReservedWord(String name) {
-        return name + "_var"; // add a generic suffix to the name
+        String escapedName = name + "_var";
+
+        // Trim leading underscores in the event the name is already underscored
+        escapedName = escapedName.replaceAll("^_+", "");
+        return escapedName;
     }
 
     private String sourceFolder() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -836,7 +836,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
                     returnEntry.append(normalizeTypeName(exResponse.dataType, exResponse.primitiveType));
                 } else {
                     if (exResponse.containerType.equals("array") || exResponse.containerType.equals("set")) {
-                        returnEntry.append(normalizeTypeName(exResponse.dataType, true));
+                        returnEntry.append(exResponse.dataType);
                     } else if (exResponse.containerType.equals("map")) {
                         returnEntry.append("map()");
                     }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -432,7 +432,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
      */
     @Override
     public String escapeReservedWord(String name) {
-        return "_" + name; // add an underscore to the name
+        return name + "_var"; // add a generic suffix to the name
     }
 
     private String sourceFolder() {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -62,8 +62,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
             "{:tesla, \"~> 1.7\"}",
             "{:jason, \"~> 1.4\"}",
             "{:ex_doc, \"~> 0.30\", only: :dev, runtime: false}",
-            "{:dialyxir, \"~> 1.3\", only: [:dev, :test], runtime: false}"
-    );
+            "{:dialyxir, \"~> 1.3\", only: [:dev, :test], runtime: false}");
 
     public ElixirClientCodegen() {
         super();
@@ -72,58 +71,55 @@ public class ElixirClientCodegen extends DefaultCodegen {
                 .includeDocumentationFeatures(DocumentationFeature.Readme)
                 .securityFeatures(EnumSet.of(
                         SecurityFeature.OAuth2_Implicit,
-                        SecurityFeature.BasicAuth
-                ))
+                        SecurityFeature.BasicAuth))
                 .excludeGlobalFeatures(
                         GlobalFeature.XMLStructureDefinitions,
                         GlobalFeature.Callbacks,
                         GlobalFeature.LinkObjects,
-                        GlobalFeature.ParameterStyling
-                )
+                        GlobalFeature.ParameterStyling)
                 .excludeSchemaSupportFeatures(
-                        SchemaSupportFeature.Polymorphism
-                )
+                        SchemaSupportFeature.Polymorphism)
                 .excludeParameterFeatures(
-                        ParameterFeature.Cookie
-                )
+                        ParameterFeature.Cookie)
                 .includeClientModificationFeatures(
-                        ClientModificationFeature.BasePath
-                )
+                        ClientModificationFeature.BasePath)
                 .includeDataTypeFeatures(
-                        DataTypeFeature.AnyType
-                )
-        );
+                        DataTypeFeature.AnyType));
 
         // set the output folder here
         outputFolder = "generated-code/elixir";
 
         /*
-         * Models.  You can write model files using the modelTemplateFiles map.
+         * Models. You can write model files using the modelTemplateFiles map.
          * if you want to create one template for file, you can do so here.
-         * for multiple files for model, just put another entry in the `modelTemplateFiles` with
+         * for multiple files for model, just put another entry in the
+         * `modelTemplateFiles` with
          * a different extension
          */
         modelTemplateFiles.put(
                 "model.mustache", // the template to use
-                ".ex");       // the extension for each file to write
+                ".ex"); // the extension for each file to write
 
         /**
-         * Api classes.  You can write classes for each Api file with the apiTemplateFiles map.
-         * as with models, add multiple entries with different extensions for multiple files per
+         * Api classes. You can write classes for each Api file with the
+         * apiTemplateFiles map.
+         * as with models, add multiple entries with different extensions for multiple
+         * files per
          * class
          */
         apiTemplateFiles.put(
-                "api.mustache",   // the template to use
-                ".ex");       // the extension for each file to write
+                "api.mustache", // the template to use
+                ".ex"); // the extension for each file to write
 
         /**
-         * Template Location.  This is the location which templates will be read from.  The generator
+         * Template Location. This is the location which templates will be read from.
+         * The generator
          * will use the resource stream to attempt to read the templates.
          */
         templateDir = "elixir";
 
         /**
-         * Reserved words.  Override this with reserved words specific to your language
+         * Reserved words. Override this with reserved words specific to your language
          * Ref: https://github.com/itsgreggreg/elixir_quick_reference#reserved-words
          */
         reservedWords = new HashSet<>(
@@ -135,51 +131,44 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "__FILE__",
                         "__DIR__",
                         "__ENV__",
-                        "__CALLER__")
-        );
+                        "__CALLER__"));
 
         /**
-         * Additional Properties.  These values can be passed to the templates and
+         * Additional Properties. These values can be passed to the templates and
          * are available in models, apis, and supporting files
          */
         additionalProperties.put("apiVersion", apiVersion);
 
         /**
-         * Supporting Files.  You can write single files for the generator with the
-         * entire object tree available.  If the input file has a suffix of `.mustache
-         * it will be processed by the template engine.  Otherwise, it will be copied
+         * Supporting Files. You can write single files for the generator with the
+         * entire object tree available. If the input file has a suffix of `.mustache
+         * it will be processed by the template engine. Otherwise, it will be copied
          */
-        supportingFiles.add(new SupportingFile("README.md.mustache",   // the input template or file
-                "",                                                       // the destination folder, relative `outputFolder`
-                "README.md")                                          // the output file
+        supportingFiles.add(new SupportingFile("README.md.mustache", // the input template or file
+                "", // the destination folder, relative `outputFolder`
+                "README.md") // the output file
         );
         supportingFiles.add(new SupportingFile("config.exs.mustache",
                 "config",
-                "config.exs")
-        );
+                "config.exs"));
         supportingFiles.add(new SupportingFile("runtime.exs.mustache",
                 "config",
-                "runtime.exs")
-        );
+                "runtime.exs"));
         supportingFiles.add(new SupportingFile("mix.exs.mustache",
                 "",
-                "mix.exs")
-        );
+                "mix.exs"));
         supportingFiles.add(new SupportingFile("formatter.exs",
                 "",
-                ".formatter.exs")
-        );
+                ".formatter.exs"));
         supportingFiles.add(new SupportingFile("test_helper.exs.mustache",
                 "test",
-                "test_helper.exs")
-        );
+                "test_helper.exs"));
         supportingFiles.add(new SupportingFile("gitignore.mustache",
                 "",
-                ".gitignore")
-        );
+                ".gitignore"));
 
         /**
-         * Language Specific Primitives.  These types will not trigger imports by
+         * Language Specific Primitives. These types will not trigger imports by
          * the client generator
          */
         languageSpecificPrimitives = new HashSet<>(
@@ -195,12 +184,12 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "AnyType",
                         "Tuple",
                         "PID",
-                        "map()", // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec datetype to evaluate the primitive
-                        "any()"
-                )
-        );
+                        "map()", // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec
+                                 // datetype to evaluate the primitive
+                        "any()"));
 
-        // ref: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+        // ref:
+        // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
         typeMapping = new HashMap<>();
         typeMapping.put("integer", "Integer");
         typeMapping.put("long", "Integer");
@@ -222,7 +211,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
         typeMapping.put("UUID", "String");
         typeMapping.put("URI", "String");
 
-        cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE, "The main namespace to use for all classes. e.g. Yay.Pets"));
+        cliOptions.add(new CliOption(CodegenConstants.INVOKER_PACKAGE,
+                "The main namespace to use for all classes. e.g. Yay.Pets"));
         cliOptions.add(new CliOption("licenseHeader", "The license header to prepend to the top of all source files."));
         cliOptions.add(new CliOption(CodegenConstants.PACKAGE_NAME, "Elixir package name (convention: lowercase)."));
     }
@@ -239,7 +229,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Configures a friendly name for the generator.  This will be used by the generator
+     * Configures a friendly name for the generator. This will be used by the
+     * generator
      * to select the library with the -g flag.
      *
      * @return the friendly name for the generator
@@ -250,7 +241,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Returns human-friendly help for the generator.  Provide the consumer with help
+     * Returns human-friendly help for the generator. Provide the consumer with help
      * tips, parameters here
      *
      * @return A string value for the help message
@@ -321,7 +312,6 @@ public class ElixirClientCodegen extends DefaultCodegen {
         supportingFiles.add(new SupportingFile("request_builder.ex.mustache",
                 sourceFolder(),
                 "request_builder.ex"));
-
 
         supportingFiles.add(new SupportingFile("deserializer.ex.mustache",
                 sourceFolder(),
@@ -407,34 +397,35 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     private String atomized(String text) {
-      StringBuilder atom = new StringBuilder();
-      Matcher m = simpleAtomPattern.matcher(text);
+        StringBuilder atom = new StringBuilder();
+        Matcher m = simpleAtomPattern.matcher(text);
 
-      atom.append(":");
+        atom.append(":");
 
-      if (!m.matches()) {
-        atom.append("\"");
-      }
+        if (!m.matches()) {
+            atom.append("\"");
+        }
 
-      atom.append(text);
+        atom.append(text);
 
-      if (!m.matches()) {
-        atom.append("\"");
-      }
+        if (!m.matches()) {
+            atom.append("\"");
+        }
 
-      return atom.toString();
+        return atom.toString();
     }
 
-
     /**
-     * Escapes a reserved word as defined in the `reservedWords` array. Handle escaping
-     * those terms here.  This logic is only called if a variable matches the reserved words
+     * Escapes a reserved word as defined in the `reservedWords` array. Handle
+     * escaping
+     * those terms here. This logic is only called if a variable matches the
+     * reserved words
      *
      * @return the escaped term
      */
     @Override
     public String escapeReservedWord(String name) {
-        return "_" + name;  // add an underscore to the name
+        return "_" + name; // add an underscore to the name
     }
 
     private String sourceFolder() {
@@ -446,7 +437,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Location to write model files.  You can use the modelPackage() as defined when the class is
+     * Location to write model files. You can use the modelPackage() as defined when
+     * the class is
      * instantiated
      */
     @Override
@@ -455,7 +447,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Location to write api files.  You can use the apiPackage() as defined when the class is
+     * Location to write api files. You can use the apiPackage() as defined when the
+     * class is
      * instantiated
      */
     @Override
@@ -528,20 +521,23 @@ public class ElixirClientCodegen extends DefaultCodegen {
 
     @Override
     public String toOperationId(String operationId) {
-        // throw exception if method name is empty (should not occur as an auto-generated method name will be used)
+        // throw exception if method name is empty (should not occur as an
+        // auto-generated method name will be used)
         if (StringUtils.isEmpty(operationId)) {
             throw new RuntimeException("Empty method name (operationId) not allowed");
         }
 
         // method name cannot use reserved keyword, e.g. return
         if (isReservedWord(operationId)) {
-            LOGGER.warn("{} (reserved word) cannot be used as method name. Renamed to {}", operationId, underscore(sanitizeName("call_" + operationId)));
+            LOGGER.warn("{} (reserved word) cannot be used as method name. Renamed to {}", operationId,
+                    underscore(sanitizeName("call_" + operationId)));
             return underscore(sanitizeName("call_" + operationId));
         }
 
         // operationId starts with a number
         if (operationId.matches("^\\d.*")) {
-            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId, underscore(sanitizeName("call_" + operationId)));
+            LOGGER.warn("{} (starting with a number) cannot be used as method name. Renamed to {}", operationId,
+                    underscore(sanitizeName("call_" + operationId)));
             operationId = "call_" + operationId;
         }
 
@@ -549,10 +545,12 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Optional - type declaration.  This is a String which is used by the templates to instantiate your
-     * types.  There is typically special handling for different property types
+     * Optional - type declaration. This is a String which is used by the templates
+     * to instantiate your
+     * types. There is typically special handling for different property types
      *
-     * @return a string value used as the `dataType` field for model templates, `returnType` for api templates
+     * @return a string value used as the `dataType` field for model templates,
+     *         `returnType` for api templates
      */
     @Override
     public String getTypeDeclaration(Schema p) {
@@ -602,8 +600,10 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     /**
-     * Optional - OpenAPI type conversion.  This is used to map OpenAPI types in a `Schema` into
-     * either language specific types via `typeMapping` or into complex models if there is not a mapping.
+     * Optional - OpenAPI type conversion. This is used to map OpenAPI types in a
+     * `Schema` into
+     * either language specific types via `typeMapping` or into complex models if
+     * there is not a mapping.
      *
      * @return a string value of the type or complex model for this property
      */
@@ -880,7 +880,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
 
         private void buildTypespec(CodegenProperty property, StringBuilder sb) {
             if (property == null) {
-                LOGGER.error("CodegenProperty cannot be null. Please report the issue to https://github.com/openapitools/openapi-generator with the spec");
+                LOGGER.error(
+                        "CodegenProperty cannot be null. Please report the issue to https://github.com/openapitools/openapi-generator with the spec");
             } else if (property.isArray) {
                 sb.append("list(");
                 buildTypespec(property.items, sb);
@@ -1001,6 +1002,8 @@ public class ElixirClientCodegen extends DefaultCodegen {
     }
 
     @Override
-    public GeneratorLanguage generatorLanguage() { return GeneratorLanguage.ELIXIR; }
+    public GeneratorLanguage generatorLanguage() {
+        return GeneratorLanguage.ELIXIR;
+    }
 
 }

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -21,7 +21,6 @@ import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Template;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import org.apache.commons.lang3.StringUtils;
@@ -197,8 +196,9 @@ public class ElixirClientCodegen extends DefaultCodegen {
                         "AnyType",
                         "Tuple",
                         "PID",
-                        "map()", // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec
-                                 // datetype to evaluate the primitive
+                        // This is a workaround, since the DefaultCodeGen uses our elixir TypeSpec
+                        // datetype to evaluate the primitive
+                        "map()",
                         "any()"));
 
         // ref:
@@ -567,7 +567,7 @@ public class ElixirClientCodegen extends DefaultCodegen {
      * types. There is typically special handling for different property types
      *
      * @return a string value used as the `dataType` field for model templates,
-     *         `returnType` for api templates
+     * `returnType` for api templates
      */
     @Override
     public String getTypeDeclaration(Schema p) {

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/ElixirClientCodegen.java
@@ -120,18 +120,25 @@ public class ElixirClientCodegen extends DefaultCodegen {
 
         /**
          * Reserved words. Override this with reserved words specific to your language
-         * Ref: https://github.com/itsgreggreg/elixir_quick_reference#reserved-words
+         * Ref: https://hexdocs.pm/elixir/1.13/syntax-reference.html#reserved-words
          */
         reservedWords = new HashSet<>(
                 Arrays.asList(
-                        "nil",
                         "true",
                         "false",
-                        "__MODULE__",
-                        "__FILE__",
-                        "__DIR__",
-                        "__ENV__",
-                        "__CALLER__"));
+                        "nil",
+                        "when",
+                        "and",
+                        "or",
+                        "not",
+                        "in",
+                        "fn",
+                        "do",
+                        "end",
+                        "catch",
+                        "rescue",
+                        "after",
+                        "else"));
 
         /**
          * Additional Properties. These values can be passed to the templates and

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -117,7 +117,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, boolean()}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, Boolean} | {:error, Tesla.Env.t}
+  @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, boolean()} | {:error, Tesla.Env.t}
   def fake_outer_boolean_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -187,7 +187,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, float()}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, Float} | {:error, Tesla.Env.t}
+  @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, float()} | {:error, Tesla.Env.t}
   def fake_outer_number_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -222,7 +222,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String} | {:error, Tesla.Env.t}
+  @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String.t} | {:error, Tesla.Env.t}
   def fake_outer_string_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -288,7 +288,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_additional_properties_reference(Tesla.Env.client, %{optional(String.t) => AnyType}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_additional_properties_reference(Tesla.Env.client, %{optional(String.t) => any()}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_additional_properties_reference(connection, request_body, _opts \\ []) do
     request =
       %{}
@@ -600,7 +600,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_inline_additional_properties(Tesla.Env.client, %{optional(String.t) => String}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_inline_additional_properties(Tesla.Env.client, %{optional(String.t) => String.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_inline_additional_properties(connection, request_body, _opts \\ []) do
     request =
       %{}
@@ -731,7 +731,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String), list(String), list(String), list(String), list(String), String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, allow_empty, opts \\ []) do
     optional_params = %{
       :language => :query
@@ -773,7 +773,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_string_map_reference(Tesla.Env.client, %{optional(String.t) => String}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_string_map_reference(Tesla.Env.client, %{optional(String.t) => String.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_string_map_reference(connection, request_body, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/fake.ex
@@ -117,7 +117,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, boolean()}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, boolean()} | {:error, Tesla.Env.t}
+  @spec fake_outer_boolean_serialize(Tesla.Env.client, keyword()) :: {:ok, Boolean} | {:error, Tesla.Env.t}
   def fake_outer_boolean_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -187,7 +187,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, float()}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, float()} | {:error, Tesla.Env.t}
+  @spec fake_outer_number_serialize(Tesla.Env.client, keyword()) :: {:ok, Float} | {:error, Tesla.Env.t}
   def fake_outer_number_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -222,7 +222,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String.t} | {:error, Tesla.Env.t}
+  @spec fake_outer_string_serialize(Tesla.Env.client, keyword()) :: {:ok, String} | {:error, Tesla.Env.t}
   def fake_outer_string_serialize(connection, opts \\ []) do
     optional_params = %{
       :body => :body
@@ -288,7 +288,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_additional_properties_reference(Tesla.Env.client, %{optional(String.t) => AnyType.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_additional_properties_reference(Tesla.Env.client, %{optional(String.t) => AnyType}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_additional_properties_reference(connection, request_body, _opts \\ []) do
     request =
       %{}
@@ -600,7 +600,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_inline_additional_properties(Tesla.Env.client, %{optional(String.t) => String.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_inline_additional_properties(Tesla.Env.client, %{optional(String.t) => String}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_inline_additional_properties(connection, request_body, _opts \\ []) do
     request =
       %{}
@@ -731,7 +731,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String.t), list(String.t), list(String.t), list(String.t), list(String.t), String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_query_parameter_collection_format(Tesla.Env.client, list(String), list(String), list(String), list(String), list(String), String.t, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_query_parameter_collection_format(connection, pipe, ioutil, http, url, context, allow_empty, opts \\ []) do
     optional_params = %{
       :language => :query
@@ -773,7 +773,7 @@ defmodule OpenapiPetstore.Api.Fake do
   - `{:ok, nil}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec test_string_map_reference(Tesla.Env.client, %{optional(String.t) => String.t}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
+  @spec test_string_map_reference(Tesla.Env.client, %{optional(String.t) => String}, keyword()) :: {:ok, nil} | {:error, Tesla.Env.t}
   def test_string_map_reference(connection, request_body, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -93,7 +93,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, [OpenapiPetstore.Model.Pet.t]} | {:error, Tesla.Env.t}
   def find_pets_by_status(connection, status, _opts \\ []) do
     request =
       %{}
@@ -125,7 +125,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, [OpenapiPetstore.Model.Pet.t]} | {:error, Tesla.Env.t}
   def find_pets_by_tags(connection, tags, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -93,7 +93,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_status(Tesla.Env.client, list(String), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_status(connection, status, _opts \\ []) do
     request =
       %{}
@@ -125,7 +125,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_tags(Tesla.Env.client, list(String), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_tags(connection, tags, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/pet.ex
@@ -93,7 +93,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_status(Tesla.Env.client, list(String), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_status(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_status(connection, status, _opts \\ []) do
     request =
       %{}
@@ -125,7 +125,7 @@ defmodule OpenapiPetstore.Api.Pet do
   - `{:ok, [%Pet{}, ...]}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec find_pets_by_tags(Tesla.Env.client, list(String), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
+  @spec find_pets_by_tags(Tesla.Env.client, list(String.t), keyword()) :: {:ok, nil} | {:ok, list(OpenapiPetstore.Model.Pet.t)} | {:error, Tesla.Env.t}
   def find_pets_by_tags(connection, tags, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
@@ -181,7 +181,7 @@ defmodule OpenapiPetstore.Api.User do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String} | {:error, Tesla.Env.t}
+  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String.t} | {:error, Tesla.Env.t}
   def login_user(connection, username, password, _opts \\ []) do
     request =
       %{}

--- a/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
+++ b/samples/client/petstore/elixir/lib/openapi_petstore/api/user.ex
@@ -181,7 +181,7 @@ defmodule OpenapiPetstore.Api.User do
   - `{:ok, String.t}` on success
   - `{:error, Tesla.Env.t}` on failure
   """
-  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String.t} | {:error, Tesla.Env.t}
+  @spec login_user(Tesla.Env.client, String.t, String.t, keyword()) :: {:ok, nil} | {:ok, String} | {:error, Tesla.Env.t}
   def login_user(connection, username, password, _opts \\ []) do
     request =
       %{}


### PR DESCRIPTION
This PR improves Elixir code generation by resolving several issues observed when generating using the Procore API spec:

1. Previous reserved words list was incomplete. Updated to use the reserved words list from the Elixir language documentation.
2. Reserved words were being prefixed with an underscore. In Elixir this indicates that the variable is not being used and when it is used it will emit a warning. This updates the renaming function to use a suffix to avoid these warnings.
3. In rare cases, Typespecs were generating invalid types with a double "t" (e.g. ".t().t"). This change normalizes the names to improve reliability of the typespec generation.

@mrmstn

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.6.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
